### PR TITLE
Feat: quota-based limiter (per-GPU-type quotas, cluster/namespace scope)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/coordinator/plugins/gpurebalance"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/throughput"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/saturation"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/scalefromzero"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
@@ -155,6 +156,15 @@ func main() {
 	flag.Duration("rest-client-timeout", 60*time.Second,
 		"The timeout for REST API calls to the Kubernetes API server. "+
 			"Increased from default ~30s to 60s for better resilience against network latency.")
+
+	flag.String("limiter-type", "inventory",
+		"GPU limiter implementation: 'inventory' (default; physical-capacity-based) or "+
+			"'quota' (operator-declared per-GPU-type quotas at cluster and/or namespace scope). "+
+			"When 'quota' is selected, --quota-config-file must point at a YAML file "+
+			"containing a QuotaLimiterEntries document.")
+	flag.String("quota-config-file", "",
+		"Path to a YAML file declaring QuotaLimiterEntries. Required when --limiter-type=quota. "+
+			"See docs/developer-guide/quota-limiter.md for the schema and examples.")
 
 	opts := ctrlzap.Options{
 		Development: true,
@@ -462,6 +472,29 @@ func main() {
 			os.Exit(1)
 		}
 
+		// Build the GPU limiter selected by --limiter-type. Validation in
+		// config.Validate already guarantees the chosen type is supported
+		// and (for quota) that the YAML loaded into a non-empty entries list.
+		gpuLimiter, err := pipeline.NewLimiterFromConfig(cfg, mgr.GetClient())
+		if err != nil {
+			setupLog.Error(err, "failed to build GPU limiter")
+			return err
+		}
+		setupLog.Info("GPU limiter constructed", "type", cfg.LimiterMode(), "name", gpuLimiter.Name())
+
+		// Quota mode means "no physical-capacity discovery" — including the
+		// inventory-collection call in the saturation engine. We honor that
+		// at the call site (see saturation.shouldCollectClusterInventory),
+		// but warn loudly here so an operator who explicitly enabled
+		// WVA_LIMITED_MODE sees that their inventory log will be suppressed.
+		if cfg.LimiterMode() == config.LimiterTypeQuota && cfg.LimitedModeEnabled() {
+			setupLog.Info("Quota limiter mode is active; cluster inventory collection is disabled "+
+				"despite WVA_LIMITED_MODE=true (no Node API access in quota mode). "+
+				"To re-enable cluster inventory logging, switch to --limiter-type=inventory.",
+				"limiterType", cfg.LimiterMode(),
+				"limitedModeEnabled", cfg.LimitedModeEnabled())
+		}
+
 		engine := saturation.NewEngine(
 			mgr.GetClient(),
 			mgr.GetAPIReader(),
@@ -469,6 +502,7 @@ func main() {
 			mgr.GetEventRecorderFor("workload-variant-autoscaler-saturation-engine"),
 			sourceRegistry,
 			cfg, // Pass unified Config to engine
+			gpuLimiter,
 		)
 		if throughputAnalyzerEnabled(cfg) {
 			registration.RegisterThroughputAnalyzerQueries(sourceRegistry)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -482,6 +482,19 @@ func main() {
 		}
 		setupLog.Info("GPU limiter constructed", "type", cfg.LimiterMode(), "name", gpuLimiter.Name())
 
+		// The GPU limiter is only consulted on the limited optimizer path, which
+		// the engine selects per-model when enableLimiter is true in the
+		// saturation-scaling ConfigMap. That flag lives in a different ConfigMap
+		// than the quota config and is not visible to config.Validate at startup,
+		// so warn explicitly: choosing --limiter-type=quota alone does NOT enforce
+		// quotas unless enableLimiter is also set.
+		if cfg.LimiterMode() == config.LimiterTypeQuota {
+			setupLog.Info("Quota limiter selected; quota caps are enforced ONLY when " +
+				"enableLimiter: true is set in the saturation-scaling ConfigMap. " +
+				"With the default enableLimiter: false the engine runs the unlimited " +
+				"optimizer and quota caps are not applied.")
+		}
+
 		// Quota mode means "no physical-capacity discovery" — including the
 		// inventory-collection call in the saturation engine. We honor that
 		// at the call site (see saturation.shouldCollectClusterInventory),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -495,6 +495,18 @@ func main() {
 				"optimizer and quota caps are not applied.")
 		}
 
+		// Symmetric guard for the reverse misconfiguration: a quota file set while
+		// limiter-type stays at the default 'inventory' is silently ignored (the
+		// file is never parsed). QUOTA_CONFIG_FILE exported but --limiter-type=quota
+		// forgotten is an easy mistake, so warn loudly rather than starting in
+		// inventory mode as if quotas were active.
+		if cfg.LimiterMode() == config.LimiterTypeInventory && cfg.QuotaConfigFile() != "" {
+			setupLog.Info("A quota config file is set but --limiter-type is 'inventory'; "+
+				"the quota file is IGNORED and no quota caps are enforced. "+
+				"Set --limiter-type=quota (or LIMITER_TYPE=quota) to activate quota enforcement.",
+				"quotaConfigFile", cfg.QuotaConfigFile())
+		}
+
 		// Quota mode means "no physical-capacity discovery" — including the
 		// inventory-collection call in the saturation engine. We honor that
 		// at the call site (see saturation.shouldCollectClusterInventory),

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Welcome to the WVA documentation! This directory contains comprehensive guides f
 - **[Unified Configuration System](developer-guide/configuration.md)** - Configuration reference for all WVA components
 - **[Metrics & Health Monitoring](developer-guide/metrics-health-monitoring.md)** - Exposed metrics and health check endpoints
 - **[Saturation Scaling Configuration](developer-guide/saturation-scaling-config.md)** - Tuning the saturation-based scaling algorithm
+- **[Quota Limiter](developer-guide/quota-limiter.md)** - Operator-declared per-accelerator GPU caps (cluster/namespace scope)
 - **[Throughput Analyzer](developer-guide/throughput-analyzer.md)** - How the throughput analyzer works
 - **[Queue Model Analyzer](developer-guide/slo-queuemodel.md)** - SLO-aware queueing model
 - **[Pod Scraping Source](developer-guide/pod-scraping-source.md)** - Direct pod metric scraping

--- a/docs/developer-guide/configuration.md
+++ b/docs/developer-guide/configuration.md
@@ -10,9 +10,25 @@ The unified `Config` consists of two parts:
    - Infrastructure settings (metrics/probe addresses, leader election)
    - Connection settings (Prometheus URL, TLS certificates)
    - Feature flags
+   - GPU limiter selection (`--limiter-type`, `--quota-config-file`)
 
 2. **DynamicConfig**: Runtime-updatable settings (can be changed via ConfigMap updates)
    - Optimization interval
    - Saturation scaling thresholds
    - Scale-to-zero configuration
    - Prometheus cache settings
+
+### GPU limiter
+
+The GPU resource limiter is selected at startup via `--limiter-type` (or
+`LIMITER_TYPE`):
+
+- `inventory` (default) — caps scaling at the physically discovered GPU
+  inventory.
+- `quota` — enforces operator-declared per-accelerator-type caps at cluster or
+  namespace scope, loaded from `--quota-config-file` (or `QUOTA_CONFIG_FILE`).
+
+Both are **StaticConfig**: the quota file is read once at startup and requires a
+controller restart to apply changes. See the
+[Quota Limiter guide](./quota-limiter.md) for the configuration schema, scopes,
+validation rules, and pipeline behavior.

--- a/docs/developer-guide/quota-limiter.md
+++ b/docs/developer-guide/quota-limiter.md
@@ -108,9 +108,12 @@ limiters:
 
 | Value | Meaning |
 |-------|---------|
-| Positive integer | Cap in GPUs |
+| Positive integer (up to `MaxQuotaValue` = 1,048,576) | Cap in GPUs |
 | `-1` | Unlimited (Kubernetes convention; pass-through in the allocator) |
 | `0` or missing entry | Denied (no allocation) |
+
+A finite cap must not exceed `MaxQuotaValue` (`1 << 20` = 1,048,576) — far above any
+realistic accelerator count; a larger value is rejected at startup (see Validation).
 
 ### Namespace lookup rules
 
@@ -145,6 +148,7 @@ per `(namespace, type)`: it applies only when `N` is wholly unlisted.
 - `namespaceQuotas` or `exclude` set on a cluster-scoped entry.
 - `quotas` set on a namespace-scoped entry.
 - Negative quota values other than `-1`.
+- A quota value exceeding `MaxQuotaValue` (1,048,576).
 - Empty accelerator type or namespace key.
 
 It returns a non-fatal **warning** when a namespace appears in both `exclude`
@@ -260,19 +264,23 @@ Remaining boundaries:
   fair-share loop stops when the finite cluster aggregate is zero). This is a
   benign under-provision, not an isolation breach; configure a finite cluster or
   per-namespace cap for any type you expect to scale under V2.
-- The same applies to an **unlimited (`-1`) cluster-scope** quota: `GetResourcePools`
-  omits unlimited entries, so under V2 that type has no aggregate budget and does
-  **not** scale up (whereas V1 `Limit` passes it through unbounded). If you want a
-  type to scale under V2, give it a finite cap rather than `-1`.
+- An **unlimited (`-1`) cluster-scope** quota scales up under V2:
+  `GetResourcePools` emits it as a sentinel pool that `mergeConstraints` carries
+  through as an unbounded budget, so the type allocates up to demand — matching
+  the V1 `Limit` pass-through. (This differs from the namespace-scope
+  purely-unlimited case above, whose cluster aggregate is derived from the finite
+  namespace caps only.)
 
 ### Fair-share interaction
 
 Quotas are **hard ceilings applied on top of** the optimizer's fair-share loop,
 not inputs to it. Two properties follow from that:
 
-- The fair-share mean each round is `cluster GPUs / number of active models` — it
-  is **not** quota-weighted. Quotas only clamp each model after the mean is
-  computed.
+- The fair-share mean each round is the **average of the active models' remaining
+  (unmet) demand** — it is **not** `cluster GPUs / number of active models`, and
+  **not** quota-weighted. The cluster GPU total is only the loop's stop condition
+  (fair-sharing halts once the aggregate budget is exhausted). Quotas only clamp
+  each model after the mean is computed.
 - Fairness is **per-model**, not per-namespace. Two models in one namespace each
   get their own fair-share slot; the namespace quota bounds each of them (and
   their running sum) but does not pool one model's allowance for the other.
@@ -301,14 +309,19 @@ Worked example — cluster of 8 GPUs, three models:
 | M2    | 4     | 4     |
 | M3    | 4     | 4     |
 
-- **Round 1:** mean ≈ 8 / 3 ≈ 2.67. M2 and M3 each take ≈ 2.67 (under their
-  quotas); M1 is capped at its quota of 2, leaving ≈ 0.67 of its slot unused.
-- **Round 2:** that leftover ≈ 0.67 is split between the still-hungry M2 and M3.
+- **Round 1:** the mean is the average of the models' remaining demand,
+  ≈ (3 + 4 + 4) / 3 ≈ 3.67. M1 is capped at its quota of 2 (below its demand of 3),
+  so part of its fair-share slot goes unused; M2 and M3 pull toward the mean under
+  their own quotas.
+- **Round 2:** with M1 satisfied at 2, the remaining cluster budget (8 − 2 = 6) is
+  split between the still-hungry M2 and M3.
 
-Final allocation: **M1 = 2, M2 ≈ 3, M3 ≈ 3** (total 8). The outcome respects
-every quota and exhausts the cluster budget; the multi-round path is why a
+Final allocation: **M1 = 2, M2 ≈ 3, M3 ≈ 3** (total 8). The outcome respects every
+quota and exhausts the cluster budget; the multi-round path is why a
 quota-constrained model's slack flows to later rounds rather than to its
-round-mates.
+round-mates. (The exact per-round means come from the fair-share metric —
+priority × score × demand — so treat the numbers here as an illustration of the
+*path*, not an exact trace.)
 
 ## Interaction with `TypeInventory`
 

--- a/docs/developer-guide/quota-limiter.md
+++ b/docs/developer-guide/quota-limiter.md
@@ -1,0 +1,361 @@
+# Quota Limiter
+
+The **quota limiter** enforces operator-declared GPU caps that are independent
+of the physical inventory observed in the cluster. It addresses the case where
+an administrator wants to cap accelerator consumption regardless of how many
+nodes actually exist — for example, to reserve burst capacity, divide a cluster
+across tenants, or simulate a smaller budget than the hardware allows.
+
+This document covers the design, configuration, and pipeline integration of
+the quota limiter. The implementation closes
+[#1002](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1002).
+
+## Enabling
+
+Two settings must both be in place for quota enforcement to take effect:
+
+1. **`--limiter-type=quota`** (or `LIMITER_TYPE=quota`) at startup, plus
+   `--quota-config-file` pointing at the quota ConfigMap. This selects the quota
+   limiter as the GPU limiter built in `main.go`.
+2. **`enableLimiter: true`** in the saturation-scaling ConfigMap. The limiter is
+   only consulted on the limited optimizer path (`GreedyByScoreOptimizer`),
+   which the engine selects when `enableLimiter` is true; with the default
+   `enableLimiter: false` the engine runs the unlimited `CostAwareOptimizer`,
+   which ignores all constraints — so quota caps are **not** enforced. This is
+   the same coupling the physical-inventory limiter has.
+
+With `--limiter-type=quota` set but `enableLimiter: false`, the limiter is
+constructed but never applied; replicas scale unconstrained by quota.
+
+## Scope
+
+The quota limiter is one of several limiters in the resource-limiting pipeline.
+It is intentionally narrow:
+
+- It does **not** discover physical inventory (that is `TypeInventory`'s job).
+- It does **not** make scaling decisions (that is the optimizer's job).
+- It does **not** compose itself with other limiters (that is the limiter
+  chain's job — see sub-issue
+  [#3](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1003)).
+
+A `QuotaInventory` instance is tied to exactly one scope. Deployments that need
+both cluster-wide and per-namespace caps configure two limiter entries; the
+limiter chain consults both before committing a decision.
+
+## Configuration
+
+The limiter is declared via a ConfigMap parsed into `QuotaLimiterEntries`. The
+top-level `limiters` key holds a list of entries; each entry has a `scope` of
+either `cluster` or `namespace`.
+
+### Cluster scope
+
+A cluster-scoped entry caps the total GPUs of a given accelerator type across
+all namespaces. The `quotas` map keys are accelerator type names (e.g.,
+`H100`); values are caps in GPUs.
+
+```yaml
+limiters:
+  - name: cluster-quota
+    type: quota
+    scope: cluster
+    quotas:
+      H100: 16
+      A100: 8
+      L40S: -1  # unlimited
+```
+
+### Namespace scope
+
+A namespace-scoped entry caps per-namespace consumption. The top-level keys of
+`namespaceQuotas` are namespace names; inner keys are accelerator types.
+
+```yaml
+limiters:
+  - name: namespace-quota
+    type: quota
+    scope: namespace
+    exclude:
+      - kube-system
+      - llm-d-system
+    namespaceQuotas:
+      team-a:
+        H100: 8
+      team-priority:
+        H100: -1   # unlimited for this tenant
+      default:
+        H100: 2    # per-namespace fallback for unlisted namespaces
+```
+
+> ⚠️ **Reserved key collision.** The string `default` is a reserved key in
+> `namespaceQuotas` and selects the per-namespace fallback for unlisted
+> namespaces. As a consequence, the *actual* Kubernetes `default` namespace
+> cannot be assigned a quota by listing it directly. To enforce a cap on
+> workloads in the K8s `default` namespace, either (a) list it in `exclude`
+> if you want it to bypass this limiter, or (b) use a strict allowlist
+> (omit the reserved key entirely so any unlisted namespace including
+> `default` is denied).
+
+### Special values
+
+| Value | Meaning |
+|-------|---------|
+| Positive integer | Cap in GPUs |
+| `-1` | Unlimited (Kubernetes convention; pass-through in the allocator) |
+| `0` or missing entry | Denied (no allocation) |
+
+### Namespace lookup rules
+
+When the allocator evaluates a request for namespace `N` and type `T` in
+`namespace` scope:
+
+1. If `N` appears in `exclude`, the limiter **passes through** — the request is
+   returned unchanged and no usage is recorded. Other limiters in the chain
+   still apply.
+2. If `namespaceQuotas[N][T]` is set, that cap is used.
+3. Otherwise, if `namespaceQuotas["default"][T]` is set, that cap is used as
+   the **per-namespace** default — each unlisted namespace consumes its own
+   budget at this level. This matches the Kubernetes `LimitRange` default
+   semantic; it is *not* a shared pool across unlisted namespaces.
+4. Otherwise, the request is denied (granted = 0).
+
+### Validation
+
+`QuotaLimiterEntries.Validate()` returns a fatal error for any of:
+
+- Empty or duplicate `name`.
+- `type` other than `"quota"`.
+- `scope` outside `{cluster, namespace}`.
+- `namespaceQuotas` or `exclude` set on a cluster-scoped entry.
+- `quotas` set on a namespace-scoped entry.
+- Negative quota values other than `-1`.
+- Empty accelerator type or namespace key.
+
+It returns a non-fatal **warning** when a namespace appears in both `exclude`
+and `namespaceQuotas`. `exclude` wins; the warning surfaces a likely
+configuration mistake without rejecting the ConfigMap.
+
+## Pipeline integration
+
+`QuotaInventory` implements the `Inventory` interface from
+`internal/engines/pipeline/limiter_interfaces.go` plus the
+`NamespaceAwareInventory` extension. The lifecycle mirrors `TypeInventory`:
+
+1. The controller constructs `QuotaInventory` from a validated config entry.
+2. Before each cycle, `DefaultLimiter.Limit` unconditionally calls
+   `inventory.SetUsed(usedByType)` and, when the inventory satisfies
+   `NamespaceAwareInventory`, additionally calls
+   `SetUsedByNamespace(usedByNS)` via feature detection. Each
+   `QuotaInventory` instance ignores the method irrelevant to its scope
+   (`SetUsed` is a no-op on namespace-scoped instances; `SetUsedByNamespace`
+   is a no-op on cluster-scoped instances), so callers do not branch on
+   scope.
+3. The controller calls `CreateAllocator` to obtain a per-cycle
+   `ResourceAllocator`.
+4. The allocation algorithm calls `TryAllocate` once per decision; the
+   allocator tracks per-cycle usage in its own snapshot and decrements
+   remaining quota in place.
+
+`Refresh` is a no-op: quotas are operator-declared and have no external
+source.
+
+### `TryAllocate` semantics
+
+`TryAllocate` returns the number of GPUs that may be allocated, which is
+`min(gpusRequested, remaining)`. Specifically:
+
+- **Unresolved accelerator** (empty `AcceleratorName`): pass-through. The
+  upstream sentinel-resolution path (PR #1026) is expected to resolve the
+  accelerator before the chain reaches a limiter that depends on it; if the
+  allocator sees an unresolved decision it logs at DEBUG level and returns the
+  full request unchanged, deferring enforcement to a later stage.
+- **Unlimited (`-1`)**: pass-through. No usage is recorded because there is no
+  finite budget to track.
+- **Cluster scope**: cap is `ClusterQuotas[type]`. Missing entry → 0.
+- **Namespace scope**: excluded namespace → pass-through; otherwise resolved
+  via the lookup rules above. Missing entry (after default fallback) → 0.
+
+### `GetResourcePools` representation
+
+`GetResourcePools` returns `map[string]ResourcePool` keyed by accelerator type.
+For the cluster scope it is one pool per configured type. For the namespace
+scope it is the per-type **sum** across explicitly-listed (non-excluded,
+non-`default`) namespaces — the aggregate cluster budget that the per-namespace
+caps then partition. The per-`(namespace, type)` breakdown is exposed separately
+via `GetNamespaceResourcePools` (see *V2 enforcement* below).
+
+Unlimited (`-1`) entries impose no constraint and are **omitted** from the map
+entirely — an absent pool means "no cap", and the allocator's `TryAllocate`
+passes such requests through. This keeps `Limit = 0` unambiguous: a pool
+emitted with `Limit = 0` always means a real **deny** cap (a configured quota
+of `0`), never "unlimited". (`TotalLimit`, `TotalAvailable`, and `Remaining`
+exclude unlimited entries the same way.)
+
+## V2 enforcement (optimizer path)
+
+The V2 (token-based saturation) analyzer — the default — drives scaling through
+the optimizer's `ResourceConstraints`, built from
+`DefaultLimiter.ComputeConstraints`. Namespace quota is enforced here with the
+**same closed-allowlist semantics as the V1 `Limit()` path** (`tryAllocateNamespace`):
+
+- **Per-type / cluster** caps come from `GetResourcePools` (`ResourceConstraints.Pools`).
+- **Per-namespace** caps come from `GetNamespaceResourcePools`
+  (`ResourceConstraints.NamespacePools`, keyed namespace → type). Each non-excluded
+  active namespace is a **closed allowlist**: the optimizer may scale a model
+  onto a type only if that namespace lists it. For a listed type, the bound is
+  `min(per-type budget, that namespace's cap)`, decremented as it allocates.
+- A type the namespace does **not** list is **denied** — it does *not* fall
+  through to the cluster aggregate, so one namespace can never draw on another's
+  quota (no cross-namespace leak). An **unlimited** (`-1`) per-namespace entry is
+  carried as a sentinel and bounds the model only by the cluster budget for that
+  type (or is unbounded if the cluster does not cap it). An **excluded**
+  namespace is omitted entirely, so it is "open" and bound only by the cluster
+  constraint — matching V1's pass-through.
+- **Multi-entry (composite)** quota configs are fully consulted: the engine
+  computes constraints from *each* constituent of a `CompositeLimiter`.
+
+Active namespaces are taken from the optimizer's request set, so a namespace
+carrying a quota but currently running zero replicas is still constrained (its
+`default` fall-through and `exclude` rules are applied via `QuotaForNamespace`).
+A namespace with neither an explicit quota nor a `default` fall-through is a
+real **deny-all**: it is present in `NamespacePools` with no listed types, and
+the optimizer allocates it nothing.
+
+Remaining boundaries:
+
+- Composing a **physical-inventory** limiter with a quota limiter as
+  `min(physical, quota)` within a single constraint set is tracked by the
+  limiter chain (sub-issue #1003).
+- A **purely unlimited** namespace-quota config with no finite cluster cap for
+  the relevant type does not scale under the V2 `GreedyByScore` optimizer (its
+  fair-share loop stops when the finite cluster aggregate is zero). This is a
+  benign under-provision, not an isolation breach; configure a finite cluster or
+  per-namespace cap for any type you expect to scale under V2.
+
+## Interaction with `TypeInventory`
+
+`QuotaInventory` is composed with `TypeInventory` by the limiter chain. The
+intended model:
+
+- `TypeInventory` knows what is **physically available** (nodes × GPUs per
+  node).
+- `QuotaInventory` knows what is **administratively allowed**.
+- The chain takes the minimum: a decision must fit under both.
+
+Used standalone, `QuotaInventory` does **not** enforce physical bounds — a
+deployment with no `TypeInventory` in the chain will happily allocate beyond
+the cluster's actual capacity if the quota permits. Always pair the two in
+production. The chain composition itself is tracked in sub-issue #1003 and is
+out of scope for the initial PR.
+
+## DecisionStep trace
+
+When `quotaAllocator.TryAllocate` caps a request (granted < requested), it
+appends a `DecisionStep` to the decision via `VariantDecision.AddDecisionStep`
+with the reason formatted as:
+
+- Cluster scope: `limited by quota[scope=cluster, type=H100]`
+- Namespace scope: `limited by quota[scope=namespace, namespace=team-a, type=H100]`
+
+The step's `Name` field is the limiter's `name` (e.g., `cluster-quota`) and
+`WasConstrained` is `true`. Pass-through paths (excluded namespace, unlimited
+quota, unresolved accelerator) do **not** record a step because they did not
+constrain the decision. The chain's `updateDecisionMetadata` separately sets
+`WasLimited` / `LimitedBy` per limiter; the DecisionStep here carries the
+finer-grained scope/type detail.
+
+## Startup wiring
+
+The controller selects between physical-inventory and quota enforcement at
+startup via the `--limiter-type` flag (or `LIMITER_TYPE` env var):
+
+| Value | Behavior |
+|-------|----------|
+| `inventory` (default) | Today's path — `TypeInventory` discovers physical GPUs via the GPU operator and caps decisions at `min(physical, requested)`. |
+| `quota` | Loads operator-declared quotas from `--quota-config-file` (or `QUOTA_CONFIG_FILE` env var). The two are mutually exclusive in PR-1 — quota mode does **not** consult physical inventory. |
+
+The selector lives on `*config.Config` (`LimiterType()`, `QuotaConfigFile()`,
+`QuotaLimiterEntries()`). The factory in
+`internal/engines/pipeline/limiter_factory.go` translates the selection into a
+concrete `pipeline.Limiter`:
+
+- **Inventory** — `DefaultLimiter` wrapping `TypeInventoryWithUsage`.
+- **Single quota entry** — `DefaultLimiter` wrapping one `QuotaInventory`.
+- **Multiple quota entries** (e.g., cluster + namespace combined) —
+  `CompositeLimiter` wrapping one `DefaultLimiter` per entry. Each constituent
+  applies its cap in declaration order against the shared decisions slice,
+  so the most-restrictive bound wins. This is intentionally simple — full
+  chain composition with `min(physical, quota)` is sub-issue #1003.
+
+### Per-namespace usage feeding
+
+`DefaultLimiter.Limit` feature-detects `NamespaceAwareInventory` and calls
+`SetUsedByNamespace(usedByNS)` in addition to the always-safe `SetUsed`.
+`usedByNS` is derived from the decisions slice the same way per-type usage is —
+`CurrentReplicas * GPUsPerReplica` summed by `(Namespace, AcceleratorName)`.
+No additional discovery or API calls are needed.
+
+### Example startup invocations
+
+Inventory mode (default; no new flags needed):
+
+```bash
+manager --metrics-bind-address=:8443
+```
+
+Quota mode pointing at a YAML file:
+
+```bash
+manager --limiter-type=quota --quota-config-file=/etc/wva/quota.yaml
+```
+
+The same selection can be provided via env vars
+(`LIMITER_TYPE=quota QUOTA_CONFIG_FILE=/etc/wva/quota.yaml`) or via the unified
+config file.
+
+Validation rejects the combination `--limiter-type=quota` with no
+`--quota-config-file`, as well as a quota file that parses to an empty entries
+list, so an operator gets a clear startup error in either misconfiguration.
+
+## Resource access in quota mode
+
+Quota mode makes the controller fully independent of physical node
+discovery. With `--limiter-type=quota`:
+
+- The limiter, inventory, allocator, and factory paths do not call
+  `discovery.K8sWithGpuOperator.Discover` / `DiscoverUsage` /
+  `DiscoverNodes`.
+- No controller-runtime informer for `corev1.NodeList` is instantiated.
+- `QuotaInventory.Refresh` is a deliberate no-op; usage is derived from
+  the in-memory decisions slice via `DefaultLimiter.calculateUsedGPUs` and
+  `calculateUsedGPUsByNamespace`.
+- `collector.CollectInventoryK8S` (called from the saturation engine's
+  per-cycle `optimize` when `WVA_LIMITED_MODE=true`) is **also** gated on
+  the limiter type via `shouldCollectClusterInventory` — it only runs when
+  `LimiterType == "inventory"`. This keeps the "no Node API access in
+  quota mode" contract intact even if an operator combines
+  `--limiter-type=quota` with `WVA_LIMITED_MODE=true`. When that
+  combination is detected at startup, `main.go` emits an informational
+  log so the operator sees that their inventory logging is intentionally
+  suppressed.
+
+Combination matrix:
+
+| `--limiter-type` | `WVA_LIMITED_MODE` | Node API access? |
+|------------------|--------------------|------------------|
+| `inventory` (default) | `false` (default) | Yes, via the limiter's `Refresh` cycle. |
+| `inventory` | `true` | Yes, via both the limiter and `CollectInventoryK8S`. |
+| `quota` | `false` | **No.** |
+| `quota` | `true` | **No.** `CollectInventoryK8S` is skipped; a startup log notes the suppression. |
+
+## Future work
+
+- **Limiter chain composition** (sub-issue #1003) — replace the simple
+  `CompositeLimiter` with a smarter chain that:
+  - Composes physical (`TypeInventory`) and quota bounds as
+    `min(physical, quota)` instead of the current mutually-exclusive choice.
+  - Owns DecisionStep ordering / `LimitedBy` selection when multiple caps
+    bind the same decision.
+- **Reservation-style limiters** — the `type: "quota"` discriminator leaves
+  room for additional limiter types (e.g., `reservation`, `priority`) under
+  the same ConfigMap schema.

--- a/docs/developer-guide/quota-limiter.md
+++ b/docs/developer-guide/quota-limiter.md
@@ -48,6 +48,14 @@ The limiter is declared via a ConfigMap parsed into `QuotaLimiterEntries`. The
 top-level `limiters` key holds a list of entries; each entry has a `scope` of
 either `cluster` or `namespace`.
 
+> **`type:` vs `--limiter-type`.** Which limiter *implementation* runs is chosen
+> globally at startup by `--limiter-type` (see [Startup wiring](#startup-wiring)),
+> not per entry. The per-entry `type:` field is a forward-looking discriminator
+> that must currently always be `"quota"` — `type: inventory` is **not** valid
+> inside this YAML and the config is rejected if any other value is used (see
+> [Validation](#validation)). The field exists so future limiter types (e.g.
+> `reservation`) can share this schema.
+
 ### Cluster scope
 
 A cluster-scoped entry caps the total GPUs of a given accelerator type across
@@ -134,6 +142,18 @@ When the allocator evaluates a request for namespace `N` and type `T` in
 It returns a non-fatal **warning** when a namespace appears in both `exclude`
 and `namespaceQuotas`. `exclude` wins; the warning surfaces a likely
 configuration mistake without rejecting the ConfigMap.
+
+### Reload lifecycle
+
+The quota configuration is read **once at startup** (from `--quota-config-file` /
+`QUOTA_CONFIG_FILE`, or the unified config file) and held in memory for the life
+of the process. The running controller does **not** watch the file or reload it.
+
+This matters when the quota file is mounted from a ConfigMap: Kubernetes updates
+the file on disk as the ConfigMap changes, but the controller keeps using the
+values it loaded at startup. A quota change therefore takes effect only after the
+controller pod restarts (e.g. `kubectl rollout restart deployment/...`). Plan
+quota edits accordingly — there is no hot reload.
 
 ## Pipeline integration
 
@@ -232,6 +252,40 @@ Remaining boundaries:
   benign under-provision, not an isolation breach; configure a finite cluster or
   per-namespace cap for any type you expect to scale under V2.
 
+### Fair-share interaction
+
+Quotas are **hard ceilings applied on top of** the optimizer's fair-share loop,
+not inputs to it. Two properties follow from that:
+
+- The fair-share mean each round is `cluster GPUs / number of active models` — it
+  is **not** quota-weighted. Quotas only clamp each model after the mean is
+  computed.
+- Fairness is **per-model**, not per-namespace. Two models in one namespace each
+  get their own fair-share slot; the namespace quota bounds each of them (and
+  their running sum) but does not pool one model's allowance for the other.
+
+When a model is capped below its fair-share slot it takes only up to its quota;
+the unused remainder is **released to subsequent rounds**, where the
+still-hungry models split it — it is not handed to other models within the same
+round.
+
+Worked example — cluster of 8 GPUs, three models:
+
+| Model | Wants | Quota |
+|-------|-------|-------|
+| M1    | 3     | 2     |
+| M2    | 4     | 4     |
+| M3    | 4     | 4     |
+
+- **Round 1:** mean ≈ 8 / 3 ≈ 2.67. M2 and M3 each take ≈ 2.67 (under their
+  quotas); M1 is capped at its quota of 2, leaving ≈ 0.67 of its slot unused.
+- **Round 2:** that leftover ≈ 0.67 is split between the still-hungry M2 and M3.
+
+Final allocation: **M1 = 2, M2 ≈ 3, M3 ≈ 3** (total 8). The outcome respects
+every quota and exhausts the cluster budget; the multi-round path is why a
+quota-constrained model's slack flows to later rounds rather than to its
+round-mates.
+
 ## Interaction with `TypeInventory`
 
 `QuotaInventory` is composed with `TypeInventory` by the limiter chain. The
@@ -272,7 +326,7 @@ startup via the `--limiter-type` flag (or `LIMITER_TYPE` env var):
 | Value | Behavior |
 |-------|----------|
 | `inventory` (default) | Today's path — `TypeInventory` discovers physical GPUs via the GPU operator and caps decisions at `min(physical, requested)`. |
-| `quota` | Loads operator-declared quotas from `--quota-config-file` (or `QUOTA_CONFIG_FILE` env var). The two are mutually exclusive in PR-1 — quota mode does **not** consult physical inventory. |
+| `quota` | Loads operator-declared quotas from `--quota-config-file` (or `QUOTA_CONFIG_FILE` env var). The two are mutually exclusive in the initial implementation (composing with physical inventory as `min(physical, quota)` is tracked in [#1003](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1003)) — quota mode does **not** consult physical inventory. |
 
 The selector lives on `*config.Config` (`LimiterType()`, `QuotaConfigFile()`,
 `QuotaLimiterEntries()`). The factory in

--- a/docs/developer-guide/quota-limiter.md
+++ b/docs/developer-guide/quota-limiter.md
@@ -217,12 +217,15 @@ non-`default`) namespaces — the aggregate cluster budget that the per-namespac
 caps then partition. The per-`(namespace, type)` breakdown is exposed separately
 via `NamespaceResourcePools` (see *V2 enforcement* below).
 
-Unlimited (`-1`) entries impose no constraint and are **omitted** from the map
-entirely — an absent pool means "no cap", and the allocator's `TryAllocate`
-passes such requests through. This keeps `Limit = 0` unambiguous: a pool
-emitted with `Limit = 0` always means a real **deny** cap (a configured quota
-of `0`), never "unlimited". (`TotalLimit`, `TotalAvailable`, and `Remaining`
-exclude unlimited entries the same way.)
+Unlimited (`-1`) entries are handled by scope. At **cluster** scope they are
+emitted as a sentinel `ResourcePool{Limit == -1}` (like the namespace branch), so
+the V2 optimizer can tell "unlimited" (allocate up to demand) apart from a type
+with no configured quota (absent → deny). At **namespace** scope an unlimited
+`(namespace, type)` is likewise emitted as a sentinel in `NamespaceResourcePools`.
+Either way `Limit = 0` stays unambiguous: a pool with `Limit = 0` always means a
+real **deny** cap (a configured quota of `0`), never "unlimited". (`TotalLimit`,
+`TotalAvailable`, and `Remaining` still exclude unlimited entries from their
+totals.)
 
 ## V2 enforcement (optimizer path)
 
@@ -277,7 +280,8 @@ Quotas are **hard ceilings applied on top of** the optimizer's fair-share loop,
 not inputs to it. Two properties follow from that:
 
 - The fair-share mean each round is the **average of the active models' remaining
-  (unmet) demand** — it is **not** `cluster GPUs / number of active models`, and
+  fair-share metric** (priority × score × unmet demand — see the worked-example
+  caveat below) — it is **not** `cluster GPUs / number of active models`, and
   **not** quota-weighted. The cluster GPU total is only the loop's stop condition
   (fair-sharing halts once the aggregate budget is exhausted). Quotas only clamp
   each model after the mean is computed.

--- a/docs/developer-guide/quota-limiter.md
+++ b/docs/developer-guide/quota-limiter.md
@@ -120,12 +120,20 @@ When the allocator evaluates a request for namespace `N` and type `T` in
 1. If `N` appears in `exclude`, the limiter **passes through** — the request is
    returned unchanged and no usage is recorded. Other limiters in the chain
    still apply.
-2. If `namespaceQuotas[N][T]` is set, that cap is used.
-3. Otherwise, if `namespaceQuotas["default"][T]` is set, that cap is used as
-   the **per-namespace** default — each unlisted namespace consumes its own
-   budget at this level. This matches the Kubernetes `LimitRange` default
-   semantic; it is *not* a shared pool across unlisted namespaces.
+2. If `N` is listed in `namespaceQuotas`, that namespace's **whole map is a
+   closed allowlist**: `namespaceQuotas[N][T]` is the cap if present, and a type
+   `T` that `N` does **not** list is **denied** (granted = 0). A listed namespace
+   never falls through to `default` for a missing type — listing a namespace opts
+   it into "only the types I name".
+3. Otherwise (`N` is not listed), if `namespaceQuotas["default"]` is present, the
+   **`default` map** becomes `N`'s per-namespace budget: each unlisted namespace
+   gets its own copy of those caps (a type absent from `default` is still
+   denied). This matches the Kubernetes `LimitRange` default semantic; it is
+   *not* a shared pool across unlisted namespaces.
 4. Otherwise, the request is denied (granted = 0).
+
+The fall-through to `default` is therefore at the **namespace** granularity, not
+per `(namespace, type)`: it applies only when `N` is wholly unlisted.
 
 ### Validation
 
@@ -184,11 +192,12 @@ source.
 `TryAllocate` returns the number of GPUs that may be allocated, which is
 `min(gpusRequested, remaining)`. Specifically:
 
-- **Unresolved accelerator** (empty `AcceleratorName`): pass-through. The
-  upstream sentinel-resolution path (PR #1026) is expected to resolve the
-  accelerator before the chain reaches a limiter that depends on it; if the
-  allocator sees an unresolved decision it logs at DEBUG level and returns the
-  full request unchanged, deferring enforcement to a later stage.
+- **Unresolved accelerator** (empty `AcceleratorName`): **deny — fail closed**
+  (granted = 0, with a `WasConstrained` DecisionStep). The allocator cannot match
+  a per-type quota without a resolved type, and passing through would let an
+  unattributed request bypass the cap. `DefaultLimiter` runs accelerator
+  resolution first and resolves single-type inventories; a multi-type quota
+  config can still leave the type unresolved here, so denial is the safe default.
 - **Unlimited (`-1`)**: pass-through. No usage is recorded because there is no
   finite budget to track.
 - **Cluster scope**: cap is `ClusterQuotas[type]`. Missing entry → 0.
@@ -202,7 +211,7 @@ For the cluster scope it is one pool per configured type. For the namespace
 scope it is the per-type **sum** across explicitly-listed (non-excluded,
 non-`default`) namespaces — the aggregate cluster budget that the per-namespace
 caps then partition. The per-`(namespace, type)` breakdown is exposed separately
-via `GetNamespaceResourcePools` (see *V2 enforcement* below).
+via `NamespaceResourcePools` (see *V2 enforcement* below).
 
 Unlimited (`-1`) entries impose no constraint and are **omitted** from the map
 entirely — an absent pool means "no cap", and the allocator's `TryAllocate`
@@ -219,7 +228,7 @@ the optimizer's `ResourceConstraints`, built from
 **same closed-allowlist semantics as the V1 `Limit()` path** (`tryAllocateNamespace`):
 
 - **Per-type / cluster** caps come from `GetResourcePools` (`ResourceConstraints.Pools`).
-- **Per-namespace** caps come from `GetNamespaceResourcePools`
+- **Per-namespace** caps come from `NamespaceResourcePools`
   (`ResourceConstraints.NamespacePools`, keyed namespace → type). Each non-excluded
   active namespace is a **closed allowlist**: the optimizer may scale a model
   onto a type only if that namespace lists it. For a listed type, the bound is
@@ -251,6 +260,10 @@ Remaining boundaries:
   fair-share loop stops when the finite cluster aggregate is zero). This is a
   benign under-provision, not an isolation breach; configure a finite cluster or
   per-namespace cap for any type you expect to scale under V2.
+- The same applies to an **unlimited (`-1`) cluster-scope** quota: `GetResourcePools`
+  omits unlimited entries, so under V2 that type has no aggregate budget and does
+  **not** scale up (whereas V1 `Limit` passes it through unbounded). If you want a
+  type to scale under V2, give it a finite cap rather than `-1`.
 
 ### Fair-share interaction
 
@@ -263,6 +276,17 @@ not inputs to it. Two properties follow from that:
 - Fairness is **per-model**, not per-namespace. Two models in one namespace each
   get their own fair-share slot; the namespace quota bounds each of them (and
   their running sum) but does not pool one model's allowance for the other.
+
+> **Ceilings, not reservations.** A finite per-namespace cap guarantees a tenant
+> will never *exceed* it — it does **not** guarantee the tenant can *reach* it.
+> Under V2 the cluster aggregate is the **sum of the finite namespace caps**, and
+> an **unlimited (`-1`)** or **excluded** namespace competing for the same
+> accelerator type draws from that shared aggregate without contributing to it,
+> so it can consume budget a finite-capped peer would otherwise have used (no
+> isolation breach — nobody exceeds their own authorization — but a real fairness
+> footgun). If you need a tenant's cap to behave like a floor, avoid mixing
+> unlimited/excluded namespaces on the same type, and give every type a finite
+> cluster-scope cap.
 
 When a model is capped below its fair-share slot it takes only up to its quota;
 the unused remainder is **released to subsequent rounds**, where the
@@ -296,11 +320,13 @@ intended model:
 - `QuotaInventory` knows what is **administratively allowed**.
 - The chain takes the minimum: a decision must fit under both.
 
-Used standalone, `QuotaInventory` does **not** enforce physical bounds — a
-deployment with no `TypeInventory` in the chain will happily allocate beyond
-the cluster's actual capacity if the quota permits. Always pair the two in
-production. The chain composition itself is tracked in sub-issue #1003 and is
-out of scope for the initial PR.
+In the initial implementation the two are **mutually exclusive**, not composed:
+`--limiter-type` selects either physical inventory **or** quota. There is no
+`min(physical, quota)` chain yet (tracked in sub-issue #1003), so quota mode does
+**not** enforce physical bounds at all — a deployment in quota mode will allocate
+beyond the cluster's actual capacity if the quota permits (the surplus simply
+yields `Pending` pods, not an isolation breach). Set quota caps at or below real
+capacity until composition with `TypeInventory` lands.
 
 ## DecisionStep trace
 
@@ -313,8 +339,11 @@ with the reason formatted as:
 
 The step's `Name` field is the limiter's `name` (e.g., `cluster-quota`) and
 `WasConstrained` is `true`. Pass-through paths (excluded namespace, unlimited
-quota, unresolved accelerator) do **not** record a step because they did not
-constrain the decision. The chain's `updateDecisionMetadata` separately sets
+quota) do **not** record a step because they did not constrain the decision. An
+**unresolved accelerator** is the exception among the "did not allocate" paths:
+it is a fail-closed **deny** and *does* record a `WasConstrained` step (reason
+`denied by quota[...]: accelerator type unresolved`). The chain's
+`updateDecisionMetadata` separately sets
 `WasLimited` / `LimitedBy` per limiter; the DecisionStep here carries the
 finer-grained scope/type detail.
 
@@ -328,8 +357,8 @@ startup via the `--limiter-type` flag (or `LIMITER_TYPE` env var):
 | `inventory` (default) | Today's path — `TypeInventory` discovers physical GPUs via the GPU operator and caps decisions at `min(physical, requested)`. |
 | `quota` | Loads operator-declared quotas from `--quota-config-file` (or `QUOTA_CONFIG_FILE` env var). The two are mutually exclusive in the initial implementation (composing with physical inventory as `min(physical, quota)` is tracked in [#1003](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1003)) — quota mode does **not** consult physical inventory. |
 
-The selector lives on `*config.Config` (`LimiterType()`, `QuotaConfigFile()`,
-`QuotaLimiterEntries()`). The factory in
+The selector lives on `*config.Config` (`LimiterMode()`, `QuotaConfigFile()`,
+`QuotaEntries()`). The factory in
 `internal/engines/pipeline/limiter_factory.go` translates the selection into a
 concrete `pipeline.Limiter`:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	qmAnalyzer  qmAnalyzerConfig  // namespace-aware
 	scaleToZero scaleToZeroConfig // namespace-aware
 	coordinator coordinatorConfig
+	limiter     limiterConfig // startup-only: selects inventory vs quota
 }
 
 // coordinatorConfig holds Coordinator loop configuration. Plugin
@@ -33,6 +34,42 @@ type Config struct {
 type coordinatorConfig struct {
 	enabled  bool
 	interval time.Duration
+}
+
+// LimiterType selects which pipeline.Limiter implementation
+// pipeline.NewLimiterFromConfig builds at startup. The two values are
+// mutually exclusive in PR-1 — composing physical and quota bounds
+// (min(physical, quota)) is the limiter chain's job, tracked in
+// sub-issue #1003.
+type LimiterType string
+
+const (
+	// LimiterTypeInventory builds the TypeInventory-backed limiter
+	// (physical GPU discovery via the GPU operator). Default.
+	LimiterTypeInventory LimiterType = "inventory"
+
+	// LimiterTypeQuota builds one or more QuotaInventory-backed limiters
+	// from an operator-supplied YAML file. Multiple entries are wrapped in
+	// a CompositeLimiter that applies them sequentially.
+	LimiterTypeQuota LimiterType = "quota"
+)
+
+// limiterConfig holds the operator-chosen GPU limiter selection and any
+// supporting configuration loaded at startup. Set once during config.Load
+// and read by main.go / the engine factory — there is no live-reload path.
+type limiterConfig struct {
+	// limiterType is one of LimiterTypeInventory (default) or
+	// LimiterTypeQuota. Selects which pipeline.Limiter implementation
+	// NewLimiterFromConfig builds.
+	limiterType LimiterType
+	// quotaConfigFile is the path to the YAML file containing
+	// QuotaLimiterEntries. Required when limiterType == LimiterTypeQuota;
+	// ignored otherwise.
+	quotaConfigFile string
+	// quotaEntries is the parsed and validated quota config. Populated only
+	// when limiterType == LimiterTypeQuota and quotaConfigFile loads
+	// successfully.
+	quotaEntries []QuotaLimiterConfig
 }
 
 // configSyncState tracks configuration sync state used for startup/readiness checks.
@@ -706,6 +743,31 @@ func (c *Config) setPrometheusBaseURLForTesting(baseURL string) {
 	c.prometheus.baseURL = baseURL
 }
 
+// SetLimiterForTest sets the limiter selection on a test Config. Used by the
+// pipeline and saturation packages' tests to drive NewLimiterFromConfig /
+// the inventory gate without going through the full Viper loader. It is
+// exported (rather than living in export_test.go) because those callers are in
+// other packages and cannot see config's test-only symbols. Not for production
+// use.
+func SetLimiterForTest(c *Config, limiterType LimiterType, quotaConfigFile string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.limiter.limiterType = limiterType
+	c.limiter.quotaConfigFile = quotaConfigFile
+	c.limiter.quotaEntries = nil
+}
+
+// ReloadQuotaForTest re-runs the quota config file loader against the path
+// already stored on the Config, populating quotaEntries. Used by cross-package
+// tests that build a quota YAML in a temp dir and want the parsed entries
+// available to NewLimiterFromConfig. Exported for the same reason as
+// SetLimiterForTest. Not for production use.
+func ReloadQuotaForTest(c *Config) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return loadQuotaLimiterEntries(&c.limiter)
+}
+
 // --- Bootstrap State Management ---
 
 // ConfigMapsBootstrapComplete returns true once the initial ConfigMap bootstrap has completed.
@@ -746,4 +808,41 @@ func (c *Config) MarkConfigMapsBootstrapFailed(err error) {
 		return
 	}
 	c.configSync.lastConfigMapsSyncError = ""
+}
+
+// LimiterMode returns the operator-selected GPU limiter implementation
+// (LimiterTypeInventory by default, or LimiterTypeQuota). Set at startup
+// via the --limiter-type flag / LIMITER_TYPE env var.
+// Thread-safe.
+func (c *Config) LimiterMode() LimiterType {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.limiter.limiterType
+}
+
+// QuotaConfigFile returns the path to the YAML file containing
+// QuotaLimiterEntries. Empty unless --limiter-type=quota was selected.
+// Thread-safe.
+func (c *Config) QuotaConfigFile() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.limiter.quotaConfigFile
+}
+
+// QuotaEntries returns a deep copy of the parsed quota limiter entries.
+// Empty when --limiter-type != "quota". Each returned entry's ClusterQuotas /
+// NamespaceQuotas maps and Exclude slice are cloned, so callers may read or
+// mutate the result freely without affecting the config-owned snapshot.
+// Thread-safe.
+func (c *Config) QuotaEntries() []QuotaLimiterConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.limiter.quotaEntries) == 0 {
+		return nil
+	}
+	out := make([]QuotaLimiterConfig, len(c.limiter.quotaEntries))
+	for i, e := range c.limiter.quotaEntries {
+		out[i] = e.clone()
+	}
+	return out
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,9 +38,9 @@ type coordinatorConfig struct {
 
 // LimiterType selects which pipeline.Limiter implementation
 // pipeline.NewLimiterFromConfig builds at startup. The two values are
-// mutually exclusive in PR-1 — composing physical and quota bounds
-// (min(physical, quota)) is the limiter chain's job, tracked in
-// sub-issue #1003.
+// mutually exclusive in the initial implementation — composing physical and
+// quota bounds (min(physical, quota)) is the limiter chain's job, tracked in
+// issue #1003.
 type LimiterType string
 
 const (

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -3,10 +3,12 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -28,6 +30,8 @@ var flagBindings = map[string]string{
 	"METRICS_CERT_PATH":              "metrics-cert-path",
 	"METRICS_CERT_NAME":              "metrics-cert-name",
 	"METRICS_CERT_KEY":               "metrics-cert-key",
+	"LIMITER_TYPE":                   "limiter-type",
+	"QUOTA_CONFIG_FILE":              "quota-config-file",
 }
 
 // Load loads and validates the unified configuration.
@@ -85,6 +89,8 @@ func loadConfig(cfg *Config, flagSet *flag.FlagSet, configFilePath string) error
 	v.SetDefault("GLOBAL_OPT_INTERVAL", "60s")
 	v.SetDefault("EXPERIMENTAL_COORDINATOR_ENABLED", false)
 	v.SetDefault("COORDINATOR_INTERVAL", "15s")
+	v.SetDefault("LIMITER_TYPE", "inventory")
+	v.SetDefault("QUOTA_CONFIG_FILE", "")
 
 	// Load from config file (mounted in the container) — sits between env and defaults in precedence
 	if configFilePath != "" {
@@ -171,6 +177,45 @@ func loadConfig(cfg *Config, flagSet *flag.FlagSet, configFilePath string) error
 	cfg.prometheus.clientCertPath = v.GetString("PROMETHEUS_CLIENT_CERT_PATH")
 	cfg.prometheus.clientKeyPath = v.GetString("PROMETHEUS_CLIENT_KEY_PATH")
 	cfg.prometheus.serverName = v.GetString("PROMETHEUS_SERVER_NAME")
+
+	cfg.limiter = limiterConfig{
+		limiterType:     LimiterType(v.GetString("LIMITER_TYPE")),
+		quotaConfigFile: v.GetString("QUOTA_CONFIG_FILE"),
+	}
+	if err := loadQuotaLimiterEntries(&cfg.limiter); err != nil {
+		return fmt.Errorf("failed to load quota limiter entries: %w", err)
+	}
+	return nil
+}
+
+// loadQuotaLimiterEntries reads, parses, and validates the YAML file at
+// limiter.quotaConfigFile when limiterType == LimiterTypeQuota. The file
+// shape is QuotaLimiterEntries. Warnings are emitted to the controller
+// log; only hard errors abort startup.
+//
+// No-op when limiterType != LimiterTypeQuota or quotaConfigFile is empty —
+// validation that QUOTA_CONFIG_FILE is set when LIMITER_TYPE=quota lives
+// in Validate() so an operator gets a single coherent error message.
+func loadQuotaLimiterEntries(limiter *limiterConfig) error {
+	if limiter.limiterType != LimiterTypeQuota || limiter.quotaConfigFile == "" {
+		return nil
+	}
+	data, err := os.ReadFile(limiter.quotaConfigFile)
+	if err != nil {
+		return fmt.Errorf("read %q: %w", limiter.quotaConfigFile, err)
+	}
+	var entries QuotaLimiterEntries
+	if err := yaml.Unmarshal(data, &entries); err != nil {
+		return fmt.Errorf("parse %q as quota limiter YAML: %w", limiter.quotaConfigFile, err)
+	}
+	warnings, err := entries.Validate()
+	if err != nil {
+		return fmt.Errorf("validate %q: %w", limiter.quotaConfigFile, err)
+	}
+	for _, w := range warnings {
+		ctrl.Log.Info("quota limiter config warning", "warning", w, "file", limiter.quotaConfigFile)
+	}
+	limiter.quotaEntries = entries.Limiters
 	return nil
 }
 

--- a/internal/config/loader_quota_test.go
+++ b/internal/config/loader_quota_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("loadQuotaLimiterEntries (via ReloadQuotaForTest)", func() {
+	var cfg *Config
+
+	BeforeEach(func() {
+		cfg = NewTestConfig()
+	})
+
+	// writeQuotaFile writes content to a temp file and points the Config's
+	// quota limiter at it (limiter-type=quota), so ReloadQuotaForTest loads it.
+	writeQuotaFile := func(content string) string {
+		path := filepath.Join(GinkgoT().TempDir(), "quota.yaml")
+		Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
+		return path
+	}
+
+	It("errors when the quota config file does not exist", func() {
+		SetLimiterForTest(cfg, LimiterTypeQuota, filepath.Join(GinkgoT().TempDir(), "missing.yaml"))
+		Expect(ReloadQuotaForTest(cfg)).To(MatchError(ContainSubstring("read")))
+	})
+
+	It("errors when the quota config file is not valid YAML", func() {
+		SetLimiterForTest(cfg, LimiterTypeQuota, writeQuotaFile("limiters: [unterminated"))
+		Expect(ReloadQuotaForTest(cfg)).To(MatchError(ContainSubstring("parse")))
+	})
+
+	It("errors when the parsed entries fail validation", func() {
+		SetLimiterForTest(cfg, LimiterTypeQuota, writeQuotaFile(
+			"limiters:\n  - name: q\n    type: quota\n    scope: bogus\n"))
+		Expect(ReloadQuotaForTest(cfg)).To(MatchError(ContainSubstring("validate")))
+	})
+
+	It("loads a valid quota config and populates QuotaEntries", func() {
+		SetLimiterForTest(cfg, LimiterTypeQuota, writeQuotaFile(
+			"limiters:\n  - name: q\n    type: quota\n    scope: cluster\n    quotas:\n      A100: 4\n"))
+		Expect(ReloadQuotaForTest(cfg)).To(Succeed())
+		entries := cfg.QuotaEntries()
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Name).To(Equal("q"))
+		Expect(entries[0].Scope).To(Equal(QuotaScopeCluster))
+		Expect(entries[0].ClusterQuotas).To(HaveKeyWithValue("A100", 4))
+	})
+
+	It("is a no-op when limiter-type is not quota", func() {
+		SetLimiterForTest(cfg, LimiterTypeInventory, writeQuotaFile("limiters: [unterminated"))
+		Expect(ReloadQuotaForTest(cfg)).To(Succeed(), "non-quota mode must not read/parse the file")
+	})
+})

--- a/internal/config/quota_limiter.go
+++ b/internal/config/quota_limiter.go
@@ -19,6 +19,13 @@ const QuotaLimiterReservedNamespaceKey = "default"
 // convention of -1 = no limit (e.g., `terminationGracePeriodSeconds: -1`).
 const QuotaUnlimited = -1
 
+// MaxQuotaValue is the largest finite quota a single entry may declare. It is
+// far above any realistic GPU count (a million accelerators) and exists only to
+// keep the aggregate sum (summed across namespaces in aggregateNamespacePools)
+// well clear of int64 overflow — an overflowed sum could wrap negative and be
+// misread as the QuotaUnlimited (-1) sentinel.
+const MaxQuotaValue = 1 << 20 // 1,048,576
+
 // QuotaScope identifies whether a quota limiter applies cluster-wide or
 // per-namespace. Both scopes can coexist; each acts independently.
 type QuotaScope string
@@ -250,6 +257,10 @@ func validateTypeQuotaMap(quotas map[string]int, location string) error {
 		if value < QuotaUnlimited {
 			errs = append(errs, fmt.Errorf("%s[%q]: quota value %d is invalid; must be >= %d (only -1 is allowed as negative — means unlimited)",
 				location, accType, value, QuotaUnlimited))
+		}
+		if value > MaxQuotaValue {
+			errs = append(errs, fmt.Errorf("%s[%q]: quota value %d exceeds the maximum of %d",
+				location, accType, value, MaxQuotaValue))
 		}
 	}
 	return errors.Join(errs...)

--- a/internal/config/quota_limiter.go
+++ b/internal/config/quota_limiter.go
@@ -1,0 +1,256 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// QuotaLimiterReservedNamespaceKey is the reserved key in the namespace-scoped
+// quotas map that matches any namespace not explicitly listed. A real namespace
+// named "default" cannot be configured directly via this key — list it in
+// `exclude` or use a strict allowlist instead.
+const QuotaLimiterReservedNamespaceKey = "default"
+
+// QuotaUnlimited is the per-type quota value that disables the cap for that
+// accelerator type in the containing namespace. Follows the Kubernetes
+// convention of -1 = no limit (e.g., `terminationGracePeriodSeconds: -1`).
+const QuotaUnlimited = -1
+
+// QuotaScope identifies whether a quota limiter applies cluster-wide or
+// per-namespace. Both scopes can coexist; each acts independently.
+type QuotaScope string
+
+const (
+	// QuotaScopeCluster caps total GPUs of a given accelerator type across
+	// all namespaces.
+	QuotaScopeCluster QuotaScope = "cluster"
+
+	// QuotaScopeNamespace caps GPUs of a given accelerator type within a
+	// specific namespace, with optional fall-through via the reserved
+	// `default` key.
+	QuotaScopeNamespace QuotaScope = "namespace"
+)
+
+// QuotaLimiterConfig is one entry in the quota-limiter ConfigMap. Each
+// entry produces an independent limiter — cluster and namespace scopes
+// are declared as separate entries so operators can enable them
+// independently.
+//
+// The active scope is chosen by the Scope field: when Scope ==
+// QuotaScopeCluster, only ClusterQuotas is consulted; when Scope ==
+// QuotaScopeNamespace, only NamespaceQuotas and Exclude are.
+type QuotaLimiterConfig struct {
+	// Name identifies the limiter in logs, metrics, and DecisionStep traces.
+	// Must be non-empty and unique across all entries.
+	Name string `yaml:"name" json:"name"`
+
+	// Type must be the literal string "quota" — leaves room for future
+	// limiter types in the same config schema (e.g., reservation, priority).
+	Type string `yaml:"type" json:"type"`
+
+	// Scope selects which quota map below is consulted.
+	Scope QuotaScope `yaml:"scope" json:"scope"`
+
+	// ClusterQuotas applies when Scope == QuotaScopeCluster. Keys are
+	// accelerator type names (e.g., "H100"); values are the cluster-wide
+	// cap in GPUs (or QuotaUnlimited for no cap).
+	ClusterQuotas map[string]int `yaml:"quotas,omitempty" json:"quotas,omitempty"`
+
+	// NamespaceQuotas applies when Scope == QuotaScopeNamespace. Top-level
+	// keys are namespace names (with the reserved key `default` matching
+	// any namespace not explicitly listed); inner keys are accelerator
+	// type names; inner values are caps (or QuotaUnlimited).
+	//
+	// Looked up via QuotaForNamespace; missing or zero entries mean "no
+	// allocation".
+	NamespaceQuotas map[string]map[string]int `yaml:"namespaceQuotas,omitempty" json:"namespaceQuotas,omitempty"`
+
+	// Exclude lists namespaces that bypass this limiter entirely (no
+	// constraint applied). Only meaningful when Scope == QuotaScopeNamespace.
+	// Useful for system namespaces or privileged tenants.
+	Exclude []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+}
+
+// IsExcluded reports whether the given namespace bypasses this limiter.
+// Always false for cluster-scoped entries.
+func (q QuotaLimiterConfig) IsExcluded(namespace string) bool {
+	if q.Scope != QuotaScopeNamespace {
+		return false
+	}
+	return slices.Contains(q.Exclude, namespace)
+}
+
+// QuotaForNamespace returns the per-type quota map for the given namespace,
+// applying the lookup rules from the design:
+//
+//  1. Excluded namespaces return (nil, true) — caller should skip enforcement.
+//  2. Exact match in NamespaceQuotas wins.
+//  3. Otherwise, fall through to the reserved `default` key. The returned map
+//     represents the cap *per* unlisted namespace (matching the Kubernetes
+//     LimitRange default semantic), not a shared pool — the limiter tracks
+//     usage per concrete namespace name, so each unlisted namespace consumes
+//     its own budget at the default level.
+//  4. Otherwise, return an empty map (treated as zero quota by callers).
+//
+// The boolean second return value indicates whether the namespace is
+// excluded (true) — the per-type map is nil in that case and callers
+// must skip enforcement rather than treating it as zero.
+//
+// The returned per-type map is a fresh copy, so callers may read or mutate it
+// without aliasing the config (and, critically, without two unlisted namespaces
+// sharing one `default` map). Always returns (nil, false) for cluster-scoped
+// entries.
+func (q QuotaLimiterConfig) QuotaForNamespace(namespace string) (map[string]int, bool) {
+	if q.Scope != QuotaScopeNamespace {
+		return nil, false
+	}
+	if q.IsExcluded(namespace) {
+		return nil, true
+	}
+	if quotas, ok := q.NamespaceQuotas[namespace]; ok {
+		return maps.Clone(quotas), false
+	}
+	if quotas, ok := q.NamespaceQuotas[QuotaLimiterReservedNamespaceKey]; ok {
+		return maps.Clone(quotas), false
+	}
+	return map[string]int{}, false
+}
+
+// clone returns a deep copy of q: the ClusterQuotas / NamespaceQuotas maps and
+// the Exclude slice are duplicated so the result shares no mutable state with
+// the original. Used by Config.QuotaEntries to hand out entries that callers
+// cannot use to mutate the config-owned snapshot.
+func (q QuotaLimiterConfig) clone() QuotaLimiterConfig {
+	out := q // copies scalar fields and (to be replaced) map/slice headers
+	if q.ClusterQuotas != nil {
+		out.ClusterQuotas = maps.Clone(q.ClusterQuotas)
+	}
+	if q.NamespaceQuotas != nil {
+		out.NamespaceQuotas = make(map[string]map[string]int, len(q.NamespaceQuotas))
+		for ns, perType := range q.NamespaceQuotas {
+			out.NamespaceQuotas[ns] = maps.Clone(perType)
+		}
+	}
+	if q.Exclude != nil {
+		out.Exclude = slices.Clone(q.Exclude)
+	}
+	return out
+}
+
+// QuotaLimiterEntries is the top-level ConfigMap shape: one or more
+// QuotaLimiterConfig entries under a single `limiters` key. Allows
+// multiple limiters (e.g., cluster + namespace) to coexist in one
+// ConfigMap data entry.
+type QuotaLimiterEntries struct {
+	Limiters []QuotaLimiterConfig `yaml:"limiters" json:"limiters"`
+}
+
+// Validate checks an entries block for structural correctness. It
+// returns nil only when every entry parses cleanly. When multiple entries
+// (or multiple fields within an entry) are broken, all errors are
+// accumulated and joined with errors.Join — an operator fixing a misformed
+// ConfigMap sees every problem in one pass instead of one-per-rebuild.
+// Error messages name the failing entry by index and field so the bad row
+// is easy to locate.
+//
+// Validation rules (all from issue #1002):
+//   - Name is non-empty and unique across entries.
+//   - Type == "quota" (other limiter types may be added later).
+//   - Scope is one of the two QuotaScope values.
+//   - Per-type quota values are >= QuotaUnlimited (only -1 is allowed as negative).
+//   - Accelerator type names are non-empty.
+//   - For namespace scope: namespace names are non-empty; warn (not error)
+//     if a namespace appears in both Exclude and NamespaceQuotas — the
+//     entry is still valid and Exclude wins.
+//
+// Returned warnings (non-fatal) are surfaced via a second return value
+// so callers can log them without rejecting the config.
+func (e *QuotaLimiterEntries) Validate() (warnings []string, err error) {
+	if e == nil {
+		return nil, errors.New("quota limiter entries are nil")
+	}
+	var errs []error
+	seenNames := make(map[string]int, len(e.Limiters))
+	for i, entry := range e.Limiters {
+		if entry.Name == "" {
+			errs = append(errs, fmt.Errorf("entry[%d]: name must not be empty", i))
+			// Without a name we cannot meaningfully validate the rest of this
+			// entry's contents (error messages would lack the entry identifier).
+			continue
+		}
+		if prev, ok := seenNames[entry.Name]; ok {
+			errs = append(errs, fmt.Errorf("entry[%d]: duplicate limiter name %q (first seen at entry[%d])", i, entry.Name, prev))
+			continue
+		}
+		seenNames[entry.Name] = i
+
+		if entry.Type != "quota" {
+			errs = append(errs, fmt.Errorf("entry[%d] (%q): type must be \"quota\", got %q", i, entry.Name, entry.Type))
+			// Keep going: scope/quotas validation is still useful diagnostically.
+		}
+
+		switch entry.Scope {
+		case QuotaScopeCluster:
+			if len(entry.NamespaceQuotas) > 0 {
+				errs = append(errs, fmt.Errorf("entry[%d] (%q): namespaceQuotas is invalid for cluster scope; use the quotas map", i, entry.Name))
+			}
+			if len(entry.Exclude) > 0 {
+				errs = append(errs, fmt.Errorf("entry[%d] (%q): exclude is invalid for cluster scope", i, entry.Name))
+			}
+			if vErr := validateTypeQuotaMap(entry.ClusterQuotas, fmt.Sprintf("entry[%d] (%q).quotas", i, entry.Name)); vErr != nil {
+				errs = append(errs, vErr)
+			}
+
+		case QuotaScopeNamespace:
+			if len(entry.ClusterQuotas) > 0 {
+				errs = append(errs, fmt.Errorf("entry[%d] (%q): quotas is invalid for namespace scope; use namespaceQuotas", i, entry.Name))
+			}
+			for _, ns := range entry.Exclude {
+				if strings.TrimSpace(ns) == "" {
+					errs = append(errs, fmt.Errorf("entry[%d] (%q): exclude contains an empty namespace name", i, entry.Name))
+				}
+			}
+			for ns, perType := range entry.NamespaceQuotas {
+				if strings.TrimSpace(ns) == "" {
+					errs = append(errs, fmt.Errorf("entry[%d] (%q): namespaceQuotas contains an empty namespace key", i, entry.Name))
+					continue
+				}
+				if entry.IsExcluded(ns) {
+					warnings = append(warnings,
+						fmt.Sprintf("entry[%d] (%q): namespace %q is in both exclude and namespaceQuotas; the quota entry will be ignored (exclude wins)", i, entry.Name, ns))
+				}
+				if vErr := validateTypeQuotaMap(perType, fmt.Sprintf("entry[%d] (%q).namespaceQuotas[%q]", i, entry.Name, ns)); vErr != nil {
+					errs = append(errs, vErr)
+				}
+			}
+
+		default:
+			errs = append(errs, fmt.Errorf("entry[%d] (%q): scope must be %q or %q, got %q",
+				i, entry.Name, QuotaScopeCluster, QuotaScopeNamespace, entry.Scope))
+		}
+	}
+	return warnings, errors.Join(errs...)
+}
+
+// validateTypeQuotaMap checks per-accelerator-type entries: type name
+// non-empty, value >= QuotaUnlimited. Empty maps are allowed (the
+// limiter simply has no caps for that scope). Errors within a single map
+// are accumulated with errors.Join so an operator with multiple bad rows
+// sees them all at once.
+func validateTypeQuotaMap(quotas map[string]int, location string) error {
+	var errs []error
+	for accType, value := range quotas {
+		if strings.TrimSpace(accType) == "" {
+			errs = append(errs, fmt.Errorf("%s: accelerator type name must not be empty", location))
+			continue
+		}
+		if value < QuotaUnlimited {
+			errs = append(errs, fmt.Errorf("%s[%q]: quota value %d is invalid; must be >= %d (only -1 is allowed as negative — means unlimited)",
+				location, accType, value, QuotaUnlimited))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/config/quota_limiter_test.go
+++ b/internal/config/quota_limiter_test.go
@@ -212,6 +212,20 @@ var _ = Describe("QuotaLimiterEntries.Validate", func() {
 					ClusterQuotas: map[string]int{"H100": -5},
 				},
 			}}, "only -1 is allowed as negative"),
+		Entry("value < -1 in namespaceQuotas inner map rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeNamespace,
+					NamespaceQuotas: map[string]map[string]int{"team-a": {"H100": -5}},
+				},
+			}}, "only -1 is allowed as negative"),
+		Entry("value above MaxQuotaValue rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeCluster,
+					ClusterQuotas: map[string]int{"H100": MaxQuotaValue + 1},
+				},
+			}}, "exceeds the maximum"),
 		Entry("empty accelerator type rejected",
 			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
 				{

--- a/internal/config/quota_limiter_test.go
+++ b/internal/config/quota_limiter_test.go
@@ -1,0 +1,238 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("QuotaLimiterConfig", func() {
+
+	Context("IsExcluded", func() {
+		DescribeTable("namespace exclusion",
+			func(entry QuotaLimiterConfig, namespace string, want bool) {
+				Expect(entry.IsExcluded(namespace)).To(Equal(want))
+			},
+			Entry("cluster scope never excludes",
+				QuotaLimiterConfig{Scope: QuotaScopeCluster, Exclude: []string{"any"}},
+				"any", false),
+			Entry("namespace scope matches exact entry",
+				QuotaLimiterConfig{Scope: QuotaScopeNamespace, Exclude: []string{"kube-system", "llm-d-system"}},
+				"kube-system", true),
+			Entry("namespace scope returns false for unlisted namespace",
+				QuotaLimiterConfig{Scope: QuotaScopeNamespace, Exclude: []string{"kube-system"}},
+				"team-a", false),
+		)
+	})
+
+	Context("QuotaForNamespace", func() {
+		var entry QuotaLimiterConfig
+
+		BeforeEach(func() {
+			entry = QuotaLimiterConfig{
+				Name:  "ns-quota",
+				Type:  "quota",
+				Scope: QuotaScopeNamespace,
+				Exclude: []string{
+					"kube-system",
+				},
+				NamespaceQuotas: map[string]map[string]int{
+					"team-a": {
+						"H100": 8,
+						"A100": 4,
+					},
+					"team-priority": {
+						"H100": QuotaUnlimited,
+					},
+					QuotaLimiterReservedNamespaceKey: {
+						"H100": 2,
+					},
+				},
+			}
+		})
+
+		It("returns excluded=true and nil map for excluded namespace", func() {
+			quotas, excluded := entry.QuotaForNamespace("kube-system")
+			Expect(excluded).To(BeTrue())
+			Expect(quotas).To(BeNil())
+		})
+
+		It("returns exact match in preference to the default key", func() {
+			quotas, excluded := entry.QuotaForNamespace("team-a")
+			Expect(excluded).To(BeFalse())
+			Expect(quotas).To(HaveKeyWithValue("H100", 8))
+		})
+
+		It("preserves QuotaUnlimited verbatim", func() {
+			quotas, _ := entry.QuotaForNamespace("team-priority")
+			Expect(quotas).To(HaveKeyWithValue("H100", QuotaUnlimited))
+		})
+
+		It("falls through to the default key for unlisted namespaces", func() {
+			quotas, _ := entry.QuotaForNamespace("unknown")
+			Expect(quotas).To(HaveKeyWithValue("H100", 2))
+		})
+
+		It("returns an empty map for strict allowlist (no default key)", func() {
+			strict := QuotaLimiterConfig{
+				Scope: QuotaScopeNamespace,
+				NamespaceQuotas: map[string]map[string]int{
+					"team-a": {"H100": 4},
+				},
+			}
+			quotas, excluded := strict.QuotaForNamespace("team-b")
+			Expect(excluded).To(BeFalse())
+			Expect(quotas).To(BeEmpty())
+		})
+
+		It("returns (nil, false) for cluster scope", func() {
+			cluster := QuotaLimiterConfig{
+				Scope:         QuotaScopeCluster,
+				ClusterQuotas: map[string]int{"H100": 16},
+			}
+			quotas, excluded := cluster.QuotaForNamespace("any")
+			Expect(excluded).To(BeFalse())
+			Expect(quotas).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("QuotaLimiterEntries.Validate", func() {
+
+	It("accepts a combined cluster + namespace config", func() {
+		entries := &QuotaLimiterEntries{
+			Limiters: []QuotaLimiterConfig{
+				{
+					Name:          "cluster-quota",
+					Type:          "quota",
+					Scope:         QuotaScopeCluster,
+					ClusterQuotas: map[string]int{"H100": 16, "A100": 8},
+				},
+				{
+					Name:    "namespace-quota",
+					Type:    "quota",
+					Scope:   QuotaScopeNamespace,
+					Exclude: []string{"kube-system"},
+					NamespaceQuotas: map[string]map[string]int{
+						"team-a":                         {"H100": 8},
+						"team-b":                         {"H100": QuotaUnlimited},
+						QuotaLimiterReservedNamespaceKey: {"H100": 2},
+					},
+				},
+			},
+		}
+		warnings, err := entries.Validate()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(warnings).To(BeEmpty())
+	})
+
+	It("warns (non-fatal) when a namespace is in both exclude and namespaceQuotas", func() {
+		entries := &QuotaLimiterEntries{
+			Limiters: []QuotaLimiterConfig{
+				{
+					Name:    "ns",
+					Type:    "quota",
+					Scope:   QuotaScopeNamespace,
+					Exclude: []string{"team-a"},
+					NamespaceQuotas: map[string]map[string]int{
+						"team-a": {"H100": 4},
+					},
+				},
+			},
+		}
+		warnings, err := entries.Validate()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(warnings).To(HaveLen(1))
+		Expect(warnings[0]).To(ContainSubstring("team-a"))
+	})
+
+	It("accumulates multiple errors instead of failing fast", func() {
+		// Two broken entries: one with wrong type, one with bad scope.
+		// errors.Join joins messages with newlines; both should appear.
+		entries := &QuotaLimiterEntries{
+			Limiters: []QuotaLimiterConfig{
+				{Name: "a", Type: "reservation", Scope: QuotaScopeCluster, ClusterQuotas: map[string]int{"H100": 1}},
+				{Name: "b", Type: "quota", Scope: "global"},
+			},
+		}
+		_, err := entries.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`type must be "quota"`))
+		Expect(err.Error()).To(ContainSubstring(`scope must be`))
+	})
+
+	DescribeTable("error cases",
+		func(entries *QuotaLimiterEntries, want string) {
+			_, err := entries.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(want))
+		},
+		Entry("empty name rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{Name: "", Type: "quota", Scope: QuotaScopeCluster, ClusterQuotas: map[string]int{"H100": 8}},
+			}}, "name must not be empty"),
+		Entry("duplicate name rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{Name: "x", Type: "quota", Scope: QuotaScopeCluster, ClusterQuotas: map[string]int{"H100": 8}},
+				{Name: "x", Type: "quota", Scope: QuotaScopeNamespace, NamespaceQuotas: map[string]map[string]int{"a": {"H100": 1}}},
+			}}, "duplicate limiter name"),
+		Entry("wrong type rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{Name: "x", Type: "reservation", Scope: QuotaScopeCluster, ClusterQuotas: map[string]int{"H100": 8}},
+			}}, `type must be "quota"`),
+		Entry("unknown scope rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{Name: "x", Type: "quota", Scope: "global"},
+			}}, "scope must be"),
+		Entry("cluster scope rejects namespaceQuotas",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeCluster,
+					NamespaceQuotas: map[string]map[string]int{"a": {"H100": 1}},
+				},
+			}}, "namespaceQuotas is invalid for cluster scope"),
+		Entry("cluster scope rejects exclude",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeCluster,
+					ClusterQuotas: map[string]int{"H100": 1},
+					Exclude:       []string{"kube-system"},
+				},
+			}}, "exclude is invalid for cluster scope"),
+		Entry("namespace scope rejects cluster quotas",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeNamespace,
+					ClusterQuotas: map[string]int{"H100": 8},
+				},
+			}}, "quotas is invalid for namespace scope"),
+		Entry("value < -1 rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeCluster,
+					ClusterQuotas: map[string]int{"H100": -5},
+				},
+			}}, "only -1 is allowed as negative"),
+		Entry("empty accelerator type rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeCluster,
+					ClusterQuotas: map[string]int{"": 8},
+				},
+			}}, "accelerator type name must not be empty"),
+		Entry("empty namespace name rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeNamespace,
+					NamespaceQuotas: map[string]map[string]int{"": {"H100": 1}},
+				},
+			}}, "namespaceQuotas contains an empty namespace key"),
+		Entry("empty exclude name rejected",
+			&QuotaLimiterEntries{Limiters: []QuotaLimiterConfig{
+				{
+					Name: "x", Type: "quota", Scope: QuotaScopeNamespace,
+					Exclude:         []string{""},
+					NamespaceQuotas: map[string]map[string]int{"team-a": {"H100": 1}},
+				},
+			}}, "exclude contains an empty namespace name"),
+	)
+})

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -26,6 +26,27 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("scale-from-zero max concurrency must be positive, got %d", cfg.ScaleFromZeroMaxConcurrency())
 	}
 
+	// Limiter selection: only the two supported values, and quota requires
+	// a config file. This is checked only at startup (config.Load → Validate);
+	// the limiter selection is not exposed via ConfigMap-backed live reload,
+	// so reconciler-time updates of other fields cannot change it.
+	switch cfg.LimiterMode() {
+	case LimiterTypeInventory:
+		// OK; the default. Ignore quota-config-file if accidentally set.
+	case LimiterTypeQuota:
+		if cfg.QuotaConfigFile() == "" {
+			return errors.New("limiter-type=quota requires --quota-config-file (or QUOTA_CONFIG_FILE env var) " +
+				"to point at a YAML file containing a QuotaLimiterEntries document")
+		}
+		if len(cfg.QuotaEntries()) == 0 {
+			return fmt.Errorf("quota config file %q parsed to an empty entries list; at least one entry is required",
+				cfg.QuotaConfigFile())
+		}
+	default:
+		return fmt.Errorf("limiter-type must be %q or %q, got %q",
+			LimiterTypeInventory, LimiterTypeQuota, cfg.LimiterMode())
+	}
+
 	return nil
 }
 

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validate limiter selection", func() {
+	// validBaseConfig returns a Config that passes Validate's non-limiter
+	// checks, so each spec exercises only the limiter-mode branch.
+	validBaseConfig := func() *Config {
+		cfg := NewTestConfig()
+		cfg.setPrometheusBaseURLForTesting("http://prometheus:9090")
+		return cfg
+	}
+
+	It("accepts limiter-type=inventory", func() {
+		cfg := validBaseConfig()
+		SetLimiterForTest(cfg, LimiterTypeInventory, "")
+		Expect(Validate(cfg)).To(Succeed())
+	})
+
+	It("rejects limiter-type=quota without a quota config file", func() {
+		cfg := validBaseConfig()
+		SetLimiterForTest(cfg, LimiterTypeQuota, "")
+		err := Validate(cfg)
+		Expect(err).To(MatchError(ContainSubstring("requires --quota-config-file")))
+	})
+
+	It("rejects limiter-type=quota whose config parsed to an empty entries list", func() {
+		cfg := validBaseConfig()
+		// Non-empty path passes the first check; quotaEntries is left empty by
+		// SetLimiterForTest, so the empty-entries branch fires.
+		SetLimiterForTest(cfg, LimiterTypeQuota, "/some/quota.yaml")
+		err := Validate(cfg)
+		Expect(err).To(MatchError(ContainSubstring("empty entries list")))
+	})
+
+	It("rejects an unknown limiter type", func() {
+		cfg := validBaseConfig()
+		SetLimiterForTest(cfg, LimiterType("bogus"), "")
+		err := Validate(cfg)
+		Expect(err).To(MatchError(ContainSubstring("limiter-type must be")))
+	})
+})

--- a/internal/engines/pipeline/composite_limiter.go
+++ b/internal/engines/pipeline/composite_limiter.go
@@ -22,8 +22,11 @@ import (
 //   - Empty constituents -> a no-op (Limit returns nil; useful for tests).
 //   - One constituent -> behaves identically to that constituent.
 //   - On error from any constituent, Limit returns immediately; decisions
-//     made by earlier constituents stay applied (TryAllocate's in-memory
-//     usage updates are per-allocator, so partial commits do not leak).
+//     made by earlier constituents stay applied. TryAllocate's in-memory usage
+//     state is per-allocator, so usage accounting never leaks across
+//     constituents; the TargetReplicas mutations earlier constituents already
+//     wrote to the shared slice do persist, which is benign because an error
+//     aborts the whole optimize cycle.
 //
 // LimitedBy semantics: when more than one constituent caps the same decision,
 // the LAST one to run wins on LimitedBy. The DecisionStep history preserves
@@ -55,9 +58,11 @@ func (c *CompositeLimiter) Constituents() []Limiter {
 }
 
 // Limit applies each constituent's Limit method in order against the shared
-// decisions slice. The decisions slice is the source of usage truth (see
-// DefaultLimiter.calculateUsedGPUs), so each constituent sees the
-// already-capped TargetReplicas from earlier constituents.
+// decisions slice. Each constituent recomputes its baseline usage from
+// CurrentReplicas (DefaultLimiter.calculateUsedGPUs), but its TryAllocate runs
+// against the already-capped TargetReplicas that earlier constituents mutated in
+// place — so the most-restrictive cap wins as each successive constituent sees a
+// lower target.
 func (c *CompositeLimiter) Limit(ctx context.Context, decisions []*interfaces.VariantDecision) error {
 	if len(decisions) == 0 || len(c.limiters) == 0 {
 		return nil

--- a/internal/engines/pipeline/composite_limiter.go
+++ b/internal/engines/pipeline/composite_limiter.go
@@ -33,12 +33,14 @@ import (
 //     algorithm swallows TryAllocate errors), so this is a robustness note
 //     rather than a live path.
 //
-// LimitedBy semantics: attribution is scoped to the constituent that actually
-// reduced a decision (see DefaultLimiter.updateDecisionMetadata) — a constituent
-// that runs but does not cap a decision leaves its LimitedBy and the limited
-// metric untouched. When more than one constituent caps the same decision, the
-// LAST one to reduce it wins on LimitedBy. The DecisionStep history preserves
-// every constituent's contribution, so the per-step trace remains accurate.
+// LimitedBy semantics: attribution is scoped to the constituent that newly
+// constrained a decision (see DefaultLimiter.updateDecisionMetadata) — a
+// constituent that runs but does not newly limit a decision leaves its LimitedBy
+// and the limited metric untouched. When more than one constituent caps the same
+// decision, the FIRST one to constrain it wins on LimitedBy (a later constituent
+// sees WasLimited already set and does not re-attribute). The DecisionStep
+// history preserves every constituent's contribution, so the per-step trace
+// remains accurate.
 type CompositeLimiter struct {
 	name     string
 	limiters []Limiter

--- a/internal/engines/pipeline/composite_limiter.go
+++ b/internal/engines/pipeline/composite_limiter.go
@@ -1,0 +1,75 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// CompositeLimiter runs a slice of Limiter instances sequentially against the
+// same set of decisions. It is the simplest possible composition: each
+// constituent caps the decisions in turn, and the most-restrictive constraint
+// wins by virtue of the decisions slice being shared mutable state.
+//
+// CompositeLimiter is the minimal wiring needed to enable an operator to
+// deploy a quota config that declares both cluster-scope and namespace-scope
+// entries before the full limiter chain (sub-issue #1003) lands. The chain
+// will replace it with explicit ordering, allocator-sharing, and
+// physical-bound composition (min(physical, quota)).
+//
+// Behavior:
+//   - Empty constituents -> a no-op (Limit returns nil; useful for tests).
+//   - One constituent -> behaves identically to that constituent.
+//   - On error from any constituent, Limit returns immediately; decisions
+//     made by earlier constituents stay applied (TryAllocate's in-memory
+//     usage updates are per-allocator, so partial commits do not leak).
+//
+// LimitedBy semantics: when more than one constituent caps the same decision,
+// the LAST one to run wins on LimitedBy. The DecisionStep history preserves
+// every constituent's contribution, so the per-step trace remains accurate.
+type CompositeLimiter struct {
+	name     string
+	limiters []Limiter
+}
+
+// NewCompositeLimiter wraps a slice of constituent limiters. The name is used
+// in logs and as the outer LimitedBy in single-constituent edge cases.
+// Constituents are not copied; the caller retains ownership.
+func NewCompositeLimiter(name string, constituents []Limiter) *CompositeLimiter {
+	return &CompositeLimiter{
+		name:     name,
+		limiters: constituents,
+	}
+}
+
+// Name returns the composite limiter identifier.
+func (c *CompositeLimiter) Name() string {
+	return c.name
+}
+
+// Constituents returns the wrapped limiters in order. Exposed for tests and
+// observability; callers must not mutate the returned slice.
+func (c *CompositeLimiter) Constituents() []Limiter {
+	return c.limiters
+}
+
+// Limit applies each constituent's Limit method in order against the shared
+// decisions slice. The decisions slice is the source of usage truth (see
+// DefaultLimiter.calculateUsedGPUs), so each constituent sees the
+// already-capped TargetReplicas from earlier constituents.
+func (c *CompositeLimiter) Limit(ctx context.Context, decisions []*interfaces.VariantDecision) error {
+	if len(decisions) == 0 || len(c.limiters) == 0 {
+		return nil
+	}
+	for i, l := range c.limiters {
+		if err := l.Limit(ctx, decisions); err != nil {
+			return fmt.Errorf("composite %q: constituent[%d] (%q) failed: %w",
+				c.name, i, l.Name(), err)
+		}
+	}
+	return nil
+}
+
+// Ensure CompositeLimiter implements Limiter.
+var _ Limiter = (*CompositeLimiter)(nil)

--- a/internal/engines/pipeline/composite_limiter.go
+++ b/internal/engines/pipeline/composite_limiter.go
@@ -24,12 +24,20 @@ import (
 //   - On error from any constituent, Limit returns immediately; decisions
 //     made by earlier constituents stay applied. TryAllocate's in-memory usage
 //     state is per-allocator, so usage accounting never leaks across
-//     constituents; the TargetReplicas mutations earlier constituents already
-//     wrote to the shared slice do persist, which is benign because an error
-//     aborts the whole optimize cycle.
+//     constituents. The TargetReplicas mutations earlier constituents already
+//     wrote to the shared slice DO persist and are NOT rolled back: on a limiter
+//     error the V1 caller (saturation engine) logs and proceeds with these
+//     partially-capped decisions rather than aborting the cycle, so a Limit
+//     error means "decisions may be partially limited." In practice quota
+//     constituents never return an error (Refresh is a no-op and the allocation
+//     algorithm swallows TryAllocate errors), so this is a robustness note
+//     rather than a live path.
 //
-// LimitedBy semantics: when more than one constituent caps the same decision,
-// the LAST one to run wins on LimitedBy. The DecisionStep history preserves
+// LimitedBy semantics: attribution is scoped to the constituent that actually
+// reduced a decision (see DefaultLimiter.updateDecisionMetadata) — a constituent
+// that runs but does not cap a decision leaves its LimitedBy and the limited
+// metric untouched. When more than one constituent caps the same decision, the
+// LAST one to reduce it wins on LimitedBy. The DecisionStep history preserves
 // every constituent's contribution, so the per-step trace remains accurate.
 type CompositeLimiter struct {
 	name     string

--- a/internal/engines/pipeline/composite_limiter_test.go
+++ b/internal/engines/pipeline/composite_limiter_test.go
@@ -111,6 +111,22 @@ var _ = Describe("CompositeLimiter", func() {
 		Expect(c.invocations).To(Equal(0))
 	})
 
+	It("preserves mutations from earlier constituents when a later one errors", func() {
+		a := &recordingLimiter{name: "a", cap: 4} // caps TargetReplicas to 4
+		b := &recordingLimiter{name: "b", err: errors.New("boom")}
+		comp := NewCompositeLimiter("composite", []Limiter{a, b})
+
+		decisions := []*interfaces.VariantDecision{{TargetReplicas: 10}}
+		err := comp.Limit(ctx, decisions)
+		Expect(err).To(HaveOccurred())
+
+		// a's cap must survive b's error: CompositeLimiter does not roll back
+		// earlier constituents' mutations (the contract — an error aborts the
+		// optimize cycle, so the partial mutation is benign).
+		Expect(decisions[0].TargetReplicas).To(Equal(4),
+			"earlier constituent's cap must persist after a later constituent errors")
+	})
+
 	It("exposes its constituents in declaration order", func() {
 		a := &recordingLimiter{name: "a"}
 		b := &recordingLimiter{name: "b"}

--- a/internal/engines/pipeline/composite_limiter_test.go
+++ b/internal/engines/pipeline/composite_limiter_test.go
@@ -1,0 +1,123 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// recordingLimiter is a test double that records each invocation and can
+// be configured to return an error or to mutate decisions deterministically.
+type recordingLimiter struct {
+	name        string
+	err         error
+	cap         int // if > 0, every decision's TargetReplicas is clamped to this value
+	invocations int
+}
+
+func (r *recordingLimiter) Name() string { return r.name }
+func (r *recordingLimiter) Limit(_ context.Context, decisions []*interfaces.VariantDecision) error {
+	r.invocations++
+	if r.err != nil {
+		return r.err
+	}
+	if r.cap > 0 {
+		for _, d := range decisions {
+			if d.TargetReplicas > r.cap {
+				d.TargetReplicas = r.cap
+				d.WasLimited = true
+			}
+		}
+	}
+	return nil
+}
+
+var _ = Describe("CompositeLimiter", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("satisfies the Limiter interface", func() {
+		var _ Limiter = (*CompositeLimiter)(nil)
+	})
+
+	It("returns its configured name", func() {
+		c := NewCompositeLimiter("my-composite", nil)
+		Expect(c.Name()).To(Equal("my-composite"))
+	})
+
+	It("is a no-op when given no decisions", func() {
+		a := &recordingLimiter{name: "a"}
+		c := NewCompositeLimiter("composite", []Limiter{a})
+		Expect(c.Limit(ctx, nil)).To(Succeed())
+		Expect(a.invocations).To(Equal(0))
+	})
+
+	It("is a no-op when given no constituents", func() {
+		c := NewCompositeLimiter("composite", nil)
+		decisions := []*interfaces.VariantDecision{{TargetReplicas: 5}}
+		Expect(c.Limit(ctx, decisions)).To(Succeed())
+		Expect(decisions[0].TargetReplicas).To(Equal(5))
+	})
+
+	It("invokes every constituent in order", func() {
+		a := &recordingLimiter{name: "a"}
+		b := &recordingLimiter{name: "b"}
+		c := &recordingLimiter{name: "c"}
+		comp := NewCompositeLimiter("composite", []Limiter{a, b, c})
+
+		decisions := []*interfaces.VariantDecision{{TargetReplicas: 10}}
+		Expect(comp.Limit(ctx, decisions)).To(Succeed())
+
+		Expect(a.invocations).To(Equal(1))
+		Expect(b.invocations).To(Equal(1))
+		Expect(c.invocations).To(Equal(1))
+	})
+
+	It("propagates the most restrictive cap via the shared decisions slice", func() {
+		// First constituent clamps to 4; second clamps to 2. The shared slice
+		// ends at the tighter cap because each constituent reads & writes
+		// TargetReplicas in place.
+		a := &recordingLimiter{name: "cluster-quota", cap: 4}
+		b := &recordingLimiter{name: "namespace-quota", cap: 2}
+		comp := NewCompositeLimiter("composite", []Limiter{a, b})
+
+		decisions := []*interfaces.VariantDecision{{TargetReplicas: 10}}
+		Expect(comp.Limit(ctx, decisions)).To(Succeed())
+		Expect(decisions[0].TargetReplicas).To(Equal(2))
+		Expect(decisions[0].WasLimited).To(BeTrue())
+	})
+
+	It("stops at the first constituent that errors", func() {
+		a := &recordingLimiter{name: "a"}
+		b := &recordingLimiter{name: "b", err: errors.New("boom")}
+		c := &recordingLimiter{name: "c"}
+		comp := NewCompositeLimiter("composite", []Limiter{a, b, c})
+
+		err := comp.Limit(ctx, []*interfaces.VariantDecision{{TargetReplicas: 1}})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`constituent[1] ("b")`))
+		Expect(err.Error()).To(ContainSubstring("boom"))
+
+		// a ran, b errored, c never executed.
+		Expect(a.invocations).To(Equal(1))
+		Expect(b.invocations).To(Equal(1))
+		Expect(c.invocations).To(Equal(0))
+	})
+
+	It("exposes its constituents in declaration order", func() {
+		a := &recordingLimiter{name: "a"}
+		b := &recordingLimiter{name: "b"}
+		comp := NewCompositeLimiter("composite", []Limiter{a, b})
+		got := comp.Constituents()
+		Expect(got).To(HaveLen(2))
+		Expect(got[0].Name()).To(Equal("a"))
+		Expect(got[1].Name()).To(Equal("b"))
+	})
+})

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -327,12 +327,84 @@ func mergeConstraints(constraints []*ResourceConstraints) map[string]int {
 			continue
 		}
 		for accType, pool := range c.Pools {
+			if pool.Limit < 0 {
+				// Unlimited sentinel: no finite cap. Skip it (an absent type
+				// imposes no cluster constraint), rather than letting
+				// Available() clamp it to 0 and silently deny the type.
+				continue
+			}
 			if existing, ok := merged[accType]; !ok || pool.Available() < existing {
 				merged[accType] = pool.Available()
 			}
 		}
 	}
 	return merged
+}
+
+// mergeNamespaceConstraints merges the per-(namespace, accelerator type) pools
+// across providers into available-GPU budgets, taking the most restrictive
+// (minimum available) where providers overlap. Returns nil when no provider
+// carries namespace pools, so the per-type-only path is unaffected.
+//
+// A namespace present in any provider's NamespacePools is materialized in the
+// result even when its inner map is empty — its presence marks a CLOSED
+// allowlist (deny-all when empty) that the optimizer enforces by allocating
+// only the listed types. An unlimited (-1 sentinel) pool is carried through as
+// a negative budget so the optimizer can distinguish "unlimited" from a finite
+// cap; tighterBudget treats it as +infinity when taking the minimum.
+func mergeNamespaceConstraints(constraints []*ResourceConstraints) map[string]map[string]int {
+	var merged map[string]map[string]int
+	for _, c := range constraints {
+		if c == nil {
+			continue
+		}
+		for ns, perType := range c.NamespacePools {
+			if merged == nil {
+				merged = make(map[string]map[string]int)
+			}
+			inner, ok := merged[ns]
+			if !ok {
+				inner = make(map[string]int)
+				merged[ns] = inner // present (even if empty) marks a closed namespace
+			}
+			for accType, pool := range perType {
+				budget := nsPoolBudget(pool)
+				if existing, ok := inner[accType]; ok {
+					inner[accType] = tighterBudget(existing, budget)
+				} else {
+					inner[accType] = budget
+				}
+			}
+		}
+	}
+	return merged
+}
+
+// nsPoolBudget returns a namespace ResourcePool's remaining budget for the
+// optimizer — the available (not total) GPU count. A negative Limit is the
+// "unlimited" sentinel and is preserved as -1; any other Limit yields the
+// finite available count (Limit - Used, clamped to 0).
+func nsPoolBudget(pool ResourcePool) int {
+	if pool.Limit < 0 {
+		return -1
+	}
+	return pool.Available()
+}
+
+// tighterBudget returns the more restrictive of two namespace budgets, treating
+// a negative (unlimited) budget as +infinity. The result is unlimited only when
+// both inputs are unlimited.
+func tighterBudget(a, b int) int {
+	switch {
+	case a < 0:
+		return b
+	case b < 0:
+		return a
+	case b < a:
+		return b
+	default:
+		return a
+	}
 }
 
 // scaleDownRoleIterated removes replicas role-by-role using the generalized

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -328,9 +328,17 @@ func mergeConstraints(constraints []*ResourceConstraints) map[string]int {
 		}
 		for accType, pool := range c.Pools {
 			if pool.Limit < 0 {
-				// Unlimited sentinel: no finite cap. Skip it (an absent type
-				// imposes no cluster constraint), rather than letting
-				// Available() clamp it to 0 and silently deny the type.
+				// Unlimited sentinel: no finite cap. Represent it as an
+				// unbounded budget (math.MaxInt) so the optimizer allocates the
+				// type up to the model's fair-share demand. Leaving it absent
+				// would let fairShareRolePick read a 0 budget and silently deny
+				// the type — inverting the -1 = unlimited semantic. A finite
+				// pool from any provider still wins via the min() below, since
+				// Available() < math.MaxInt; only set the sentinel when no finite
+				// budget is present yet.
+				if _, ok := merged[accType]; !ok {
+					merged[accType] = math.MaxInt
+				}
 				continue
 			}
 			if existing, ok := merged[accType]; !ok || pool.Available() < existing {

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"math"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -953,13 +954,32 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(merged["H100"]).To(Equal(4))
 		})
 
-		It("mergeConstraints skips an unlimited (negative) pool rather than clamping it to a deny", func() {
+		It("mergeConstraints carries an unlimited (negative) pool through as an unbounded budget", func() {
 			merged := mergeConstraints([]*ResourceConstraints{
 				{Pools: map[string]ResourcePool{"A100": {Limit: -1}, "H100": {Limit: 4}}},
 			})
 
-			Expect(merged).NotTo(HaveKey("A100"), "unlimited => no cap => absent, not 0 (deny)")
+			// Unlimited must be present as an unbounded budget, NOT absent: an
+			// absent type reads as 0 in fairShareRolePick and is silently denied,
+			// which would invert the -1 = unlimited semantic.
+			Expect(merged["A100"]).To(Equal(math.MaxInt), "unlimited => unbounded budget")
 			Expect(merged["H100"]).To(Equal(4))
+		})
+
+		It("mergeConstraints lets a finite pool win over an unlimited sentinel regardless of provider order", func() {
+			// finite before sentinel
+			m1 := mergeConstraints([]*ResourceConstraints{
+				{Pools: map[string]ResourcePool{"A100": {Limit: 5}}},
+				{Pools: map[string]ResourcePool{"A100": {Limit: -1}}},
+			})
+			Expect(m1["A100"]).To(Equal(5), "finite cap is more restrictive than unlimited")
+
+			// sentinel before finite
+			m2 := mergeConstraints([]*ResourceConstraints{
+				{Pools: map[string]ResourcePool{"A100": {Limit: -1}}},
+				{Pools: map[string]ResourcePool{"A100": {Limit: 5}}},
+			})
+			Expect(m2["A100"]).To(Equal(5), "finite cap wins even when the sentinel is seen first")
 		})
 	})
 })

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -967,6 +967,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("mergeConstraints lets a finite pool win over an unlimited sentinel regardless of provider order", func() {
+			// This pins the min()-across-providers ordering property (the
+			// sentinel-carry regression itself is guarded by the math.MaxInt
+			// assertion above); a finite cap must beat unlimited either way.
 			// finite before sentinel
 			m1 := mergeConstraints([]*ResourceConstraints{
 				{Pools: map[string]ResourcePool{"A100": {Limit: 5}}},

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -952,6 +952,15 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(merged["A100"]).To(Equal(6))
 			Expect(merged["H100"]).To(Equal(4))
 		})
+
+		It("mergeConstraints skips an unlimited (negative) pool rather than clamping it to a deny", func() {
+			merged := mergeConstraints([]*ResourceConstraints{
+				{Pools: map[string]ResourcePool{"A100": {Limit: -1}, "H100": {Limit: 4}}},
+			})
+
+			Expect(merged).NotTo(HaveKey("A100"), "unlimited => no cap => absent, not 0 (deny)")
+			Expect(merged["H100"]).To(Equal(4))
+		})
 	})
 })
 
@@ -962,3 +971,113 @@ func decisionMap(decisions []interfaces.VariantDecision) map[string]interfaces.V
 	}
 	return m
 }
+
+var _ = Describe("namespace constraint merge helpers", func() {
+	Describe("nsPoolBudget", func() {
+		It("preserves the unlimited sentinel as -1", func() {
+			Expect(nsPoolBudget(ResourcePool{Limit: -1})).To(Equal(-1))
+		})
+		It("returns the available count for a finite pool", func() {
+			Expect(nsPoolBudget(ResourcePool{Limit: 6, Used: 2})).To(Equal(4))
+		})
+		It("clamps a finite over-used pool to 0", func() {
+			Expect(nsPoolBudget(ResourcePool{Limit: 2, Used: 5})).To(Equal(0))
+		})
+	})
+
+	Describe("tighterBudget", func() {
+		It("returns the smaller of two finite budgets", func() {
+			Expect(tighterBudget(4, 2)).To(Equal(2))
+			Expect(tighterBudget(2, 4)).To(Equal(2))
+		})
+		It("treats a negative (unlimited) input as +infinity", func() {
+			Expect(tighterBudget(-1, 4)).To(Equal(4), "unlimited vs finite -> finite")
+			Expect(tighterBudget(4, -1)).To(Equal(4), "finite vs unlimited -> finite")
+		})
+		It("stays unlimited only when both inputs are unlimited", func() {
+			Expect(tighterBudget(-1, -1)).To(Equal(-1))
+		})
+	})
+
+	Describe("mergeNamespaceConstraints", func() {
+		It("returns nil when no provider carries namespace pools", func() {
+			Expect(mergeNamespaceConstraints([]*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 4}}}})).To(BeNil())
+		})
+
+		It("materializes a present-but-empty namespace as a closed (deny-all) marker", func() {
+			merged := mergeNamespaceConstraints([]*ResourceConstraints{
+				{NamespacePools: map[string]map[string]ResourcePool{"team-x": {}}},
+			})
+			Expect(merged).To(HaveKey("team-x"))
+			Expect(merged["team-x"]).To(BeEmpty())
+			Expect(merged["team-x"]).NotTo(BeNil(), "non-nil empty map signals a closed namespace, not 'open'")
+		})
+
+		It("carries the unlimited sentinel through as -1", func() {
+			merged := mergeNamespaceConstraints([]*ResourceConstraints{
+				{NamespacePools: map[string]map[string]ResourcePool{"team-a": {"A100": {Limit: -1}}}},
+			})
+			Expect(merged["team-a"]).To(HaveKeyWithValue("A100", -1))
+		})
+
+		It("takes the tighter budget across two providers for the same (ns,type)", func() {
+			merged := mergeNamespaceConstraints([]*ResourceConstraints{
+				{NamespacePools: map[string]map[string]ResourcePool{"team-a": {"A100": {Limit: 8, Used: 1}}}}, // avail 7
+				{NamespacePools: map[string]map[string]ResourcePool{"team-a": {"A100": {Limit: 4}}}},          // avail 4
+			})
+			Expect(merged["team-a"]).To(HaveKeyWithValue("A100", 4), "min(7,4)")
+		})
+
+		It("lets a finite provider win over an unlimited one for the same (ns,type)", func() {
+			merged := mergeNamespaceConstraints([]*ResourceConstraints{
+				{NamespacePools: map[string]map[string]ResourcePool{"team-a": {"A100": {Limit: -1}}}},
+				{NamespacePools: map[string]map[string]ResourcePool{"team-a": {"A100": {Limit: 5}}}},
+			})
+			Expect(merged["team-a"]).To(HaveKeyWithValue("A100", 5))
+		})
+	})
+
+	Describe("aggregateNamespacePools", func() {
+		It("sums only finite per-(ns,type) pools across namespaces", func() {
+			agg := aggregateNamespacePools(map[string]map[string]ResourcePool{
+				"team-a": {"A100": {Limit: 4, Used: 1}},
+				"team-b": {"A100": {Limit: 2}, "H100": {Limit: 3}},
+			})
+			Expect(agg["A100"]).To(Equal(ResourcePool{Limit: 6, Used: 1}))
+			Expect(agg["H100"]).To(Equal(ResourcePool{Limit: 3}))
+		})
+
+		It("skips unlimited (negative) pools so an all-unlimited config yields an empty map", func() {
+			agg := aggregateNamespacePools(map[string]map[string]ResourcePool{
+				"team-a": {"A100": {Limit: -1}},
+				"team-b": {"H100": {Limit: -1}},
+			})
+			Expect(agg).To(BeEmpty(), "unlimited types impose no finite cluster cap")
+		})
+
+		It("includes finite types but drops unlimited ones in a mixed namespace", func() {
+			agg := aggregateNamespacePools(map[string]map[string]ResourcePool{
+				"team-a": {"A100": {Limit: 4}, "H100": {Limit: -1}},
+			})
+			Expect(agg).To(HaveKey("A100"))
+			Expect(agg).NotTo(HaveKey("H100"))
+		})
+	})
+
+	Describe("poolTotals", func() {
+		It("sums limit/used and returns available", func() {
+			limit, used, avail := poolTotals(map[string]ResourcePool{
+				"A100": {Limit: 8, Used: 3},
+				"H100": {Limit: 4, Used: 1},
+			})
+			Expect(limit).To(Equal(12))
+			Expect(used).To(Equal(4))
+			Expect(avail).To(Equal(8))
+		})
+
+		It("clamps available to 0 when usage exceeds limit", func() {
+			_, _, avail := poolTotals(map[string]ResourcePool{"A100": {Limit: 2, Used: 5}})
+			Expect(avail).To(Equal(0))
+		})
+	})
+})

--- a/internal/engines/pipeline/default_limiter.go
+++ b/internal/engines/pipeline/default_limiter.go
@@ -76,13 +76,24 @@ func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*interfaces.Vari
 	// Step 3: Create allocator with available resources
 	allocator := l.inventory.CreateAllocator(ctx)
 
+	// Snapshot TargetReplicas so updateDecisionMetadata can tell whether THIS
+	// limiter actually reduced a decision. In a CompositeLimiter each constituent
+	// runs Limit over the same slice; attributing on the sticky WasLimited flag
+	// alone would make every constituent that runs at/after the capping one
+	// re-emit the limited metric under its own name and overwrite LimitedBy.
+	// Comparing before/after scopes attribution to the limiter that did the cap.
+	targetBefore := make([]int, len(decisions))
+	for i, d := range decisions {
+		targetBefore[i] = d.TargetReplicas
+	}
+
 	// Step 4: Run allocation algorithm to distribute resources
 	if err := l.algorithm.Allocate(ctx, decisions, allocator); err != nil {
 		return fmt.Errorf("allocation algorithm failed: %w", err)
 	}
 
 	// Step 5: Update decision metadata
-	l.updateDecisionMetadata(decisions)
+	l.updateDecisionMetadata(decisions, targetBefore)
 
 	return nil
 }
@@ -140,19 +151,26 @@ func (l *DefaultLimiter) calculateUsedGPUsByNamespace(decisions []*interfaces.Va
 	return usedByNS
 }
 
-// updateDecisionMetadata sets LimitedBy and adds DecisionSteps.
-// Note: WasLimited is set by the algorithm during allocation.
-func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantDecision) {
-	for _, d := range decisions {
-		// If the algorithm marked the decision as limited, set LimitedBy
-		if d.WasLimited {
+// updateDecisionMetadata sets LimitedBy and adds DecisionSteps. targetBefore is
+// the per-decision TargetReplicas snapshot taken before this limiter's algorithm
+// ran, indexed to match decisions.
+//
+// Attribution (LimitedBy + the limited metric) is recorded only when THIS
+// limiter actually reduced the decision this pass (WasLimited is set AND the
+// target dropped). WasLimited is sticky across a CompositeLimiter's constituents,
+// so gating on it alone would double-count the metric and misattribute LimitedBy
+// to a constituent that merely ran after the one that capped.
+func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantDecision, targetBefore []int) {
+	for i, d := range decisions {
+		cappedHere := d.WasLimited && d.TargetReplicas < targetBefore[i]
+		if cappedHere {
 			d.LimitedBy = l.name
 			l.metricsEmitter.RecordDecisionsLimitedTotalMetric(d.VariantName, d.Namespace, d.LimitedBy)
 		}
 
 		// Add decision step for observability
 		reason := l.buildStepReason(d)
-		d.AddDecisionStep(l.name, reason, d.WasLimited)
+		d.AddDecisionStep(l.name, reason, cappedHere)
 	}
 }
 

--- a/internal/engines/pipeline/default_limiter.go
+++ b/internal/engines/pipeline/default_limiter.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
@@ -63,6 +65,14 @@ func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*interfaces.Vari
 	usedByType := l.calculateUsedGPUs(decisions)
 	l.inventory.SetUsed(usedByType)
 
+	// Step 2b: Feed namespace-aware inventories the per-namespace usage map.
+	// The per-type SetUsed above is always safe (namespace-only inventories
+	// treat it as a no-op); namespace-scoped inventories additionally need
+	// usage bucketed by namespace to enforce per-tenant caps correctly.
+	if nai, ok := l.inventory.(NamespaceAwareInventory); ok {
+		nai.SetUsedByNamespace(l.calculateUsedGPUsByNamespace(decisions))
+	}
+
 	// Step 3: Create allocator with available resources
 	allocator := l.inventory.CreateAllocator(ctx)
 
@@ -110,6 +120,26 @@ func (l *DefaultLimiter) calculateUsedGPUs(decisions []*interfaces.VariantDecisi
 	return usedByType
 }
 
+// calculateUsedGPUsByNamespace computes current GPU usage bucketed by
+// (namespace, accelerator type). Outer key: namespace; inner key: accelerator
+// type. Used to feed NamespaceAwareInventory implementations the per-namespace
+// usage map needed for per-tenant cap enforcement.
+func (l *DefaultLimiter) calculateUsedGPUsByNamespace(decisions []*interfaces.VariantDecision) map[string]map[string]int {
+	usedByNS := make(map[string]map[string]int)
+	for _, d := range decisions {
+		if d.AcceleratorName == "" || d.Namespace == "" {
+			continue
+		}
+		perType, ok := usedByNS[d.Namespace]
+		if !ok {
+			perType = make(map[string]int)
+			usedByNS[d.Namespace] = perType
+		}
+		perType[d.AcceleratorName] += d.CurrentReplicas * d.GPUsPerReplica
+	}
+	return usedByNS
+}
+
 // updateDecisionMetadata sets LimitedBy and adds DecisionSteps.
 // Note: WasLimited is set by the algorithm during allocation.
 func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantDecision) {
@@ -139,29 +169,99 @@ func (l *DefaultLimiter) buildStepReason(d *interfaces.VariantDecision) string {
 	return fmt.Sprintf("allocated %d GPUs for +%d replicas", d.GPUsAllocated, replicaChange)
 }
 
-// ComputeConstraints refreshes the inventory and returns per-type resource availability.
+// ComputeConstraints refreshes the inventory and returns its resource availability.
 // This is the V2 path: expose constraints for the optimizer instead of modifying
 // decisions directly (which is what Limit() does for the V1 path).
-func (l *DefaultLimiter) ComputeConstraints(ctx context.Context, currentUsage map[string]int) (*ResourceConstraints, error) {
+//
+// It always exposes per-type (cluster) availability via Pools. When the
+// underlying inventory is namespace-aware (e.g. a namespace-scoped quota), it
+// additionally exposes per-(namespace, type) caps via NamespacePools for the
+// active namespaces (the keys of usageByNamespace) as a closed allowlist; the
+// optimizer caps a model's allocation at min(per-type pool, that namespace's
+// pool) for listed types and denies types the namespace does not list (full
+// V1/V2 parity — see GetNamespaceResourcePools). Multi-entry quotas are handled
+// by the engine computing constraints from each constituent of a CompositeLimiter.
+//
+// The keys of usageByNamespace define the active-namespace set: a namespace with
+// a quota but zero current usage must still appear here (with an empty inner
+// map) for its caps to be materialized and enforced.
+//
+// Remaining gap (tracked by the limiter chain, sub-issue #1003): composing a
+// physical-inventory limiter with a quota limiter as min(physical, quota) within
+// a single ComputeConstraints. See docs/developer-guide/quota-limiter.md.
+func (l *DefaultLimiter) ComputeConstraints(ctx context.Context, usageByType map[string]int, usageByNamespace map[string]map[string]int) (*ResourceConstraints, error) {
 	// Step 1: Refresh inventory (same as Limit step 1)
 	if err := l.inventory.Refresh(ctx); err != nil {
 		return nil, fmt.Errorf("failed to refresh inventory: %w", err)
 	}
 
 	// Step 2: Set current usage (same as Limit step 2)
-	l.inventory.SetUsed(currentUsage)
+	l.inventory.SetUsed(usageByType)
 
 	// Step 3: Expose per-type availability
-	pools := l.inventory.GetResourcePools()
-
 	rc := &ResourceConstraints{
 		ProviderName: l.name,
-		Pools:        pools,
+		Pools:        l.inventory.GetResourcePools(),
 		TotalLimit:   l.inventory.TotalLimit(),
 		TotalUsed:    l.inventory.TotalUsed(),
 		TotalAvail:   l.inventory.TotalAvailable(),
 	}
+
+	// Step 4: For namespace-aware inventories carrying per-namespace caps for the
+	// active namespaces, expose them via NamespacePools and derive the cluster
+	// per-type aggregate (Pools/Totals) from the SAME active set. Deriving the
+	// aggregate from the active namespaces — rather than the static
+	// GetResourcePools sum — keeps it consistent with the per-namespace budgets
+	// the optimizer partitions: it includes default fall-through namespaces and
+	// never under-counts, so the optimizer's per-type budget cannot be driven
+	// negative as namespaces draw against it. When the inventory carries no
+	// namespace caps (e.g. a cluster-scoped quota), Pools is left as the
+	// per-type GetResourcePools result above.
+	if nai, ok := l.inventory.(NamespaceAwareInventory); ok {
+		nai.SetUsedByNamespace(usageByNamespace)
+		activeNamespaces := slices.Collect(maps.Keys(usageByNamespace))
+		if nsPools := nai.GetNamespaceResourcePools(activeNamespaces); len(nsPools) > 0 {
+			rc.NamespacePools = nsPools
+			rc.Pools = aggregateNamespacePools(nsPools)
+			rc.TotalLimit, rc.TotalUsed, rc.TotalAvail = poolTotals(rc.Pools)
+		}
+	}
 	return rc, nil
+}
+
+// aggregateNamespacePools sums per-(namespace, type) pools into a per-type
+// cluster aggregate — the total finite budget that the per-namespace caps
+// partition. Unlimited (negative-Limit sentinel) pools are skipped: they impose
+// no finite cap, so a type that is only ever unlimited across namespaces is
+// absent from the aggregate (no cluster cap), consistent with GetResourcePools.
+func aggregateNamespacePools(nsPools map[string]map[string]ResourcePool) map[string]ResourcePool {
+	agg := make(map[string]ResourcePool)
+	for _, perType := range nsPools {
+		for accType, pool := range perType {
+			if pool.Limit < 0 {
+				continue
+			}
+			a := agg[accType]
+			a.Limit += pool.Limit
+			a.Used += pool.Used
+			agg[accType] = a
+		}
+	}
+	return agg
+}
+
+// poolTotals returns the summed Limit, Used, and available (clamped at 0)
+// across the given pools.
+func poolTotals(pools map[string]ResourcePool) (limit, used, avail int) {
+	for _, p := range pools {
+		limit += p.Limit
+		used += p.Used
+	}
+	avail = limit - used
+	if avail < 0 {
+		avail = 0
+	}
+	return limit, used, avail
 }
 
 // Ensure DefaultLimiter implements Limiter interface

--- a/internal/engines/pipeline/default_limiter.go
+++ b/internal/engines/pipeline/default_limiter.go
@@ -76,19 +76,25 @@ func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*interfaces.Vari
 	// Step 3: Create allocator with available resources
 	allocator := l.inventory.CreateAllocator(ctx)
 
-	// Snapshot each decision's WasLimited so updateDecisionMetadata can tell
-	// whether THIS limiter newly constrained it. WasLimited is sticky (the
-	// algorithm only ever sets it true) and, in a CompositeLimiter, every
-	// constituent runs Limit over the same slice — so attributing on WasLimited
-	// alone would make each constituent that runs after the capping one re-emit
-	// the limited metric under its own name and overwrite LimitedBy. A limiter
-	// constrained a decision this pass iff it NEWLY set WasLimited, which the
-	// allocation algorithm does on any GPU denial (including one a MinReplicas
-	// floor later keeps from lowering the target, and excluding a MaxReplicas cap
-	// that is a user ceiling rather than a resource limit).
+	// Snapshot each decision's WasLimited and TargetReplicas before the algorithm
+	// runs. updateDecisionMetadata derives two DIFFERENT signals from them,
+	// because "which limiter to credit" and "did this pass tighten the target"
+	// are distinct questions in a CompositeLimiter (WasLimited is sticky — the
+	// algorithm only ever sets it true — and every constituent runs Limit over
+	// the same slice):
+	//   - Attribution (LimitedBy + the limited metric) fires on the WasLimited
+	//     false→true transition, so the FIRST constituent to constrain a decision
+	//     is credited exactly once (no double-count across constituents, and a
+	//     GPU denial a MinReplicas floor later hides is still counted).
+	//   - The DecisionStep's WasConstrained flag / "limited" wording fires when
+	//     THIS pass actually reduced the target due to a resource limit (not a
+	//     MaxReplicas user ceiling), so every constituent that tightens the target
+	//     is recorded accurately in the per-step trace.
 	limitedBefore := make([]bool, len(decisions))
+	targetBefore := make([]int, len(decisions))
 	for i, d := range decisions {
 		limitedBefore[i] = d.WasLimited
+		targetBefore[i] = d.TargetReplicas
 	}
 
 	// Step 4: Run allocation algorithm to distribute resources
@@ -97,7 +103,7 @@ func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*interfaces.Vari
 	}
 
 	// Step 5: Update decision metadata
-	l.updateDecisionMetadata(decisions, limitedBefore)
+	l.updateDecisionMetadata(decisions, limitedBefore, targetBefore)
 
 	return nil
 }
@@ -155,28 +161,27 @@ func (l *DefaultLimiter) calculateUsedGPUsByNamespace(decisions []*interfaces.Va
 	return usedByNS
 }
 
-// updateDecisionMetadata sets LimitedBy and adds DecisionSteps. limitedBefore is
-// the per-decision WasLimited snapshot taken before this limiter's algorithm ran,
-// indexed to match decisions.
-//
-// Attribution (LimitedBy + the limited metric) and the DecisionStep's limited
-// flag are recorded only when THIS limiter newly constrained the decision this
-// pass (WasLimited transitioned false→true). WasLimited is sticky across a
-// CompositeLimiter's constituents, so gating on it alone would double-count the
-// metric and misattribute LimitedBy to a constituent that merely ran after the
-// one that capped.
-func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantDecision, limitedBefore []bool) {
+// updateDecisionMetadata sets LimitedBy and adds DecisionSteps. limitedBefore and
+// targetBefore are the per-decision WasLimited / TargetReplicas snapshots taken
+// before this limiter's algorithm ran, indexed to match decisions. See Limit for
+// why attribution and the per-step flag use different signals.
+func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantDecision, limitedBefore []bool, targetBefore []int) {
 	for i, d := range decisions {
-		cappedHere := d.WasLimited && !limitedBefore[i]
-		if cappedHere {
+		// Attribution: credit the first limiter that newly marks the decision
+		// resource-limited (WasLimited is sticky across composite constituents).
+		if d.WasLimited && !limitedBefore[i] {
 			d.LimitedBy = l.name
 			l.metricsEmitter.RecordDecisionsLimitedTotalMetric(d.VariantName, d.Namespace, d.LimitedBy)
 		}
 
-		// Add decision step for observability; keep the reason text consistent
-		// with the limited flag (both driven by cappedHere).
-		reason := l.buildStepReason(d, cappedHere)
-		d.AddDecisionStep(l.name, reason, cappedHere)
+		// Per-step trace: mark the step constrained (and word the reason
+		// "limited:") when THIS pass reduced the target due to a resource limit,
+		// so a later constituent that further tightens the target is still
+		// recorded. A MaxReplicas user ceiling reduces the target without setting
+		// WasLimited, so it is not counted as a resource limit here.
+		reducedHere := d.WasLimited && d.TargetReplicas < targetBefore[i]
+		reason := l.buildStepReason(d, reducedHere)
+		d.AddDecisionStep(l.name, reason, reducedHere)
 	}
 }
 

--- a/internal/engines/pipeline/default_limiter.go
+++ b/internal/engines/pipeline/default_limiter.go
@@ -179,7 +179,7 @@ func (l *DefaultLimiter) buildStepReason(d *interfaces.VariantDecision) string {
 // active namespaces (the keys of usageByNamespace) as a closed allowlist; the
 // optimizer caps a model's allocation at min(per-type pool, that namespace's
 // pool) for listed types and denies types the namespace does not list (full
-// V1/V2 parity — see GetNamespaceResourcePools). Multi-entry quotas are handled
+// V1/V2 parity — see NamespaceResourcePools). Multi-entry quotas are handled
 // by the engine computing constraints from each constituent of a CompositeLimiter.
 //
 // The keys of usageByNamespace define the active-namespace set: a namespace with
@@ -220,7 +220,7 @@ func (l *DefaultLimiter) ComputeConstraints(ctx context.Context, usageByType map
 	if nai, ok := l.inventory.(NamespaceAwareInventory); ok {
 		nai.SetUsedByNamespace(usageByNamespace)
 		activeNamespaces := slices.Collect(maps.Keys(usageByNamespace))
-		if nsPools := nai.GetNamespaceResourcePools(activeNamespaces); len(nsPools) > 0 {
+		if nsPools := nai.NamespaceResourcePools(activeNamespaces); len(nsPools) > 0 {
 			rc.NamespacePools = nsPools
 			rc.Pools = aggregateNamespacePools(nsPools)
 			rc.TotalLimit, rc.TotalUsed, rc.TotalAvail = poolTotals(rc.Pools)

--- a/internal/engines/pipeline/default_limiter.go
+++ b/internal/engines/pipeline/default_limiter.go
@@ -76,15 +76,19 @@ func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*interfaces.Vari
 	// Step 3: Create allocator with available resources
 	allocator := l.inventory.CreateAllocator(ctx)
 
-	// Snapshot TargetReplicas so updateDecisionMetadata can tell whether THIS
-	// limiter actually reduced a decision. In a CompositeLimiter each constituent
-	// runs Limit over the same slice; attributing on the sticky WasLimited flag
-	// alone would make every constituent that runs at/after the capping one
-	// re-emit the limited metric under its own name and overwrite LimitedBy.
-	// Comparing before/after scopes attribution to the limiter that did the cap.
-	targetBefore := make([]int, len(decisions))
+	// Snapshot each decision's WasLimited so updateDecisionMetadata can tell
+	// whether THIS limiter newly constrained it. WasLimited is sticky (the
+	// algorithm only ever sets it true) and, in a CompositeLimiter, every
+	// constituent runs Limit over the same slice — so attributing on WasLimited
+	// alone would make each constituent that runs after the capping one re-emit
+	// the limited metric under its own name and overwrite LimitedBy. A limiter
+	// constrained a decision this pass iff it NEWLY set WasLimited, which the
+	// allocation algorithm does on any GPU denial (including one a MinReplicas
+	// floor later keeps from lowering the target, and excluding a MaxReplicas cap
+	// that is a user ceiling rather than a resource limit).
+	limitedBefore := make([]bool, len(decisions))
 	for i, d := range decisions {
-		targetBefore[i] = d.TargetReplicas
+		limitedBefore[i] = d.WasLimited
 	}
 
 	// Step 4: Run allocation algorithm to distribute resources
@@ -93,7 +97,7 @@ func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*interfaces.Vari
 	}
 
 	// Step 5: Update decision metadata
-	l.updateDecisionMetadata(decisions, targetBefore)
+	l.updateDecisionMetadata(decisions, limitedBefore)
 
 	return nil
 }
@@ -151,37 +155,41 @@ func (l *DefaultLimiter) calculateUsedGPUsByNamespace(decisions []*interfaces.Va
 	return usedByNS
 }
 
-// updateDecisionMetadata sets LimitedBy and adds DecisionSteps. targetBefore is
-// the per-decision TargetReplicas snapshot taken before this limiter's algorithm
-// ran, indexed to match decisions.
+// updateDecisionMetadata sets LimitedBy and adds DecisionSteps. limitedBefore is
+// the per-decision WasLimited snapshot taken before this limiter's algorithm ran,
+// indexed to match decisions.
 //
-// Attribution (LimitedBy + the limited metric) is recorded only when THIS
-// limiter actually reduced the decision this pass (WasLimited is set AND the
-// target dropped). WasLimited is sticky across a CompositeLimiter's constituents,
-// so gating on it alone would double-count the metric and misattribute LimitedBy
-// to a constituent that merely ran after the one that capped.
-func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantDecision, targetBefore []int) {
+// Attribution (LimitedBy + the limited metric) and the DecisionStep's limited
+// flag are recorded only when THIS limiter newly constrained the decision this
+// pass (WasLimited transitioned false→true). WasLimited is sticky across a
+// CompositeLimiter's constituents, so gating on it alone would double-count the
+// metric and misattribute LimitedBy to a constituent that merely ran after the
+// one that capped.
+func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantDecision, limitedBefore []bool) {
 	for i, d := range decisions {
-		cappedHere := d.WasLimited && d.TargetReplicas < targetBefore[i]
+		cappedHere := d.WasLimited && !limitedBefore[i]
 		if cappedHere {
 			d.LimitedBy = l.name
 			l.metricsEmitter.RecordDecisionsLimitedTotalMetric(d.VariantName, d.Namespace, d.LimitedBy)
 		}
 
-		// Add decision step for observability
-		reason := l.buildStepReason(d)
+		// Add decision step for observability; keep the reason text consistent
+		// with the limited flag (both driven by cappedHere).
+		reason := l.buildStepReason(d, cappedHere)
 		d.AddDecisionStep(l.name, reason, cappedHere)
 	}
 }
 
-// buildStepReason creates a human-readable reason for the decision step.
-func (l *DefaultLimiter) buildStepReason(d *interfaces.VariantDecision) string {
+// buildStepReason creates a human-readable reason for the decision step. limited
+// reflects whether THIS limiter constrained the decision this pass (matching the
+// step's limited flag), not the sticky WasLimited.
+func (l *DefaultLimiter) buildStepReason(d *interfaces.VariantDecision, limited bool) string {
 	replicaChange := d.TargetReplicas - d.CurrentReplicas
 
 	if replicaChange <= 0 {
 		return fmt.Sprintf("no scale-up (target=%d, current=%d)", d.TargetReplicas, d.CurrentReplicas)
 	}
-	if d.WasLimited {
+	if limited {
 		return fmt.Sprintf("limited: allocated %d GPUs for +%d replicas", d.GPUsAllocated, replicaChange)
 	}
 	return fmt.Sprintf("allocated %d GPUs for +%d replicas", d.GPUsAllocated, replicaChange)

--- a/internal/engines/pipeline/default_limiter_namespace_test.go
+++ b/internal/engines/pipeline/default_limiter_namespace_test.go
@@ -16,8 +16,8 @@ type namespaceAwareMockInventory struct {
 	mockInventory
 	usedByNS                map[string]map[string]int
 	setUsedByNamespaceCalls int
-	nsPools                 map[string]map[string]ResourcePool // returned by GetNamespaceResourcePools
-	lastActiveNamespaces    []string                           // arg captured from the last GetNamespaceResourcePools call
+	nsPools                 map[string]map[string]ResourcePool // returned by NamespaceResourcePools
+	lastActiveNamespaces    []string                           // arg captured from the last NamespaceResourcePools call
 }
 
 func newNamespaceAwareMockInventory(limitByType map[string]int) *namespaceAwareMockInventory {
@@ -35,7 +35,7 @@ func (m *namespaceAwareMockInventory) SetUsedByNamespace(usedByNS map[string]map
 	m.usedByNS = usedByNS
 }
 
-func (m *namespaceAwareMockInventory) GetNamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool {
+func (m *namespaceAwareMockInventory) NamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool {
 	m.lastActiveNamespaces = activeNamespaces
 	return m.nsPools
 }
@@ -156,10 +156,10 @@ var _ = Describe("DefaultLimiter namespace-aware feature detection", func() {
 
 	It("ComputeConstraints falls back to GetResourcePools when no namespace pools are produced", func() {
 		// e.g. a cluster-scoped quota, or an active set that is entirely excluded:
-		// GetNamespaceResourcePools returns empty, so Pools/Totals stay the static
+		// NamespaceResourcePools returns empty, so Pools/Totals stay the static
 		// per-type GetResourcePools result and NamespacePools is nil.
 		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 8})
-		inv.nsPools = nil // GetNamespaceResourcePools returns empty
+		inv.nsPools = nil // NamespaceResourcePools returns empty
 		limiter := NewDefaultLimiter("test", inv, algorithm)
 
 		rc, err := limiter.ComputeConstraints(ctx,

--- a/internal/engines/pipeline/default_limiter_namespace_test.go
+++ b/internal/engines/pipeline/default_limiter_namespace_test.go
@@ -1,0 +1,173 @@
+package pipeline
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// namespaceAwareMockInventory extends mockInventory with SetUsedByNamespace
+// and records every invocation so the Ginkgo spec can verify the
+// DefaultLimiter feature-detection path.
+type namespaceAwareMockInventory struct {
+	mockInventory
+	usedByNS                map[string]map[string]int
+	setUsedByNamespaceCalls int
+	nsPools                 map[string]map[string]ResourcePool // returned by GetNamespaceResourcePools
+	lastActiveNamespaces    []string                           // arg captured from the last GetNamespaceResourcePools call
+}
+
+func newNamespaceAwareMockInventory(limitByType map[string]int) *namespaceAwareMockInventory {
+	return &namespaceAwareMockInventory{
+		mockInventory: mockInventory{
+			name:        "nai",
+			limitByType: limitByType,
+			usedByType:  make(map[string]int),
+		},
+	}
+}
+
+func (m *namespaceAwareMockInventory) SetUsedByNamespace(usedByNS map[string]map[string]int) {
+	m.setUsedByNamespaceCalls++
+	m.usedByNS = usedByNS
+}
+
+func (m *namespaceAwareMockInventory) GetNamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool {
+	m.lastActiveNamespaces = activeNamespaces
+	return m.nsPools
+}
+
+// Compile-time check that the mock satisfies NamespaceAwareInventory.
+var _ NamespaceAwareInventory = (*namespaceAwareMockInventory)(nil)
+
+var _ = Describe("DefaultLimiter namespace-aware feature detection", func() {
+	var (
+		ctx       context.Context
+		algorithm *mockAlgorithm
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		algorithm = &mockAlgorithm{name: "noop"}
+	})
+
+	It("calls SetUsedByNamespace on inventories that implement NamespaceAwareInventory", func() {
+		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 100})
+		limiter := NewDefaultLimiter("test", inv, algorithm)
+
+		decisions := []*interfaces.VariantDecision{
+			{VariantName: "v1", Namespace: "team-a", AcceleratorName: "H100", CurrentReplicas: 2, GPUsPerReplica: 4},
+			{VariantName: "v2", Namespace: "team-a", AcceleratorName: "H100", CurrentReplicas: 1, GPUsPerReplica: 2},
+			{VariantName: "v3", Namespace: "team-b", AcceleratorName: "A100", CurrentReplicas: 3, GPUsPerReplica: 1},
+		}
+		Expect(limiter.Limit(ctx, decisions)).To(Succeed())
+
+		Expect(inv.setUsedByNamespaceCalls).To(Equal(1))
+		Expect(inv.usedByNS).To(HaveKey("team-a"))
+		Expect(inv.usedByNS["team-a"]).To(HaveKeyWithValue("H100", 10), "2*4 + 1*2 = 10")
+		Expect(inv.usedByNS).To(HaveKey("team-b"))
+		Expect(inv.usedByNS["team-b"]).To(HaveKeyWithValue("A100", 3), "3*1 = 3")
+	})
+
+	It("skips decisions with empty namespace or accelerator in the namespace bucketing", func() {
+		// Heterogeneous inventory (>1 type) so resolveUnknownAccelerators cannot
+		// auto-resolve the empty-accelerator decision to a single type — it stays
+		// unresolved and must be skipped by the namespace bucketing.
+		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 100, "A100": 100})
+		limiter := NewDefaultLimiter("test", inv, algorithm)
+
+		decisions := []*interfaces.VariantDecision{
+			{Namespace: "team-a", AcceleratorName: "H100", CurrentReplicas: 1, GPUsPerReplica: 1},
+			{Namespace: "", AcceleratorName: "H100", CurrentReplicas: 99, GPUsPerReplica: 99},   // skipped (empty ns)
+			{Namespace: "team-a", AcceleratorName: "", CurrentReplicas: 99, GPUsPerReplica: 99}, // skipped (empty type, unresolvable)
+		}
+		Expect(limiter.Limit(ctx, decisions)).To(Succeed())
+
+		Expect(inv.usedByNS).To(HaveLen(1))
+		Expect(inv.usedByNS["team-a"]).To(HaveKeyWithValue("H100", 1))
+	})
+
+	It("does NOT call SetUsedByNamespace on plain Inventory implementations", func() {
+		// The existing mockInventory does not implement NamespaceAwareInventory.
+		inv := newMockInventory("plain", map[string]int{"H100": 100})
+		limiter := NewDefaultLimiter("test", inv, algorithm)
+
+		decisions := []*interfaces.VariantDecision{
+			{Namespace: "team-a", AcceleratorName: "H100", CurrentReplicas: 1, GPUsPerReplica: 1},
+		}
+		Expect(limiter.Limit(ctx, decisions)).To(Succeed())
+		// usedByType is still populated by SetUsed (verified indirectly by inv.TotalUsed).
+		Expect(inv.TotalUsed()).To(Equal(1))
+	})
+
+	It("ComputeConstraints feeds namespace usage and exposes NamespacePools", func() {
+		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 10})
+		inv.nsPools = map[string]map[string]ResourcePool{"team-a": {"H100": {Limit: 4, Used: 1}}}
+		limiter := NewDefaultLimiter("test", inv, algorithm)
+
+		rc, err := limiter.ComputeConstraints(ctx,
+			map[string]int{"H100": 3},
+			map[string]map[string]int{"team-a": {"H100": 1}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inv.setUsedByNamespaceCalls).To(Equal(1), "per-namespace usage fed to the inventory")
+		Expect(rc.NamespacePools["team-a"]).To(HaveKeyWithValue("H100", ResourcePool{Limit: 4, Used: 1}))
+		Expect(inv.lastActiveNamespaces).To(ConsistOf("team-a"),
+			"active-namespace set is derived from the keys of usageByNamespace")
+	})
+
+	It("ComputeConstraints derives the active-namespace set from usageByNamespace keys", func() {
+		// The configured inventory knows about team-a and team-b, but only
+		// team-a has current usage; team-b must NOT be queried/materialized.
+		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 10})
+		inv.nsPools = map[string]map[string]ResourcePool{"team-a": {"H100": {Limit: 4}}}
+		limiter := NewDefaultLimiter("test", inv, algorithm)
+
+		_, err := limiter.ComputeConstraints(ctx,
+			map[string]int{"H100": 1},
+			map[string]map[string]int{"team-a": {"H100": 1}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inv.lastActiveNamespaces).To(ConsistOf("team-a"))
+		Expect(inv.lastActiveNamespaces).NotTo(ContainElement("team-b"),
+			"a namespace absent from usageByNamespace is not in the active set")
+	})
+
+	It("ComputeConstraints derives the cluster aggregate from the active namespace pools", func() {
+		// GetResourcePools would report H100:999, but with namespace caps present
+		// the aggregate must be the sum across active namespaces (incl. a default
+		// fall-through namespace like team-z), not the static per-type value.
+		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 999})
+		inv.nsPools = map[string]map[string]ResourcePool{
+			"team-a": {"H100": {Limit: 4, Used: 1}},
+			"team-z": {"H100": {Limit: 2, Used: 0}},
+		}
+		limiter := NewDefaultLimiter("test", inv, algorithm)
+
+		rc, err := limiter.ComputeConstraints(ctx,
+			map[string]int{"H100": 1},
+			map[string]map[string]int{"team-a": {"H100": 1}, "team-z": {}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rc.Pools).To(HaveKeyWithValue("H100", ResourcePool{Limit: 6, Used: 1}), "aggregate of team-a(4)+team-z(2), not GetResourcePools(999)")
+		Expect(rc.TotalLimit).To(Equal(6))
+		Expect(rc.NamespacePools).To(HaveKey("team-z"))
+	})
+
+	It("ComputeConstraints falls back to GetResourcePools when no namespace pools are produced", func() {
+		// e.g. a cluster-scoped quota, or an active set that is entirely excluded:
+		// GetNamespaceResourcePools returns empty, so Pools/Totals stay the static
+		// per-type GetResourcePools result and NamespacePools is nil.
+		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 8})
+		inv.nsPools = nil // GetNamespaceResourcePools returns empty
+		limiter := NewDefaultLimiter("test", inv, algorithm)
+
+		rc, err := limiter.ComputeConstraints(ctx,
+			map[string]int{"H100": 2},
+			map[string]map[string]int{"team-a": {"H100": 2}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inv.setUsedByNamespaceCalls).To(Equal(1), "still namespace-aware: usage is fed")
+		Expect(rc.NamespacePools).To(BeNil(), "no namespace caps materialized")
+		Expect(rc.Pools).To(HaveKeyWithValue("H100", ResourcePool{Limit: 8, Used: 2}), "static GetResourcePools fallback")
+	})
+})

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -192,6 +192,13 @@ func (o *GreedyByScoreOptimizer) fairShareScaleUp(
 
 		totalGPUs := 0
 		for _, v := range available {
+			// An unbounded (math.MaxInt) budget marks an unlimited quota type;
+			// saturate rather than overflow the sum, which is only used for the
+			// "== 0" stop check below.
+			if v == math.MaxInt {
+				totalGPUs = math.MaxInt
+				break
+			}
 			totalGPUs += v
 		}
 		if totalGPUs == 0 {
@@ -297,7 +304,7 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 		if nsBudget != nil {
 			// Decrement only finite namespace caps; the unlimited sentinel
 			// (negative) imposes no budget to draw down.
-			if cap, capped := nsBudget[accType]; capped && cap >= 0 {
+			if nsCap, capped := nsBudget[accType]; capped && nsCap >= 0 {
 				nsBudget[accType] -= consumed
 			}
 		}

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"maps"
 	"math"
 	"sort"
 
@@ -95,6 +96,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 ) []interfaces.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx).WithName(o.Name())
 	available := mergeConstraints(constraints)
+	availableByNS := mergeNamespaceConstraints(constraints)
 
 	var scaleUpWork []*modelWork
 	var otherRequests []ModelScalingRequest
@@ -118,7 +120,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 		}
 	}
 
-	o.fairShareScaleUp(ctx, scaleUpWork, available)
+	o.fairShareScaleUp(ctx, scaleUpWork, available, availableByNS)
 
 	allDecisions := make([]interfaces.VariantDecision, 0, len(scaleUpWork))
 
@@ -178,6 +180,7 @@ func (o *GreedyByScoreOptimizer) fairShareScaleUp(
 	ctx context.Context,
 	work []*modelWork,
 	available map[string]int,
+	availableByNS map[string]map[string]int,
 ) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -210,7 +213,7 @@ func (o *GreedyByScoreOptimizer) fairShareScaleUp(
 			allocationMean = mean - (w.remaining / float64(len(active)))
 		}
 
-		allocated := o.allocateForModel(ctx, w, allocationMean, available)
+		allocated := o.allocateForModel(ctx, w, allocationMean, available, availableByNS)
 
 		if !allocated {
 			w.remaining = -1
@@ -235,6 +238,7 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	w *modelWork,
 	mean float64,
 	available map[string]int,
+	availableByNS map[string]map[string]int,
 ) bool {
 	target := w.remaining - mean
 	if target <= 0 {
@@ -256,11 +260,48 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 		}
 	}
 
+	// This model belongs to one namespace, so its per-type budget is the
+	// minimum of the cluster-wide budget and this namespace's quota. The shared
+	// allocateForModelPaired only understands a flat per-type budget, so we pass
+	// the effective copy and reconcile consumption back to both budgets
+	// afterwards. A non-nil nsBudget means a closed namespace-quota allowlist
+	// (see effectiveAvailable); nil means the namespace is open (cluster-scope
+	// quota or an excluded namespace).
+	//
+	// nsBudget is a reference into the cycle-wide availableByNS map, shared by
+	// every model in this namespace; the reconcile below decrements it in place,
+	// so later same-namespace models correctly see the reduced remaining budget.
+	nsBudget := availableByNS[w.req.Namespace]
+	effAvail := effectiveAvailable(available, nsBudget)
+	beforeEff := maps.Clone(effAvail)
+
 	// Unified path: fairShareRolePick behind the RolePickFn interface.
 	// α logic removed in commit 3.
 	pick := fairShareRolePick(target, w.s, w.roles)
-	allocateForModelPaired(ctx, w.s, w.satEntry.VariantCapacities, stateMap, available,
+	allocateForModelPaired(ctx, w.s, w.satEntry.VariantCapacities, stateMap, effAvail,
 		w.targets, pick, ps, w.roles)
+
+	// Reconcile: apply what was consumed (before − after) to the cluster-wide
+	// budget and, where this namespace caps the type, to the namespace budget.
+	// Only decrement the cluster budget for types it actually constrains (a type
+	// present in `available`); a type bounded solely by the namespace must not
+	// drive the cluster budget negative and pollute the loop's totalGPUs check.
+	for accType, before := range beforeEff {
+		consumed := before - effAvail[accType]
+		if consumed <= 0 {
+			continue
+		}
+		if _, clusterCapped := available[accType]; clusterCapped {
+			available[accType] -= consumed
+		}
+		if nsBudget != nil {
+			// Decrement only finite namespace caps; the unlimited sentinel
+			// (negative) imposes no budget to draw down.
+			if cap, capped := nsBudget[accType]; capped && cap >= 0 {
+				nsBudget[accType] -= consumed
+			}
+		}
+	}
 
 	// Recompute w.remaining for fair-share ordering.
 	// For "both" (non-disag): use fresh ps so applyAllocation-decremented
@@ -273,6 +314,46 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 		w.remaining = fairShareValue(w.req.Priority, w.s, ps, w.roles)
 	}
 	return w.remaining < oldRemaining
+}
+
+// effectiveAvailable returns the per-type budget the optimizer may spend on a
+// model in this namespace, given the cluster-wide budget and the namespace's
+// quota. A budget value < 0 in nsBudget is the "unlimited" sentinel for that
+// (namespace, type); all other values are finite GPU counts.
+//
+// nsBudget == nil → the namespace is OPEN (a cluster-scope quota, or an
+// excluded namespace): the model is bound only by the cluster budget, so the
+// result is a copy of `available`.
+//
+// nsBudget != nil → the namespace is a CLOSED allowlist (namespace-scope
+// quota), mirroring the V1 tryAllocateNamespace contract: the model may use
+// ONLY the accelerator types the namespace lists. The result is therefore built
+// from nsBudget alone — a type the namespace does not list is absent, and the
+// optimizer's gpusAvail==0 check denies it (no fall-through to the cluster
+// aggregate, which previously let one namespace draw on another's quota). For a
+// listed type: a finite cap binds at min(cluster, cap); an unlimited cap binds
+// at the cluster budget for that type, or is unbounded (math.MaxInt) when the
+// cluster does not constrain it.
+func effectiveAvailable(available, nsBudget map[string]int) map[string]int {
+	if nsBudget == nil {
+		return maps.Clone(available)
+	}
+	eff := make(map[string]int, len(nsBudget))
+	for accType, nsAvail := range nsBudget {
+		if nsAvail < 0 { // unlimited for this (namespace, type)
+			if cv, ok := available[accType]; ok {
+				eff[accType] = cv
+			} else {
+				eff[accType] = math.MaxInt
+			}
+			continue
+		}
+		eff[accType] = nsAvail
+		if cv, ok := available[accType]; ok && cv < nsAvail {
+			eff[accType] = cv
+		}
+	}
+	return eff
 }
 
 // fairShareRolePick returns a RolePickFn for the unified allocateForModelPaired loop.

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -298,7 +298,13 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 		if consumed <= 0 {
 			continue
 		}
-		if _, clusterCapped := available[accType]; clusterCapped {
+		// Decrement only a FINITE cluster budget. An unbounded (math.MaxInt)
+		// budget marks an unlimited-quota type and must stay exactly math.MaxInt:
+		// depleting it to MaxInt-consumed would (a) be meaningless (you cannot
+		// draw down infinity) and (b) defeat the fairShareScaleUp stop-check,
+		// whose `== math.MaxInt` guard would then miss it and let the totalGPUs
+		// sum overflow with two or more unlimited types.
+		if cur, clusterCapped := available[accType]; clusterCapped && cur != math.MaxInt {
 			available[accType] -= consumed
 		}
 		if nsBudget != nil {

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"math"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1309,5 +1310,345 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			Expect(dm["pf"].TargetReplicas).To(Equal(2)) // 1+1
 			Expect(dm["dc"].TargetReplicas).To(Equal(4)) // 1+3
 		})
+	})
+
+	Context("Namespace-Scoped Quota", func() {
+
+		It("caps a model at its namespace budget even when cluster GPUs remain", func() {
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "m",
+				Namespace:        "team-a",
+				RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
+					ModelID:   "m",
+					Namespace: "team-a",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2},
+					},
+				}),
+			}
+			// Cluster has plenty of A100, but team-a's quota leaves only 2 GPUs
+			// (cap 4 − 2 in use) = room for exactly one more 2-GPU replica.
+			constraints := []*ResourceConstraints{
+				{
+					Pools: map[string]ResourcePool{"A100": {Limit: 100}},
+					NamespacePools: map[string]map[string]ResourcePool{
+						"team-a": {"A100": {Limit: 4, Used: 2}},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			Expect(dm["v"].TargetReplicas).To(Equal(2), "bounded by team-a quota (2 GPUs), not cluster (100)")
+		})
+
+		It("enforces independent per-namespace budgets across models", func() {
+			rA := &interfaces.AnalyzerResult{
+				ModelID: "mA", Namespace: "team-a", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "a", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rB := &interfaces.AnalyzerResult{
+				ModelID: "mB", Namespace: "team-b", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "b", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(rA, ModelScalingRequest{
+					ModelID: "mA", Namespace: "team-a",
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "a", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+				withSatEntry(rB, ModelScalingRequest{
+					ModelID: "mB", Namespace: "team-b",
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "b", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+			}
+			// Cluster is unconstrained relative to the quotas; team-a is capped
+			// to +1 replica (2 GPUs free) and team-b to +3 (6 GPUs free).
+			constraints := []*ResourceConstraints{
+				{
+					Pools: map[string]ResourcePool{"A100": {Limit: 100}},
+					NamespacePools: map[string]map[string]ResourcePool{
+						"team-a": {"A100": {Limit: 4, Used: 2}},
+						"team-b": {"A100": {Limit: 6, Used: 0}},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			Expect(dm["a"].TargetReplicas).To(Equal(2), "team-a bounded to +1 by its 2-GPU quota")
+			Expect(dm["b"].TargetReplicas).To(BeNumerically(">", 2), "team-b has a larger quota, so it scales further")
+			Expect(dm["b"].TargetReplicas).To(BeNumerically("<=", 4), "but no further than its 6-GPU quota (+3)")
+		})
+
+		It("shares one namespace budget across same-namespace models, higher priority first", func() {
+			rHi := &interfaces.AnalyzerResult{
+				ModelID: "hi", Namespace: "team-a", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "hi-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rLo := &interfaces.AnalyzerResult{
+				ModelID: "lo", Namespace: "team-a", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "lo-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(rHi, ModelScalingRequest{
+					ModelID: "hi", Namespace: "team-a", Priority: 10,
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "hi-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+				withSatEntry(rLo, ModelScalingRequest{
+					ModelID: "lo", Namespace: "team-a", Priority: 1,
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "lo-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+			}
+			// Both models are in team-a, which has 4 free GPUs (cap 6 − 2 used) =
+			// 2 replicas to share. The cluster has far more, so the namespace cap
+			// is the binding constraint and the two models draw from one budget.
+			constraints := []*ResourceConstraints{
+				{
+					Pools: map[string]ResourcePool{"A100": {Limit: 100}},
+					NamespacePools: map[string]map[string]ResourcePool{
+						"team-a": {"A100": {Limit: 6, Used: 2}},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+			hiAdded := dm["hi-v"].TargetReplicas - 1
+			loAdded := dm["lo-v"].TargetReplicas - 1
+
+			Expect(hiAdded+loAdded).To(Equal(2), "the shared team-a budget (4 GPUs) bounds the sum across both models")
+			Expect(hiAdded).To(BeNumerically(">=", loAdded), "the higher-priority model gets at least as much of the shared budget")
+		})
+
+		It("gives a scarce shared namespace budget to the higher-priority model first", func() {
+			// Only 2 free GPUs in team-a (cap 4 − 2 used) = room for exactly ONE
+			// 2-GPU replica. With a 100x priority gap, the winner is deterministic:
+			// hi takes the single replica, lo gets nothing. A weaker >= assertion
+			// would not catch a priority inversion here.
+			rHi := &interfaces.AnalyzerResult{
+				ModelID: "hi", Namespace: "team-a", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "hi-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rLo := &interfaces.AnalyzerResult{
+				ModelID: "lo", Namespace: "team-a", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "lo-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(rHi, ModelScalingRequest{
+					ModelID: "hi", Namespace: "team-a", Priority: 100,
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "hi-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+				withSatEntry(rLo, ModelScalingRequest{
+					ModelID: "lo", Namespace: "team-a", Priority: 1,
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "lo-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+			}
+			constraints := []*ResourceConstraints{
+				{
+					Pools: map[string]ResourcePool{"A100": {Limit: 100}},
+					NamespacePools: map[string]map[string]ResourcePool{
+						"team-a": {"A100": {Limit: 4, Used: 2}},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			Expect(dm["hi-v"].TargetReplicas).To(Equal(2), "hi (priority 100) wins the single shared replica")
+			Expect(dm["lo-v"].TargetReplicas).To(Equal(1), "lo (priority 1) gets nothing from the exhausted budget")
+		})
+
+		It("denies a type the namespace does not list instead of leaking another namespace's quota", func() {
+			// Heterogeneous config: team-a caps H100 only, team-b caps A100 only.
+			// A team-a model whose variant runs on A100 must be DENIED (A100 is
+			// not in team-a's allowlist) — it must NOT draw on team-b's A100
+			// quota via the cluster aggregate. This is the cross-namespace
+			// isolation breach the closed-allowlist model closes.
+			rA := &interfaces.AnalyzerResult{
+				ModelID: "mA", Namespace: "team-a", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "a", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rB := &interfaces.AnalyzerResult{
+				ModelID: "mB", Namespace: "team-b", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "b", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(rA, ModelScalingRequest{
+					ModelID: "mA", Namespace: "team-a",
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "a", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+				withSatEntry(rB, ModelScalingRequest{
+					ModelID: "mB", Namespace: "team-b",
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "b", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+			}
+			constraints := []*ResourceConstraints{
+				{
+					Pools: map[string]ResourcePool{"H100": {Limit: 100}, "A100": {Limit: 100}},
+					NamespacePools: map[string]map[string]ResourcePool{
+						"team-a": {"H100": {Limit: 10}}, // A100 unlisted → denied for team-a
+						"team-b": {"A100": {Limit: 6}},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			Expect(dm["a"].TargetReplicas).To(Equal(1), "team-a's A100 model is denied — A100 is not in team-a's allowlist")
+			Expect(dm["b"].TargetReplicas).To(BeNumerically(">", 1), "team-b scales on its own A100 quota, unaffected")
+		})
+
+		It("denies all scale-up for a closed namespace with no listed types (deny-all)", func() {
+			r := &interfaces.AnalyzerResult{
+				ModelID: "m", Namespace: "team-x", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
+					ModelID: "m", Namespace: "team-x",
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+			}
+			// team-x is present (closed) but lists no types — a real deny-all.
+			constraints := []*ResourceConstraints{
+				{
+					Pools:          map[string]ResourcePool{"A100": {Limit: 100}},
+					NamespacePools: map[string]map[string]ResourcePool{"team-x": {}},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			Expect(dm["v"].TargetReplicas).To(Equal(1), "deny-all namespace allocates nothing despite ample cluster GPUs")
+		})
+
+		It("honors an unlimited (-1) per-namespace cap, bounding only by the cluster budget", func() {
+			r := &interfaces.AnalyzerResult{
+				ModelID: "m", Namespace: "team-a", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
+					ModelID: "m", Namespace: "team-a",
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+			}
+			// team-a holds an unlimited A100 cap (sentinel Limit == -1) from a
+			// namespace-scope provider, composed with a separate cluster-scope
+			// provider supplying the only finite bound (100 A100). This mirrors
+			// production: a finite cluster Pools alongside an unlimited ns cap
+			// only arises from a distinct provider, never from
+			// aggregateNamespacePools (which skips unlimited). The model should
+			// scale to meet demand, not be denied (the bug would drop the
+			// unlimited entry and deny A100 as "unlisted").
+			constraints := []*ResourceConstraints{
+				{ProviderName: "ns-quota", NamespacePools: map[string]map[string]ResourcePool{
+					"team-a": {"A100": {Limit: -1}},
+				}},
+				{ProviderName: "cluster-quota", Pools: map[string]ResourcePool{"A100": {Limit: 100}}},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			Expect(dm["v"].TargetReplicas).To(BeNumerically(">=", 4), "unlimited ns cap scales to demand, bounded only by the cluster budget")
+		})
+
+		It("does not scale a purely-unlimited namespace config with no finite cluster cap (documented V2 limitation)", func() {
+			r := &interfaces.AnalyzerResult{
+				ModelID: "m", Namespace: "team-a", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
+					ModelID: "m", Namespace: "team-a",
+					VariantStates: []interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				}),
+			}
+			// All-unlimited ns config: aggregateNamespacePools yields an empty
+			// cluster Pools, so available is empty and fairShareScaleUp's
+			// totalGPUs==0 guard stops immediately. This is the documented
+			// under-provision boundary (not an isolation breach) — pinned here so
+			// it can't silently change. Pools is built via aggregateNamespacePools
+			// to stay faithful to what ComputeConstraints would emit.
+			nsPools := map[string]map[string]ResourcePool{"team-a": {"A100": {Limit: -1}}}
+			constraints := []*ResourceConstraints{
+				{Pools: aggregateNamespacePools(nsPools), NamespacePools: nsPools},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			Expect(dm["v"].TargetReplicas).To(Equal(1), "no finite cluster budget -> no V2 scaling (documented limitation)")
+		})
+	})
+})
+
+var _ = Describe("effectiveAvailable", func() {
+	It("returns a copy of the cluster budget when the namespace is open (nil nsBudget)", func() {
+		available := map[string]int{"A100": 8, "H100": 4}
+		eff := effectiveAvailable(available, nil)
+		Expect(eff).To(Equal(available))
+		eff["A100"] = 0 // mutate the copy
+		Expect(available["A100"]).To(Equal(8), "must be a copy, not an alias")
+	})
+
+	It("binds a listed finite type at min(cluster, namespace cap)", func() {
+		eff := effectiveAvailable(map[string]int{"A100": 8}, map[string]int{"A100": 3})
+		Expect(eff).To(HaveKeyWithValue("A100", 3))
+	})
+
+	It("denies a type the closed namespace does not list (absent => optimizer sees 0)", func() {
+		eff := effectiveAvailable(map[string]int{"A100": 8, "H100": 8}, map[string]int{"A100": 3})
+		Expect(eff).To(HaveKey("A100"))
+		Expect(eff).NotTo(HaveKey("H100"), "unlisted type is omitted so gpusAvail==0 denies it")
+	})
+
+	It("bounds an unlimited listed type by the cluster budget when the cluster caps it", func() {
+		eff := effectiveAvailable(map[string]int{"A100": 8}, map[string]int{"A100": -1})
+		Expect(eff).To(HaveKeyWithValue("A100", 8))
+	})
+
+	It("treats an unlimited listed type as unbounded when the cluster does not cap it", func() {
+		eff := effectiveAvailable(map[string]int{}, map[string]int{"A100": -1})
+		Expect(eff).To(HaveKeyWithValue("A100", math.MaxInt))
+	})
+
+	It("denies everything for a closed deny-all namespace (empty nsBudget)", func() {
+		eff := effectiveAvailable(map[string]int{"A100": 8}, map[string]int{})
+		Expect(eff).To(BeEmpty())
 	})
 })

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -443,6 +443,44 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			Expect(unlimited["v1"].TargetReplicas).To(Equal(abundant["v1"].TargetReplicas),
 				"unlimited behaves like abundant finite capacity")
 		})
+
+		It("scales a finite-type model even when unlimited types were consumed first", func() {
+			// Regression for the fairShareScaleUp stop-check overflow: two
+			// unlimited (sentinel) budgets are decremented during the round but
+			// must stay recognized as unbounded, so the totalGPUs sum cannot wrap
+			// to 0 and starve a model on an unrelated finite type.
+			mk := func(id, variant, accel string) ModelScalingRequest {
+				r := &interfaces.AnalyzerResult{
+					ModelID: id, Namespace: "default", AnalyzedAt: time.Now(),
+					RequiredCapacity: 25000,
+					VariantCapacities: []interfaces.VariantCapacity{
+						{VariantName: variant, AcceleratorName: accel, Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					},
+				}
+				return withSatEntry(r, ModelScalingRequest{
+					ModelID: id, Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: variant, CurrentReplicas: 1, GPUsPerReplica: 1},
+					},
+				})
+			}
+			requests := []ModelScalingRequest{
+				mk("model-A", "a-v1", "A100"),
+				mk("model-B", "b-v1", "H100"),
+				mk("model-C", "c-v1", "L40S"),
+			}
+			// -1 is config.QuotaUnlimited for A100/H100; L40S is finite.
+			constraints := []*ResourceConstraints{
+				{Pools: map[string]ResourcePool{
+					"A100": {Limit: -1}, "H100": {Limit: -1}, "L40S": {Limit: 4},
+				}},
+			}
+
+			dm := decisionMap(optimizer.Optimize(ctx, requests, constraints))
+			Expect(dm["a-v1"].TargetReplicas).To(BeNumerically(">", 1), "unlimited A100 scales up")
+			Expect(dm["b-v1"].TargetReplicas).To(BeNumerically(">", 1), "unlimited H100 scales up")
+			Expect(dm["c-v1"].TargetReplicas).To(BeNumerically(">", 1), "finite L40S model is not starved by an overflowed stop-check")
+		})
 	})
 
 	Context("Scale-Down", func() {

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -402,6 +402,47 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 			Expect(dm["v1"].TargetReplicas).To(Equal(1))
 		})
+
+		It("treats a cluster-scope unlimited (sentinel) pool like abundant capacity, not a deny", func() {
+			// Regression for the cluster-unlimited-under-V2 bug: a -1
+			// (config.QuotaUnlimited) cluster quota is emitted as a sentinel pool
+			// (Limit < 0), which mergeConstraints carries through as an unbounded
+			// budget. Before the fix the type was absent from the merged budget,
+			// so fairShareRolePick read a 0 budget and denied every scale-up —
+			// inverting -1 = unlimited into a hard deny.
+			newReq := func() []ModelScalingRequest {
+				r := &interfaces.AnalyzerResult{
+					ModelID:          "model-1",
+					Namespace:        "default",
+					AnalyzedAt:       time.Now(),
+					RequiredCapacity: 40000,
+					VariantCapacities: []interfaces.VariantCapacity{
+						{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					},
+				}
+				return []ModelScalingRequest{
+					withSatEntry(r, ModelScalingRequest{
+						ModelID:   "model-1",
+						Namespace: "default",
+						VariantStates: []interfaces.VariantReplicaState{
+							{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
+						},
+					}),
+				}
+			}
+
+			// -1 is config.QuotaUnlimited; used as a literal here to avoid a config
+			// import in this optimizer-level test.
+			unlimited := decisionMap(optimizer.Optimize(ctx, newReq(),
+				[]*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: -1}}}}))
+			abundant := decisionMap(optimizer.Optimize(ctx, newReq(),
+				[]*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 1000}}}}))
+
+			Expect(unlimited["v1"].Action).To(Equal(interfaces.ActionScaleUp), "unlimited cluster quota must not deny scale-up")
+			Expect(unlimited["v1"].TargetReplicas).To(BeNumerically(">", 1))
+			Expect(unlimited["v1"].TargetReplicas).To(Equal(abundant["v1"].TargetReplicas),
+				"unlimited behaves like abundant finite capacity")
+		})
 	})
 
 	Context("Scale-Down", func() {

--- a/internal/engines/pipeline/limiter_factory.go
+++ b/internal/engines/pipeline/limiter_factory.go
@@ -1,0 +1,73 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/discovery"
+)
+
+// NewLimiterFromConfig constructs the GPU limiter selected by the operator
+// at startup via the --limiter-type flag (or LIMITER_TYPE env var).
+//
+//   - LimiterTypeInventory: today's behavior — TypeInventoryWithUsage +
+//     GreedyBySaturation wrapped in a DefaultLimiter. Discovers physical
+//     GPUs via the GPU operator.
+//   - LimiterTypeQuota: parses config.QuotaEntries() into one
+//     DefaultLimiter per entry, each wrapping a QuotaInventory. Multiple
+//     entries are wrapped in a CompositeLimiter that runs them
+//     sequentially. Pure operator-declared caps — physical capacity is
+//     NOT consulted.
+//
+// The kubeClient is only used by the inventory path (for GPU operator
+// discovery); the quota path ignores it. config.Validate is expected to
+// have run before this call, so unknown limiter types reaching the
+// default branch represent a programming error in the loader.
+func NewLimiterFromConfig(cfg *config.Config, kubeClient client.Client) (Limiter, error) {
+	switch t := cfg.LimiterMode(); t {
+	case config.LimiterTypeInventory:
+		return newInventoryLimiter(kubeClient), nil
+	case config.LimiterTypeQuota:
+		return newQuotaLimiter(cfg)
+	default:
+		return nil, fmt.Errorf("limiter factory: unknown limiter type %q (valid: %q, %q)",
+			t, config.LimiterTypeInventory, config.LimiterTypeQuota)
+	}
+}
+
+// newInventoryLimiter builds the physical-capacity GPU limiter: a
+// TypeInventoryWithUsage (GPUs discovered via the GPU operator) driven by the
+// GreedyBySaturation algorithm, wrapped in a DefaultLimiter.
+func newInventoryLimiter(kubeClient client.Client) Limiter {
+	gpuDiscovery := discovery.NewK8sWithGpuOperator(kubeClient)
+	gpuInventory := NewTypeInventoryWithUsage("cluster-gpu-inventory", gpuDiscovery)
+	gpuAlgorithm := NewGreedyBySaturation()
+	return NewDefaultLimiter("gpu-limiter", gpuInventory, gpuAlgorithm)
+}
+
+// newQuotaLimiter builds one DefaultLimiter per QuotaLimiterConfig entry.
+// Each wraps a QuotaInventory with GreedyBySaturation. When more than one
+// entry is configured, the result is wrapped in a CompositeLimiter so they
+// run in declaration order against the shared decisions slice.
+func newQuotaLimiter(cfg *config.Config) (Limiter, error) {
+	entries := cfg.QuotaEntries()
+	if len(entries) == 0 {
+		return nil, errors.New("limiter factory: limiter-type=quota requires at least one entry " +
+			"in the quota config file (--quota-config-file)")
+	}
+	constituents := make([]Limiter, 0, len(entries))
+	for _, entry := range entries {
+		inv := NewQuotaInventory(entry)
+		// One algorithm instance per constituent — GreedyBySaturation is
+		// stateless today, but a per-limiter instance avoids a shared-state
+		// surprise if that ever changes.
+		constituents = append(constituents, NewDefaultLimiter(entry.Name, inv, NewGreedyBySaturation()))
+	}
+	if len(constituents) == 1 {
+		return constituents[0], nil
+	}
+	return NewCompositeLimiter("quota-limiter", constituents), nil
+}

--- a/internal/engines/pipeline/limiter_factory_test.go
+++ b/internal/engines/pipeline/limiter_factory_test.go
@@ -1,0 +1,110 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+)
+
+// writeQuotaConfigFile writes a YAML quota config to a temp file and returns
+// the path. The file is cleaned up automatically when the test completes.
+func writeQuotaConfigFile(content string) string {
+	GinkgoHelper()
+	dir := GinkgoT().TempDir()
+	path := filepath.Join(dir, "quota.yaml")
+	Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
+	return path
+}
+
+// loadTestConfig builds a Config populated with the minimum prometheus
+// settings (so Validate succeeds) plus the supplied limiter selection.
+func loadTestConfig(limiterType config.LimiterType, quotaConfigFile string) *config.Config {
+	GinkgoHelper()
+	// Use NewTestConfig as the base, then mutate the limiter selection
+	// through the same loader path that production uses.
+	cfg := config.NewTestConfig()
+	// Mutate via a focused helper to keep the field private to the package.
+	config.SetLimiterForTest(cfg, limiterType, quotaConfigFile)
+	return cfg
+}
+
+var _ = Describe("NewLimiterFromConfig", func() {
+
+	It("returns an inventory limiter by default", func() {
+		cfg := loadTestConfig(config.LimiterTypeInventory, "")
+		l, err := NewLimiterFromConfig(cfg, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(l).NotTo(BeNil())
+		Expect(l.Name()).To(Equal("gpu-limiter"))
+		// The inventory limiter is a DefaultLimiter wrapping TypeInventory.
+		_, ok := l.(*DefaultLimiter)
+		Expect(ok).To(BeTrue(), "inventory mode should produce a DefaultLimiter")
+	})
+
+	It("rejects unknown limiter types", func() {
+		cfg := loadTestConfig(config.LimiterType("bogus"), "")
+		_, err := NewLimiterFromConfig(cfg, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`unknown limiter type "bogus"`))
+	})
+
+	It("returns a single DefaultLimiter when quota config has one entry", func() {
+		path := writeQuotaConfigFile(`limiters:
+  - name: cluster-quota
+    type: quota
+    scope: cluster
+    quotas:
+      H100: 16
+`)
+		cfg := loadTestConfig(config.LimiterTypeQuota, path)
+		// Re-run the loader against the file so Config carries the entries.
+		Expect(config.ReloadQuotaForTest(cfg)).To(Succeed())
+
+		l, err := NewLimiterFromConfig(cfg, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(l).NotTo(BeNil())
+		Expect(l.Name()).To(Equal("cluster-quota"))
+		_, ok := l.(*DefaultLimiter)
+		Expect(ok).To(BeTrue(), "single-entry quota should produce a DefaultLimiter")
+	})
+
+	It("wraps multiple quota entries in a CompositeLimiter", func() {
+		path := writeQuotaConfigFile(`limiters:
+  - name: cluster-quota
+    type: quota
+    scope: cluster
+    quotas:
+      H100: 16
+  - name: namespace-quota
+    type: quota
+    scope: namespace
+    namespaceQuotas:
+      team-a:
+        H100: 8
+`)
+		cfg := loadTestConfig(config.LimiterTypeQuota, path)
+		Expect(config.ReloadQuotaForTest(cfg)).To(Succeed())
+
+		l, err := NewLimiterFromConfig(cfg, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		comp, ok := l.(*CompositeLimiter)
+		Expect(ok).To(BeTrue(), "multi-entry quota should produce a CompositeLimiter")
+		Expect(comp.Name()).To(Equal("quota-limiter"))
+		Expect(comp.Constituents()).To(HaveLen(2))
+		Expect(comp.Constituents()[0].Name()).To(Equal("cluster-quota"))
+		Expect(comp.Constituents()[1].Name()).To(Equal("namespace-quota"))
+	})
+
+	It("errors when limiter-type=quota but no entries are loaded", func() {
+		cfg := loadTestConfig(config.LimiterTypeQuota, "")
+		// No reload — quotaEntries is empty.
+		_, err := NewLimiterFromConfig(cfg, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("at least one entry"))
+	})
+})

--- a/internal/engines/pipeline/limiter_interfaces.go
+++ b/internal/engines/pipeline/limiter_interfaces.go
@@ -148,6 +148,13 @@ type ResourcePool struct {
 
 // Available returns the number of allocatable resources (Limit - Used),
 // clamped to a minimum of 0.
+//
+// Available is only meaningful for a FINITE pool (Limit >= 0). A pool carrying
+// the unlimited sentinel (Limit < 0, emitted per-(namespace, type) by
+// GetNamespaceResourcePools) would clamp to 0 here, which reads as "deny" —
+// the opposite of "unlimited". Callers that may see the sentinel must branch on
+// Limit < 0 first (see nsPoolBudget and mergeConstraints); do not call
+// Available on such a pool.
 func (p ResourcePool) Available() int {
 	avail := p.Limit - p.Used
 	if avail < 0 {
@@ -161,9 +168,15 @@ func (p ResourcePool) Available() int {
 type ResourceConstraints struct {
 	ProviderName string                  // e.g., "gpu-limiter", "quota-limiter"
 	Pools        map[string]ResourcePool // accelerator type → pool
-	TotalLimit   int
-	TotalUsed    int
-	TotalAvail   int
+	// NamespacePools carries per-(namespace, accelerator type) caps for
+	// namespace-scoped providers (e.g. a namespace-scoped quota limiter).
+	// Outer key: namespace; inner key: accelerator type. Nil for providers
+	// that only impose cluster/per-type constraints. The optimizer caps a
+	// model's allocation at min(per-type pool, this namespace's pool).
+	NamespacePools map[string]map[string]ResourcePool
+	TotalLimit     int
+	TotalUsed      int
+	TotalAvail     int
 }
 
 // ConstraintProvider exposes hard constraints for the optimizer.
@@ -177,8 +190,12 @@ type ConstraintProvider interface {
 	Name() string
 
 	// ComputeConstraints refreshes resource data and returns hard constraints.
-	// currentUsage maps accelerator type → GPUs currently in use.
-	ComputeConstraints(ctx context.Context, currentUsage map[string]int) (*ResourceConstraints, error)
+	// usageByType maps accelerator type → GPUs currently in use (cluster-wide).
+	// usageByNamespace maps namespace → accelerator type → GPUs in use, and its
+	// keys also define the set of active namespaces for which namespace-scoped
+	// caps are materialized (so a namespace with a quota but zero current usage
+	// is still constrained). It may be nil for providers that ignore namespaces.
+	ComputeConstraints(ctx context.Context, usageByType map[string]int, usageByNamespace map[string]map[string]int) (*ResourceConstraints, error)
 }
 
 // Inventory provides resource availability and creates allocators.
@@ -230,4 +247,42 @@ type Inventory interface {
 	// GetResourcePools returns per-type resource availability.
 	// Each key is an accelerator type (e.g., "A100", "H100").
 	GetResourcePools() map[string]ResourcePool
+}
+
+// NamespaceAwareInventory is an Inventory whose constraints depend on the
+// namespace of the decision, not just the accelerator type. Implementations
+// bucket usage by namespace in addition to type; the chain orchestrator is
+// expected to feed them the per-namespace usage map alongside the per-type
+// map.
+//
+// Use feature detection at the chain level:
+//
+//	if nai, ok := inv.(NamespaceAwareInventory); ok {
+//	    nai.SetUsedByNamespace(usedByNS)
+//	}
+//	inv.SetUsed(usedByType) // always safe; namespace-only inventories ignore it
+//
+// Implementations should remain valid Inventory values: SetUsed must not
+// panic when called on a namespace-scoped inventory (it may simply be a
+// no-op).
+type NamespaceAwareInventory interface {
+	Inventory
+
+	// SetUsedByNamespace updates the per-namespace usage map.
+	// Outer key: namespace; inner key: accelerator type.
+	// Should be called before CreateAllocator, alongside SetUsed.
+	SetUsedByNamespace(usedByNS map[string]map[string]int)
+
+	// GetNamespaceResourcePools returns per-(namespace, accelerator type) pools
+	// for the given active namespaces as a CLOSED allowlist, resolving each
+	// namespace's caps via the inventory's lookup rules (e.g. explicit entry →
+	// default fall-through → exclude). Outer key: namespace; inner key:
+	// accelerator type. A namespace that is unconstrained (excluded) is omitted,
+	// signalling "open" — bound only by the cluster/per-type constraint. Every
+	// other active namespace is present (a closed allowlist; an empty inner map
+	// is a deny-all). A listed type with an unlimited cap is emitted as a
+	// sentinel pool with Limit < 0 (so it stays distinct from a type the
+	// namespace does not list, which the optimizer must deny). SetUsedByNamespace
+	// should be called first so the returned pools carry current usage.
+	GetNamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool
 }

--- a/internal/engines/pipeline/limiter_interfaces.go
+++ b/internal/engines/pipeline/limiter_interfaces.go
@@ -151,7 +151,7 @@ type ResourcePool struct {
 //
 // Available is only meaningful for a FINITE pool (Limit >= 0). A pool carrying
 // the unlimited sentinel (Limit < 0, emitted per-(namespace, type) by
-// GetNamespaceResourcePools) would clamp to 0 here, which reads as "deny" —
+// NamespaceResourcePools) would clamp to 0 here, which reads as "deny" —
 // the opposite of "unlimited". Callers that may see the sentinel must branch on
 // Limit < 0 first (see nsPoolBudget and mergeConstraints); do not call
 // Available on such a pool.
@@ -273,7 +273,7 @@ type NamespaceAwareInventory interface {
 	// Should be called before CreateAllocator, alongside SetUsed.
 	SetUsedByNamespace(usedByNS map[string]map[string]int)
 
-	// GetNamespaceResourcePools returns per-(namespace, accelerator type) pools
+	// NamespaceResourcePools returns per-(namespace, accelerator type) pools
 	// for the given active namespaces as a CLOSED allowlist, resolving each
 	// namespace's caps via the inventory's lookup rules (e.g. explicit entry →
 	// default fall-through → exclude). Outer key: namespace; inner key:
@@ -284,5 +284,5 @@ type NamespaceAwareInventory interface {
 	// sentinel pool with Limit < 0 (so it stays distinct from a type the
 	// namespace does not list, which the optimizer must deny). SetUsedByNamespace
 	// should be called first so the returned pools carry current usage.
-	GetNamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool
+	NamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool
 }

--- a/internal/engines/pipeline/noop_limiter.go
+++ b/internal/engines/pipeline/noop_limiter.go
@@ -1,0 +1,33 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// NoOpLimiter is a Limiter whose Limit method returns nil without
+// touching the decisions slice. Useful as the zero value of the Limiter
+// interface — pipelines that want to disable limiting without rewiring,
+// and tests that construct an engine without exercising the limiter
+// path.
+type NoOpLimiter struct {
+	name string
+}
+
+// NewNoOpLimiter constructs a NoOpLimiter with the given name. The name
+// surfaces in logs and decision traces.
+func NewNoOpLimiter(name string) *NoOpLimiter {
+	return &NoOpLimiter{name: name}
+}
+
+// Name returns the no-op limiter identifier.
+func (l *NoOpLimiter) Name() string { return l.name }
+
+// Limit is a no-op; decisions are returned unchanged.
+func (l *NoOpLimiter) Limit(_ context.Context, _ []*interfaces.VariantDecision) error {
+	return nil
+}
+
+// Ensure NoOpLimiter implements Limiter.
+var _ Limiter = (*NoOpLimiter)(nil)

--- a/internal/engines/pipeline/quota_inventory.go
+++ b/internal/engines/pipeline/quota_inventory.go
@@ -163,11 +163,13 @@ func (q *QuotaInventory) totalLimitLocked() int {
 	return total
 }
 
-// TotalUsed returns the sum of recorded usage. At cluster scope it counts only
-// accelerator types that carry a finite ClusterQuota — the same key set as
-// TotalLimit — so usage of unquotaed or unlimited types does not make
-// TotalAvailable under-report. At namespace scope it sums usage across all
-// tracked namespaces.
+// TotalUsed returns the sum of recorded usage, counting only the key set that
+// TotalLimit does so the two stay symmetric and TotalAvailable does not
+// under-report. At cluster scope that is the accelerator types with a finite
+// ClusterQuota; at namespace scope it is the non-excluded, non-"default"
+// namespaces and their finite-quota types. Usage of unquotaed, unlimited (-1),
+// excluded, or default-fall-through entries is therefore excluded — matching
+// TotalLimit, which does not count their caps.
 func (q *QuotaInventory) TotalUsed() int {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
@@ -175,6 +177,8 @@ func (q *QuotaInventory) TotalUsed() int {
 }
 
 // totalUsedLocked computes TotalUsed. Callers must hold q.mu (read or write).
+// Both branches iterate the SAME key set as totalLimitLocked so that TotalUsed
+// and TotalLimit cover identical entries.
 func (q *QuotaInventory) totalUsedLocked() int {
 	total := 0
 	switch q.cfg.Scope {
@@ -189,9 +193,21 @@ func (q *QuotaInventory) totalUsedLocked() int {
 			total += q.usedByType[accType]
 		}
 	case config.QuotaScopeNamespace:
-		for _, perType := range q.usedByNS {
-			for _, v := range perType {
-				total += v
+		// Mirror totalLimitLocked: skip the reserved "default" key, excluded
+		// namespaces, and unlimited types, so excluded/unlimited/default-
+		// fall-through usage is not charged against the finite namespace budget.
+		for ns, perType := range q.cfg.NamespaceQuotas {
+			if ns == config.QuotaLimiterReservedNamespaceKey {
+				continue
+			}
+			if q.cfg.IsExcluded(ns) {
+				continue
+			}
+			for accType, limit := range perType {
+				if limit == config.QuotaUnlimited {
+					continue
+				}
+				total += q.usedByNS[ns][accType]
 			}
 		}
 	}

--- a/internal/engines/pipeline/quota_inventory.go
+++ b/internal/engines/pipeline/quota_inventory.go
@@ -163,9 +163,11 @@ func (q *QuotaInventory) totalLimitLocked() int {
 	return total
 }
 
-// TotalUsed returns the sum of recorded usage across all tracked
-// accelerator-type pools (cluster scope) or all tracked namespaces
-// (namespace scope).
+// TotalUsed returns the sum of recorded usage. At cluster scope it counts only
+// accelerator types that carry a finite ClusterQuota — the same key set as
+// TotalLimit — so usage of unquotaed or unlimited types does not make
+// TotalAvailable under-report. At namespace scope it sums usage across all
+// tracked namespaces.
 func (q *QuotaInventory) TotalUsed() int {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
@@ -177,8 +179,14 @@ func (q *QuotaInventory) totalUsedLocked() int {
 	total := 0
 	switch q.cfg.Scope {
 	case config.QuotaScopeCluster:
-		for _, v := range q.usedByType {
-			total += v
+		// Count usage only for types with a finite cluster quota, mirroring
+		// totalLimitLocked. Usage of unquotaed types (real replicas with no
+		// configured cap) must not be subtracted from the quotaed budget.
+		for accType, limit := range q.cfg.ClusterQuotas {
+			if limit == config.QuotaUnlimited {
+				continue
+			}
+			total += q.usedByType[accType]
 		}
 	case config.QuotaScopeNamespace:
 		for _, perType := range q.usedByNS {
@@ -214,11 +222,13 @@ func (q *QuotaInventory) TotalAvailable() int {
 // min(per-type total, that namespace's cap).
 //
 // Quota value semantics on the emitted Limit:
-//   - Unlimited (-1) entries impose no constraint and are OMITTED (consistent
-//     with how TotalLimit/Remaining exclude them). An absent pool means "no
-//     cap"; the allocator's TryAllocate passes such requests through.
-//   - A quota of 0 is a real cap (deny) and is emitted with Limit == 0. Omitting
-//     unlimited keeps Limit == 0 unambiguous — it always means deny.
+//   - Unlimited (-1) entries are emitted as a sentinel ResourcePool{Limit ==
+//     QuotaUnlimited} (matching NamespaceResourcePools), so the V2 optimizer can
+//     tell "unlimited" (allow up to demand) apart from a type with no configured
+//     quota (absent → deny). mergeConstraints branches on Limit < 0 and treats
+//     the sentinel as unbounded; TotalLimit/TotalUsed/TotalAvailable exclude it,
+//     so the reported totals are unchanged.
+//   - A quota of 0 is a real cap (deny) and is emitted with Limit == 0.
 func (q *QuotaInventory) GetResourcePools() map[string]ResourcePool {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
@@ -226,9 +236,11 @@ func (q *QuotaInventory) GetResourcePools() map[string]ResourcePool {
 	switch q.cfg.Scope {
 	case config.QuotaScopeCluster:
 		for accType, limit := range q.cfg.ClusterQuotas {
-			if limit == config.QuotaUnlimited {
-				continue
-			}
+			// Emit every configured type, including unlimited (-1). An omitted
+			// type is read as 0 available by the V2 optimizer and silently
+			// denied, which would invert the -1 = unlimited semantic (see the
+			// function doc above). The sentinel is carried through
+			// mergeConstraints as an unbounded budget.
 			pools[accType] = ResourcePool{
 				Limit: limit,
 				Used:  q.usedByType[accType],

--- a/internal/engines/pipeline/quota_inventory.go
+++ b/internal/engines/pipeline/quota_inventory.go
@@ -452,6 +452,12 @@ func (a *quotaAllocator) tryAllocateNamespace(ns, accType string, gpusRequested 
 // Remaining returns the sum of available GPUs across all pools the allocator
 // tracks. Unlimited (-1) entries contribute 0 — the value is reserved for
 // post-allocation reporting, not for capacity comparisons.
+//
+// Namespace scope caveat: this sums only the explicitly-listed NamespaceQuotas
+// keys. Headroom consumed by unlisted namespaces that allocate via the "default"
+// per-namespace fallback is not subtracted here, so the namespace-scope total
+// can over-report remaining headroom. This affects reporting only — allocation
+// is unaffected, since TryAllocate tracks each namespace's own budget.
 func (a *quotaAllocator) Remaining() int {
 	total := 0
 	switch a.scope {

--- a/internal/engines/pipeline/quota_inventory.go
+++ b/internal/engines/pipeline/quota_inventory.go
@@ -1,0 +1,498 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"sync"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+)
+
+// QuotaInventory enforces operator-declared GPU quotas independent of physical
+// cluster inventory. It implements the Inventory interface for use in the
+// limiter pipeline. Each instance is tied to exactly one QuotaLimiterConfig
+// scope — a deployment that needs both cluster and namespace caps composes two
+// QuotaInventory instances via the limiter chain (sub-issue #1003).
+//
+// Quota values are static; QuotaInventory.Refresh is a no-op because there's
+// no external source to discover. Usage is tracked the same way as
+// TypeInventory: callers invoke SetUsed before each cycle, then CreateAllocator
+// for the per-cycle ResourceAllocator.
+//
+// QuotaInventory is decoupled from physical inventory. The limiter chain
+// composes a QuotaInventory with TypeInventory so allocations are bounded by
+// min(physical, quota); used standalone, no physical bound is enforced.
+type QuotaInventory struct {
+	name string
+	// cfg is a value copy taken at construction and is immutable thereafter, so
+	// it is safe to read (incl. cfg.IsExcluded / cfg.QuotaForNamespace) without
+	// holding mu. Only usedByType / usedByNS are mutable and mu-protected.
+	cfg config.QuotaLimiterConfig
+
+	mu sync.RWMutex
+	// usedByType is the cluster-scoped usage map (Scope == QuotaScopeCluster).
+	usedByType map[string]int
+	// usedByNS is the per-namespace usage map (Scope == QuotaScopeNamespace).
+	// Outer key: namespace; inner key: accelerator type.
+	usedByNS map[string]map[string]int
+}
+
+// NewQuotaInventory constructs an inventory from a validated config entry.
+// The caller is responsible for running config.QuotaLimiterEntries.Validate()
+// before this call — the constructor accepts the entry as-is and trusts it.
+func NewQuotaInventory(cfg config.QuotaLimiterConfig) *QuotaInventory {
+	return &QuotaInventory{
+		name:       cfg.Name,
+		cfg:        cfg,
+		usedByType: make(map[string]int),
+		usedByNS:   make(map[string]map[string]int),
+	}
+}
+
+// Compile-time interface assertions.
+var (
+	_ Inventory               = (*QuotaInventory)(nil)
+	_ NamespaceAwareInventory = (*QuotaInventory)(nil)
+	_ ResourceAllocator       = (*quotaAllocator)(nil)
+)
+
+// Name returns the limiter identifier (e.g., "cluster-quota"). Used in logs
+// and DecisionStep traces (the trace format is `limited by quota[scope=...]`,
+// per issue #1002).
+func (q *QuotaInventory) Name() string {
+	return q.name
+}
+
+// Refresh is a no-op for QuotaInventory: quotas are operator-declared via
+// ConfigMap and don't have an external source to refresh from. The method
+// satisfies the Inventory interface and returns nil to allow uniform
+// pipeline orchestration.
+func (q *QuotaInventory) Refresh(_ context.Context) error {
+	return nil
+}
+
+// SetUsed updates the cluster-scoped usage map for cluster-scoped inventories.
+// For namespace-scoped inventories this method is a no-op — namespace-scoped
+// inventories need per-namespace usage and should use SetUsedByNamespace
+// instead (the Inventory interface predates the per-namespace case; rather
+// than widen the interface we accept both shapes and only the relevant one
+// is consulted).
+func (q *QuotaInventory) SetUsed(usedByType map[string]int) {
+	if q.cfg.Scope != config.QuotaScopeCluster {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.usedByType = maps.Clone(usedByType)
+}
+
+// SetUsedByNamespace updates the per-namespace usage map used by
+// namespace-scoped inventories. The outer key is the namespace; the inner
+// key is the accelerator type. Excluded namespaces are still tracked but
+// CreateAllocator skips enforcement for them.
+//
+// For cluster-scoped inventories this method is a no-op.
+func (q *QuotaInventory) SetUsedByNamespace(usedByNS map[string]map[string]int) {
+	if q.cfg.Scope != config.QuotaScopeNamespace {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.usedByNS = copyNestedIntMap(usedByNS)
+}
+
+// CreateAllocator returns a ResourceAllocator that enforces this inventory's
+// quotas. The allocator is per-cycle: callers create one fresh after each
+// SetUsed / SetUsedByNamespace, exhaust it during the allocation pass, then
+// discard it.
+func (q *QuotaInventory) CreateAllocator(_ context.Context) ResourceAllocator {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return &quotaAllocator{
+		name:  q.name,
+		scope: q.cfg.Scope,
+		// Snapshot the config to keep the allocator self-contained.
+		cfg:        q.cfg,
+		usedByType: maps.Clone(q.usedByType),
+		usedByNS:   copyNestedIntMap(q.usedByNS),
+	}
+}
+
+// TotalLimit returns the cluster-wide sum of quotas across accelerator types
+// for the cluster scope, or the sum of all per-namespace quotas (excluding
+// excluded namespaces and the reserved default key) for the namespace scope.
+// QuotaUnlimited (-1) is excluded from sums — there is no finite total.
+func (q *QuotaInventory) TotalLimit() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.totalLimitLocked()
+}
+
+// totalLimitLocked computes TotalLimit. Callers must hold q.mu (read or write).
+func (q *QuotaInventory) totalLimitLocked() int {
+	total := 0
+	switch q.cfg.Scope {
+	case config.QuotaScopeCluster:
+		for _, v := range q.cfg.ClusterQuotas {
+			if v == config.QuotaUnlimited {
+				continue
+			}
+			total += v
+		}
+	case config.QuotaScopeNamespace:
+		for ns, perType := range q.cfg.NamespaceQuotas {
+			if ns == config.QuotaLimiterReservedNamespaceKey {
+				continue
+			}
+			if q.cfg.IsExcluded(ns) {
+				continue
+			}
+			for _, v := range perType {
+				if v == config.QuotaUnlimited {
+					continue
+				}
+				total += v
+			}
+		}
+	}
+	return total
+}
+
+// TotalUsed returns the sum of recorded usage across all tracked
+// accelerator-type pools (cluster scope) or all tracked namespaces
+// (namespace scope).
+func (q *QuotaInventory) TotalUsed() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.totalUsedLocked()
+}
+
+// totalUsedLocked computes TotalUsed. Callers must hold q.mu (read or write).
+func (q *QuotaInventory) totalUsedLocked() int {
+	total := 0
+	switch q.cfg.Scope {
+	case config.QuotaScopeCluster:
+		for _, v := range q.usedByType {
+			total += v
+		}
+	case config.QuotaScopeNamespace:
+		for _, perType := range q.usedByNS {
+			for _, v := range perType {
+				total += v
+			}
+		}
+	}
+	return total
+}
+
+// TotalAvailable returns max(0, TotalLimit - TotalUsed). Notes the same
+// caveat as TotalLimit: unlimited (-1) entries are excluded from both terms,
+// so TotalAvailable underreports availability when unlimited quotas are
+// configured. Limit and used are read under a single lock so the pair is
+// internally consistent.
+func (q *QuotaInventory) TotalAvailable() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	avail := q.totalLimitLocked() - q.totalUsedLocked()
+	if avail < 0 {
+		return 0
+	}
+	return avail
+}
+
+// GetResourcePools returns per-accelerator-type pools. For the cluster scope it
+// is one pool per configured type. For the namespace scope it is the per-type
+// SUM across explicitly-listed (non-excluded, non-"default") namespaces — i.e.
+// the aggregate cluster budget that the per-namespace caps partition. The
+// per-(namespace, type) breakdown is exposed separately via
+// GetNamespaceResourcePools; the optimizer combines them as
+// min(per-type total, that namespace's cap).
+//
+// Quota value semantics on the emitted Limit:
+//   - Unlimited (-1) entries impose no constraint and are OMITTED (consistent
+//     with how TotalLimit/Remaining exclude them). An absent pool means "no
+//     cap"; the allocator's TryAllocate passes such requests through.
+//   - A quota of 0 is a real cap (deny) and is emitted with Limit == 0. Omitting
+//     unlimited keeps Limit == 0 unambiguous — it always means deny.
+func (q *QuotaInventory) GetResourcePools() map[string]ResourcePool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	pools := make(map[string]ResourcePool)
+	switch q.cfg.Scope {
+	case config.QuotaScopeCluster:
+		for accType, limit := range q.cfg.ClusterQuotas {
+			if limit == config.QuotaUnlimited {
+				continue
+			}
+			pools[accType] = ResourcePool{
+				Limit: limit,
+				Used:  q.usedByType[accType],
+			}
+		}
+	case config.QuotaScopeNamespace:
+		for ns, perType := range q.cfg.NamespaceQuotas {
+			if ns == config.QuotaLimiterReservedNamespaceKey {
+				continue
+			}
+			if q.cfg.IsExcluded(ns) {
+				continue
+			}
+			for accType, limit := range perType {
+				if limit == config.QuotaUnlimited {
+					continue
+				}
+				pool := pools[accType]
+				pool.Limit += limit
+				pool.Used += q.usedByNS[ns][accType]
+				pools[accType] = pool
+			}
+		}
+	}
+	return pools
+}
+
+// GetNamespaceResourcePools implements NamespaceAwareInventory. For the cluster
+// scope it returns nil (no namespace dimension). For the namespace scope it
+// exposes each active namespace as a CLOSED allowlist that mirrors the V1
+// tryAllocateNamespace contract, so namespace quota is enforced identically on
+// the V1 Limit() and V2 optimizer paths:
+//
+//   - An excluded namespace is OMITTED from the result entirely. Its absence
+//     signals "open" to the optimizer (no namespace cap; only the cluster/
+//     per-type constraint applies), matching V1's pass-through for excludes.
+//   - Every other active namespace is always present (even with an empty inner
+//     map), which marks it as a closed allowlist. An empty map is a real
+//     deny-all (a namespace with neither an explicit quota nor a "default"
+//     fall-through): the optimizer allocates it nothing.
+//   - Within a present namespace, each listed accelerator type is emitted: a
+//     finite cap as ResourcePool{Limit: n} (including 0, a real deny cap), and
+//     an unlimited (-1) cap as a sentinel ResourcePool{Limit: QuotaUnlimited}
+//     so the optimizer can tell "unlimited" (allow up to the cluster budget)
+//     apart from "type not listed" (deny). A type the namespace does not list
+//     is simply absent, which the optimizer denies — it does NOT fall through
+//     to the cluster aggregate (that fall-through was the cross-namespace leak).
+//
+// Used counts come from the most recent SetUsedByNamespace call.
+func (q *QuotaInventory) GetNamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	if q.cfg.Scope != config.QuotaScopeNamespace {
+		return nil
+	}
+	out := make(map[string]map[string]ResourcePool)
+	for _, ns := range activeNamespaces {
+		quotas, excluded := q.cfg.QuotaForNamespace(ns)
+		if excluded {
+			// Omit: an absent namespace is "open" (pass-through), so the
+			// model is bound only by the cluster/per-type constraint.
+			continue
+		}
+		// Always materialize the namespace so it is a closed allowlist; an
+		// empty map is a deny-all namespace.
+		perType, ok := out[ns]
+		if !ok {
+			perType = make(map[string]ResourcePool)
+			out[ns] = perType
+		}
+		for accType, limit := range quotas {
+			// Emit unlimited as a sentinel (Limit == QuotaUnlimited) rather
+			// than dropping it, so the optimizer distinguishes it from a
+			// type the namespace does not list (which it must deny).
+			perType[accType] = ResourcePool{
+				Limit: limit,
+				Used:  q.usedByNS[ns][accType],
+			}
+		}
+	}
+	return out
+}
+
+// quotaAllocator is the per-cycle ResourceAllocator returned by
+// QuotaInventory.CreateAllocator. It holds a snapshot of the config and
+// current usage; TryAllocate decrements the in-memory usage counters as
+// allocations are granted.
+//
+// The allocator is intentionally tied to one scope. Composing cluster +
+// namespace quotas is the limiter chain's job (sub-issue #1003) — one
+// allocator per scope, both consulted before a decision is committed.
+type quotaAllocator struct {
+	name       string
+	scope      config.QuotaScope
+	cfg        config.QuotaLimiterConfig
+	usedByType map[string]int            // cluster scope only
+	usedByNS   map[string]map[string]int // namespace scope only
+}
+
+// TryAllocate enforces this allocator's quota against the given decision.
+// Returns the number of GPUs that may be allocated (between 0 and
+// gpusRequested), accounting for both the configured cap and the current
+// usage snapshot. On grant, the in-memory usage counter is incremented so
+// subsequent calls in the same cycle see the updated remaining quota.
+//
+// Per-scope semantics:
+//   - Cluster: cap is q.cfg.ClusterQuotas[type]; if missing or zero, returns 0.
+//   - Namespace: applies the namespace lookup rules from issue #1002:
+//     excluded → pass-through (return gpusRequested without recording usage,
+//     so this limiter doesn't double-count against another limiter that
+//     does enforce); exact match → cap; fall-through to `default` → cap;
+//     missing → 0.
+//   - Unlimited (-1) on either scope: pass-through.
+func (a *quotaAllocator) TryAllocate(ctx context.Context, decision *interfaces.VariantDecision, gpusRequested int) (int, error) {
+	if gpusRequested <= 0 {
+		return 0, nil
+	}
+	if decision == nil {
+		return 0, fmt.Errorf("quota allocator %q: decision is nil", a.name)
+	}
+
+	accType := decision.AcceleratorName
+	if accType == "" {
+		// Without a resolved accelerator type we cannot match a per-type quota.
+		// Fail CLOSED (deny) rather than passing through: DefaultLimiter runs
+		// resolveUnknownAccelerators first, but that only resolves a single-type
+		// inventory — a multi-type quota config (the case quotas exist to bound)
+		// leaves the type unresolved here, and passing through would let an
+		// unattributed request bypass the cap entirely.
+		ctrl.LoggerFrom(ctx).WithName("quotaAllocator").V(logging.DEBUG).Info(
+			"Denying allocation: accelerator unresolved, cannot enforce quota",
+			"limiter", a.name,
+			"variant", decision.VariantName,
+			"namespace", decision.Namespace,
+		)
+		decision.AddDecisionStep(a.name,
+			fmt.Sprintf("denied by quota[scope=%s]: accelerator type unresolved", a.scope), true)
+		return 0, nil
+	}
+
+	var granted int
+	switch a.scope {
+	case config.QuotaScopeCluster:
+		granted = a.tryAllocateCluster(accType, gpusRequested)
+	case config.QuotaScopeNamespace:
+		granted = a.tryAllocateNamespace(decision.Namespace, accType, gpusRequested)
+	default:
+		return 0, fmt.Errorf("quota allocator %q: unknown scope %q", a.name, a.scope)
+	}
+
+	// Record a DecisionStep when the allocator actually capped the request.
+	// Pass-through paths (excluded namespace, unlimited quota) do not record
+	// a step because they did not constrain the decision. Per issue #1002 the
+	// reason is formatted as `limited by quota[scope=..., type=...]` (and
+	// `namespace=...` for the namespace scope) so traces are filterable.
+	if granted < gpusRequested {
+		decision.AddDecisionStep(a.name, a.formatLimitReason(decision.Namespace, accType), true)
+	}
+	return granted, nil
+}
+
+// formatLimitReason returns the human-readable trace string emitted on a
+// DecisionStep when this allocator caps a request. The format mirrors the
+// one documented in issue #1002 and the developer guide.
+func (a *quotaAllocator) formatLimitReason(namespace, accType string) string {
+	switch a.scope {
+	case config.QuotaScopeNamespace:
+		return fmt.Sprintf("limited by quota[scope=namespace, namespace=%s, type=%s]", namespace, accType)
+	default:
+		return fmt.Sprintf("limited by quota[scope=%s, type=%s]", a.scope, accType)
+	}
+}
+
+func (a *quotaAllocator) tryAllocateCluster(accType string, gpusRequested int) int {
+	limit, ok := a.cfg.ClusterQuotas[accType]
+	if !ok {
+		// No entry == zero quota for this type at cluster scope.
+		return 0
+	}
+	if limit == config.QuotaUnlimited {
+		return gpusRequested
+	}
+	available := limit - a.usedByType[accType]
+	if available <= 0 {
+		return 0
+	}
+	// usedByType is always non-nil here: NewQuotaInventory initializes it and
+	// CreateAllocator clones it from a non-nil source.
+	granted := min(gpusRequested, available)
+	a.usedByType[accType] += granted
+	return granted
+}
+
+func (a *quotaAllocator) tryAllocateNamespace(ns, accType string, gpusRequested int) int {
+	quotas, excluded := a.cfg.QuotaForNamespace(ns)
+	if excluded {
+		// Pass-through: namespace bypasses this limiter entirely. Caller's
+		// other limiters (e.g., cluster scope, physical inventory) still
+		// apply.
+		return gpusRequested
+	}
+	limit, ok := quotas[accType]
+	if !ok {
+		return 0
+	}
+	if limit == config.QuotaUnlimited {
+		return gpusRequested
+	}
+	if a.usedByNS[ns] == nil {
+		a.usedByNS[ns] = make(map[string]int)
+	}
+	available := limit - a.usedByNS[ns][accType]
+	if available <= 0 {
+		return 0
+	}
+	granted := min(gpusRequested, available)
+	a.usedByNS[ns][accType] += granted
+	return granted
+}
+
+// Remaining returns the sum of available GPUs across all pools the allocator
+// tracks. Unlimited (-1) entries contribute 0 — the value is reserved for
+// post-allocation reporting, not for capacity comparisons.
+func (a *quotaAllocator) Remaining() int {
+	total := 0
+	switch a.scope {
+	case config.QuotaScopeCluster:
+		for accType, limit := range a.cfg.ClusterQuotas {
+			if limit == config.QuotaUnlimited {
+				continue
+			}
+			avail := limit - a.usedByType[accType]
+			if avail > 0 {
+				total += avail
+			}
+		}
+	case config.QuotaScopeNamespace:
+		for ns, perType := range a.cfg.NamespaceQuotas {
+			if ns == config.QuotaLimiterReservedNamespaceKey {
+				continue
+			}
+			if a.cfg.IsExcluded(ns) {
+				continue
+			}
+			for accType, limit := range perType {
+				if limit == config.QuotaUnlimited {
+					continue
+				}
+				avail := limit - a.usedByNS[ns][accType]
+				if avail > 0 {
+					total += avail
+				}
+			}
+		}
+	}
+	return total
+}
+
+// copyNestedIntMap returns a deep copy of a two-level nested int map.
+// maps.Clone is shallow, so the inner maps are cloned explicitly.
+func copyNestedIntMap(src map[string]map[string]int) map[string]map[string]int {
+	dst := make(map[string]map[string]int, len(src))
+	for outer, inner := range src {
+		dst[outer] = maps.Clone(inner)
+	}
+	return dst
+}

--- a/internal/engines/pipeline/quota_inventory.go
+++ b/internal/engines/pipeline/quota_inventory.go
@@ -210,7 +210,7 @@ func (q *QuotaInventory) TotalAvailable() int {
 // SUM across explicitly-listed (non-excluded, non-"default") namespaces — i.e.
 // the aggregate cluster budget that the per-namespace caps partition. The
 // per-(namespace, type) breakdown is exposed separately via
-// GetNamespaceResourcePools; the optimizer combines them as
+// NamespaceResourcePools; the optimizer combines them as
 // min(per-type total, that namespace's cap).
 //
 // Quota value semantics on the emitted Limit:
@@ -256,7 +256,7 @@ func (q *QuotaInventory) GetResourcePools() map[string]ResourcePool {
 	return pools
 }
 
-// GetNamespaceResourcePools implements NamespaceAwareInventory. For the cluster
+// NamespaceResourcePools implements NamespaceAwareInventory. For the cluster
 // scope it returns nil (no namespace dimension). For the namespace scope it
 // exposes each active namespace as a CLOSED allowlist that mirrors the V1
 // tryAllocateNamespace contract, so namespace quota is enforced identically on
@@ -278,7 +278,7 @@ func (q *QuotaInventory) GetResourcePools() map[string]ResourcePool {
 //     to the cluster aggregate (that fall-through was the cross-namespace leak).
 //
 // Used counts come from the most recent SetUsedByNamespace call.
-func (q *QuotaInventory) GetNamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool {
+func (q *QuotaInventory) NamespaceResourcePools(activeNamespaces []string) map[string]map[string]ResourcePool {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 	if q.cfg.Scope != config.QuotaScopeNamespace {

--- a/internal/engines/pipeline/quota_inventory_test.go
+++ b/internal/engines/pipeline/quota_inventory_test.go
@@ -365,7 +365,7 @@ var _ = Describe("QuotaInventory", func() {
 		})
 	})
 
-	Describe("GetNamespaceResourcePools", func() {
+	Describe("NamespaceResourcePools", func() {
 		It("returns per-(namespace,type) caps, applying default fall-through and excludes, with unlimited as a sentinel", func() {
 			inv := newNamespaceQuotaInv(map[string]map[string]int{
 				"team-a":                                {"H100": 4, "A100": config.QuotaUnlimited},
@@ -376,7 +376,7 @@ var _ = Describe("QuotaInventory", func() {
 
 			// team-a explicit; team-z unlisted (falls through to default);
 			// kube-system excluded.
-			pools := inv.GetNamespaceResourcePools([]string{"team-a", "team-z", "kube-system"})
+			pools := inv.NamespaceResourcePools([]string{"team-a", "team-z", "kube-system"})
 
 			Expect(pools["team-a"]).To(HaveKeyWithValue("H100", ResourcePool{Limit: 4, Used: 1}))
 			Expect(pools["team-a"]).To(HaveKeyWithValue("A100", ResourcePool{Limit: config.QuotaUnlimited, Used: 0}),
@@ -391,7 +391,7 @@ var _ = Describe("QuotaInventory", func() {
 			}, nil)
 
 			// team-z is unlisted and there is no "default" fall-through.
-			pools := inv.GetNamespaceResourcePools([]string{"team-a", "team-z"})
+			pools := inv.NamespaceResourcePools([]string{"team-a", "team-z"})
 
 			Expect(pools).To(HaveKey("team-z"), "present (closed allowlist) so the optimizer denies it")
 			Expect(pools["team-z"]).To(BeEmpty(), "no listed types — a real deny-all")
@@ -399,7 +399,7 @@ var _ = Describe("QuotaInventory", func() {
 
 		It("returns nil for cluster scope", func() {
 			inv := newClusterQuotaInv(map[string]int{"H100": 8})
-			Expect(inv.GetNamespaceResourcePools([]string{"team-a"})).To(BeNil())
+			Expect(inv.NamespaceResourcePools([]string{"team-a"})).To(BeNil())
 		})
 	})
 
@@ -456,6 +456,25 @@ var _ = Describe("QuotaInventory", func() {
 			// team-a H100 (4) only; A100 unlimited contributes 0; excluded
 			// kube-system and the reserved default key contribute 0.
 			Expect(alloc.Remaining()).To(Equal(4))
+		})
+
+		It("namespace scope: over-reports when a default-fallback namespace allocates (documented limitation)", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a":                                {"H100": 4},
+				config.QuotaLimiterReservedNamespaceKey: {"H100": 2},
+			}, nil)
+			alloc := inv.CreateAllocator(ctx)
+
+			// team-z is unlisted and allocates 2 via the "default" fallback.
+			got, err := alloc.TryAllocate(ctx, quotaDecisionFor("team-z", "H100"), 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(2))
+
+			// Remaining iterates the listed NamespaceQuotas keys only (team-a, and
+			// the reserved default key which is skipped), so team-z's usage is not
+			// subtracted. It reports team-a's full 4 — the documented over-report.
+			Expect(alloc.Remaining()).To(Equal(4),
+				"default-fallback namespace usage is not subtracted from Remaining")
 		})
 	})
 

--- a/internal/engines/pipeline/quota_inventory_test.go
+++ b/internal/engines/pipeline/quota_inventory_test.go
@@ -1,0 +1,507 @@
+package pipeline
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+func newClusterQuotaInv(quotas map[string]int) *QuotaInventory {
+	return NewQuotaInventory(config.QuotaLimiterConfig{
+		Name:          "cluster-quota",
+		Type:          "quota",
+		Scope:         config.QuotaScopeCluster,
+		ClusterQuotas: quotas,
+	})
+}
+
+func newNamespaceQuotaInv(quotas map[string]map[string]int, exclude []string) *QuotaInventory {
+	return NewQuotaInventory(config.QuotaLimiterConfig{
+		Name:            "namespace-quota",
+		Type:            "quota",
+		Scope:           config.QuotaScopeNamespace,
+		NamespaceQuotas: quotas,
+		Exclude:         exclude,
+	})
+}
+
+func quotaDecisionFor(namespace, accType string) *interfaces.VariantDecision {
+	return &interfaces.VariantDecision{
+		Namespace:       namespace,
+		AcceleratorName: accType,
+		VariantName:     "v",
+	}
+}
+
+var _ = Describe("QuotaInventory", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("Inventory interface contract", func() {
+		It("satisfies the Inventory interface", func() {
+			var _ Inventory = (*QuotaInventory)(nil)
+		})
+
+		It("satisfies the NamespaceAwareInventory interface", func() {
+			var _ NamespaceAwareInventory = (*QuotaInventory)(nil)
+		})
+
+		It("returns the configured name", func() {
+			inv := NewQuotaInventory(config.QuotaLimiterConfig{
+				Name:          "my-quota",
+				Type:          "quota",
+				Scope:         config.QuotaScopeCluster,
+				ClusterQuotas: map[string]int{"H100": 1},
+			})
+			Expect(inv.Name()).To(Equal("my-quota"))
+		})
+
+		It("treats Refresh as a no-op", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 1})
+			Expect(inv.Refresh(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("cluster scope", func() {
+		It("grants up to the cap then exhausts the pool", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 4, "A100": 2})
+			alloc := inv.CreateAllocator(ctx)
+
+			got, err := alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 3)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(3))
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-b", "H100"), 5)
+			Expect(got).To(Equal(1), "cap=4, used=3, expected 1 remaining")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-c", "H100"), 1)
+			Expect(got).To(Equal(0), "pool exhausted")
+
+			// A100 has its own independent pool.
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "A100"), 2)
+			Expect(got).To(Equal(2))
+		})
+
+		It("denies unknown types and passes through unlimited", func() {
+			inv := newClusterQuotaInv(map[string]int{
+				"H100": config.QuotaUnlimited,
+				"A100": 2,
+			})
+			alloc := inv.CreateAllocator(ctx)
+
+			got, _ := alloc.TryAllocate(ctx, quotaDecisionFor("any", "L40S"), 4)
+			Expect(got).To(Equal(0), "unknown type denied")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("any", "H100"), 999)
+			Expect(got).To(Equal(999), "unlimited pass-through")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("any", "H100"), 100)
+			Expect(got).To(Equal(100), "unlimited has no accounting")
+		})
+
+		It("respects SetUsed", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 8})
+			inv.SetUsed(map[string]int{"H100": 6})
+
+			alloc := inv.CreateAllocator(ctx)
+			got, _ := alloc.TryAllocate(ctx, quotaDecisionFor("any", "H100"), 5)
+			Expect(got).To(Equal(2), "cap=8, used=6, expected 2 remaining")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("any", "H100"), 1)
+			Expect(got).To(Equal(0))
+		})
+	})
+
+	Describe("namespace scope", func() {
+		It("grants up to per-namespace caps and exhausts independently", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 4},
+				"team-b": {"H100": 2},
+			}, nil)
+			alloc := inv.CreateAllocator(ctx)
+
+			got, _ := alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 3)
+			Expect(got).To(Equal(3))
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-b", "H100"), 2)
+			Expect(got).To(Equal(2), "team-b independent budget")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 5)
+			Expect(got).To(Equal(1))
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 1)
+			Expect(got).To(Equal(0), "team-a exhausted")
+		})
+
+		It("passes through excluded namespaces without recording usage", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 1},
+			}, []string{"kube-system"})
+			alloc := inv.CreateAllocator(ctx)
+
+			got, _ := alloc.TryAllocate(ctx, quotaDecisionFor("kube-system", "H100"), 50)
+			Expect(got).To(Equal(50), "excluded namespace pass-through")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 1)
+			Expect(got).To(Equal(1), "team-a unaffected by excluded call")
+		})
+
+		It("falls through to the default key with per-namespace budgets", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a":                                {"H100": 4},
+				config.QuotaLimiterReservedNamespaceKey: {"H100": 2},
+			}, nil)
+			alloc := inv.CreateAllocator(ctx)
+
+			// Each unlisted namespace gets its OWN budget at the default level
+			// (Kubernetes LimitRange convention, not a shared pool).
+			got, _ := alloc.TryAllocate(ctx, quotaDecisionFor("team-z", "H100"), 5)
+			Expect(got).To(Equal(2))
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-y", "H100"), 5)
+			Expect(got).To(Equal(2), "second unlisted namespace has its own default budget")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-z", "H100"), 1)
+			Expect(got).To(Equal(0), "team-z bucket already exhausted")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 4)
+			Expect(got).To(Equal(4), "exact match wins over default")
+		})
+
+		It("denies missing namespaces under a strict allowlist (no default)", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 4},
+			}, nil)
+			alloc := inv.CreateAllocator(ctx)
+
+			got, _ := alloc.TryAllocate(ctx, quotaDecisionFor("team-b", "H100"), 1)
+			Expect(got).To(Equal(0), "strict allowlist: unlisted namespace denied")
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 4)
+			Expect(got).To(Equal(4))
+		})
+
+		It("treats QuotaUnlimited as pass-through per namespace", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-priority": {"H100": config.QuotaUnlimited},
+				"team-capped":   {"H100": 2},
+			}, nil)
+			alloc := inv.CreateAllocator(ctx)
+
+			got, _ := alloc.TryAllocate(ctx, quotaDecisionFor("team-priority", "H100"), 1000)
+			Expect(got).To(Equal(1000))
+
+			got, _ = alloc.TryAllocate(ctx, quotaDecisionFor("team-capped", "H100"), 5)
+			Expect(got).To(Equal(2), "unlimited usage in another namespace does not leak")
+		})
+
+		It("respects SetUsedByNamespace", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 4},
+			}, nil)
+			inv.SetUsedByNamespace(map[string]map[string]int{
+				"team-a": {"H100": 3},
+			})
+			alloc := inv.CreateAllocator(ctx)
+			got, _ := alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 5)
+			Expect(got).To(Equal(1), "cap=4, used=3, expected 1 remaining")
+		})
+	})
+
+	Describe("error and edge cases", func() {
+		It("returns an error on a nil decision", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 4})
+			alloc := inv.CreateAllocator(ctx)
+			_, err := alloc.TryAllocate(ctx, nil, 1)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("short-circuits on a zero-GPU request", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 4})
+			alloc := inv.CreateAllocator(ctx)
+			got, err := alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(0))
+		})
+
+		It("denies (fails closed) when the accelerator type is unresolved", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 4})
+			alloc := inv.CreateAllocator(ctx)
+			d := quotaDecisionFor("team-a", "")
+			got, err := alloc.TryAllocate(ctx, d, 7)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(0), "unresolved accelerator must not bypass the quota")
+			Expect(d.DecisionSteps).To(HaveLen(1))
+			Expect(d.DecisionSteps[0].Reason).To(ContainSubstring("accelerator type unresolved"))
+			Expect(d.DecisionSteps[0].WasConstrained).To(BeTrue())
+		})
+	})
+
+	Describe("DecisionStep tracing (issue #1002 acceptance)", func() {
+		It("records a step formatted as `limited by quota[scope=cluster, type=...]` when the cluster cap binds", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 2})
+			alloc := inv.CreateAllocator(ctx)
+			d := quotaDecisionFor("team-a", "H100")
+
+			_, err := alloc.TryAllocate(ctx, d, 5)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(d.DecisionSteps).To(HaveLen(1))
+			Expect(d.DecisionSteps[0].Name).To(Equal("cluster-quota"))
+			Expect(d.DecisionSteps[0].Reason).To(Equal("limited by quota[scope=cluster, type=H100]"))
+			Expect(d.DecisionSteps[0].WasConstrained).To(BeTrue())
+		})
+
+		It("records a step formatted as `limited by quota[scope=namespace, namespace=..., type=...]` when the namespace cap binds", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 2},
+			}, nil)
+			alloc := inv.CreateAllocator(ctx)
+			d := quotaDecisionFor("team-a", "H100")
+
+			_, err := alloc.TryAllocate(ctx, d, 5)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(d.DecisionSteps).To(HaveLen(1))
+			Expect(d.DecisionSteps[0].Reason).To(Equal("limited by quota[scope=namespace, namespace=team-a, type=H100]"))
+			Expect(d.DecisionSteps[0].WasConstrained).To(BeTrue())
+		})
+
+		It("does NOT record a step for pass-through allocations (full grant)", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 10})
+			alloc := inv.CreateAllocator(ctx)
+			d := quotaDecisionFor("team-a", "H100")
+
+			_, err := alloc.TryAllocate(ctx, d, 5)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(d.DecisionSteps).To(BeEmpty(), "no constraint applied, no step")
+		})
+
+		It("does NOT record a step for excluded namespaces", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 1},
+			}, []string{"kube-system"})
+			alloc := inv.CreateAllocator(ctx)
+			d := quotaDecisionFor("kube-system", "H100")
+
+			_, err := alloc.TryAllocate(ctx, d, 50)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(d.DecisionSteps).To(BeEmpty())
+		})
+
+		It("does NOT record a step for unlimited quotas", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": config.QuotaUnlimited})
+			alloc := inv.CreateAllocator(ctx)
+			d := quotaDecisionFor("team-a", "H100")
+
+			_, err := alloc.TryAllocate(ctx, d, 999)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(d.DecisionSteps).To(BeEmpty())
+		})
+	})
+
+	Describe("combined cluster + namespace", func() {
+		// Two independent QuotaInventory instances, composed by the test
+		// harness in the simplest way (cluster first, then namespace fed the
+		// cluster's grant). Verifies the cluster cap is felt across namespace
+		// boundaries. Full chain orchestration is sub-issue #1003.
+		It("yields min(cluster, namespace) when each is enforced in turn", func() {
+			clusterInv := newClusterQuotaInv(map[string]int{"H100": 4})
+			nsInv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 3},
+				"team-b": {"H100": 3},
+			}, nil)
+
+			clusterAlloc := clusterInv.CreateAllocator(ctx)
+			nsAlloc := nsInv.CreateAllocator(ctx)
+
+			tryBoth := func(ns string, req int) int {
+				gotCluster, _ := clusterAlloc.TryAllocate(ctx, quotaDecisionFor(ns, "H100"), req)
+				gotNS, _ := nsAlloc.TryAllocate(ctx, quotaDecisionFor(ns, "H100"), gotCluster)
+				return gotNS
+			}
+
+			Expect(tryBoth("team-a", 3)).To(Equal(3), "team-a fits in both caps")
+			Expect(tryBoth("team-b", 3)).To(Equal(1), "cluster cap pinches team-b (cluster left=1)")
+			Expect(tryBoth("team-b", 1)).To(Equal(0), "cluster exhausted")
+		})
+	})
+
+	Describe("GetResourcePools", func() {
+		It("returns per-type pools for cluster scope, omitting unlimited and keeping zero caps", func() {
+			inv := newClusterQuotaInv(map[string]int{
+				"H100": 8,
+				"A100": config.QuotaUnlimited,
+				"L40S": 0,
+			})
+			inv.SetUsed(map[string]int{"H100": 3})
+
+			pools := inv.GetResourcePools()
+			Expect(pools).To(HaveKey("H100"))
+			Expect(pools["H100"].Limit).To(Equal(8))
+			Expect(pools["H100"].Used).To(Equal(3))
+			Expect(pools).NotTo(HaveKey("A100"), "unlimited imposes no constraint, so it is omitted")
+			Expect(pools).To(HaveKey("L40S"))
+			Expect(pools["L40S"].Limit).To(Equal(0), "a quota of 0 is a real deny cap, distinct from unlimited")
+		})
+
+		It("sums per-type across listed namespaces for namespace scope, skipping default and excluded", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a":                                {"H100": 4},
+				"team-b":                                {"H100": 2, "A100": 3},
+				"kube-system":                           {"H100": 99},
+				config.QuotaLimiterReservedNamespaceKey: {"H100": 1},
+			}, []string{"kube-system"})
+
+			pools := inv.GetResourcePools()
+			Expect(pools["H100"].Limit).To(Equal(6), "team-a(4)+team-b(2); default and excluded kube-system skipped")
+			Expect(pools["A100"].Limit).To(Equal(3))
+			Expect(pools).NotTo(HaveKey("team-a/H100"), "namespace scope no longer emits composite keys")
+		})
+	})
+
+	Describe("GetNamespaceResourcePools", func() {
+		It("returns per-(namespace,type) caps, applying default fall-through and excludes, with unlimited as a sentinel", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a":                                {"H100": 4, "A100": config.QuotaUnlimited},
+				"kube-system":                           {"H100": 99},
+				config.QuotaLimiterReservedNamespaceKey: {"H100": 2},
+			}, []string{"kube-system"})
+			inv.SetUsedByNamespace(map[string]map[string]int{"team-a": {"H100": 1}})
+
+			// team-a explicit; team-z unlisted (falls through to default);
+			// kube-system excluded.
+			pools := inv.GetNamespaceResourcePools([]string{"team-a", "team-z", "kube-system"})
+
+			Expect(pools["team-a"]).To(HaveKeyWithValue("H100", ResourcePool{Limit: 4, Used: 1}))
+			Expect(pools["team-a"]).To(HaveKeyWithValue("A100", ResourcePool{Limit: config.QuotaUnlimited, Used: 0}),
+				"unlimited cap emitted as a sentinel, not omitted, so it stays distinguishable from an unlisted (denied) type")
+			Expect(pools["team-z"]).To(HaveKeyWithValue("H100", ResourcePool{Limit: 2, Used: 0}), "default fall-through cap")
+			Expect(pools).NotTo(HaveKey("kube-system"), "excluded namespace omitted (open / pass-through)")
+		})
+
+		It("materializes a namespace with neither an explicit quota nor a default as an empty deny-all allowlist", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 4},
+			}, nil)
+
+			// team-z is unlisted and there is no "default" fall-through.
+			pools := inv.GetNamespaceResourcePools([]string{"team-a", "team-z"})
+
+			Expect(pools).To(HaveKey("team-z"), "present (closed allowlist) so the optimizer denies it")
+			Expect(pools["team-z"]).To(BeEmpty(), "no listed types — a real deny-all")
+		})
+
+		It("returns nil for cluster scope", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 8})
+			Expect(inv.GetNamespaceResourcePools([]string{"team-a"})).To(BeNil())
+		})
+	})
+
+	Describe("totals", func() {
+		It("excludes unlimited entries from cluster scope totals", func() {
+			inv := newClusterQuotaInv(map[string]int{
+				"H100": 8,
+				"A100": config.QuotaUnlimited,
+				"L40S": 2,
+			})
+			inv.SetUsed(map[string]int{"H100": 3, "L40S": 1})
+
+			Expect(inv.TotalLimit()).To(Equal(10))
+			Expect(inv.TotalUsed()).To(Equal(4))
+			Expect(inv.TotalAvailable()).To(Equal(6))
+		})
+
+		It("skips default and excluded namespaces in namespace scope", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a":                                {"H100": 4},
+				"team-b":                                {"H100": 2},
+				"kube-system":                           {"H100": 99},
+				config.QuotaLimiterReservedNamespaceKey: {"H100": 1},
+			}, []string{"kube-system"})
+
+			Expect(inv.TotalLimit()).To(Equal(6), "sum of team-a + team-b only")
+		})
+	})
+
+	Describe("Remaining", func() {
+		It("sums available across pools and treats unlimited as zero contribution", func() {
+			inv := newClusterQuotaInv(map[string]int{
+				"H100": 4,
+				"A100": 2,
+				"L40S": config.QuotaUnlimited,
+			})
+			alloc := inv.CreateAllocator(ctx)
+
+			Expect(alloc.Remaining()).To(Equal(6))
+
+			_, err := alloc.TryAllocate(ctx, quotaDecisionFor("x", "H100"), 3)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(alloc.Remaining()).To(Equal(3))
+		})
+
+		It("namespace scope: sums listed namespaces only, skipping excluded and unlimited", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a":                                {"H100": 4, "A100": config.QuotaUnlimited},
+				"kube-system":                           {"H100": 99},
+				config.QuotaLimiterReservedNamespaceKey: {"H100": 1},
+			}, []string{"kube-system"})
+			alloc := inv.CreateAllocator(ctx)
+
+			// team-a H100 (4) only; A100 unlimited contributes 0; excluded
+			// kube-system and the reserved default key contribute 0.
+			Expect(alloc.Remaining()).To(Equal(4))
+		})
+	})
+
+	Describe("SetUsed / SetUsedByNamespace scope guards", func() {
+		It("namespace-scoped inventory ignores cluster-wide SetUsed and uses per-namespace usage", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{"team-a": {"H100": 4}}, nil)
+
+			// Cluster-wide SetUsed must be a no-op for a namespace-scoped inventory.
+			inv.SetUsed(map[string]int{"H100": 99})
+			Expect(inv.TotalUsed()).To(Equal(0), "cluster SetUsed ignored at namespace scope")
+
+			inv.SetUsedByNamespace(map[string]map[string]int{"team-a": {"H100": 3}})
+			alloc := inv.CreateAllocator(ctx)
+			// 4 cap − 3 used = 1 remaining for team-a/H100.
+			got, err := alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 5)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(1), "only SetUsedByNamespace usage applies")
+		})
+
+		It("cluster-scoped inventory ignores per-namespace SetUsedByNamespace", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 4})
+
+			// Per-namespace usage must be a no-op for a cluster-scoped inventory.
+			inv.SetUsedByNamespace(map[string]map[string]int{"team-a": {"H100": 99}})
+			alloc := inv.CreateAllocator(ctx)
+			// Full 4 still available — the bogus per-namespace usage was ignored.
+			got, err := alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 4)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(4), "cluster scope ignores SetUsedByNamespace")
+		})
+	})
+
+	Describe("more edge cases", func() {
+		It("TotalAvailable clamps to 0 when usage exceeds the configured quota", func() {
+			inv := newClusterQuotaInv(map[string]int{"H100": 2})
+			inv.SetUsed(map[string]int{"H100": 5}) // over-used
+			Expect(inv.TotalAvailable()).To(Equal(0), "never reports negative availability")
+		})
+
+		It("TryAllocate errors on an unknown allocator scope", func() {
+			inv := NewQuotaInventory(config.QuotaLimiterConfig{
+				Name: "bad", Type: "quota", Scope: config.QuotaScope("bogus"),
+			})
+			alloc := inv.CreateAllocator(ctx)
+			_, err := alloc.TryAllocate(ctx, quotaDecisionFor("team-a", "H100"), 1)
+			Expect(err).To(MatchError(ContainSubstring("unknown scope")))
+		})
+	})
+})

--- a/internal/engines/pipeline/quota_inventory_test.go
+++ b/internal/engines/pipeline/quota_inventory_test.go
@@ -303,6 +303,37 @@ var _ = Describe("QuotaInventory", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(d.DecisionSteps).To(BeEmpty())
 		})
+
+		It("denies with a step when a cluster quota of 0 is a hard deny (distinct from unlimited)", func() {
+			// Locks in that 0 is a real deny cap, not folded into the unlimited
+			// pass-through path — a regression that did so would turn a hard-deny
+			// quota into a pass-through and no other spec would catch it.
+			inv := newClusterQuotaInv(map[string]int{"H100": 0})
+			alloc := inv.CreateAllocator(ctx)
+			d := quotaDecisionFor("team-a", "H100")
+
+			got, err := alloc.TryAllocate(ctx, d, 5)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(0), "a cluster cap of 0 denies all allocation")
+			Expect(d.DecisionSteps).To(HaveLen(1))
+			Expect(d.DecisionSteps[0].Reason).To(Equal("limited by quota[scope=cluster, type=H100]"))
+			Expect(d.DecisionSteps[0].WasConstrained).To(BeTrue())
+		})
+
+		It("denies with a step when a namespace quota of 0 is a hard deny", func() {
+			inv := newNamespaceQuotaInv(map[string]map[string]int{
+				"team-a": {"H100": 0},
+			}, nil)
+			alloc := inv.CreateAllocator(ctx)
+			d := quotaDecisionFor("team-a", "H100")
+
+			got, err := alloc.TryAllocate(ctx, d, 5)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(0), "a namespace cap of 0 denies all allocation")
+			Expect(d.DecisionSteps).To(HaveLen(1))
+			Expect(d.DecisionSteps[0].Reason).To(Equal("limited by quota[scope=namespace, namespace=team-a, type=H100]"))
+			Expect(d.DecisionSteps[0].WasConstrained).To(BeTrue())
+		})
 	})
 
 	Describe("combined cluster + namespace", func() {
@@ -333,7 +364,7 @@ var _ = Describe("QuotaInventory", func() {
 	})
 
 	Describe("GetResourcePools", func() {
-		It("returns per-type pools for cluster scope, omitting unlimited and keeping zero caps", func() {
+		It("returns per-type pools for cluster scope, emitting unlimited as a sentinel and keeping zero caps", func() {
 			inv := newClusterQuotaInv(map[string]int{
 				"H100": 8,
 				"A100": config.QuotaUnlimited,
@@ -345,7 +376,8 @@ var _ = Describe("QuotaInventory", func() {
 			Expect(pools).To(HaveKey("H100"))
 			Expect(pools["H100"].Limit).To(Equal(8))
 			Expect(pools["H100"].Used).To(Equal(3))
-			Expect(pools).NotTo(HaveKey("A100"), "unlimited imposes no constraint, so it is omitted")
+			Expect(pools).To(HaveKey("A100"), "unlimited is emitted as a sentinel so the V2 optimizer can distinguish it from an unconfigured (deny) type")
+			Expect(pools["A100"].Limit).To(Equal(config.QuotaUnlimited), "unlimited is carried as the QuotaUnlimited sentinel")
 			Expect(pools).To(HaveKey("L40S"))
 			Expect(pools["L40S"].Limit).To(Equal(0), "a quota of 0 is a real deny cap, distinct from unlimited")
 		})

--- a/internal/engines/pipeline/quota_limit_integration_test.go
+++ b/internal/engines/pipeline/quota_limit_integration_test.go
@@ -1,0 +1,105 @@
+package pipeline
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// These specs exercise the V1 Limit() enforcement path end-to-end: a real
+// QuotaInventory driven by the real GreedyBySaturation through DefaultLimiter
+// (and CompositeLimiter), asserting that a quota actually reduces a decision's
+// TargetReplicas. The per-allocator and per-optimizer behaviors are covered
+// elsewhere; this fills the composition gap where a regression in the wiring
+// (SetUsed(ByNamespace) → CreateAllocator → algorithm → updateDecisionMetadata)
+// would otherwise pass unnoticed.
+var _ = Describe("Quota limiter V1 enforcement (integration)", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	newDecision := func() *interfaces.VariantDecision {
+		return &interfaces.VariantDecision{
+			VariantName:     "v1",
+			Namespace:       "team-a",
+			AcceleratorName: "H100",
+			CurrentReplicas: 2, // 2 * 2 = 4 GPUs already used
+			TargetReplicas:  5, // wants +3 replicas = +6 GPUs
+			GPUsPerReplica:  2,
+		}
+	}
+
+	clusterLimiter := func(name string, quota int) *DefaultLimiter {
+		inv := NewQuotaInventory(config.QuotaLimiterConfig{
+			Name: name, Type: "quota", Scope: config.QuotaScopeCluster,
+			ClusterQuotas: map[string]int{"H100": quota},
+		})
+		return NewDefaultLimiter(name, inv, NewGreedyBySaturation())
+	}
+	namespaceLimiter := func(name string, quota int) *DefaultLimiter {
+		inv := NewQuotaInventory(config.QuotaLimiterConfig{
+			Name: name, Type: "quota", Scope: config.QuotaScopeNamespace,
+			NamespaceQuotas: map[string]map[string]int{"team-a": {"H100": quota}},
+		})
+		return NewDefaultLimiter(name, inv, NewGreedyBySaturation())
+	}
+
+	It("caps TargetReplicas at the cluster quota headroom", func() {
+		d := newDecision()
+		// cap 6, used 4 → 2 free = 1 replica; target lands at 2 + 1 = 3.
+		Expect(clusterLimiter("cluster-quota", 6).Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+
+		Expect(d.TargetReplicas).To(Equal(3), "capped at cluster quota headroom")
+		Expect(d.WasLimited).To(BeTrue())
+		Expect(d.LimitedBy).To(Equal("cluster-quota"))
+	})
+
+	It("caps TargetReplicas at the namespace quota headroom", func() {
+		d := newDecision()
+		Expect(namespaceLimiter("namespace-quota", 6).Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+
+		Expect(d.TargetReplicas).To(Equal(3), "capped at namespace quota headroom")
+		Expect(d.WasLimited).To(BeTrue())
+		Expect(d.LimitedBy).To(Equal("namespace-quota"))
+	})
+
+	It("applies the most restrictive of a cluster+namespace composite", func() {
+		// cluster is ample (100); namespace (6) binds. Composite runs cluster then
+		// namespace against the shared slice.
+		comp := NewCompositeLimiter("quota-limiter", []Limiter{
+			clusterLimiter("cluster-quota", 100),
+			namespaceLimiter("namespace-quota", 6),
+		})
+		d := newDecision()
+		Expect(comp.Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+
+		Expect(d.TargetReplicas).To(Equal(3), "namespace quota is the binding constraint")
+		Expect(d.WasLimited).To(BeTrue())
+		Expect(d.LimitedBy).To(Equal("namespace-quota"),
+			"attribution goes to the constituent that actually reduced the target")
+	})
+
+	It("does not let a later non-capping constituent steal LimitedBy", func() {
+		// Regression for the sticky-WasLimited misattribution: the namespace
+		// quota caps first; the ample cluster quota runs AFTER and must not
+		// overwrite LimitedBy (nor re-emit the limited metric) just because
+		// WasLimited stays true across constituents.
+		comp := NewCompositeLimiter("quota-limiter", []Limiter{
+			namespaceLimiter("namespace-quota", 6),
+			clusterLimiter("cluster-quota", 100),
+		})
+		d := newDecision()
+		Expect(comp.Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+
+		Expect(d.TargetReplicas).To(Equal(3))
+		Expect(d.WasLimited).To(BeTrue())
+		Expect(d.LimitedBy).To(Equal("namespace-quota"),
+			"the constituent that actually capped keeps attribution even though cluster-quota ran last")
+	})
+})

--- a/internal/engines/pipeline/quota_limit_integration_test.go
+++ b/internal/engines/pipeline/quota_limit_integration_test.go
@@ -85,6 +85,28 @@ var _ = Describe("Quota limiter V1 enforcement (integration)", func() {
 			"attribution goes to the constituent that actually reduced the target")
 	})
 
+	It("attributes a quota cap even when a MinReplicas floor keeps the target from dropping", func() {
+		// The quota denies GPUs (only +1 of the +3 requested replicas is
+		// schedulable) but a MinReplicas floor restores the target to the
+		// requested value. WasLimited still transitions to true, so the cap must
+		// be attributed (LimitedBy set, step marked limited) — the before/after
+		// target alone would miss this.
+		inv := NewQuotaInventory(config.QuotaLimiterConfig{
+			Name: "cluster-quota", Type: "quota", Scope: config.QuotaScopeCluster,
+			ClusterQuotas: map[string]int{"H100": 6}, // 6 - 4 used = +1 replica
+		})
+		limiter := NewDefaultLimiter("cluster-quota", inv, NewGreedyBySaturation())
+
+		minReplicas := 5
+		d := newDecision()
+		d.MinReplicas = &minReplicas
+		Expect(limiter.Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+
+		Expect(d.TargetReplicas).To(Equal(5), "MinReplicas floor restores the requested target")
+		Expect(d.WasLimited).To(BeTrue(), "the quota still denied GPUs")
+		Expect(d.LimitedBy).To(Equal("cluster-quota"), "the cap is attributed despite the floor")
+	})
+
 	It("does not let a later non-capping constituent steal LimitedBy", func() {
 		// Regression for the sticky-WasLimited misattribution: the namespace
 		// quota caps first; the ample cluster quota runs AFTER and must not

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -38,7 +38,6 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/discovery"
 	queueingmodel "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel"
 	saturation_v2 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/saturation_v2"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/executor"
@@ -188,10 +187,16 @@ type Engine struct {
 
 // NewEngine creates a new instance of the saturation engine.
 // Config must be non-nil (validated in main.go before engine creation).
-// Panics if cfg is nil to fail fast on programming errors.
-func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Scheme, recorder record.EventRecorder, metricsRegistry *source.SourceRegistry, cfg *config.Config) *Engine {
+// gpuLimiter is the operator-selected limiter built by
+// pipeline.NewLimiterFromConfig in main.go and must be non-nil — tests
+// that do not exercise the limiter path can pass pipeline.NewNoOpLimiter.
+// Panics if cfg or gpuLimiter is nil to fail fast on programming errors.
+func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Scheme, recorder record.EventRecorder, metricsRegistry *source.SourceRegistry, cfg *config.Config, gpuLimiter pipeline.Limiter) *Engine {
 	if cfg == nil {
 		panic("config is nil in NewEngine - this should not happen (validated in main.go before engine creation)")
+	}
+	if gpuLimiter == nil {
+		panic("gpuLimiter is nil in NewEngine - production callers must use pipeline.NewLimiterFromConfig; tests should pass pipeline.NewNoOpLimiter")
 	}
 	promSource := metricsRegistry.Get("prometheus") // assume prometheus source is registered
 
@@ -199,12 +204,6 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 	requestCountFunc := func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 		return registration.CollectModelRequestCount(ctx, promSource, modelID, namespace, retentionPeriod)
 	}
-
-	// Create GPU limiter with TypeInventory and GreedyBySaturation algorithm
-	gpuDiscovery := discovery.NewK8sWithGpuOperator(client)
-	gpuInventory := pipeline.NewTypeInventoryWithUsage("cluster-gpu-inventory", gpuDiscovery)
-	gpuAlgorithm := pipeline.NewGreedyBySaturation()
-	gpuLimiter := pipeline.NewDefaultLimiter("gpu-limiter", gpuInventory, gpuAlgorithm)
 
 	capacityStore := saturation_v2.NewCapacityKnowledgeStore()
 	satV2 := saturation_v2.NewSaturationAnalyzer(capacityStore)
@@ -373,8 +372,15 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	// Initialize vaEventTracker for this optimize cycle
 	e.vaEventTracker = make(map[string]bool)
 
-	// Collected accelerator inventory (only in limited mode)
-	if e.Config.LimitedModeEnabled() {
+	// Collect accelerator inventory (only in limited mode AND only when the
+	// operator selected the inventory-based limiter). When --limiter-type=quota,
+	// the controller deliberately runs without consulting physical capacity —
+	// listing Nodes here would defeat that contract (and trigger a
+	// controller-runtime Node informer for the lifetime of the process). The
+	// collected inventory is currently only logged anyway (see comment at
+	// internal/collector/collector.go), so skipping it in quota mode loses
+	// nothing of operational value.
+	if e.Config.LimitedModeEnabled() && shouldCollectClusterInventory(e.Config) {
 		inventory, err := collector.CollectInventoryK8S(ctx, e.client)
 		if err != nil {
 			logger.Error(err, "Failed to collect cluster inventory")
@@ -777,17 +783,37 @@ func (e *Engine) selectV2Optimizer(
 		return optimizer, nil
 	}
 
-	provider, ok := e.GPULimiter.(pipeline.ConstraintProvider)
-	if !ok {
+	// Collect constraints from every provider backing the GPU limiter: a single
+	// DefaultLimiter, or each constituent of a CompositeLimiter (so multi-entry
+	// quota configs are all consulted, and namespace-scoped providers contribute
+	// per-namespace caps via NamespacePools).
+	providers := gpuConstraintProviders(e.GPULimiter)
+	if len(providers) == 0 {
 		return pipeline.NewCostAwareOptimizer(), nil
 	}
 
-	constraint, err := provider.ComputeConstraints(ctx, computeCurrentGPUUsage(requests))
-	if err != nil {
-		logger.Error(err, "Failed to compute GPU constraints, falling back to unlimited (cost-aware) optimizer for this cycle")
+	currentUsage := computeCurrentGPUUsage(requests)
+	currentUsageByNS := computeCurrentGPUUsageByNamespace(requests)
+	var constraints []*pipeline.ResourceConstraints
+	for _, cp := range providers {
+		constraint, err := cp.ComputeConstraints(ctx, currentUsage, currentUsageByNS)
+		if err != nil {
+			logger.Error(err, "Failed to compute GPU constraints, skipping provider", "provider", cp.Name())
+			continue
+		}
+		constraints = append(constraints, constraint)
+	}
+
+	// GreedyByScore treats absent constraints as zero available capacity
+	// (deny-all), not as unlimited. When no provider could supply constraints
+	// (limiter is not constraint-backed, or every provider failed — e.g. GPU
+	// capacity cannot be discovered), fall back to the cost-aware optimizer, the
+	// engine's unlimited path, so scale-up proceeds instead of being silently
+	// blocked.
+	if len(constraints) == 0 {
 		return pipeline.NewCostAwareOptimizer(), nil
 	}
-	return optimizer, []*pipeline.ResourceConstraints{constraint}
+	return optimizer, constraints
 }
 
 // optimizeV2 runs the V2 token-based optimizer path (saturation-token-based).

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
@@ -60,7 +61,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			sourceRegistry := source.NewSourceRegistry()
 			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
 			testConfig := config.NewTestConfig()
-			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 
 			Expect(engine.analyzers).To(HaveLen(1))
 			Expect(engine.analyzers[0].name).To(Equal(interfaces.SaturationAnalyzerName))
@@ -118,7 +119,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			sourceRegistry := source.NewSourceRegistry()
 			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
 			testConfig := config.NewTestConfig()
-			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 
 			Expect(engine.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})).To(Succeed())
 			Expect(engine.RegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})).To(Succeed())
@@ -143,7 +144,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			sourceRegistry := source.NewSourceRegistry()
 			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
 			testConfig := config.NewTestConfig()
-			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 			Expect(engine.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})).To(Succeed())
 
 			startCtx, cancelStart := context.WithCancel(context.Background())

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	interfaces "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	utils "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
@@ -225,7 +226,7 @@ var _ = Describe("Saturation Engine", func() {
 				"default": {},
 			})
 			fakeRecorder := record.NewFakeRecorder(100)
-			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), fakeRecorder, sourceRegistry, testConfig)
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), fakeRecorder, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 
 			By("Performing optimization loop")
 			err := engine.optimize(ctx)
@@ -277,7 +278,7 @@ var _ = Describe("Saturation Engine", func() {
 			// Create minimal test config
 			testConfig := config.NewTestConfig()
 			fakeRecorder := record.NewFakeRecorder(100)
-			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), fakeRecorder, sourceRegistry, testConfig)
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), fakeRecorder, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 			decisions := engine.convertSaturationTargetsToDecisions(context.Background(), saturationTargets, saturationAnalysis, variantStates)
 
 			By("Verifying all variants are included in decisions")
@@ -438,7 +439,7 @@ var _ = Describe("Saturation Engine", func() {
 				"default": {},
 			})
 			fakeRecorder := record.NewFakeRecorder(100)
-			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), fakeRecorder, sourceRegistry, testConfig)
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), fakeRecorder, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 
 			By("Performing optimization loop with source infrastructure")
 			err := engine.optimize(ctx)
@@ -539,7 +540,7 @@ var _ = Describe("Saturation Engine", func() {
 					EnableLimiter: false,
 				},
 			})
-			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 
 			By("Running optimize() with EnableLimiter=false")
 			err := engine.optimize(ctx)

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -322,6 +322,67 @@ func computeCurrentGPUUsage(requests []pipeline.ModelScalingRequest) map[string]
 	return usage
 }
 
+// computeCurrentGPUUsageByNamespace mirrors computeCurrentGPUUsage but buckets
+// usage by namespace, then accelerator type. Every request's namespace is
+// represented (with at least an empty per-type map) so namespaces carrying a
+// quota but zero current usage are still surfaced as active namespaces to the
+// constraint providers (and therefore still constrained).
+func computeCurrentGPUUsageByNamespace(requests []pipeline.ModelScalingRequest) map[string]map[string]int {
+	usage := make(map[string]map[string]int)
+	for _, req := range requests {
+		perType, ok := usage[req.Namespace]
+		if !ok {
+			perType = make(map[string]int)
+			usage[req.Namespace] = perType
+		}
+		var satEntry *interfaces.AnalyzerResult
+		for _, e := range req.AnalyzerResults {
+			if e.Name == interfaces.SaturationAnalyzerName {
+				satEntry = e.Result
+				break
+			}
+		}
+		if satEntry == nil {
+			continue
+		}
+		stateMap := make(map[string]interfaces.VariantReplicaState, len(req.VariantStates))
+		for _, s := range req.VariantStates {
+			stateMap[s.VariantName] = s
+		}
+		for _, vc := range satEntry.VariantCapacities {
+			state := stateMap[vc.VariantName]
+			gpusPerReplica := state.GPUsPerReplica
+			if gpusPerReplica <= 0 {
+				gpusPerReplica = 1
+			}
+			perType[vc.AcceleratorName] += state.CurrentReplicas * gpusPerReplica
+		}
+	}
+	return usage
+}
+
+// gpuConstraintProviders returns the ConstraintProvider(s) backing the GPU
+// limiter for the V2 optimizer path. A limiter that is itself a
+// ConstraintProvider (a *DefaultLimiter) contributes itself; a CompositeLimiter
+// contributes each constituent that is a ConstraintProvider, so multi-entry
+// quota configs are all consulted. Other limiter shapes (e.g. NoOpLimiter)
+// contribute nothing.
+func gpuConstraintProviders(l pipeline.Limiter) []pipeline.ConstraintProvider {
+	switch lim := l.(type) {
+	case pipeline.ConstraintProvider:
+		return []pipeline.ConstraintProvider{lim}
+	case *pipeline.CompositeLimiter:
+		var providers []pipeline.ConstraintProvider
+		for _, c := range lim.Constituents() {
+			if cp, ok := c.(pipeline.ConstraintProvider); ok {
+				providers = append(providers, cp)
+			}
+		}
+		return providers
+	}
+	return nil
+}
+
 // collectV2ModelRequest performs V2 analysis for a single model and returns
 // a ModelScalingRequest for the optimizer, or nil if analysis should be skipped.
 func (e *Engine) collectV2ModelRequest(

--- a/internal/engines/saturation/engine_v2_quota_test.go
+++ b/internal/engines/saturation/engine_v2_quota_test.go
@@ -1,0 +1,79 @@
+package saturation
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// satReq builds a ModelScalingRequest with a saturation analyzer entry whose
+// variant capacities and replica states drive computeCurrentGPUUsageByNamespace.
+func satReq(namespace string, vcs []interfaces.VariantCapacity, states []interfaces.VariantReplicaState) pipeline.ModelScalingRequest {
+	return pipeline.ModelScalingRequest{
+		Namespace: namespace,
+		AnalyzerResults: []pipeline.NamedAnalyzerResult{{
+			Name:   interfaces.SaturationAnalyzerName,
+			Result: &interfaces.AnalyzerResult{Namespace: namespace, VariantCapacities: vcs},
+		}},
+		VariantStates: states,
+	}
+}
+
+var _ = Describe("computeCurrentGPUUsageByNamespace", func() {
+	It("sums currentReplicas*gpusPerReplica per (namespace, accelerator type)", func() {
+		usage := computeCurrentGPUUsageByNamespace([]pipeline.ModelScalingRequest{
+			satReq("team-a",
+				[]interfaces.VariantCapacity{{VariantName: "v", AcceleratorName: "A100"}},
+				[]interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 2, GPUsPerReplica: 2}}),
+			satReq("team-b",
+				[]interfaces.VariantCapacity{{VariantName: "w", AcceleratorName: "H100"}},
+				[]interfaces.VariantReplicaState{{VariantName: "w", CurrentReplicas: 1, GPUsPerReplica: 4}}),
+		})
+		Expect(usage["team-a"]).To(HaveKeyWithValue("A100", 4))
+		Expect(usage["team-b"]).To(HaveKeyWithValue("H100", 4))
+	})
+
+	It("defaults GPUsPerReplica <= 0 to 1", func() {
+		usage := computeCurrentGPUUsageByNamespace([]pipeline.ModelScalingRequest{
+			satReq("team-a",
+				[]interfaces.VariantCapacity{{VariantName: "v", AcceleratorName: "A100"}},
+				[]interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 3, GPUsPerReplica: 0}}),
+		})
+		Expect(usage["team-a"]).To(HaveKeyWithValue("A100", 3), "GPUsPerReplica defaulted to 1")
+	})
+
+	It("marks a namespace active (empty map) even when the request has no saturation entry", func() {
+		usage := computeCurrentGPUUsageByNamespace([]pipeline.ModelScalingRequest{{Namespace: "team-z"}})
+		Expect(usage).To(HaveKey("team-z"), "zero-replica / no-saturation namespace must still be constrained")
+		Expect(usage["team-z"]).To(BeEmpty())
+	})
+})
+
+var _ = Describe("gpuConstraintProviders", func() {
+	clusterQuota := func(name string) *pipeline.DefaultLimiter {
+		inv := pipeline.NewQuotaInventory(config.QuotaLimiterConfig{
+			Name: name, Type: "quota", Scope: config.QuotaScopeCluster,
+			ClusterQuotas: map[string]int{"A100": 4},
+		})
+		return pipeline.NewDefaultLimiter(name, inv, pipeline.NewGreedyBySaturation())
+	}
+
+	It("returns a DefaultLimiter (ConstraintProvider) as its own single provider", func() {
+		dl := clusterQuota("q")
+		got := gpuConstraintProviders(dl)
+		Expect(got).To(HaveLen(1))
+		Expect(got[0]).To(BeIdenticalTo(dl))
+	})
+
+	It("returns each ConstraintProvider constituent of a CompositeLimiter", func() {
+		comp := pipeline.NewCompositeLimiter("c", []pipeline.Limiter{clusterQuota("a"), clusterQuota("b")})
+		Expect(gpuConstraintProviders(comp)).To(HaveLen(2))
+	})
+
+	It("returns nil for a limiter that is not a ConstraintProvider (NoOpLimiter)", func() {
+		Expect(gpuConstraintProviders(pipeline.NewNoOpLimiter("noop"))).To(BeNil())
+	})
+})

--- a/internal/engines/saturation/event_optimization_failed_test.go
+++ b/internal/engines/saturation/event_optimization_failed_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 )
 
@@ -84,7 +85,7 @@ func TestRecordOptimizationFailedEvent(t *testing.T) {
 
 			testConfig := config.NewTestConfig()
 
-			engine := NewEngine(k8sClient, k8sClient, scheme, fakeRecorder, sourceRegistry, testConfig)
+			engine := NewEngine(k8sClient, k8sClient, scheme, fakeRecorder, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 
 			variantAutoscalings := make([]llmdVariantAutoscalingV1alpha1.VariantAutoscaling, 0, tt.numVAs)
 			for i := 0; i < tt.numVAs; i++ {
@@ -150,7 +151,7 @@ func TestRecordOptimizationFailedEvent_NilRecorder(t *testing.T) {
 	testConfig := config.NewTestConfig()
 
 	// Create engine with nil recorder
-	engine := NewEngine(k8sClient, k8sClient, scheme, nil, sourceRegistry, testConfig)
+	engine := NewEngine(k8sClient, k8sClient, scheme, nil, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 
 	variantAutoscalings := []llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
 		{

--- a/internal/engines/saturation/inventory_gate.go
+++ b/internal/engines/saturation/inventory_gate.go
@@ -1,0 +1,15 @@
+package saturation
+
+import (
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+)
+
+// shouldCollectClusterInventory reports whether the per-cycle
+// collector.CollectInventoryK8S call is appropriate for the active
+// configuration. The intent is to keep quota-mode deployments free of any
+// Node API traffic: when the operator selected --limiter-type=quota, the
+// physical-capacity path is deliberately disabled and listing Nodes here
+// (even just for logging) would defeat that contract.
+func shouldCollectClusterInventory(cfg *config.Config) bool {
+	return cfg.LimiterMode() == config.LimiterTypeInventory
+}

--- a/internal/engines/saturation/inventory_gate_test.go
+++ b/internal/engines/saturation/inventory_gate_test.go
@@ -1,0 +1,23 @@
+package saturation
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+)
+
+var _ = Describe("shouldCollectClusterInventory", func() {
+
+	DescribeTable("limiter type determines whether cluster inventory is collected",
+		func(limiterType config.LimiterType, want bool) {
+			cfg := config.NewTestConfig()
+			config.SetLimiterForTest(cfg, limiterType, "")
+			Expect(shouldCollectClusterInventory(cfg)).To(Equal(want))
+		},
+		Entry("inventory mode allows inventory collection", config.LimiterTypeInventory, true),
+		Entry("quota mode blocks inventory collection", config.LimiterTypeQuota, false),
+		Entry("empty limiter type is treated as non-inventory", config.LimiterType(""), false),
+		Entry("unknown limiter type is treated as non-inventory", config.LimiterType("bogus"), false),
+	)
+})


### PR DESCRIPTION
## Summary

Adds a quota limiter that enforces operator-declared GPU caps independent of
physical inventory, and wires it as a startup-selectable replacement for the
existing physical-inventory limiter. Operators choose one mode at deploy time:

- `--limiter-type=inventory` (default) — today's behavior; `TypeInventory`
  discovers physical GPUs via the GPU operator.
- `--limiter-type=quota --quota-config-file=/path/to/quotas.yaml` — pure
  operator-declared caps; **no Node API access** in the controller.

The two modes are mutually exclusive in this PR. Composing physical and
quota bounds (`min(physical, quota)`) is the limiter chain's job and is
out of scope here — tracked in sub-issue #1003.

## What's new

### Configuration

```yaml
limiters:
  - name: cluster-quota
    type: quota
    scope: cluster
    quotas:
      H100: 16
      A100: 8
      L40S: -1   # unlimited
  - name: namespace-quota
    type: quota
    scope: namespace
    exclude:
      - kube-system
      - llm-d-system
    namespaceQuotas:
      team-a:
        H100: 8
      team-priority:
        H100: -1
      default:
        H100: 2   # per-namespace fallback for unlisted namespaces
```

### Special values

| Value | Meaning |
|-------|---------|
| Positive integer | Cap in GPUs |
| `-1` | Unlimited — allocator passes through, no usage recorded |
| `0` or missing entry | Denied (no allocation) |

### Namespace lookup rules (`namespace` scope)

For namespace `N` and accelerator type `T`:

1. `N` in `exclude` → **pass-through**; the limiter records no usage so other
   chain members still apply.
2. `namespaceQuotas[N][T]` exists → that cap.
3. Else `namespaceQuotas["default"][T]` exists → that cap as the
   **per-namespace** default (Kubernetes `LimitRange` convention — each
   unlisted namespace gets its own budget at this level, not a shared pool).
4. Else → denied (0).

> ⚠️ The reserved key `default` collides with the real Kubernetes `default`
> namespace. To enforce a cap on workloads in the K8s `default` namespace,
> use `exclude` or omit the reserved key (strict allowlist).

## Operator UX

```bash
# Default (today's behavior, no flags needed):
manager

# Quota mode pointing at a YAML file:
manager --limiter-type=quota --quota-config-file=/etc/wva/quota.yaml
```

Also honored via env vars (`LIMITER_TYPE` / `QUOTA_CONFIG_FILE`) or the
unified config file. `config.Validate` rejects invalid combinations
(quota without file, unknown limiter type, empty entries) at startup
before any reconciler runs.

## Resource access in quota mode

Quota mode is fully Node-API-free. The limiter, inventory, allocator, and
factory paths never call `discovery.K8sWithGpuOperator.*` and never
instantiate a `corev1.NodeList` informer. The previously orthogonal
`collector.CollectInventoryK8S` call (gated by `WVA_LIMITED_MODE`) is now
**also** gated on `LimiterType == inventory` via the
`shouldCollectClusterInventory` predicate, so even the combination
`--limiter-type=quota` + `WVA_LIMITED_MODE=true` no longer lists Nodes.
`main.go` emits an informational log when this combination is detected.

| `--limiter-type` | `WVA_LIMITED_MODE` | Node API access |
|------------------|--------------------|------------------|
| `inventory` (default) | `false` (default) | Limiter path only (unchanged) |
| `inventory` | `true` | Limiter + `CollectInventoryK8S` (unchanged) |
| `quota` | `false` | **None** |
| `quota` | `true` | **None** (`CollectInventoryK8S` suppressed; startup log explains why) |

## DecisionStep observability

When `quotaAllocator.TryAllocate` caps a request (`granted < requested`), it
appends a `DecisionStep` via `VariantDecision.AddDecisionStep` formatted per
issue #1002:

- Cluster scope: `limited by quota[scope=cluster, type=H100]`
- Namespace scope: `limited by quota[scope=namespace, namespace=team-a, type=H100]`

Pass-through paths (excluded namespace, unlimited quota, unresolved
accelerator) do **not** record a step. Spec assertions use exact match, so
drift from the documented format fails CI.

## Validation

`QuotaLimiterEntries.Validate()` accumulates **all** errors with
`errors.Join`. Operators see every misconfiguration in a single pass:

- Empty / duplicate `name`.
- `type` other than `"quota"`.
- `scope` outside `{cluster, namespace}`.
- Cluster scope rejects `namespaceQuotas` and `exclude`.
- Namespace scope rejects `quotas`.
- Per-type values < `-1`.
- Empty accelerator type or namespace keys.
- **Warning (non-fatal)**: namespace appears in both `exclude` and
  `namespaceQuotas` — entry stays valid, `exclude` wins.

## Tests

All new tests use Ginkgo v2 + Gomega to match the project's existing suites.

| File | Specs | Coverage |
|------|-------|----------|
| `internal/config/quota_limiter_test.go` | 23 | `IsExcluded`, `QuotaForNamespace`, `Validate` (happy path + accumulating errors + table of error cases) |
| `internal/engines/pipeline/quota_inventory_test.go` | 27 | Cluster + namespace happy paths, exhaustion, missing-namespace, unknown-type, unlimited, exclude pass-through, default fallback, strict allowlist, combined cluster+namespace, DecisionStep emission contract (exact-match-pinned), `NamespaceAwareInventory` satisfaction, `GetResourcePools` for both scopes, totals, `Remaining` |
| `internal/engines/pipeline/composite_limiter_test.go` | 7 | Interface satisfaction, no-op paths, in-order invocation, most-restrictive-cap propagation, error fan-out, constituent introspection |
| `internal/engines/pipeline/limiter_factory_test.go` | 5 | Inventory mode, unknown-type rejection, single-entry quota → `DefaultLimiter`, multi-entry quota → `CompositeLimiter`, empty-entries error. Helpers use real YAML temp files via `GinkgoT().TempDir()` |
| `internal/engines/pipeline/default_limiter_namespace_test.go` | 3 | `NamespaceAwareInventory` receives `SetUsedByNamespace` with expected per-(ns,type) sums; missing-namespace/missing-type decisions skipped; plain `Inventory` implementations still work |
| `internal/engines/saturation/inventory_gate_test.go` | 4 | `shouldCollectClusterInventory` predicate |

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./internal/{config,engines/{pipeline,saturation}}/...` clean.
- [x] `gofmt -d` clean on all touched files (LF-normalized against autocrlf working tree).
- [x] `go test ./internal/config/... ./internal/engines/pipeline/...` on Windows → pass.
- [x] `go test ./internal/config/... ./internal/engines/pipeline/... ./internal/engines/saturation/...` in WSL + envtest 1.34.0 → all green, **23/23 saturation Ginkgo specs pass** (including the new `shouldCollectClusterInventory` table).
- [x] DCO sign-off present on every commit.

## Documentation

`docs/developer-guide/quota-limiter.md` (new) covers:

- Design overview and scope (single-instance per scope; chain composition is #1003).
- Configuration schema with examples.
- Special values (`-1`, `0`, missing).
- Namespace lookup rules including the per-namespace-budget semantic and the
  `default` key collision callout.
- Validation rules + warning behavior.
- Pipeline integration (current contract: `DefaultLimiter.Limit` unconditionally
  calls `SetUsed` and conditionally calls `SetUsedByNamespace` via feature
  detection; each `QuotaInventory` ignores the method irrelevant to its scope).
- Startup wiring (flags, factory dispatch, multi-entry composite).
- Resource-access contract in quota mode (combination matrix above).
- `DecisionStep` trace format.
- Future work (limiter chain composition, reservation-style limiters).

## Follow-ups (separate PRs)

- **#1003** — Limiter chain composition. Replace the simple
  `CompositeLimiter` with a smarter chain that:
  - Composes physical (`TypeInventory`) and quota bounds as
    `min(physical, quota)` instead of the current mutually-exclusive choice.
  - Owns `DecisionStep` ordering / `LimitedBy` selection when multiple caps
    bind the same decision.
- Reservation-style limiters — the `type: "quota"` discriminator leaves
  room for additional limiter types (`reservation`, `priority`) under the
  same ConfigMap schema.