### PR TITLE
docs(proposals): minimal ScalingPolicy CRD core (split from #1194)

### DIFF
--- a/docs/proposals/design-scalingpolicy-crd.md
+++ b/docs/proposals/design-scalingpolicy-crd.md
@@ -1,144 +1,220 @@
-# Proposal: ScalingPolicy CRD — minimal core
+# Proposal: WVA scaling configuration — schema and resolution (ConfigMap first, CRD later)
 
-## Scope
+## Problem — what this addresses
 
-This is the **bare-minimum** core of the WVA configuration CRD, split out from the broader analysis in **#1194** (kept open for reference). Per review, it answers the two questions that gate the design — and settles only the minimum they force (the resolution tiers and the status surface):
+Today WVA is configured by **one cluster-wide ConfigMap** plus **per-workload labels/annotations** on the KEDA `ScaledObject` (`llm-d.ai/managed`, `llm-d.ai/model-id`, `inference.optimization/acceleratorName`). That is enough for a single global configuration, but it cannot express:
 
-1. **What is the relationship between the Config CRD and the HPA object?** (§2)
-2. **What is the generic shape (schema) of the CRD?** (§3)
+- **per-namespace or per-pool policy** — every workload shares one global `priority`, `scaleToZero`, and analyzer configuration;
+- **an ownership boundary** — cluster-admin-owned enforcement (GPU limiters / quota) and tenant-owned tuning (thresholds, priority) live in the same undifferentiated blob, with no way to give them different RBAC;
+- **validation** — a typo in the ConfigMap is silently ignored;
+- **a resolved-configuration surface** — an operator cannot see *what policy WVA actually applied* to a given pool.
 
-Everything else from #1194 — migration tooling, deprecation phases, the full status-condition catalog, per-role detail, alternatives, comparison matrices — is **deliberately deferred** (§6); the dependency on the VA-deprecation proposal (discovery, cost source) and one remaining open question are in §5. The goal here is to agree the CRD's *boundary* and *shape* first; the rest layers on top without changing either.
+This proposal fixes the configuration **schema** and **resolution** (the fields, the scope tiers, the pluggable-plugin envelope, and the merge order). It is **transport-neutral** and lands in two phases:
 
-## 1. The object
+- **Phase 1 — extend the existing ConfigMap** with this schema. No CRD, no migration, no new install step. Validation via `ValidatingAdmissionPolicy` (CEL) + the controller; the ownership boundary via RBAC. This is the minimal core.
+- **Phase 2 — promote the schema to a `ScalingPolicy` CRD** when field-level typed validation, `kubectl explain`, and a native `.status` are worth the operational cost of a CRD (§6). Same schema, same resolution — a delivery upgrade, not a redesign.
 
-One namespaced CRD, `ScalingPolicy` (`scaling.llm-d.ai/v1alpha1`), carries WVA's scaling configuration. It is matched to a workload through that workload's **`InferencePool`** (defined by the Gateway API Inference Extension; the workload→pool link is the pool's pod selector) — not through the workload, and not through its HPA:
+It does **not** change how WVA *actuates* (it still emits `wva_desired_replicas` for a `ScaledObject`, §3) or how it *identifies* the workloads it manages (§7).
+
+## Optional and backward-compatible
+
+The structured configuration is **optional and additive**. A workload with only the managed labels keeps scaling under WVA's defaults exactly as today — the schema adds *scoped overrides*, it does not become required. Upgrading an existing cluster needs **no migration**: phase 1 *is* the ConfigMap WVA already reads, with more structure in it. Fields that exist today (`priority`, `scaleToZero`, analyzer settings, limiter selection) keep their current meaning at the cluster tier; per-namespace and per-pool scoping is the new capability.
+
+**Before / after — the cluster tier is today's ConfigMap, restructured.** Today's flat cluster config gains a scope label and the typed shape; the values carry over:
 
 ```yaml
+# today (illustrative): one global ConfigMap
+data: { priority: "1.0", scaleToZero: "false", analyzer: "saturation", scaleUpThreshold: "0.9" }
+# phase 1: same values, structured, labelled as the cluster-default tier (§2)
+metadata: { labels: { scaling.llm-d.ai/config: "true", scaling.llm-d.ai/tier: cluster } }
+data:
+  config: |
+    priority: 1.0
+    scaleToZero: { enabled: false }
+    analyzers: [ { type: saturation, parameters: { scaleUpThreshold: 0.9 } } ]
+    limiters:  [ { type: gpu-inventory } ]      # admin-only, cluster tier
+```
+
+**Minimal usage.** A pool with no `ScalingPolicy`/ConfigMap of its own scales under the cluster default (unchanged behavior). To raise one pool's priority, a tenant adds *just* the per-pool object with only the delta:
+
+```yaml
+metadata: { namespace: production, labels: { scaling.llm-d.ai/config: "true", scaling.llm-d.ai/tier: pool, scaling.llm-d.ai/pool: granite-premium-pool } }
+data: { config: "inferencePoolRef: { name: granite-premium-pool }\npriority: 2.0" }
+```
+
+Everything else (`scaleToZero`, `behavior`, `analyzers`) inherits from the tiers above (§2).
+
+## 1. The configuration object and how it is matched
+
+The configuration is **one schema** carried by one object per scope:
+
+- **Phase 1:** a ConfigMap whose `data` holds the schema as a YAML document (one per tier, §2).
+- **Phase 2:** a namespaced `ScalingPolicy` custom resource (`scaling.llm-d.ai/v1alpha1`).
+
+It is matched to a workload through that workload's **`InferencePool`** (the Gateway API Inference Extension object; the workload→pool link is the pool's pod selector) via `inferencePoolRef` — **not** through the workload and **not** through its `ScaledObject`. The config points at the pool; the pool's workloads carry no reference back.
+
+```yaml
+# Phase 2 (CRD) form — the phase-1 ConfigMap carries the same document under data:
 apiVersion: scaling.llm-d.ai/v1alpha1
 kind: ScalingPolicy
-metadata:
-  name: granite-premium-priority
-  namespace: production
+metadata: { name: granite-premium-priority, namespace: production }
 spec:
-  inferencePoolRef:
-    name: granite-premium-pool      # the pool this policy configures
-  priority: 2.0
-  scaleToZero: { enabled: false }
+  inferencePoolRef: { name: granite-premium-pool }   # the pool this config governs (per-pool tier)
+  priority: 2.0                                       # per-model; see §2
+  scaleToZero: { enabled: false }                     # per-model
+  behavior:                                           # per-model; autoscaling/v2 HPA behavior (§4)
+    scaleDown: { stabilizationWindowSeconds: 300 }
   analyzers:
     - type: saturation
-      parameters: { scaleUpThreshold: 0.95 }
+      parameters: { scaleUpThreshold: 0.95 }          # plugin-owned; see §4
 ```
 
-The policy **points at the pool**; the pool's workloads carry no reference back to the policy. Why that direction matters is §2.
+The tunable field families and their meaning, defined here so nothing below is referenced before it is defined:
 
-## 2. Relationship to the HPA / ScaledObject (review question 1)
+- **`priority`** *(per-model)* — the model's weight when models contend for a shared GPU budget. It is only meaningful **relative to other models drawing on the same budget**: within a namespace quota if one exists, otherwise the shared cluster budget (so priority *does* compose across un-quota'd namespaces on the same accelerator type — how it does is engine/rescale territory, not this schema). It is not comparable across *independent* budgets. Default `1.0`.
+- **`scaleToZero`** *(per-model)* — whether WVA may emit a desired count of `0` for an idle model (§3).
+- **`behavior`** *(per-model, tenant-tunable)* — the HPA-style stabilization behavior WVA applies to its own recommendation (trailing windows, per-period rate policies, tolerance) before emitting it. This is a **typed** field reusing `k8s.io/api/autoscaling/v2` `HorizontalPodAutoscalerBehavior` verbatim (§4); its *shape* is fixed here, its *algorithm* is the stabilization proposal's.
+- **`analyzers`** *(per-model, tenant-tunable)* — the saturation/queueing analysis plugins and their thresholds (§4). Per-**role** (prefill/decode) tuning lives *inside* an analyzer's `parameters`, not as top-level fields (§5).
 
-**They own different things:** WVA owns the scaling decision, the HPA owns actuation. `ScalingPolicy` configures the decision; the HPA actuates it by reading WVA's `wva_desired_replicas` metric. Neither the policy nor the HPA references the other's *config*. WVA reads the HPA/`ScaledObject` to identify the workloads it manages, but the *mechanism* (the #1130 label) is the **VA-deprecation proposal's** — and this CRD's shape does not depend on it.**
+`limiters`/`quota` are **not** in that list — they are admin-only and cluster-scoped (§2).
 
-| | Owns | Reads | Writes |
+## 2. Scope tiers — one schema, up to three placements
+
+The surface is **one schema**, resolved at up to **three placements of it** — not three schemas, not three kinds — by a deterministic lookup in fixed order. In phase 1 each placement is a ConfigMap; in phase 2 each is a `ScalingPolicy` object.
+
+1. **Cluster-default** — in the system namespace, no `inferencePoolRef`. **Admin-owned.**
+2. **Namespace-default** — in the workload's namespace, no `inferencePoolRef`. **Tenant-owned.**
+3. **Per-pool** — in the workload's namespace, `inferencePoolRef` set. **Tenant-owned.** A workload-specific policy is *just this placement* — it needs only the fields it overrides.
+
+**How the controller finds a tier (phase 1).** A CRD has identity from its kind, namespace, and `spec.inferencePoolRef`; a ConfigMap does not, so phase 1 classifies ConfigMaps by a fixed label set the controller watches (`scaling.llm-d.ai/config: "true"`):
+
+| tier | namespace | labels |
+|---|---|---|
+| cluster-default | system (`workload-variant-autoscaler-system`) | `scaling.llm-d.ai/tier: cluster` |
+| namespace-default | workload's | `scaling.llm-d.ai/tier: namespace` |
+| per-pool | workload's | `scaling.llm-d.ai/tier: pool`, `scaling.llm-d.ai/pool: <inferencePool>` |
+
+The controller resolves a workload's policy from the labelled ConfigMaps in (system-ns, workload-ns); the `inferencePoolRef` inside the document must agree with the `pool` label (admission-checked). In phase 2 this labelling goes away — the CR's kind + namespace + `spec.inferencePoolRef` are the identity.
+
+**Resolution is inheritance, not replacement.** Fields merge **cluster → namespace → per-pool**, higher tier winning **per field** — a per-pool object that sets only `priority` inherits `scaleToZero`, `behavior`, and `analyzers` from the tiers above it. `analyzers` merge **by `name`** (§4): a lower tier can add or replace an analyzer entry without redeclaring the others. Note the granularity: because a plugin's `parameters` is **opaque** to the envelope (§4), it cannot be structurally deep-merged — a same-`name` entry **replaces the whole `parameters` block**, it does not patch one key. So a tenant writes the minimum set of *entries*, but retuning one threshold means restating that analyzer's `parameters`. This is the "narrower than intended" point from review: real per-field/per-entry inheritance across tiers, with parameters as the replace-granular leaf.
+
+**One kind, two purposes — deliberately.** The same schema serves two owners because it is placed differently and gated by different RBAC: at the **cluster-default** tier it is the admin's **enforcement** carrier (limiters/quota); at the **namespace/per-pool** tiers it is the tenant's **tuning** surface (priority, scaleToZero, analyzers). This dual purpose is intentional — one schema and one merge, partitioned by placement and RBAC, rather than two objects to keep in sync.
+
+**Which fields live at which tier:**
+
+| field family | tiers allowed | owner | rationale |
 |---|---|---|---|
-| **HPA / KEDA `ScaledObject`** (tenant-owned) | replica **actuation** | the `wva_desired_replicas` metric | the workload's `spec.replicas` |
-| **WVA controller** | the scaling **decision** | `ScalingPolicy`, cluster/pool state, and the HPA/`ScaledObject` that marks its managed workloads (per the VA-deprecation proposal) | the `wva_desired_replicas` metric (+ `ScalingPolicy.status`) |
-| **`ScalingPolicy` CRD** | the scaling **policy** (priority, thresholds, scale-to-zero, quota) | — | — |
+| `analyzers`, `priority`, `scaleToZero` | any tier | tenant (ns/pool), admin sets cluster defaults | per-model tuning; safe to delegate |
+| **`limiters` / `quota`** | **cluster-default only** | **admin** | instance-wide **enforcement**, not a tenant knob |
 
-The data flow is one-directional:
+**`limiters`/`quota` are cluster-default-only, and this is a security boundary, not a style choice.** They are excluded from the merge entirely — a lower tier can neither override nor remove them. That is why **`inferencePoolRef` and `limiters` never co-occur**: `limiters` exist only on the cluster-default, which by definition has no `inferencePoolRef`. If a tenant could set `limiters` on a policy they own, they could drop the `quota` limiter (or set `limiters: []`) and **escape their own cap**.
+
+The isolation **guarantee** is RBAC plus the controller; admission is only UX:
+
+1. **RBAC (the guarantee)** — tenants have no permission to write the cluster-default (it lives in the system namespace). Identical in both phases; this is what actually prevents cap-escape.
+2. **Controller (defense in depth)** — WVA only honors `limiters`/`quota` from the cluster-default tier; a `limiters` block on a tenant-tier object is *ignored*, so even a mis-scoped config cannot weaken enforcement.
+3. **Admission (feedback, not a control)** — a **`ValidatingAdmissionPolicy` (CEL)** rejects a namespace/per-pool config carrying `limiters` so the tenant gets an immediate error instead of a silent ignore. In phase 1 this is a string-level check on the ConfigMap document (a regex, not a security boundary); phase 2's CRD `x-kubernetes-validations` makes it field-precise (§6). It is convenience over (1)+(2), never a substitute for them.
+
+**`analyzers` and `limiters` type selection vs. the controller's global mode.** The analyzer *type* a policy names (`saturation`, `queueing`) selects a plugin; whether the engine runs the V1 or V2 analysis pipeline, and whether the GPU limiter is active at all, are **controller-global modes** (today: the `enableLimiter` / analyzer-version switches), not per-policy fields. A policy *configures* the analyzers/limiters the controller is running; it does not turn the pipeline on or off. Keeping that boundary explicit answers "is the analyzer type global?" — the *pipeline* is; the *plugin selection and parameters* are policy.
+
+**Two objects matching the same scope** (two per-pool policies for one pool, or two namespace-defaults in one namespace) are a configuration error. This is a *set* invariant — admission (VAP or CRD CEL) validates one object in isolation and cannot see siblings — so it is **detected by the controller**, which refuses to resolve an ambiguous scope and raises a `Conflict` (a duplicate on a status-bearing object; a controller log/event in the status-less phase-1 ConfigMap case) rather than picking one non-deterministically.
+
+## 3. Relationship to the `ScaledObject` (review question 1)
+
+WVA and the scaler own **different things, on different objects**:
+
+- **WVA** computes the scaling **decision** and publishes it as the `wva_desired_replicas` **metric**. It configures *its own* decision via this schema. It does **not** create, own, or write the `ScaledObject`, and never sets `spec.replicas`.
+- The **KEDA `ScaledObject`** (the scaler WVA integrates with) is a **standalone autoscaler** owned by the tenant. It actuates `spec.replicas` from whatever metrics it is configured with — WVA simply supplies one of them (`wva_desired_replicas`). It can scale without WVA; WVA feeds it a signal.
+
+So there is **no configuration cross-reference in either direction**: the config points at the `InferencePool`, not the `ScaledObject`; the `ScaledObject` references the metric, not any WVA config object. Configuring WVA never means editing a tenant's `ScaledObject`.
 
 ```
-ScalingPolicy ──configures──▶ WVA ──emits──▶ wva_desired_replicas ──read by──▶ HPA / ScaledObject ──sets──▶ spec.replicas
+ScalingConfig ─configures→ WVA ─emits→ wva_desired_replicas ─read by→ ScaledObject ─sets→ spec.replicas
 ```
 
-The consequences answer the question directly:
+Consequences:
 
-- **No config cross-reference.** The HPA / `ScaledObject` carries no reference to a WVA *config* object, and `ScalingPolicy` points at the `InferencePool`, **not** the HPA — so configuring WVA never means editing a tenant's HPA. The HPA's tie to WVA is that it reads the `wva_desired_replicas` metric to actuate. (An `HPA → ScalingPolicy` config reference would put a WVA-specific field on every workload — that's what this avoids.)
-- **WVA never *writes* tenant-owned objects.** It does not set `spec.replicas` or modify the HPA / `ScaledObject`; it publishes the `wva_desired_replicas` metric, which the HPA consumes. WVA *does* **read** the HPA/`ScaledObject` to identify its managed set — the mechanism (the `llm-d.ai/managed` label on those objects, #1130) belongs to the VA-deprecation proposal, not this one.
-- **HPA `maxReplicas` stays, as a complementary hard ceiling.** `ScalingPolicy` does not replace it: WVA's desired count is clamped by the HPA exactly as today. `ScalingPolicy` sets the *policy* WVA decides within; `maxReplicas` is the tenant's final per-workload safety cap.
-- **Scale-to-zero is a policy toggle, actuated by the HPA layer.** `spec.scaleToZero.enabled` lets WVA emit a desired of 0; KEDA/HPA actuate it. WVA decides 0; it does not force it.
+- **`maxReplicas` stays** as the tenant's hard per-workload ceiling on the `ScaledObject`. WVA's desired count is clamped by it exactly as today; the config sets the *policy* WVA decides within, not the safety cap.
+- **Scale-to-zero** — `scaleToZero.enabled` lets WVA emit a desired of `0`; the `ScaledObject` (with KEDA's idle-replica support) actuates it.
+- **Managed-set identification is unchanged.** WVA discovers the workloads it manages from the `llm-d.ai/managed` label on the `ScaledObject` (and reads `llm-d.ai/model-id`, `inference.optimization/acceleratorName`) — the current mechanism. This proposal does not change it (§7).
 
-**Net:** a workload is *configured* via its pool (§1's "not through the HPA") and *actuated* via the metric; the CRD sits *upstream* of that metric, so it slots into the existing HPA/KEDA flow without modifying it. How a workload is *identified as WVA-managed* is the VA-deprecation proposal's, not here.
+## 4. The generic schema shape (review question 2)
 
-## 3. The generic schema shape (review question 2)
-
-The CRD is a **thin typed envelope around pluggable, schemaless plugin lists** — so the schema itself is small and fixed, and new analyzers/limiters never change it. Two validation tiers, deliberately:
+The schema is a **thin typed envelope around pluggable, schemaless plugin lists**, so the envelope is small and fixed and new plugins never change it:
 
 ```yaml
-spec:
-  # (a) typed, cross-cutting fields — OpenAPI/CEL-validated, `kubectl explain`-able
-  inferencePoolRef: { name: granite-premium-pool }   # per-pool only; mutually exclusive with limiters (§4)
-  priority: 2.0
-  scaleToZero: { enabled: false }
+# (a) cross-cutting fields — typed, well-known schemas, validated
+inferencePoolRef: { name: granite-premium-pool }   # match key (per-pool tier only)
+priority: 2.0
+scaleToZero: { enabled: false }
+behavior:                      # k8s.io/api/autoscaling/v2 HorizontalPodAutoscalerBehavior, verbatim
+  scaleDown: { stabilizationWindowSeconds: 300, policies: [ { type: Percent, value: 100, periodSeconds: 60 } ] }
 
-  # (b) pluggable lists — {type, name, parameters}; `parameters` is plugin-owned
-  analyzers:                          # one or more; TENANT-tunable, any tier
-    - type: saturation
-      name: sat                       # identity, used for cross-tier merge
-      parameters:                     # x-kubernetes-preserve-unknown-fields
-        scaleUpThreshold: 0.95
-  limiters:                           # zero or more; chain; CLUSTER-DEFAULT ONLY (admin)
-    - type: gpu-inventory
-    - type: quota                     # parameters schema owned by #1162
+# (b) plugin lists — {type, name, parameters}; parameters is plugin-owned
+analyzers:                     # per-model, tenant-tunable, any tier
+  - type: saturation
+    name: sat                  # identity for cross-tier merge; defaults to `type`
+    parameters:                # opaque to the envelope; each plugin validates its own
+      scaleUpThreshold: 0.95
+limiters:                      # cluster-default only (§2)
+  - type: gpu-inventory
+  - type: quota                # parameters owned by the quota work (#1162)
 ```
 
-*Field catalog, not a single valid object: a real `ScalingPolicy` is one tier, and `inferencePoolRef` and `limiters`/`quota` never co-occur — limiters live only on the cluster-default, which has no `inferencePoolRef` (§4).*
+- **(a) cross-cutting fields** (`priority`, `scaleToZero`, `behavior`, `inferencePoolRef`) are the small stable set. Each has a **fixed, well-known schema** — `behavior` in particular is `autoscaling/v2` `HorizontalPodAutoscalerBehavior` reused verbatim (a k8s building block, not a WVA invention). In **phase 2** they are OpenAPI-typed and `kubectl explain`-able; in **phase 1** the controller validates them on load and a `ValidatingAdmissionPolicy` guards the coarse shape.
+- **(b) plugin lists** are name-keyed `{type, name, parameters}` — the **EPP `EndpointPickerConfig` shape** reused so the plugin-list convention is one WVA already ships as an InferencePool consumer, not a bespoke one. **`parameters` is opaque to the envelope** (phase 2: `x-kubernetes-preserve-unknown-fields`) — each plugin validates its own. `name` keys the cross-tier merge (replace-granular, §2), **defaults to `type`** for a single instance, and must be unique within a tier.
 
-- **(a) Stable typed fields** — the tunable cross-cutting fields (`priority`, `scaleToZero`) and the match key (`inferencePoolRef`) are **typed**: OpenAPI/CEL-validated, discoverable via `kubectl explain`.
-- **(b) Plugin lists** (`analyzers`, `limiters`) are name-keyed `{type, name, parameters}` where **`parameters` is `x-kubernetes-preserve-unknown-fields`** — each plugin validates its own at load. This reuses the **EPP `EndpointPickerConfig` shape** (not its config — both sides merely read the `InferencePool`). `name` keys the cross-tier merge (§4) and **defaults to `type`** for a single instance; it's required only for two instances of one `type`, and must be unique within a tier (admission-enforced).
-- **Tenant-tunable vs admin-only — an isolation boundary, not a style choice.** `analyzers`, `priority`, and `scaleToZero` are tenant-tunable at any tier. **`limiters` (and `quota`) are cluster-default-only**: they are *instance-wide enforcement*, not tenant knobs. A **CEL rule rejects `limiters`/`quota` on any namespace or per-pool `ScalingPolicy`**, and tenants have no RBAC to write the cluster-default object (it lives in the system namespace). This is load-bearing for security: if a tenant could set `limiters` on a policy they own, they could drop the `quota` limiter — or set `limiters: []` — and **escape their own cap**. So `limiters`/`quota` are never authored, merged, or overridable below the cluster-default tier (§4).
+**This is what keeps the surface generic — and why one config object suffices rather than a new CRD per feature.** Adding an analyzer or limiter ships *its own* `parameters` keys; the envelope does not change. A future `optimizer` block slots in the same way with no redesign. This directly answers the "won't we keep needing new CRDs / should the kind be more general" concern: the envelope *is* the generality — the plugin list absorbs new config without a schema change, so a single `ScalingPolicy` (or its phase-1 ConfigMap) does not need to become a broader kind to grow.
 
-The one property that makes the shape "generic": **adding an analyzer or limiter ships its own `parameters` keys and the CRD schema does not change.** The optimizer is a single fixed stage with nothing to configure today; the schema leaves room for a `spec.optimizer` block later with no redesign.
+**Schema vs. engine — the boundary this proposal draws.** This document fixes the **schema and resolution** only: the fields, the tiers, the merge, the plugin envelope, and the `status` *shape*. It does **not** specify engine behavior — how an analyzer resolves a threshold, how per-role parameters are applied, how the optimizer consumes `priority`. Those are engine concerns, tracked separately, and are deliberately left open so the schema can be agreed without pinning the implementation.
 
-(The `quota` limiter's `parameters` schema and its cluster-scope enforcement are owned by **#1162** / issue #1002 — quota lives on this surface, but its shape is settled there, not here.)
+## 5. Per-role (prefill/decode) configuration
 
-## 4. Why more than one tier (the quota constraint)
+Per-role tuning is a real need for disaggregated (P/D) models, and it has a clear home: **inside an analyzer's `parameters`** (e.g. a `roleOverrides` block), **not** as top-level fields. The reason is ownership of the concern — `priority` and `scaleToZero` are **per-model** decisions (the whole model scales to zero, or has a priority), while role-specific thresholds are **per-analyzer** knobs. So the envelope carries no `prefill`/`decode` fields; a P/D model configures both roles through the analyzer plugin that understands them:
 
-The surface is still **one CRD**. It is resolved at up to **three placements** of that same object — not three schemas and not three kinds — by a deterministic lookup in fixed order:
+```yaml
+analyzers:
+  - type: saturation
+    parameters:
+      roleOverrides:
+        prefill: { scaleUpThreshold: 0.90 }
+        decode:  { scaleUpThreshold: 0.95 }
+```
 
-1. **Cluster-default** — `ScalingPolicy` in the system namespace, no `inferencePoolRef`.
-2. **Namespace-default** — `ScalingPolicy` in the workload's namespace, no `inferencePoolRef`.
-3. **Per-pool** — `ScalingPolicy` in the workload's namespace, `inferencePoolRef` set.
+*Applying* per-role thresholds is an **engine** change (resolving and enforcing role-scoped parameters), out of scope here and tracked separately — this proposal only fixes that per-role config is a `parameters` concern, so it needs no envelope change.
 
-Fields merge cluster → namespace → per-pool (higher tier wins; `analyzers` merge by `name`). **`limiters` and `quota` are excluded from the merge entirely — they exist *only* on the cluster-default tier** (CEL-rejected on the others, §3), so a lower tier can neither override them nor remove them. A tenant cannot weaken or delete their own cap by editing a policy they own; the only objects they can write (namespace / per-pool) cannot carry a limiter at all.
+## 6. Surfacing the resolved configuration (status) — and the CRD's phase-2 value
 
-Two `ScalingPolicy` objects matching the **same** scope (two per-pool policies for one pool, or two namespace-defaults in one namespace) are a configuration error, **rejected at admission** — so resolution is always deterministic, never order- or name-dependent.
-
-**Two tiers are forced by ownership, not preference.** Quota is **cluster-admin-owned and cluster-scoped** (a tenant must not raise their own cap, and a cluster aggregate needs a cluster-wide view — per-namespace instances would each see full node inventory and collectively overcommit); thresholds/`priority`/`scaleToZero` are **tenant-owned and namespace-scoped**. Different owners, different RBAC — they can't share one object without letting tenants edit quota or admins own every tenant's thresholds. So **cluster-default + namespace are structural, not convenience.**
-
-The **third (per-pool) tier costs no extra schema** — it is the *same* CRD with `inferencePoolRef` set, in the tenant's namespace, adding override *granularity*, not a new surface. So "multiple levels" is three placements of one object resolved by a small deterministic merge — not three configuration systems.
-
-### Status — surfacing the resolution
-
-The per-pool object's status publishes both *what was resolved* and *what it governs* — so `kubectl get scalingpolicy <name> -o yaml` shows exactly what WVA decided, no unseen algorithm (for pools with a per-pool object; §5 covers default-only pools):
+An operator must be able to see *what WVA actually decided* for a pool — the merged policy and the workloads it governs — without reverse-engineering the merge. The **shape** of that surface:
 
 ```yaml
 status:
-  managedVariants:                     # variants WVA manages in this pool (managed set; identified per VA-deprecation proposal)
+  effectivePolicy: { … }          # merged result (cluster → ns → per-pool)
+  sources: [ … ]                  # which tier each field came from, in precedence order
+  managedVariants:                # workloads WVA manages in this pool (managed set, §7)
     - workloadRef: { kind: Deployment, name: granite-premium-prefill }
-      role: prefill                    # when known
-      cost: 40.0                       # per-replica $/hr (see source below)
-    - workloadRef: { kind: Deployment, name: granite-premium-decode }
-      role: decode
-      cost: 24.0
-  effectivePolicy: { … }               # merged result (cluster → ns → per-pool)
-  sources: [ … ]                       # contributing tiers, in precedence order
+      role: prefill               # when known
+      cost: 40.0                  # per-replica $/hr — the stable cost input, surfaced here
+  conditions: [ { type: PolicyMatched, … } ]   # False when no managed workload matched
 ```
 
-- **`effectivePolicy`** (+ **`sources`**) — the merged result and which tier each field came from.
-- **`managedVariants`** — the workloads this policy manages, each with `workloadRef`, `role`, and per-replica `cost`. *Which* workloads and *how* they're identified is the VA-deprecation proposal's (§5); this fixes only the **shape**. It is **distinct from pool membership** (an unmanaged pool member wouldn't appear); `cost` is a stable input surfaced so the cost basis of each decision is visible in one place; an **empty list** (no managed workloads) raises `PolicyMatched: False`. Live replica counts stay in the metric — status holds the stable mapping.
+- **`effectivePolicy` + `sources`** make the merge auditable in one place.
+- **`managedVariants`** is the policy→workload mapping (distinct from pool membership — an unmanaged pool member does not appear); `cost` is surfaced so the basis of each scaling decision is visible. *Which* workloads and *how* they are identified, and where `cost` is sourced, are the VA-deprecation proposal's (§7) — this fixes only the shape.
 
-## 5. Dependencies and open questions
+**Be explicit: phase 1 is config-only — this visibility does not exist yet.** A ConfigMap has no `.status`, so in phase 1 there is **no `kubectl get` view of the merged policy**; the resolved configuration is surfaced (if at all) by a `wva-config explain <pool>` command or a WVA-maintained status-only object, otherwise deferred. Do not expect the effective-policy surface in phase 1. **This is the concrete reason the CRD earns phase 2:** promoting to the CRD gives a **native, per-object `.status`**, plus **field-level typed validation** (`x-kubernetes-validations` walking the actual fields, vs. phase-1 string checks on the ConfigMap blob) and **`kubectl explain`**. Security is *not* on that list — RBAC + controller enforcement (§2) already secure phase 1 — so the CRD is a validation/UX/observability upgrade, taken when its cost is justified, not a prerequisite.
 
-**Depends on the VA-deprecation proposal — not decided here.** That proposal owns how WVA identifies the workloads it manages and where per-variant `cost` is sourced. This proposal fixes only the **shape** of `managedVariants` (`workloadRef`, `role`, `cost`) and is independent of the mechanism. *(For context: that proposal marks managed objects with the `llm-d.ai/managed` label on the HPA/`ScaledObject` (#1130), which WVA reads — so per-variant `cost` would co-locate there; `cost` comes from the `VariantAutoscaling` CR until then.)*
+**Open question — where the effective config is shown for a pool with no per-pool object.** Per-pool objects are optional, so a pool governed by the namespace/cluster default alone has no per-object status in phase 2 either. Candidate homes: the `InferencePool` status, a WVA status-only object per managed pool, or the `wva-config explain` view. Unresolved; the same answer serves both phases.
 
-**Open — where is the effective policy published for a pool with no per-pool object?** `effectivePolicy` / `managedVariants` are shown on the per-pool `ScalingPolicy` status — but per-pool objects are **optional** (a pool governed by the namespace/cluster default alone has none), so today the resolved policy is invisible in exactly the common case. Candidate homes: the `InferencePool` status, a WVA-maintained status-only object per managed pool, or a `wva-config explain <pool>` view. Unresolved.
+## 7. Dependencies and out of scope
 
-## 6. Deliberately out of scope (deferred to #1194)
+**Managed-set identification and per-variant cost are not decided here.** How WVA identifies the workloads it manages, and where per-replica `cost` comes from, are owned by the **VA-deprecation proposal**. For context: managed workloads are marked with the `llm-d.ai/managed` label on their `ScaledObject`, which WVA reads; per-variant `cost` comes from the `VariantAutoscaling` CR until that proposal relocates it. This proposal fixes only the **shape** of `managedVariants` and is independent of the mechanism.
 
-To hold this to the bare minimum, the following are **not** decided here and remain in #1194 for reference:
+Deferred (a later revision or companion proposal):
 
-- Migration path and the `wva-config` CLI / migration tool.
-- Deprecation phases and the ConfigMap-removal timeline.
-- The full `status` schema beyond what's defined above — the fields `effectivePolicy`, `sources`, `managedVariants` and the `PolicyMatched` condition are in scope; additional conditions, timestamps, and observed generations are deferred.
-- Per-role (prefill/decode) configuration — an analyzer-`parameters` concern, not a CRD-shape concern.
-- Alternatives considered and the autoscaler comparison matrices.
-- The `quota` `parameters` schema and enforcement — owned by #1162.
+- **Migration/tooling** — a `wva-config` CLI, ConfigMap→CRD promotion, deprecation timeline.
+- **The full `status` catalog** beyond `effectivePolicy`/`sources`/`managedVariants`/`PolicyMatched` — extra conditions, timestamps, observed generations.
+- **Per-role application** — the engine change to resolve and enforce analyzer `roleOverrides` (§5).
+- **The `quota` `parameters` schema and enforcement** — owned by the quota work (#1162 / issue #1002).
+- **Alternatives and autoscaler comparison matrices.**
 
-Once the CRD boundary (§2) and shape (§3) are agreed, these layer on top without changing either.
+Once the schema (§4), the tier resolution (§2), and the `ScaledObject` boundary (§3) are agreed, these layer on top without changing any of them — in either the ConfigMap or the CRD phase.

--- a/docs/proposals/design-scalingpolicy-crd.md
+++ b/docs/proposals/design-scalingpolicy-crd.md
@@ -33,7 +33,7 @@ The policy **points at the pool**; the pool's workloads carry no reference back 
 
 ## 2. Relationship to the HPA / ScaledObject (review question 1)
 
-**They own different things: WVA owns the scaling decision, the HPA owns actuation. `ScalingPolicy` configures the decision; the HPA actuates it by reading WVA's `wva_desired_replicas` metric. Neither the policy nor the HPA references the other's *config*. WVA reads the HPA/`ScaledObject` to identify the workloads it manages, but the *mechanism* (the #1130 label) is the **VA-deprecation proposal's** — a separate, forthcoming proposal, *not* #1194 — and this CRD's shape does not depend on it.**
+**They own different things:** WVA owns the scaling decision, the HPA owns actuation. `ScalingPolicy` configures the decision; the HPA actuates it by reading WVA's `wva_desired_replicas` metric. Neither the policy nor the HPA references the other's *config*. WVA reads the HPA/`ScaledObject` to identify the workloads it manages, but the *mechanism* (the #1130 label) is the **VA-deprecation proposal's** — and this CRD's shape does not depend on it.**
 
 | | Owns | Reads | Writes |
 |---|---|---|---|

--- a/docs/proposals/design-scalingpolicy-crd.md
+++ b/docs/proposals/design-scalingpolicy-crd.md
@@ -1,236 +1,165 @@
-# Proposal: WVA scaling configuration — schema and resolution (ConfigMap first, CRD later)
+# Proposal: WVA scaling-configuration schema — ConfigMap first, `ScalingPolicy` CRD later
 
-## Problem — what this addresses
+## Scope
 
-Today WVA is configured by **one cluster-wide ConfigMap** plus **per-workload labels/annotations** on the KEDA `ScaledObject` (`llm-d.ai/managed`, `llm-d.ai/model-id`, `inference.optimization/acceleratorName`). That is enough for a single global configuration, but it cannot express:
+This fixes the bare-minimum core of WVA's scaling configuration: the **schema** (fields + a pluggable plugin envelope) and its **resolution**. It answers the two questions that gate the design:
 
-- **per-namespace or per-pool policy** — every workload shares one global `priority`, `scaleToZero`, and analyzer configuration;
-- **an ownership boundary** — cluster-admin-owned enforcement (GPU limiters / quota) and tenant-owned tuning (thresholds, priority) live in the same undifferentiated blob, with no way to give them different RBAC;
-- **validation** — a typo in the ConfigMap is silently ignored;
-- **a resolved-configuration surface** — an operator cannot see *what policy WVA actually applied* to a given pool.
+1. **How does the config relate to the workload's autoscaler?** (§2)
+2. **What is the generic shape of the config?** (§3)
 
-This proposal fixes the configuration **schema** and **resolution** (the fields, the scope tiers, the pluggable-plugin envelope, and the merge order). It is **transport-neutral** and lands in two phases:
+It lands in **two phases** (see *Delivery*): **Phase 1** adds the schema to today's ConfigMap; **Phase 2** promotes it to a `ScalingPolicy` CRD. Migration tooling, per-role detail, the full status catalog, and alternatives are **out of scope** (§6).
 
-- **Phase 1 — extend the existing ConfigMap** with this schema. No CRD, no migration, no new install step. Validation via `ValidatingAdmissionPolicy` (CEL) + the controller; the ownership boundary via RBAC. This is the minimal core.
-- **Phase 2 — promote the schema to a `ScalingPolicy` CRD** when field-level typed validation, `kubectl explain`, and a native `.status` are worth the operational cost of a CRD (§6). Same schema, same resolution — a delivery upgrade, not a redesign.
+**What approving this ratifies:** the off-the-`ScaledObject` boundary (§2) and the schema shape (§3), and a green light for the Phase-1 ConfigMap extension. The Phase-2 CRD is **directional** — its shape is fixed here, but the delivery mechanics (validation, admission, the status surface) land in follow-ups and are called out inline where they're still open.
 
-It does **not** change how WVA *actuates* (it still emits `wva_desired_replicas` for a `ScaledObject`, §3) or how it *identifies* the workloads it manages (§7).
+> **"Schema"** = the fixed set of typed fields (`priority`, `scaleToZero`, `inferencePoolRef`) plus a pluggable `{type, name, parameters}` list for `analyzers`/`limiters`, where `parameters` is plugin-owned. Adding an analyzer or limiter ships its own `parameters` and never changes this schema.
 
-## Optional and backward-compatible
+## What exists today, and what each phase adds
 
-The structured configuration is **optional and additive** — a workload with only the managed labels keeps scaling under WVA's defaults exactly as today. Two things to be accurate about, because the value here is **unification**, not "adding tiers":
+**Today.** WVA is configured by **one cluster-wide, admin-owned ConfigMap** (`saturation-scaling-config`): a `default` entry plus per-(model, namespace) override entries carrying `priority` and thresholds. Scale-to-zero and analyzer selection are controller config. A workload is *scaled* by WVA publishing a `wva_desired_replicas` metric that the workload's KEDA `ScaledObject` reads — and **the config is optional**: a workload with only the managed labels scales under WVA's defaults, and its `ScaledObject` scales it even without WVA.
 
-- **WVA already tiers per-model/namespace.** The `saturation-scaling-config` ConfigMap already carries a `default` entry **plus per-model/namespace override entries** (each carrying `priority` and per-analyzer `score` and thresholds), and `scaleToZero` and the queueing-model analyzer are already namespace-aware in the controller config. So per-namespace scoping is **not new**.
-- **What *is* new:** one **unified schema** across those currently-separate surfaces; the **per-pool** tier (finer than per-model/namespace); the admin/tenant **ownership boundary** (§2); and the typed **`behavior`** field (§4). `priority` (per-model), `scaleToZero`, thresholds and `enableLimiter` keep their current meaning.
+**Phase 1 (ConfigMap) adds the *schema* — plus one behavior rule.** The new fields and the `{type, name, parameters}` plugin envelope become recognized in the *same* admin-owned ConfigMap. It stays one admin-managed object: `priority` stays per-model, existing entries keep working, adoption is additive and per-entry. Three things about Phase-1 semantics are worth calling out plainly:
 
-Upgrading needs **no value migration**, but be honest that it *is* a **consolidation** — three config surfaces fold into one — not a pure restructuring of a single ConfigMap.
+- **Precedence (a genuine behavior change, not just schema).** For `scaleToZero` and analyzer selection, a value set in the ConfigMap wins; the controller-config setting is the fallback used when the field is absent.
+- **`limiters` are honored in Phase 1.** Phase 1 is all-admin, so a `limiters` block in the ConfigMap takes effect. The `limiters`-only-on-cluster-default *boundary* (§3) begins in Phase 2 — it's a placement rule, not a Phase-1 restriction. Only an entry naming a limiter *type* that isn't implemented yet is ignored.
+- **No validation.** Phase 1 ships no admission/CEL, so an unrecognized or Phase-2-only field (e.g. `inferencePoolRef`) is silently ignored, not rejected — typed validation is exactly what Phase 2 adds.
 
-**Before / after.** Today's real `saturation-scaling-config` (abbreviated):
+Adopting the envelope keeps the legacy flat form working, so the loader parses **both** the flat and the `{type, parameters}` shapes for as long as Phase 1 lives (see *Before / after*). (Per-variant `cost` is unchanged — VA-sourced, §5, not a config field.)
+
+**Phase 2 (CRD)** adds what a ConfigMap does poorly or not at all — typed validation, native `.status`, a single discoverable kind, and a clean per-object ownership boundary. The CRD's reason to exist is spelled out in §Delivery.
+
+**Before / after — Phase 1, same surface.** Today:
 
 ```yaml
-metadata:
-  name: saturation-scaling-config
-  labels: { app.kubernetes.io/name: workload-variant-autoscaler }   # controller cache filters on this
-data:
-  default: |                         # global defaults
-    scaleUpThreshold: 0.85
-    priority: 1.0                    # per-model multiplier
-    analyzers: [ { name: saturation, score: 1.0 } ]   # per-analyzer weight
-    enableLimiter: false
-  premium-override: |                # a per-(model, namespace) override entry
-    model_id: granite-premium
-    namespace: production
-    priority: 2.0
+# ConfigMap saturation-scaling-config (admin-owned), data:
+default: |
+  priority: 1.0
+  scaleUpThreshold: 0.85
+premium-override: |
+  model_id: granite-premium
+  namespace: production
+  priority: 2.0
+  scaleUpThreshold: 0.95
 ```
 
-Phase 1 keeps the same values in the unified schema, resolved by tier/placement (§2) instead of in-data `model_id`/`namespace` keys:
+After Phase 1 — the **same ConfigMap**. Adoption is **per entry and optional**: `default` is left untouched (the flat top-level `scaleUpThreshold` binds to WVA's default saturation analyzer and still parses), and `premium-override` opts into the new schema — adding the genuinely-new fields (`scaleToZero`, the `analyzers` plugin envelope) and re-expressing the same `scaleUpThreshold` explicitly under it:
 
 ```yaml
-# cluster-default tier == the 'default' entry above
-priority: 1.0
-scaleToZero: { enabled: false }
-analyzers: [ { type: saturation, name: saturation, score: 1.0, parameters: { scaleUpThreshold: 0.85 } } ]
-limiters:  [ { type: gpu-inventory } ]              # admin-only, cluster tier (§2)
-
-# per-pool tier for granite-premium (== the override above), only the delta:
-#   inferencePoolRef: { name: granite-premium-pool }
-#   priority: 2.0
+default: |                     # UNCHANGED — flat legacy form still parses
+  priority: 1.0
+  scaleUpThreshold: 0.85
+premium-override: |            # opted into the new schema (same values)
+  model_id: granite-premium
+  namespace: production
+  priority: 2.0
+  scaleToZero: { enabled: false }
+  analyzers: [ { type: saturation, parameters: { scaleUpThreshold: 0.95 } } ]
 ```
 
-**Minimal usage.** A pool with no config of its own scales under the cluster default (unchanged). To raise one pool's priority, a tenant adds *just* the per-pool object carrying the delta (`inferencePoolRef` + `priority: 2.0`); everything else (`scaleToZero`, `behavior`, `analyzers`) inherits from the tiers above (§2).
+No new object, no install step, no forced rewrite — that is the whole of Phase 1. **Its worth:** it lands and de-risks the pluggable analyzer/limiter *schema* and moves `scaleToZero`/analyzer selection onto config, usable now, before committing to the CRD's validation/admission machinery.
 
-## 1. The configuration object and how it is matched
+## Delivery — ConfigMap first (Phase 1), CRD later (Phase 2)
 
-The configuration is **one schema** carried by one object per scope:
+- **Phase 1 — extend the existing ConfigMap** with the schema above. Admin-managed, additive, no CRD/migration/install. **What it does *not* deliver:** the tenant/admin ownership boundary, per-pool granularity, typed validation, or status — see why below.
+- **Phase 2 — promote to the `ScalingPolicy` CRD** (§1–§5), which adds those.
 
-- **Phase 1:** a ConfigMap whose `data` holds the schema as a YAML document (one per tier, §2).
-- **Phase 2:** a namespaced `ScalingPolicy` custom resource (`scaling.llm-d.ai/v1alpha1`).
+**Why the CRD (not just more ConfigMaps).** The concrete driver is the ownership boundary. Kubernetes RBAC is **per-object, not per-field**: in one shared ConfigMap whoever can write the object writes *every* field — so a tenant allowed to tune `priority`/thresholds could also set `limiters: []` and **escape their own cap**. The boundary is closed by the `limiters`-only-on-cluster-default **merge rule** (§4) plus an **admin-owned** object holding them. That boundary does *not*, by itself, require a CRD — per-namespace ConfigMaps (tenant) + a cluster ConfigMap (admin) separate objects too. What a CRD **uniquely** adds is a **typed, discoverable, single-kind** surface: OpenAPI validation + `kubectl explain`, and a native `.status`. Ownership and per-pool matching are *cleaner* with the CRD but not impossible without it. The one unqualified win is **typed validation** — a ConfigMap's only check is a controller parse. Native `.status` is a *partial* win: it gives a resolved-policy view for pools that have an explicit per-pool object, but the common default-only case has no such object and its status surface is still open (§4 caveat, §5). So the honest CRD case rests first on typed validation, with status as a follow-on for pools that opt into a per-pool object. So Phase 1 stays admin-owned (as today's single ConfigMap already is); **tenant self-service and the ownership boundary arrive in Phase 2.** Its field *schema* (§3) matches Phase 1's — the one part Phase 1 does **not** de-risk is the **match identity**: Phase 1 keys entries by `model_id`+`namespace`, the CRD matches by `inferencePoolRef` → pool (§1).
 
-It is matched to a workload through that workload's **`InferencePool`** (the Gateway API Inference Extension object; the workload→pool link is the pool's pod selector) via `inferencePoolRef` — **not** through the workload and **not** through its `ScaledObject`. The config points at the pool; the pool's workloads carry no reference back.
+## 1. The object (Phase 2)
+
+One namespaced CRD, `ScalingPolicy` (`scaling.llm-d.ai/v1alpha1`). It is matched to a workload through that workload's **`InferencePool`** (Gateway API Inference Extension; the workload→pool link is the pool's pod selector), **replacing Phase 1's `model_id`+`namespace` keying** — not through the workload or its autoscaler. The referenced pool is assumed co-namespaced with the `ScalingPolicy` (`inferencePoolRef` carries no namespace).
 
 ```yaml
-# Phase 2 (CRD) form — the phase-1 ConfigMap carries the same document under data:
 apiVersion: scaling.llm-d.ai/v1alpha1
 kind: ScalingPolicy
-metadata: { name: granite-premium-priority, namespace: production }
+metadata:
+  name: granite-premium            # object name is free-form; the match is via inferencePoolRef below
+  namespace: production
 spec:
-  inferencePoolRef: { name: granite-premium-pool }   # the pool this config governs (per-pool tier)
-  priority: 2.0                                       # per-model; see §2
-  scaleToZero: { enabled: false }                     # per-model
-  behavior:                                           # per-model; autoscaling/v2 HPA behavior (§4)
-    scaleDown: { stabilizationWindowSeconds: 300 }
+  inferencePoolRef: { name: granite-premium-pool }
+  priority: 2.0
+  scaleToZero: { enabled: false }
   analyzers:
     - type: saturation
-      parameters: { scaleUpThreshold: 0.95 }          # plugin-owned; see §4
+      parameters: { scaleUpThreshold: 0.95 }
 ```
 
-The tunable field families and their meaning, defined here so nothing below is referenced before it is defined:
+The policy **points at the pool**; the pool's workloads carry no reference back. *(The kind is **`ScalingPolicy`** — the name this proposal commits to.)*
 
-- **`priority`** *(per-model)* — the model's weight when models contend for a shared GPU budget. It is only meaningful **relative to other models drawing on the same budget**: within a namespace quota if one exists, otherwise the shared cluster budget (so priority *does* compose across un-quota'd namespaces on the same accelerator type — how it does is engine/rescale territory, not this schema). It is not comparable across *independent* budgets. Default `1.0`.
-- **`scaleToZero`** *(per-model)* — whether WVA may emit a desired count of `0` for an idle model (§3).
-- **`behavior`** *(per-model, tenant-tunable)* — the HPA-style stabilization behavior WVA applies to its own recommendation (trailing windows, per-period rate policies, tolerance) before emitting it. This is a **typed** field reusing `k8s.io/api/autoscaling/v2` `HorizontalPodAutoscalerBehavior` verbatim (§4); its *shape* is fixed here, its *algorithm* is the stabilization proposal's.
-- **`analyzers`** *(per-model, tenant-tunable)* — the saturation/queueing analysis plugins and their thresholds (§4). Per-**role** (prefill/decode) tuning lives *inside* an analyzer's `parameters`, not as top-level fields (§5).
+## 2. Relationship to the workload's autoscaler (question 1)
 
-`limiters`/`quota` are **not** in that list — they are admin-only and cluster-scoped (§2).
+WVA drives scaling through a **KEDA `ScaledObject`**, and they own different things: **WVA owns the scaling decision; the `ScaledObject` owns actuation.** The config (ConfigMap or `ScalingPolicy`) configures the decision; the `ScaledObject` actuates it by reading WVA's `wva_desired_replicas` external metric. The decisive point: **the `ScaledObject` can scale its workload independently of WVA** — it is a general autoscaler that happens to read a metric WVA publishes — so WVA's config must live *off* it.
 
-## 2. Scope tiers — one schema, up to three placements
-
-The surface is **one schema**, resolved at up to **three placements of it** — not three schemas, not three kinds — by a deterministic lookup in fixed order. In phase 1 each placement is a ConfigMap; in phase 2 each is a `ScalingPolicy` object.
-
-1. **Cluster-default** — in the system namespace, no `inferencePoolRef`. **Admin-owned.**
-2. **Namespace-default** — in the workload's namespace, no `inferencePoolRef`. **Tenant-owned.**
-3. **Per-pool** — in the workload's namespace, `inferencePoolRef` set. **Tenant-owned.** A workload-specific policy is *just this placement* — it needs only the fields it overrides.
-
-**How the controller finds a tier (phase 1).** A CRD has identity from its kind, namespace, and `spec.inferencePoolRef`; a ConfigMap does not, so phase 1 classifies ConfigMaps by a fixed label set the controller watches (`scaling.llm-d.ai/config: "true"`):
-
-| tier | namespace | labels |
-|---|---|---|
-| cluster-default | system (`workload-variant-autoscaler-system`) | `scaling.llm-d.ai/tier: cluster` |
-| namespace-default | workload's | `scaling.llm-d.ai/tier: namespace` |
-| per-pool | workload's | `scaling.llm-d.ai/tier: pool`, `scaling.llm-d.ai/pool: <inferencePool>` |
-
-The controller resolves a workload's policy from the labelled ConfigMaps in (system-ns, workload-ns); the `inferencePoolRef` inside the document must agree with the `pool` label (admission-checked). In phase 2 this labelling goes away — the CR's kind + namespace + `spec.inferencePoolRef` are the identity.
-
-**Resolution is inheritance, not replacement.** Fields merge **cluster → namespace → per-pool**, higher tier winning **per field** — a per-pool object that sets only `priority` inherits `scaleToZero`, `behavior`, and `analyzers` from the tiers above it. `analyzers` merge **by `name`** (§4): a lower tier can add or replace an analyzer entry without redeclaring the others. Note the granularity: because a plugin's `parameters` is **opaque** to the envelope (§4), it cannot be structurally deep-merged — a same-`name` entry **replaces the whole `parameters` block**, it does not patch one key. So a tenant writes the minimum set of *entries*, but retuning one threshold means restating that analyzer's `parameters`. This is the "narrower than intended" point from review: real per-field/per-entry inheritance across tiers, with parameters as the replace-granular leaf.
-
-**One kind, two purposes — deliberately.** The same schema serves two owners because it is placed differently and gated by different RBAC: at the **cluster-default** tier it is the admin's **enforcement** carrier (limiters/quota); at the **namespace/per-pool** tiers it is the tenant's **tuning** surface (priority, scaleToZero, analyzers). This dual purpose is intentional — one schema and one merge, partitioned by placement and RBAC, rather than two objects to keep in sync.
-
-**Which fields live at which tier:**
-
-| field family | tiers allowed | owner | rationale |
+| | Owns | Reads | Writes |
 |---|---|---|---|
-| `analyzers`, `priority`, `scaleToZero` | any tier | tenant (ns/pool), admin sets cluster defaults | per-model tuning; safe to delegate |
-| **`limiters` / `quota`** | **cluster-default only** | **admin** | instance-wide **enforcement**, not a tenant knob |
+| **KEDA `ScaledObject`** (tenant-owned) | replica **actuation** | the `wva_desired_replicas` metric | the workload's `spec.replicas` |
+| **WVA controller** | the scaling **decision** | the config + cluster/pool state | the `wva_desired_replicas` metric (+ `ScalingPolicy.status` in Phase 2) |
+| **config** (ConfigMap → `ScalingPolicy`) | the scaling **policy** (priority, thresholds, scale-to-zero, `limiters` incl. `quota`) | — | — |
 
-**`limiters`/`quota` are cluster-default-only, and this is a security boundary, not a style choice.** They are excluded from the merge entirely — a lower tier can neither override nor remove them. That is why **`inferencePoolRef` and `limiters` never co-occur**: `limiters` exist only on the cluster-default, which by definition has no `inferencePoolRef`. If a tenant could set `limiters` on a policy they own, they could drop the `quota` limiter (or set `limiters: []`) and **escape their own cap**.
+Consequences: WVA config never lands on the tenant's autoscaler object; WVA never writes `spec.replicas` or edits the `ScaledObject` (it only publishes the metric); the `ScaledObject`'s `maxReplicas` stays as the tenant's final hard ceiling; and `scaleToZero.enabled` lets WVA emit a desired of 0 that KEDA actuates. *(How a workload is identified as WVA-managed is settled by the VA-deprecation proposal, §5, and does not affect this shape.)*
 
-The isolation **guarantee** is RBAC plus the controller; admission is only UX:
+## 3. The generic schema shape (question 2)
 
-1. **RBAC (the guarantee)** — tenants have no permission to write the cluster-default (it lives in the system namespace). Identical in both phases; this is what actually prevents cap-escape.
-2. **Controller (defense in depth)** — WVA only honors `limiters`/`quota` from the cluster-default tier; a `limiters` block on a tenant-tier object is *ignored*, so even a mis-scoped config cannot weaken enforcement.
-3. **Admission (feedback, not a control)** — a **`ValidatingAdmissionPolicy` (CEL)** rejects a namespace/per-pool config carrying `limiters` so the tenant gets an immediate error instead of a silent ignore. In phase 1 this is a string-level check on the ConfigMap document (a regex, not a security boundary); phase 2's CRD `x-kubernetes-validations` makes it field-precise (§6). It is convenience over (1)+(2), never a substitute for them.
+A **thin typed envelope around pluggable plugin lists** (per the *Schema* definition above). In **Phase 1** every field lives in the one admin ConfigMap (admin-set); the **tier** and **owner** columns below are the **Phase-2** world:
 
-**`analyzers` and `limiters` type selection vs. the controller's global mode.** The analyzer *type* a policy names (`saturation`, `queueing`) selects a plugin; whether the engine runs the V1 or V2 analysis pipeline, and whether the GPU limiter is active at all, are **controller-global modes** (today: the `enableLimiter` / analyzer-version switches), not per-policy fields. A policy *configures* the analyzers/limiters the controller is running; it does not turn the pipeline on or off. Keeping that boundary explicit answers "is the analyzer type global?" — the *pipeline* is; the *plugin selection and parameters* are policy.
+| Field | Phase-2 tier | Owner | Typed? |
+|---|---|---|---|
+| `inferencePoolRef` | per-pool only | tenant | typed |
+| `priority` | any tier | tenant — **write-blocked until admin cap ships (§5)** | typed |
+| `scaleToZero` | any tier | tenant | typed |
+| `analyzers[]` `{type,name,parameters}` | any tier | tenant | envelope typed; `parameters` plugin-owned |
+| `limiters[]` (incl. `quota`) | **cluster-default only** | **admin** | envelope typed; `parameters` plugin-owned |
 
-**Two objects matching the same scope** (two per-pool policies for one pool, or two namespace-defaults in one namespace) are a configuration error. This is a *set* invariant — admission (VAP or CRD CEL) validates one object in isolation and cannot see siblings — so it is **detected by the controller**, which refuses to resolve an ambiguous scope and raises a `Conflict` (a duplicate on a status-bearing object; a controller log/event in the status-less phase-1 ConfigMap case) rather than picking one non-deterministically.
-
-## 3. Relationship to the `ScaledObject` (review question 1)
-
-WVA and the scaler own **different things, on different objects**:
-
-- **WVA** computes the scaling **decision** and publishes it as the `wva_desired_replicas` **metric**. It configures *its own* decision via this schema. It does **not** create, own, or write the `ScaledObject`, and never sets `spec.replicas`.
-- The **KEDA `ScaledObject`** (the scaler WVA integrates with) is a **standalone autoscaler** owned by the tenant. It actuates `spec.replicas` from whatever metrics it is configured with — WVA simply supplies one of them (`wva_desired_replicas`). It can scale without WVA; WVA feeds it a signal.
-
-So there is **no configuration cross-reference in either direction**: the config points at the `InferencePool`, not the `ScaledObject`; the `ScaledObject` references the metric, not any WVA config object. Configuring WVA never means editing a tenant's `ScaledObject`.
-
-```
-ScalingConfig ─configures→ WVA ─emits→ wva_desired_replicas ─read by→ ScaledObject ─sets→ spec.replicas
-```
-
-Consequences:
-
-- **`maxReplicas` stays** as the tenant's hard per-workload ceiling on the `ScaledObject`. WVA's desired count is clamped by it exactly as today; the config sets the *policy* WVA decides within, not the safety cap.
-- **Scale-to-zero** — `scaleToZero.enabled` lets WVA emit a desired of `0`; the `ScaledObject` (with KEDA's idle-replica support) actuates it.
-- **`behavior` means WVA owns stabilization — the `ScaledObject` must not double it.** `spec.behavior` (§4) makes WVA apply the HPA-style damping (windows, rate policies) to its *own* recommendation before emitting it. But the `ScaledObject`/HPA can *also* stabilize the metric it reads, and two stabilizers in series **compound lag** (a spike is damped by WVA, then damped again downstream). The contract when `behavior` is set: **WVA owns stabilization; the `ScaledObject`/HPA `behavior` is configured near-passthrough** (`stabilizationWindowSeconds: 0`). Where the two are reconciled (operator convention vs. WVA generating the `ScaledObject` behavior) is the stabilization proposal's, not this schema's — this proposal only fixes that `behavior` is a per-model field and that it is the *single* stabilizer of record.
-- **Managed-set identification is unchanged.** WVA discovers the workloads it manages from the `llm-d.ai/managed` label on the `ScaledObject` (and reads `llm-d.ai/model-id`, `inference.optimization/acceleratorName`) — the current mechanism. This proposal does not change it (§7).
-
-## 4. The generic schema shape (review question 2)
-
-The schema is a **thin typed envelope around pluggable, schemaless plugin lists**, so the envelope is small and fixed and new plugins never change it:
+Two valid objects, because `inferencePoolRef` and `limiters` never co-occur — a per-pool object (tenant) and the cluster-default (admin):
 
 ```yaml
-# (a) cross-cutting fields — typed, well-known schemas, validated
-inferencePoolRef: { name: granite-premium-pool }   # match key (per-pool tier only)
-priority: 2.0
-scaleToZero: { enabled: false }
-behavior:                      # k8s.io/api/autoscaling/v2 HorizontalPodAutoscalerBehavior, verbatim
-  scaleDown: { stabilizationWindowSeconds: 300, policies: [ { type: Percent, value: 100, periodSeconds: 60 } ] }
-
-# (b) plugin lists — {type, name, parameters}; parameters is plugin-owned
-analyzers:                     # per-model, tenant-tunable, any tier
-  - type: saturation
-    name: sat                  # identity for cross-tier merge; defaults to `type`
-    parameters:                # opaque to the envelope; each plugin validates its own
-      scaleUpThreshold: 0.95
-limiters:                      # cluster-default only (§2)
-  - type: gpu-inventory
-  - type: quota                # parameters owned by the quota work (#1162)
+# (a) per-pool object (tenant tier) — tunes an analyzer, no limiters
+spec:
+  inferencePoolRef: { name: granite-premium-pool }
+  priority: 2.0
+  scaleToZero: { enabled: false }
+  analyzers:
+    - type: saturation
+      name: sat            # identity for cross-tier merge; defaults to `type`
+      parameters: { scaleUpThreshold: 0.95 }          # x-kubernetes-preserve-unknown-fields
+---
+# (b) cluster-default object (admin tier) — carries limiters, no inferencePoolRef
+spec:
+  limiters:
+    - type: gpu-inventory
+    - type: quota          # a limiter type; parameters owned by the quota work
 ```
 
-- **(a) cross-cutting fields** (`priority`, `scaleToZero`, `behavior`, `inferencePoolRef`) are the small stable set. Each has a **fixed, well-known schema** — `behavior` in particular is `autoscaling/v2` `HorizontalPodAutoscalerBehavior` reused verbatim (a k8s building block, not a WVA invention). In **phase 2** they are OpenAPI-typed and `kubectl explain`-able; in **phase 1** the controller validates them on load and a `ValidatingAdmissionPolicy` guards the coarse shape.
-- **(b) plugin lists** are name-keyed `{type, name, parameters}` — the **EPP `EndpointPickerConfig` shape** reused so the plugin-list convention is one WVA already ships as an InferencePool consumer, not a bespoke one. **`parameters` is opaque to the envelope** (phase 2: `x-kubernetes-preserve-unknown-fields`) — each plugin validates its own. `name` keys the cross-tier merge (replace-granular, §2), **defaults to `type`** for a single instance, and must be unique within a tier.
+- **`parameters` is `x-kubernetes-preserve-unknown-fields`** — each plugin validates its own at load. `name` keys the cross-tier **parameter** merge and defaults to `type`; required only for two instances of one `type`.
+- **`limiters` are cluster-default-only** (instance-wide enforcement, not tenant knobs — the ownership boundary from §Delivery). The boundary is closed by the **merge rule**: the engine reads `limiters` only from the cluster-default object, so a tenant copy is inert. A CEL rule *rejecting* them outright is Phase-2 hardening on top (§6), not what closes the hole.
+- **`analyzers`: per-tier *parameter tuning* is fine; per-tier *type selection* is engine-future.** Tuning an active analyzer's `parameters` at a lower tier — what every example here does (e.g. a per-pool `scaleUpThreshold`) — merges normally, keyed by `name`. But **changing *which* analyzer types run per tier** (enabling/disabling types) is not yet honored: the engine applies one type-selection today, so Phase 2 **surfaces a per-tier type-selection change in `.status`** rather than silently accept a field the engine drops. (Rejecting it at admission is possible later hardening, not the Phase-2 behavior.)
 
-**This is what keeps the surface generic — and why one config object suffices rather than a new CRD per feature.** Adding an analyzer or limiter ships *its own* `parameters` keys; the envelope does not change. A future `optimizer` block slots in the same way with no redesign. This directly answers the "won't we keep needing new CRDs / should the kind be more general" concern: the envelope *is* the generality — the plugin list absorbs new config without a schema change, so a single `ScalingPolicy` (or its phase-1 ConfigMap) does not need to become a broader kind to grow.
+## 4. Tiers (Phase 2 — why the CRD is more than one object)
 
-**Schema vs. engine — the boundary this proposal draws.** This document fixes the **schema and resolution** only: the fields, the tiers, the merge, the plugin envelope, and the `status` *shape*. It does **not** specify engine behavior — how an analyzer resolves a threshold, how per-role parameters are applied, how the optimizer consumes `priority`. Those are engine concerns, tracked separately, and are deliberately left open so the schema can be agreed without pinning the implementation.
+Phase 1's single admin ConfigMap already holds a `default` entry **plus per-(model, namespace) in-data overrides** — all admin-owned. Phase 2 turns those into the *same* CRD resolved at up to **three object placements**, and adds the per-object **tenant ownership** and the **per-pool** tier a ConfigMap can't (per §Delivery):
 
-## 5. Per-role (prefill/decode) configuration
+1. **Cluster-default** — a namespaced object in the system namespace, no `inferencePoolRef` (admin). ("Cluster-default" names its *role*, not a cluster-scoped resource.)
+2. **Namespace-default** — the workload's namespace, no `inferencePoolRef` (tenant).
+3. **Per-pool** — the workload's namespace, `inferencePoolRef` set (tenant).
 
-Per-role tuning is a real need for disaggregated (P/D) models, and it has a clear home: **inside an analyzer's `parameters`** (e.g. a `roleOverrides` block), **not** as top-level fields. The reason is ownership of the concern — `priority` and `scaleToZero` are **per-model** decisions (the whole model scales to zero, or has a priority), while role-specific thresholds are **per-analyzer** knobs. So the envelope carries no `prefill`/`decode` fields; a P/D model configures both roles through the analyzer plugin that understands them:
+Fields merge cluster → namespace → per-pool (higher wins); a lower tier tunes an analyzer's `parameters` by `name`. `limiters`/`quota` are **excluded** — cluster-default only. Per-tier **analyzer type-selection** is engine-future — ignored by the engine and surfaced in `.status` (§3). Two objects at the same placement (two cluster-defaults, two namespace-defaults in one namespace, or two per-pool objects on the same `inferencePoolRef`) are a config error, caught by the **WVA controller at reconcile** — a cross-object rule, so not expressible in OpenAPI/CEL alone; a validating webhook is optional later hardening.
 
-```yaml
-analyzers:
-  - type: saturation
-    parameters:
-      roleOverrides:
-        prefill: { scaleUpThreshold: 0.90 }
-        decode:  { scaleUpThreshold: 0.95 }
-```
+### Status (Phase 2)
 
-*Applying* per-role thresholds is an **engine** change (resolving and enforcing role-scoped parameters), out of scope here and tracked separately — this proposal only fixes that per-role config is a `parameters` concern, so it needs no envelope change.
+The per-pool object's `.status` publishes `effectivePolicy` (the merged result) + `sources` (contributing tiers) and `managedVariants` (the workloads it governs, each with `workloadRef`, `role`, `cost`; empty ⇒ `PolicyMatched: False`). **Caveat:** this only shows on pools that *have* a per-pool object; a pool governed solely by a higher-tier default has **no per-pool object and thus no resolved-policy view** — the common case. Where to publish it there is open (§5), so "`kubectl get scalingpolicy` shows what WVA decided" holds only for pools with an explicit object.
 
-## 6. Surfacing the resolved configuration (status) — and the CRD's phase-2 value
+## 5. Dependencies and open questions
 
-An operator must be able to see *what WVA actually decided* for a pool — the merged policy and the workloads it governs — without reverse-engineering the merge. The **shape** of that surface:
+- **Depends on the VA-deprecation proposal.** It owns how WVA identifies managed workloads and where per-variant `cost` comes from; this proposal fixes only the `managedVariants` **shape** (`workloadRef`, `role`, `cost`). Because that shape leans on an undecided proposal, treat the status surface as **shape-settled, source-pending**.
+- **Cross-tenant `priority` bound (open).** `priority` is tenant-owned yet compared on **one global scale** across namespaces when WVA allocates scarce GPUs. That is the mirror of the `limiters` hole: nothing yet stops a tenant setting `priority: 1e9` to starve other tenants. Phase 2 needs an admin-set cap or normalization on tenant priority. The schema and tiers may land first, but **tenant-writable `priority` is blocked until that cap/normalization ships** — until then `priority` stays admin-set.
+- **Effective policy for default-only pools (open).** As above (§4 status caveat): where the resolved policy is shown for a pool with no per-pool object. Candidates: the `InferencePool` status, a WVA-maintained status object, or a `wva-config explain <pool>` view.
 
-```yaml
-status:
-  effectivePolicy: { … }          # merged result (cluster → ns → per-pool)
-  sources: [ … ]                  # which tier each field came from, in precedence order
-  managedVariants:                # workloads WVA manages in this pool (managed set, §7)
-    - workloadRef: { kind: Deployment, name: granite-premium-prefill }
-      role: prefill               # when known
-      cost: 40.0                  # per-replica $/hr — the stable cost input, surfaced here
-  conditions: [ { type: PolicyMatched, … } ]   # False when no managed workload matched
-```
+## 6. Deliberately out of scope
 
-- **`effectivePolicy` + `sources`** make the merge auditable in one place.
-- **`managedVariants`** is the policy→workload mapping (distinct from pool membership — an unmanaged pool member does not appear); `cost` is surfaced so the basis of each scaling decision is visible. *Which* workloads and *how* they are identified, and where `cost` is sourced, are the VA-deprecation proposal's (§7) — this fixes only the shape.
+- The Phase-1→Phase-2 **promotion/migration** mechanics (the `wva-config` tool) and the ConfigMap **removal timeline** — the two-phase delivery is above; its tooling and end-state are deferred.
+- **Extra CEL/admission *rules*** — cross-field constraints beyond the CRD's inherent OpenAPI typing (which *is* Phase 2). These are defense-in-depth on top of the merge-rule boundary (§Delivery), not what it depends on.
+- The full `.status` schema beyond the fields above (extra conditions, timestamps, observed generations).
+- Per-role (prefill/decode) configuration — an analyzer-`parameters` concern, not a schema-shape one.
+- Alternatives considered and autoscaler comparison matrices.
+- The `quota` limiter's `parameters` schema and enforcement — owned by the quota work.
 
-**Be explicit: phase 1 is config-only — this visibility does not exist yet.** A ConfigMap has no `.status`, so in phase 1 there is **no `kubectl get` view of the merged policy**; the resolved configuration is surfaced (if at all) by a `wva-config explain <pool>` command or a WVA-maintained status-only object, otherwise deferred. Do not expect the effective-policy surface in phase 1. **This is the concrete reason the CRD earns phase 2:** promoting to the CRD gives a **native, per-object `.status`**, plus **field-level typed validation** (`x-kubernetes-validations` walking the actual fields, vs. phase-1 string checks on the ConfigMap blob) and **`kubectl explain`**. Security is *not* on that list — RBAC + controller enforcement (§2) already secure phase 1 — so the CRD is a validation/UX/observability upgrade, taken when its cost is justified, not a prerequisite.
-
-**Open question — where the effective config is shown for a pool with no per-pool object.** Per-pool objects are optional, so a pool governed by the namespace/cluster default alone has no per-object status in phase 2 either. Candidate homes: the `InferencePool` status, a WVA status-only object per managed pool, or the `wva-config explain` view. Unresolved; the same answer serves both phases.
-
-## 7. Dependencies and out of scope
-
-**Managed-set identification and per-variant cost are not decided here.** How WVA identifies the workloads it manages, and where per-replica `cost` comes from, are owned by the **VA-deprecation proposal**. For context: managed workloads are marked with the `llm-d.ai/managed` label on their `ScaledObject`, which WVA reads; per-variant `cost` comes from the `VariantAutoscaling` CR until that proposal relocates it. This proposal fixes only the **shape** of `managedVariants` and is independent of the mechanism.
-
-Deferred (a later revision or companion proposal):
-
-- **Migration/tooling** — a `wva-config` CLI, ConfigMap→CRD promotion, deprecation timeline.
-- **The full `status` catalog** beyond `effectivePolicy`/`sources`/`managedVariants`/`PolicyMatched` — extra conditions, timestamps, observed generations.
-- **Per-role application** — the engine change to resolve and enforce analyzer `roleOverrides` (§5).
-- **The `quota` `parameters` schema and enforcement** — owned by the quota work (#1162 / issue #1002).
-- **Alternatives and autoscaler comparison matrices.**
-
-Once the schema (§4), the tier resolution (§2), and the `ScaledObject` boundary (§3) are agreed, these layer on top without changing any of them — in either the ConfigMap or the CRD phase.
+Once the boundary (§2) and shape (§3) are agreed, these layer on top without changing either.

--- a/docs/proposals/design-scalingpolicy-crd.md
+++ b/docs/proposals/design-scalingpolicy-crd.md
@@ -68,18 +68,19 @@ spec:
   scaleToZero: { enabled: false }
 
   # (b) pluggable lists — {type, name, parameters}; `parameters` is plugin-owned
-  analyzers:                          # one or more; tenant-tunable
+  analyzers:                          # one or more; TENANT-tunable, any tier
     - type: saturation
       name: sat                       # identity, used for cross-tier merge
       parameters:                     # x-kubernetes-preserve-unknown-fields
         scaleUpThreshold: 0.95
-  limiters:                           # zero or more; compose as a chain
+  limiters:                           # zero or more; chain; CLUSTER-DEFAULT ONLY (admin)
     - type: gpu-inventory
     - type: quota                     # parameters schema owned by #1162
 ```
 
 - **(a) Stable cross-cutting fields** (`priority`, `scaleToZero`, `inferencePoolRef`) are **typed** — OpenAPI/CEL-validated, discoverable via `kubectl explain`.
 - **(b) Plugin lists** (`analyzers`, `limiters`) are name-keyed lists of `{type, name, parameters}` where **`parameters` is `x-kubernetes-preserve-unknown-fields`** — each plugin parses and validates its own parameters at load. This is the **EPP `EndpointPickerConfig` pattern** (llm-d's inference scheduler already configures plugins this way), reused for *shape* only — there is no shared config between EPP and WVA; both merely read the `InferencePool`.
+- **Tenant-tunable vs admin-only — an isolation boundary, not a style choice.** `analyzers`, `priority`, and `scaleToZero` are tenant-tunable at any tier. **`limiters` (and `quota`) are cluster-default-only**: they are *instance-wide enforcement*, not tenant knobs. A **CEL rule rejects `limiters`/`quota` on any namespace or per-pool `ScalingPolicy`**, and tenants have no RBAC to write the cluster-default object (it lives in the system namespace). This is load-bearing for security: if a tenant could set `limiters` on a policy they own, they could drop the `quota` limiter — or set `limiters: []` — and **escape their own cap**. So `limiters`/`quota` are never authored, merged, or overridable below the cluster-default tier (§4).
 
 The one property that makes the shape "generic": **adding an analyzer or limiter ships its own `parameters` keys and the CRD schema does not change.** The optimizer is a single fixed stage with nothing to configure today; the schema leaves room for a `spec.optimizer` block later with no redesign.
 
@@ -93,7 +94,7 @@ The surface is still **one CRD**. It is resolved at up to **three placements** o
 2. **Namespace-default** — `ScalingPolicy` in the workload's namespace, no `inferencePoolRef`.
 3. **Per-pool** — `ScalingPolicy` in the workload's namespace, `inferencePoolRef` set.
 
-Fields merge cluster → namespace → per-pool (higher tier wins; `analyzers` merge by `name`).
+Fields merge cluster → namespace → per-pool (higher tier wins; `analyzers` merge by `name`). **`limiters` and `quota` are excluded from the merge entirely — they exist *only* on the cluster-default tier** (CEL-rejected on the others, §3), so a lower tier can neither override them nor remove them. A tenant cannot weaken or delete their own cap by editing a policy they own; the only objects they can write (namespace / per-pool) cannot carry a limiter at all.
 
 **This cannot collapse to a single tier, because quota forces at least two — by ownership, not preference:**
 

--- a/docs/proposals/design-scalingpolicy-crd.md
+++ b/docs/proposals/design-scalingpolicy-crd.md
@@ -1,0 +1,120 @@
+# Proposal: ScalingPolicy CRD — minimal core
+
+## Scope
+
+This is the **bare-minimum** core of the WVA configuration CRD, split out from the broader analysis in **#1194** (kept open for reference). Per review, it answers only the two questions that gate the design:
+
+1. **What is the relationship between the Config CRD and the HPA object?** (§2)
+2. **What is the generic shape (schema) of the CRD?** (§3)
+
+Everything else from #1194 — migration tooling, deprecation phases, the full status-condition catalog, per-role detail, alternatives, comparison matrices — is **deliberately deferred** (§5). The goal here is to agree the CRD's *boundary* and *shape* first; the rest layers on top without changing either.
+
+## 1. The object
+
+One namespaced CRD, `ScalingPolicy` (`scaling.llm-d.ai/v1alpha1`), carries WVA's scaling configuration. It is matched to a workload through that workload's **`InferencePool`** (defined by the Gateway API Inference Extension) — not through the workload, and not through its HPA:
+
+```yaml
+apiVersion: scaling.llm-d.ai/v1alpha1
+kind: ScalingPolicy
+metadata:
+  name: granite-premium-priority
+  namespace: production
+spec:
+  inferencePoolRef:
+    name: granite-premium-pool      # the pool this policy configures
+  priority: 2.0
+  scaleToZero: { enabled: false }
+  analyzers:
+    - type: saturation
+      parameters: { scaleUpThreshold: 0.95 }
+```
+
+The policy **points at the pool**; the pool's workloads carry no reference back to the policy. Why that direction matters is §2.
+
+## 2. Relationship to the HPA / ScaledObject (review question 1)
+
+**They are decoupled and own different things. WVA does not replace, write to, or reference the HPA.**
+
+| | Owns | Reads | Writes |
+|---|---|---|---|
+| **HPA / KEDA `ScaledObject`** (tenant-owned) | replica **actuation** | the `wva_desired_replicas` metric | the workload's `spec.replicas` |
+| **WVA controller** | the scaling **decision** | `ScalingPolicy` + cluster/pool state | the `wva_desired_replicas` metric (+ `ScalingPolicy.status`) |
+| **`ScalingPolicy` CRD** | the scaling **policy** (priority, thresholds, scale-to-zero, quota) | — | — |
+
+The data flow is one-directional:
+
+```
+ScalingPolicy ──configures──▶ WVA ──emits──▶ wva_desired_replicas ──read by──▶ HPA / ScaledObject ──sets──▶ spec.replicas
+```
+
+The consequences answer the question directly:
+
+- **No cross-reference, either way.** The HPA / `ScaledObject` carries **no** WVA-specific field, and `ScalingPolicy` references the `InferencePool`, **not** the HPA. This is the entire point of a single surface: adding WVA config must not mean editing every tenant's HPA. (An `HPA → ScalingPolicy` reference would put a WVA-specific field back on every workload — exactly what this avoids.)
+- **WVA is read-only on the HPA / `ScaledObject`.** It never writes `spec.replicas` directly; it only publishes the metric the HPA already consumes. Tenant-owned objects stay tenant-owned.
+- **HPA `maxReplicas` stays, as a complementary hard ceiling.** `ScalingPolicy` does not replace it: WVA's desired count is clamped by the HPA exactly as today. `ScalingPolicy` sets the *policy* WVA decides within; `maxReplicas` is the tenant's final per-workload safety cap.
+- **Scale-to-zero is a policy toggle, actuated by the HPA layer.** `spec.scaleToZero.enabled` lets WVA emit a desired of 0; KEDA/HPA actuate it. WVA decides 0; it does not force it.
+
+In short: **`ScalingPolicy` configures the decision; the HPA actuates it.** The CRD sits *upstream* of the metric the HPA already reads, so it slots into the existing HPA/KEDA flow without modifying it.
+
+## 3. The generic schema shape (review question 2)
+
+The CRD is a **thin typed envelope around pluggable, schemaless plugin lists** — so the schema itself is small and fixed, and new analyzers/limiters never change it. Two validation tiers, deliberately:
+
+```yaml
+spec:
+  # (a) typed, cross-cutting fields — OpenAPI/CEL-validated, `kubectl explain`-able
+  inferencePoolRef: { name: granite-premium-pool }   # match key (optional; see §4)
+  priority: 2.0
+  scaleToZero: { enabled: false }
+
+  # (b) pluggable lists — {type, name, parameters}; `parameters` is plugin-owned
+  analyzers:                          # one or more; tenant-tunable
+    - type: saturation
+      name: sat                       # identity, used for cross-tier merge
+      parameters:                     # x-kubernetes-preserve-unknown-fields
+        scaleUpThreshold: 0.95
+  limiters:                           # zero or more; compose as a chain
+    - type: gpu-inventory
+    - type: quota                     # parameters schema owned by #1162
+```
+
+- **(a) Stable cross-cutting fields** (`priority`, `scaleToZero`, `inferencePoolRef`) are **typed** — OpenAPI/CEL-validated, discoverable via `kubectl explain`.
+- **(b) Plugin lists** (`analyzers`, `limiters`) are name-keyed lists of `{type, name, parameters}` where **`parameters` is `x-kubernetes-preserve-unknown-fields`** — each plugin parses and validates its own parameters at load. This is the **EPP `EndpointPickerConfig` pattern** (llm-d's inference scheduler already configures plugins this way), reused for *shape* only — there is no shared config between EPP and WVA; both merely read the `InferencePool`.
+
+The one property that makes the shape "generic": **adding an analyzer or limiter ships its own `parameters` keys and the CRD schema does not change.** The optimizer is a single fixed stage with nothing to configure today; the schema leaves room for a `spec.optimizer` block later with no redesign.
+
+(The `quota` limiter's `parameters` schema and its cluster-scope enforcement are owned by **#1162** / issue #1002 — quota lives on this surface, but its shape is settled there, not here.)
+
+## 4. Why more than one tier (the quota constraint)
+
+The surface is still **one CRD**. It is resolved at up to **three placements** of that same object — not three schemas and not three kinds — by a deterministic lookup in fixed order:
+
+1. **Cluster-default** — `ScalingPolicy` in the system namespace, no `inferencePoolRef`.
+2. **Namespace-default** — `ScalingPolicy` in the workload's namespace, no `inferencePoolRef`.
+3. **Per-pool** — `ScalingPolicy` in the workload's namespace, `inferencePoolRef` set.
+
+Fields merge cluster → namespace → per-pool (higher tier wins; `analyzers` merge by `name`).
+
+**This cannot collapse to a single tier, because quota forces at least two — by ownership, not preference:**
+
+- **Quota is cluster-admin-owned and cluster-scoped.** A per-namespace cap is a cluster-admin decision a tenant must not be able to raise, and a cluster *aggregate* needs a cluster-wide view (independent per-namespace instances each see full node inventory and would collectively overcommit). So quota must live on a cluster-admin-owned, system-namespace object.
+- **Thresholds / `priority` / `scaleToZero` are tenant-owned and namespace-scoped.** A tenant tunes these for their own pools.
+
+These two have **different owners and different RBAC**; they cannot share one object without either letting tenants edit quota or letting admins own every tenant's thresholds. So **cluster-default + namespace are structurally required** — independent of any convenience argument.
+
+The **third (per-pool) tier costs no extra schema**: it is the *same* CRD with `inferencePoolRef` set, in the tenant's own namespace. It adds override *granularity* (one pool tuned differently from its namespace default), not a new surface or a new kind. So "multiple levels" here means three placements of one object resolved by a small, deterministic merge — not three configuration systems.
+
+> The merged result is published on the per-pool object's `status.effectivePolicy` (with `status.sources`), so `kubectl get scalingpolicy <name> -o yaml` shows exactly what is in force and which tiers produced it — the resolution is observable, not an unseen algorithm. (Status field detail deferred to #1194.)
+
+## 5. Deliberately out of scope (deferred to #1194)
+
+To hold this to the bare minimum, the following are **not** decided here and remain in #1194 for reference:
+
+- Migration path and the `wva-config` CLI / migration tool.
+- Deprecation phases and the ConfigMap-removal timeline.
+- The full `status` condition catalog (only `effectivePolicy` / `sources` are referenced above).
+- Per-role (prefill/decode) configuration — an analyzer-`parameters` concern, not a CRD-shape concern.
+- Alternatives considered and the autoscaler comparison matrices.
+- The `quota` `parameters` schema and enforcement — owned by #1162.
+
+Once the CRD boundary (§2) and shape (§3) are agreed, these layer on top without changing either.

--- a/docs/proposals/design-scalingpolicy-crd.md
+++ b/docs/proposals/design-scalingpolicy-crd.md
@@ -2,16 +2,16 @@
 
 ## Scope
 
-This is the **bare-minimum** core of the WVA configuration CRD, split out from the broader analysis in **#1194** (kept open for reference). Per review, it answers only the two questions that gate the design:
+This is the **bare-minimum** core of the WVA configuration CRD, split out from the broader analysis in **#1194** (kept open for reference). Per review, it answers the two questions that gate the design — and settles only the minimum they force (the resolution tiers and the status surface):
 
 1. **What is the relationship between the Config CRD and the HPA object?** (§2)
 2. **What is the generic shape (schema) of the CRD?** (§3)
 
-Everything else from #1194 — migration tooling, deprecation phases, the full status-condition catalog, per-role detail, alternatives, comparison matrices — is **deliberately deferred** (§5). The goal here is to agree the CRD's *boundary* and *shape* first; the rest layers on top without changing either.
+Everything else from #1194 — migration tooling, deprecation phases, the full status-condition catalog, per-role detail, alternatives, comparison matrices — is **deliberately deferred** (§6); the dependency on the VA-deprecation proposal (discovery, cost source) and one remaining open question are in §5. The goal here is to agree the CRD's *boundary* and *shape* first; the rest layers on top without changing either.
 
 ## 1. The object
 
-One namespaced CRD, `ScalingPolicy` (`scaling.llm-d.ai/v1alpha1`), carries WVA's scaling configuration. It is matched to a workload through that workload's **`InferencePool`** (defined by the Gateway API Inference Extension) — not through the workload, and not through its HPA:
+One namespaced CRD, `ScalingPolicy` (`scaling.llm-d.ai/v1alpha1`), carries WVA's scaling configuration. It is matched to a workload through that workload's **`InferencePool`** (defined by the Gateway API Inference Extension; the workload→pool link is the pool's pod selector) — not through the workload, and not through its HPA:
 
 ```yaml
 apiVersion: scaling.llm-d.ai/v1alpha1
@@ -33,12 +33,12 @@ The policy **points at the pool**; the pool's workloads carry no reference back 
 
 ## 2. Relationship to the HPA / ScaledObject (review question 1)
 
-**They are decoupled and own different things. WVA does not replace, write to, or reference the HPA.**
+**They own different things: WVA owns the scaling decision, the HPA owns actuation. `ScalingPolicy` configures the decision; the HPA actuates it by reading WVA's `wva_desired_replicas` metric. Neither the policy nor the HPA references the other's *config*. WVA reads the HPA/`ScaledObject` to identify the workloads it manages, but the *mechanism* (the #1130 label) is the **VA-deprecation proposal's** — a separate, forthcoming proposal, *not* #1194 — and this CRD's shape does not depend on it.**
 
 | | Owns | Reads | Writes |
 |---|---|---|---|
 | **HPA / KEDA `ScaledObject`** (tenant-owned) | replica **actuation** | the `wva_desired_replicas` metric | the workload's `spec.replicas` |
-| **WVA controller** | the scaling **decision** | `ScalingPolicy` + cluster/pool state | the `wva_desired_replicas` metric (+ `ScalingPolicy.status`) |
+| **WVA controller** | the scaling **decision** | `ScalingPolicy`, cluster/pool state, and the HPA/`ScaledObject` that marks its managed workloads (per the VA-deprecation proposal) | the `wva_desired_replicas` metric (+ `ScalingPolicy.status`) |
 | **`ScalingPolicy` CRD** | the scaling **policy** (priority, thresholds, scale-to-zero, quota) | — | — |
 
 The data flow is one-directional:
@@ -49,12 +49,12 @@ ScalingPolicy ──configures──▶ WVA ──emits──▶ wva_desired_rep
 
 The consequences answer the question directly:
 
-- **No cross-reference, either way.** The HPA / `ScaledObject` carries **no** WVA-specific field, and `ScalingPolicy` references the `InferencePool`, **not** the HPA. This is the entire point of a single surface: adding WVA config must not mean editing every tenant's HPA. (An `HPA → ScalingPolicy` reference would put a WVA-specific field back on every workload — exactly what this avoids.)
-- **WVA is read-only on the HPA / `ScaledObject`.** It never writes `spec.replicas` directly; it only publishes the metric the HPA already consumes. Tenant-owned objects stay tenant-owned.
+- **No config cross-reference.** The HPA / `ScaledObject` carries no reference to a WVA *config* object, and `ScalingPolicy` points at the `InferencePool`, **not** the HPA — so configuring WVA never means editing a tenant's HPA. The HPA's tie to WVA is that it reads the `wva_desired_replicas` metric to actuate. (An `HPA → ScalingPolicy` config reference would put a WVA-specific field on every workload — that's what this avoids.)
+- **WVA never *writes* tenant-owned objects.** It does not set `spec.replicas` or modify the HPA / `ScaledObject`; it publishes the `wva_desired_replicas` metric, which the HPA consumes. WVA *does* **read** the HPA/`ScaledObject` to identify its managed set — the mechanism (the `llm-d.ai/managed` label on those objects, #1130) belongs to the VA-deprecation proposal, not this one.
 - **HPA `maxReplicas` stays, as a complementary hard ceiling.** `ScalingPolicy` does not replace it: WVA's desired count is clamped by the HPA exactly as today. `ScalingPolicy` sets the *policy* WVA decides within; `maxReplicas` is the tenant's final per-workload safety cap.
 - **Scale-to-zero is a policy toggle, actuated by the HPA layer.** `spec.scaleToZero.enabled` lets WVA emit a desired of 0; KEDA/HPA actuate it. WVA decides 0; it does not force it.
 
-In short: **`ScalingPolicy` configures the decision; the HPA actuates it.** The CRD sits *upstream* of the metric the HPA already reads, so it slots into the existing HPA/KEDA flow without modifying it.
+**Net:** a workload is *configured* via its pool (§1's "not through the HPA") and *actuated* via the metric; the CRD sits *upstream* of that metric, so it slots into the existing HPA/KEDA flow without modifying it. How a workload is *identified as WVA-managed* is the VA-deprecation proposal's, not here.
 
 ## 3. The generic schema shape (review question 2)
 
@@ -63,7 +63,7 @@ The CRD is a **thin typed envelope around pluggable, schemaless plugin lists** �
 ```yaml
 spec:
   # (a) typed, cross-cutting fields — OpenAPI/CEL-validated, `kubectl explain`-able
-  inferencePoolRef: { name: granite-premium-pool }   # match key (optional; see §4)
+  inferencePoolRef: { name: granite-premium-pool }   # per-pool only; mutually exclusive with limiters (§4)
   priority: 2.0
   scaleToZero: { enabled: false }
 
@@ -78,8 +78,10 @@ spec:
     - type: quota                     # parameters schema owned by #1162
 ```
 
-- **(a) Stable cross-cutting fields** (`priority`, `scaleToZero`, `inferencePoolRef`) are **typed** — OpenAPI/CEL-validated, discoverable via `kubectl explain`.
-- **(b) Plugin lists** (`analyzers`, `limiters`) are name-keyed lists of `{type, name, parameters}` where **`parameters` is `x-kubernetes-preserve-unknown-fields`** — each plugin parses and validates its own parameters at load. This is the **EPP `EndpointPickerConfig` pattern** (llm-d's inference scheduler already configures plugins this way), reused for *shape* only — there is no shared config between EPP and WVA; both merely read the `InferencePool`.
+*Field catalog, not a single valid object: a real `ScalingPolicy` is one tier, and `inferencePoolRef` and `limiters`/`quota` never co-occur — limiters live only on the cluster-default, which has no `inferencePoolRef` (§4).*
+
+- **(a) Stable typed fields** — the tunable cross-cutting fields (`priority`, `scaleToZero`) and the match key (`inferencePoolRef`) are **typed**: OpenAPI/CEL-validated, discoverable via `kubectl explain`.
+- **(b) Plugin lists** (`analyzers`, `limiters`) are name-keyed `{type, name, parameters}` where **`parameters` is `x-kubernetes-preserve-unknown-fields`** — each plugin validates its own at load. This reuses the **EPP `EndpointPickerConfig` shape** (not its config — both sides merely read the `InferencePool`). `name` keys the cross-tier merge (§4) and **defaults to `type`** for a single instance; it's required only for two instances of one `type`, and must be unique within a tier (admission-enforced).
 - **Tenant-tunable vs admin-only — an isolation boundary, not a style choice.** `analyzers`, `priority`, and `scaleToZero` are tenant-tunable at any tier. **`limiters` (and `quota`) are cluster-default-only**: they are *instance-wide enforcement*, not tenant knobs. A **CEL rule rejects `limiters`/`quota` on any namespace or per-pool `ScalingPolicy`**, and tenants have no RBAC to write the cluster-default object (it lives in the system namespace). This is load-bearing for security: if a tenant could set `limiters` on a policy they own, they could drop the `quota` limiter — or set `limiters: []` — and **escape their own cap**. So `limiters`/`quota` are never authored, merged, or overridable below the cluster-default tier (§4).
 
 The one property that makes the shape "generic": **adding an analyzer or limiter ships its own `parameters` keys and the CRD schema does not change.** The optimizer is a single fixed stage with nothing to configure today; the schema leaves room for a `spec.optimizer` block later with no redesign.
@@ -96,41 +98,45 @@ The surface is still **one CRD**. It is resolved at up to **three placements** o
 
 Fields merge cluster → namespace → per-pool (higher tier wins; `analyzers` merge by `name`). **`limiters` and `quota` are excluded from the merge entirely — they exist *only* on the cluster-default tier** (CEL-rejected on the others, §3), so a lower tier can neither override them nor remove them. A tenant cannot weaken or delete their own cap by editing a policy they own; the only objects they can write (namespace / per-pool) cannot carry a limiter at all.
 
-**This cannot collapse to a single tier, because quota forces at least two — by ownership, not preference:**
+Two `ScalingPolicy` objects matching the **same** scope (two per-pool policies for one pool, or two namespace-defaults in one namespace) are a configuration error, **rejected at admission** — so resolution is always deterministic, never order- or name-dependent.
 
-- **Quota is cluster-admin-owned and cluster-scoped.** A per-namespace cap is a cluster-admin decision a tenant must not be able to raise, and a cluster *aggregate* needs a cluster-wide view (independent per-namespace instances each see full node inventory and would collectively overcommit). So quota must live on a cluster-admin-owned, system-namespace object.
-- **Thresholds / `priority` / `scaleToZero` are tenant-owned and namespace-scoped.** A tenant tunes these for their own pools.
+**Two tiers are forced by ownership, not preference.** Quota is **cluster-admin-owned and cluster-scoped** (a tenant must not raise their own cap, and a cluster aggregate needs a cluster-wide view — per-namespace instances would each see full node inventory and collectively overcommit); thresholds/`priority`/`scaleToZero` are **tenant-owned and namespace-scoped**. Different owners, different RBAC — they can't share one object without letting tenants edit quota or admins own every tenant's thresholds. So **cluster-default + namespace are structural, not convenience.**
 
-These two have **different owners and different RBAC**; they cannot share one object without either letting tenants edit quota or letting admins own every tenant's thresholds. So **cluster-default + namespace are structurally required** — independent of any convenience argument.
+The **third (per-pool) tier costs no extra schema** — it is the *same* CRD with `inferencePoolRef` set, in the tenant's namespace, adding override *granularity*, not a new surface. So "multiple levels" is three placements of one object resolved by a small deterministic merge — not three configuration systems.
 
-The **third (per-pool) tier costs no extra schema**: it is the *same* CRD with `inferencePoolRef` set, in the tenant's own namespace. It adds override *granularity* (one pool tuned differently from its namespace default), not a new surface or a new kind. So "multiple levels" here means three placements of one object resolved by a small, deterministic merge — not three configuration systems.
+### Status — surfacing the resolution
 
-### Status — the resolution is observable
-
-The per-pool object's status publishes both *what was resolved* and *what it governs*, so `kubectl get scalingpolicy <name> -o yaml` shows exactly what WVA decided — no unseen algorithm:
+The per-pool object's status publishes both *what was resolved* and *what it governs* — so `kubectl get scalingpolicy <name> -o yaml` shows exactly what WVA decided, no unseen algorithm (for pools with a per-pool object; §5 covers default-only pools):
 
 ```yaml
 status:
-  observedPool: granite-premium-pool
-  managedVariants:                     # the workloads this policy governs
+  managedVariants:                     # variants WVA manages in this pool (managed set; identified per VA-deprecation proposal)
     - workloadRef: { kind: Deployment, name: granite-premium-prefill }
       role: prefill                    # when known
+      cost: 40.0                       # per-replica $/hr (see source below)
     - workloadRef: { kind: Deployment, name: granite-premium-decode }
       role: decode
+      cost: 24.0
   effectivePolicy: { … }               # merged result (cluster → ns → per-pool)
   sources: [ … ]                       # contributing tiers, in precedence order
 ```
 
 - **`effectivePolicy`** (+ **`sources`**) — the merged result and which tier each field came from.
-- **`managedVariants`** — the workloads this policy actually governs. The policy matches an `InferencePool`; WVA resolves that pool to its pods and their owning workloads (the *variants*) at reconcile time and lists each by its **workload reference — the same object a tenant's HPA/`ScaledObject` `scaleTargetRef` points at.** Discovery is via the pool, *not* by reading HPA objects (§2), so this adds no HPA dependency; it just lets an operator line up *policy → variants → their HPAs*. An **empty list is a loud misconfiguration signal** (the `inferencePoolRef` matched a pool with no workloads — wrong ref or selector mismatch), surfaced as a `PolicyMatched: False` condition. Live per-variant replica counts stay in the `wva_desired_replicas` metric — status holds the stable mapping, not the churning numbers.
+- **`managedVariants`** — the workloads this policy manages, each with `workloadRef`, `role`, and per-replica `cost`. *Which* workloads and *how* they're identified is the VA-deprecation proposal's (§5); this fixes only the **shape**. It is **distinct from pool membership** (an unmanaged pool member wouldn't appear); `cost` is a stable input surfaced so the cost basis of each decision is visible in one place; an **empty list** (no managed workloads) raises `PolicyMatched: False`. Live replica counts stay in the metric — status holds the stable mapping.
 
-## 5. Deliberately out of scope (deferred to #1194)
+## 5. Dependencies and open questions
+
+**Depends on the VA-deprecation proposal — not decided here.** That proposal owns how WVA identifies the workloads it manages and where per-variant `cost` is sourced. This proposal fixes only the **shape** of `managedVariants` (`workloadRef`, `role`, `cost`) and is independent of the mechanism. *(For context: that proposal marks managed objects with the `llm-d.ai/managed` label on the HPA/`ScaledObject` (#1130), which WVA reads — so per-variant `cost` would co-locate there; `cost` comes from the `VariantAutoscaling` CR until then.)*
+
+**Open — where is the effective policy published for a pool with no per-pool object?** `effectivePolicy` / `managedVariants` are shown on the per-pool `ScalingPolicy` status — but per-pool objects are **optional** (a pool governed by the namespace/cluster default alone has none), so today the resolved policy is invisible in exactly the common case. Candidate homes: the `InferencePool` status, a WVA-maintained status-only object per managed pool, or a `wva-config explain <pool>` view. Unresolved.
+
+## 6. Deliberately out of scope (deferred to #1194)
 
 To hold this to the bare minimum, the following are **not** decided here and remain in #1194 for reference:
 
 - Migration path and the `wva-config` CLI / migration tool.
 - Deprecation phases and the ConfigMap-removal timeline.
-- The full `status` *condition* catalog (only `effectivePolicy`, `sources`, `managedVariants`, and the `PolicyMatched` condition are defined above).
+- The full `status` schema beyond what's defined above — the fields `effectivePolicy`, `sources`, `managedVariants` and the `PolicyMatched` condition are in scope; additional conditions, timestamps, and observed generations are deferred.
 - Per-role (prefill/decode) configuration — an analyzer-`parameters` concern, not a CRD-shape concern.
 - Alternatives considered and the autoscaler comparison matrices.
 - The `quota` `parameters` schema and enforcement — owned by #1162.

--- a/docs/proposals/design-scalingpolicy-crd.md
+++ b/docs/proposals/design-scalingpolicy-crd.md
@@ -18,31 +18,46 @@ It does **not** change how WVA *actuates* (it still emits `wva_desired_replicas`
 
 ## Optional and backward-compatible
 
-The structured configuration is **optional and additive**. A workload with only the managed labels keeps scaling under WVA's defaults exactly as today — the schema adds *scoped overrides*, it does not become required. Upgrading an existing cluster needs **no migration**: phase 1 *is* the ConfigMap WVA already reads, with more structure in it. Fields that exist today (`priority`, `scaleToZero`, analyzer settings, limiter selection) keep their current meaning at the cluster tier; per-namespace and per-pool scoping is the new capability.
+The structured configuration is **optional and additive** — a workload with only the managed labels keeps scaling under WVA's defaults exactly as today. Two things to be accurate about, because the value here is **unification**, not "adding tiers":
 
-**Before / after — the cluster tier is today's ConfigMap, restructured.** Today's flat cluster config gains a scope label and the typed shape; the values carry over:
+- **WVA already tiers per-model/namespace.** The `saturation-scaling-config` ConfigMap already carries a `default` entry **plus per-model/namespace override entries** (each carrying `priority` and per-analyzer `score` and thresholds), and `scaleToZero` and the queueing-model analyzer are already namespace-aware in the controller config. So per-namespace scoping is **not new**.
+- **What *is* new:** one **unified schema** across those currently-separate surfaces; the **per-pool** tier (finer than per-model/namespace); the admin/tenant **ownership boundary** (§2); and the typed **`behavior`** field (§4). `priority` (per-model), `scaleToZero`, thresholds and `enableLimiter` keep their current meaning.
+
+Upgrading needs **no value migration**, but be honest that it *is* a **consolidation** — three config surfaces fold into one — not a pure restructuring of a single ConfigMap.
+
+**Before / after.** Today's real `saturation-scaling-config` (abbreviated):
 
 ```yaml
-# today (illustrative): one global ConfigMap
-data: { priority: "1.0", scaleToZero: "false", analyzer: "saturation", scaleUpThreshold: "0.9" }
-# phase 1: same values, structured, labelled as the cluster-default tier (§2)
-metadata: { labels: { scaling.llm-d.ai/config: "true", scaling.llm-d.ai/tier: cluster } }
+metadata:
+  name: saturation-scaling-config
+  labels: { app.kubernetes.io/name: workload-variant-autoscaler }   # controller cache filters on this
 data:
-  config: |
-    priority: 1.0
-    scaleToZero: { enabled: false }
-    analyzers: [ { type: saturation, parameters: { scaleUpThreshold: 0.9 } } ]
-    limiters:  [ { type: gpu-inventory } ]      # admin-only, cluster tier
+  default: |                         # global defaults
+    scaleUpThreshold: 0.85
+    priority: 1.0                    # per-model multiplier
+    analyzers: [ { name: saturation, score: 1.0 } ]   # per-analyzer weight
+    enableLimiter: false
+  premium-override: |                # a per-(model, namespace) override entry
+    model_id: granite-premium
+    namespace: production
+    priority: 2.0
 ```
 
-**Minimal usage.** A pool with no `ScalingPolicy`/ConfigMap of its own scales under the cluster default (unchanged behavior). To raise one pool's priority, a tenant adds *just* the per-pool object with only the delta:
+Phase 1 keeps the same values in the unified schema, resolved by tier/placement (§2) instead of in-data `model_id`/`namespace` keys:
 
 ```yaml
-metadata: { namespace: production, labels: { scaling.llm-d.ai/config: "true", scaling.llm-d.ai/tier: pool, scaling.llm-d.ai/pool: granite-premium-pool } }
-data: { config: "inferencePoolRef: { name: granite-premium-pool }\npriority: 2.0" }
+# cluster-default tier == the 'default' entry above
+priority: 1.0
+scaleToZero: { enabled: false }
+analyzers: [ { type: saturation, name: saturation, score: 1.0, parameters: { scaleUpThreshold: 0.85 } } ]
+limiters:  [ { type: gpu-inventory } ]              # admin-only, cluster tier (§2)
+
+# per-pool tier for granite-premium (== the override above), only the delta:
+#   inferencePoolRef: { name: granite-premium-pool }
+#   priority: 2.0
 ```
 
-Everything else (`scaleToZero`, `behavior`, `analyzers`) inherits from the tiers above (§2).
+**Minimal usage.** A pool with no config of its own scales under the cluster default (unchanged). To raise one pool's priority, a tenant adds *just* the per-pool object carrying the delta (`inferencePoolRef` + `priority: 2.0`); everything else (`scaleToZero`, `behavior`, `analyzers`) inherits from the tiers above (§2).
 
 ## 1. The configuration object and how it is matched
 
@@ -136,6 +151,7 @@ Consequences:
 
 - **`maxReplicas` stays** as the tenant's hard per-workload ceiling on the `ScaledObject`. WVA's desired count is clamped by it exactly as today; the config sets the *policy* WVA decides within, not the safety cap.
 - **Scale-to-zero** — `scaleToZero.enabled` lets WVA emit a desired of `0`; the `ScaledObject` (with KEDA's idle-replica support) actuates it.
+- **`behavior` means WVA owns stabilization — the `ScaledObject` must not double it.** `spec.behavior` (§4) makes WVA apply the HPA-style damping (windows, rate policies) to its *own* recommendation before emitting it. But the `ScaledObject`/HPA can *also* stabilize the metric it reads, and two stabilizers in series **compound lag** (a spike is damped by WVA, then damped again downstream). The contract when `behavior` is set: **WVA owns stabilization; the `ScaledObject`/HPA `behavior` is configured near-passthrough** (`stabilizationWindowSeconds: 0`). Where the two are reconciled (operator convention vs. WVA generating the `ScaledObject` behavior) is the stabilization proposal's, not this schema's — this proposal only fixes that `behavior` is a per-model field and that it is the *single* stabilizer of record.
 - **Managed-set identification is unchanged.** WVA discovers the workloads it manages from the `llm-d.ai/managed` label on the `ScaledObject` (and reads `llm-d.ai/model-id`, `inference.optimization/acceleratorName`) — the current mechanism. This proposal does not change it (§7).
 
 ## 4. The generic schema shape (review question 2)

--- a/docs/proposals/design-scalingpolicy-crd.md
+++ b/docs/proposals/design-scalingpolicy-crd.md
@@ -105,7 +105,24 @@ These two have **different owners and different RBAC**; they cannot share one ob
 
 The **third (per-pool) tier costs no extra schema**: it is the *same* CRD with `inferencePoolRef` set, in the tenant's own namespace. It adds override *granularity* (one pool tuned differently from its namespace default), not a new surface or a new kind. So "multiple levels" here means three placements of one object resolved by a small, deterministic merge — not three configuration systems.
 
-> The merged result is published on the per-pool object's `status.effectivePolicy` (with `status.sources`), so `kubectl get scalingpolicy <name> -o yaml` shows exactly what is in force and which tiers produced it — the resolution is observable, not an unseen algorithm. (Status field detail deferred to #1194.)
+### Status — the resolution is observable
+
+The per-pool object's status publishes both *what was resolved* and *what it governs*, so `kubectl get scalingpolicy <name> -o yaml` shows exactly what WVA decided — no unseen algorithm:
+
+```yaml
+status:
+  observedPool: granite-premium-pool
+  managedVariants:                     # the workloads this policy governs
+    - workloadRef: { kind: Deployment, name: granite-premium-prefill }
+      role: prefill                    # when known
+    - workloadRef: { kind: Deployment, name: granite-premium-decode }
+      role: decode
+  effectivePolicy: { … }               # merged result (cluster → ns → per-pool)
+  sources: [ … ]                       # contributing tiers, in precedence order
+```
+
+- **`effectivePolicy`** (+ **`sources`**) — the merged result and which tier each field came from.
+- **`managedVariants`** — the workloads this policy actually governs. The policy matches an `InferencePool`; WVA resolves that pool to its pods and their owning workloads (the *variants*) at reconcile time and lists each by its **workload reference — the same object a tenant's HPA/`ScaledObject` `scaleTargetRef` points at.** Discovery is via the pool, *not* by reading HPA objects (§2), so this adds no HPA dependency; it just lets an operator line up *policy → variants → their HPAs*. An **empty list is a loud misconfiguration signal** (the `inferencePoolRef` matched a pool with no workloads — wrong ref or selector mismatch), surfaced as a `PolicyMatched: False` condition. Live per-variant replica counts stay in the `wva_desired_replicas` metric — status holds the stable mapping, not the churning numbers.
 
 ## 5. Deliberately out of scope (deferred to #1194)
 
@@ -113,7 +130,7 @@ To hold this to the bare minimum, the following are **not** decided here and rem
 
 - Migration path and the `wva-config` CLI / migration tool.
 - Deprecation phases and the ConfigMap-removal timeline.
-- The full `status` condition catalog (only `effectivePolicy` / `sources` are referenced above).
+- The full `status` *condition* catalog (only `effectivePolicy`, `sources`, `managedVariants`, and the `PolicyMatched` condition are defined above).
 - Per-role (prefill/decode) configuration — an analyzer-`parameters` concern, not a CRD-shape concern.
 - Alternatives considered and the autoscaler comparison matrices.
 - The `quota` `parameters` schema and enforcement — owned by #1162.


### PR DESCRIPTION
## What

A **bare-minimum** design for the WVA configuration CRD — `docs/proposals/design-scalingpolicy-crd.md` split out from #1194 so we can agree the CRD's *boundary* and *shape* before anything is layered on top.

**#1194 stays open as the reference** for the full analysis (migration, deprecation phases, status catalog, alternatives, comparison matrices); none of that is decided here.

## Why

Per review of #1194: *"The current proposal covers too much ground and should be trimmed to the bare minimum. Having a CRD is a good start. The questions to answer are what is the relationship between the Config CRD and the HPA object, and what is the generic shape (schema) of the CRD."*

This PR answers exactly those two questions and settles only the minimum they force (the resolution tiers and the status shape).

## The two questions

**1. CRD ↔ HPA relationship (§2).** They are config-decoupled. `ScalingPolicy` configures WVA's *decision*; the HPA/`ScaledObject` *actuates* it by reading the `wva_desired_replicas` metric. Neither references the other's config — so adding WVA config never means editing a tenant's HPA. `maxReplicas` stays as a complementary hard ceiling; scale-to-zero is a policy toggle the HPA layer actuates. (WVA *does* read the HPA/`ScaledObject` to identify the workloads it manages — but the discovery *mechanism* belongs to the separate VA-deprecation proposal, see below, not this CRD's shape.)

**2. Generic schema shape (§3).** A thin **typed envelope** (`priority`, `scaleToZero`, `inferencePoolRef`) around **pluggable `{type, name, parameters}` lists** (`analyzers`, `limiters`) whose `parameters` are `x-kubernetes-preserve-unknown-fields` — the EPP `EndpointPickerConfig` shape. Adding an analyzer or limiter never changes the CRD schema.

## On "even multiple levels is too much"

Kept **three tiers** (cluster-default → namespace → per-pool), but minimally and structurally, not by preference (§4):

- **Quota forces cluster + namespace.** Quota is cluster-admin-owned and cluster-scoped; thresholds/`priority`/`scaleToZero` are tenant-owned and namespace-scoped. Different owners, different RBAC — they can't share one object without letting tenants edit quota or admins own every tenant's thresholds.
- **Per-pool costs zero extra schema** — it's the *same* CRD with `inferencePoolRef` set, in the tenant's namespace; override granularity, not a new surface.

So "multiple levels" is three placements of **one** CRD resolved by a small deterministic merge — not three configuration systems. **`limiters`/`quota` are cluster-default-only** (CEL-rejected on namespace/per-pool, and tenants lack RBAC on the system namespace), so a tenant can't drop the quota limiter and escape their own cap.

## Status (§4) and what's deferred

`status` surfaces `effectivePolicy`/`sources` (the tier-merge result) and `managedVariants` — the workloads this policy manages, each with `workloadRef`, `role`, and per-replica `cost`. This proposal fixes only the **shape** of those fields.

**Two dependencies/open items (§5):**
- **Discovery and cost-sourcing depend on VA-deprecation proposal**. That proposal owns how WVA identifies managed workloads — currently the `llm-d.ai/managed` label on the HPA/`ScaledObject` (#1130) — and where per-variant `cost` comes from (`VariantAutoscaling` `cost` today; co-located there post-VA). This proposal is independent of the mechanism.
- **Open question:** where the effective policy is published for a pool governed only by defaults (no per-pool object). Candidates: `InferencePool` status, a status-only object, or a `wva-config explain` view.

**Out of scope, deferred to #1194 (§6):** migration tooling, deprecation phases, the full status-condition catalog, per-role config, alternatives/comparison matrices, and the `quota` `parameters` schema (owned by #1162).

---

Looking for agreement on **§2 (boundary)** and **§3 (shape)** first; the rest layers on top without changing either. #1194 remains open as the reference companion.