### PR TITLE
 use cp instead of ln -s

### DIFF
--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -95,6 +95,20 @@ EOF
     log_info "Installing WVA CRDs..."
     kubectl apply -k "$WVA_PROJECT/config/base/crd/"
 
+    # When namespace-scoped, restrict the controller to its own namespace only.
+    # Copy (not symlink) the patch into the temp overlay — kustomize v5 blocks symlinks
+    # that point outside the kustomize root directory.
+    if [ "$NAMESPACE_SCOPED" = "true" ]; then
+        cp "$WVA_PROJECT/config/manager/namespace-scoped-patch.yaml" "$tmp_overlay/namespace-scoped-patch.yaml"
+        cat >> "$tmp_overlay/kustomization.yaml" <<'PATCH'
+patches:
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: ./namespace-scoped-patch.yaml
+PATCH
+    fi
+
     log_info "Applying Kustomize overlay: $kustomize_overlay"
     kubectl apply -k "$tmp_overlay"
 


### PR DESCRIPTION
Fix issue #1192 

When deploying WVA with NAMESPACE_SCOPED=true, the install script builds a temporary kustomize overlay in a scratch directory ($tmp_overlay). That overlay needs to reference config/manager/namespace-scoped-patch.yaml, which lives inside the WVA repo checkout ($WVA_PROJECT).

The original approach created a symlink from the temp directory into the repo:


```
ln -s "$WVA_PROJECT/config/manager/namespace-scoped-patch.yaml" \
      "$tmp_overlay/namespace-scoped-patch.yaml"
```

**The problem**

Kustomize v5 introduced a [security restriction](https://github.com/kubernetes-sigs/kustomize/issues/4867) that blocks symlinks whose target resolves outside the kustomize root directory. Because $tmp_overlay is a separate temp dir and the symlink target is inside $WVA_PROJECT (a completely different path), kustomize v5 refuses to follow the symlink and the build fails.

The Makefile downloads kustomize v5, so this affects all users of the deploy scripts.

**The fix**

Replace the symlink with a plain file copy:


cp "$WVA_PROJECT/config/manager/namespace-scoped-patch.yaml" \
   "$tmp_overlay/namespace-scoped-patch.yaml"
The temp directory is cleaned up (rm -rf "$tmp_overlay") immediately after kubectl apply -k, so no stale copies are left behind.

**Impact**

NAMESPACE_SCOPED=true deployments always failed silently or with a kustomize error on any environment running kustomize v5. The cluster-scoped path was unaffected.