### PR TITLE
feat(chart): expose analyzerName and V2 thresholds in helm values

### DIFF
--- a/charts/workload-variant-autoscaler/templates/manager/wva-cp-configmap.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-cp-configmap.yaml
@@ -23,15 +23,27 @@ metadata:
 data:
   # Global defaults applied to all variants unless overridden
   default: |
+{{- if .Values.wva.capacityScaling.default.analyzerName }}
+    analyzerName: {{ .Values.wva.capacityScaling.default.analyzerName }}
+{{- end }}
     kvCacheThreshold: {{ .Values.wva.capacityScaling.default.kvCacheThreshold }}
     queueLengthThreshold: {{ .Values.wva.capacityScaling.default.queueLengthThreshold }}
     kvSpareTrigger: {{ .Values.wva.capacityScaling.default.kvSpareTrigger }}
     queueSpareTrigger: {{ .Values.wva.capacityScaling.default.queueSpareTrigger }}
+{{- if .Values.wva.capacityScaling.default.scaleUpThreshold }}
+    scaleUpThreshold: {{ .Values.wva.capacityScaling.default.scaleUpThreshold }}
+{{- end }}
+{{- if .Values.wva.capacityScaling.default.scaleDownBoundary }}
+    scaleDownBoundary: {{ .Values.wva.capacityScaling.default.scaleDownBoundary }}
+{{- end }}
 {{- if .Values.wva.capacityScaling.overrides }}
 {{- range $name, $override := .Values.wva.capacityScaling.overrides }}
   {{ $name }}: |
     model_id: {{ $override.modelID | quote }}
     namespace: {{ $override.namespace | quote }}
+{{- if $override.analyzerName }}
+    analyzerName: {{ $override.analyzerName }}
+{{- end }}
 {{- if $override.kvCacheThreshold }}
     kvCacheThreshold: {{ $override.kvCacheThreshold }}
 {{- end }}
@@ -43,6 +55,12 @@ data:
 {{- end }}
 {{- if $override.queueSpareTrigger }}
     queueSpareTrigger: {{ $override.queueSpareTrigger }}
+{{- end }}
+{{- if $override.scaleUpThreshold }}
+    scaleUpThreshold: {{ $override.scaleUpThreshold }}
+{{- end }}
+{{- if $override.scaleDownBoundary }}
+    scaleDownBoundary: {{ $override.scaleDownBoundary }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -68,11 +68,24 @@ wva:
   capacityScaling:
     # Global defaults applied to all variants unless overridden
     default:
+      # Saturation analyzer selection.
+      # "saturation" (default) — V2 token-based analyzer: reads real KV-memory capacity
+      #                from vllm:cache_config_info, aggregates demand across running
+      #                requests, waiting queue, and EPP queue, and steers scale-up toward
+      #                the cheapest variant first.
+      # ""           — V1 percentage-based analyzer (legacy; set explicitly to opt out of V2)
+      analyzerName: saturation
+
+      # V1 thresholds (used by the default analyzer and as saturation checks in V2)
       kvCacheThreshold: 0.80      # Replica saturated if KV cache utilization >= threshold (0.0-1.0)
       queueLengthThreshold: 5     # Replica saturated if queue length >= threshold
       kvSpareTrigger: 0.1         # Scale-up if avg spare KV capacity < trigger (0.0-1.0)
       queueSpareTrigger: 3        # Scale-up if avg spare queue capacity < trigger
-    
+
+      # V2 thresholds (only used when analyzerName: saturation; controller defaults apply when 0)
+      scaleUpThreshold: 0         # Utilization fraction above which scale-up triggers (controller default: 0.85)
+      scaleDownBoundary: 0        # Utilization fraction below which scale-down is safe (controller default: 0.70)
+
     # Per-model/namespace overrides (optional)
     # Example:
     # overrides:
@@ -81,6 +94,9 @@ wva:
     #     namespace: "llm-d-autoscaler"
     #     kvCacheThreshold: 0.70
     #     kvSpareTrigger: 0.35
+    #     analyzerName: saturation   # override analyzer for this model only
+    #     scaleUpThreshold: 0.80
+    #     scaleDownBoundary: 0.65
     overrides: {}
 
 llmd:


### PR DESCRIPTION
Closes #1231

## What

Adds `analyzerName`, `scaleUpThreshold`, and `scaleDownBoundary` to
`wva.capacityScaling.default` (and to the per-model overrides schema)
in the WVA helm chart, and makes **V2 the default analyzer**.

### Default behavior after this PR

A plain `helm install workload-variant-autoscaler` now produces:

```yaml
data:
  default: |
    analyzerName: saturation
    kvCacheThreshold: 0.8
    queueLengthThreshold: 5
    kvSpareTrigger: 0.1
    queueSpareTrigger: 3
```

The controller's `ApplyDefaults()` fills in `scaleUpThreshold: 0.85`
and `scaleDownBoundary: 0.70` when those fields are absent.

### Opt out (revert to V1)

```yaml
wva:
  capacityScaling:
    default:
      analyzerName: ""
```

### Override thresholds

```yaml
wva:
  capacityScaling:
    default:
      analyzerName: saturation
      scaleUpThreshold: 0.80    # tighter than the 0.85 default
      scaleDownBoundary: 0.65
```

## ⚠️ Breaking change note

Changing `analyzerName` default from `""` (V1) to `"saturation"` (V2)
is a **behavior-changing default**. Anyone upgrading the chart without
explicitly pinning `analyzerName: ""` in their values file will silently
switch from V1 to V2.

V2 uses real KV-memory capacity from `vllm:cache_config_info` instead
of percentage thresholds, which requires the model server to emit that
metric (available in vLLM ≥ 0.9.x). Deployments on older vLLM versions
or those that suppressed `cache_config_info` will fall back gracefully
(V2 has a `computeReplicaCapacityFallback` path), but the scaling
behavior will differ from V1.

**Recommendation for maintainers:** call this out in the CHANGELOG and
consider bumping the chart's minor version when this is released.

## Files changed

| File | Change |
|------|--------|
| `charts/workload-variant-autoscaler/values.yaml` | `analyzerName: saturation` as default; add `scaleUpThreshold: 0`, `scaleDownBoundary: 0`; update overrides example comment |
| `charts/workload-variant-autoscaler/templates/manager/wva-cp-configmap.yaml` | Conditionally emit all three fields for `default` and per-model override entries |

## Testing

```bash
# Default — V2 is active
helm template r ./charts/workload-variant-autoscaler \
  | grep -A6 'default: |'
# analyzerName: saturation
# kvCacheThreshold: 0.8  ...

# Opt-out — V1 only
helm template r ./charts/workload-variant-autoscaler \
  --set wva.capacityScaling.default.analyzerName="" \
  | grep -A6 'default: |'
# kvCacheThreshold: 0.8  ...  (no analyzerName line)
```

## Related

- `llm-d/llm-d-benchmark#1451` — multi-variant WVA benchmark; once this
  PR is released, the standalone `two-variant-wva-v2-config.yaml`
  ConfigMap and the separate `kubectl apply` step in that guide can be
  removed.