### PR TITLE
ci: add stub workflow for multi-controller e2e job (3/4)

### DIFF
--- a/.github/workflows/ci-e2e-multi-controller.yaml
+++ b/.github/workflows/ci-e2e-multi-controller.yaml
@@ -1,0 +1,16 @@
+name: CI - E2E Multi-controller
+
+# Stub workflow for the dedicated dual namespace-scoped controllers e2e job.
+# A subsequent PR replaces the placeholder step with the real kind-based job
+# (mirroring `e2e-tests-smoke` in ci-pr-checks.yaml). The job name is fixed
+# now so branch-protection rules can reference it.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e-multi-controller:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stub
+        run: echo "stub - implementation lands in a follow-up PR"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci-e2e-multi-controller.yaml` as a stub: `workflow_dispatch` trigger, single placeholder step.
- The job name `e2e-multi-controller` is fixed now so branch-protection rules can reference it.

The full implementation (kind setup, image build, `make test-e2e-multi-controller-with-setup`) lands in PR 4.

This is **PR 3 of 4** for #1205. Independent of PR 1 and PR 2 — only adds a new workflow file.

## Test plan
- [x] YAML parses
- [ ] Workflow appears in the Actions tab and `workflow_dispatch` is available after merge

Refs #1205
