### PR TITLE
feat(benchmark): add post-processing script for tabular benchmark reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,7 @@ benchmark-report: ## Generate a markdown table from the latest benchmark results
 	fi; \
 	echo "Results directory: $$LATEST_DIR"; \
 	echo ""; \
-	python3 $(CURDIR)/hack/benchmark/postprocess.py \
+	python3 $(CURDIR)/scripts/postprocess.py \
 		--gpus-per-replica $(BENCHMARK_GPUS_PER_REPLICA) \
 		$$LATEST_DIR
 

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ benchmark-report: ## Generate a markdown table from the latest benchmark results
 	fi; \
 	echo "Results directory: $$LATEST_DIR"; \
 	echo ""; \
-	python3 $(CURDIR)/scripts/postprocess.py $$LATEST_DIR
+	python3 $(CURDIR)/hack/benchmark/postprocess.py $$LATEST_DIR
 
 BURSTY_WORKLOAD    ?= bursty.yaml
 BENCHMARK_WAIT_TIMEOUT ?= 7200

--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,26 @@ benchmark-run: ## Run a single benchmark workload (set BENCHMARK_NAMESPACE=<name
 		-w $(BENCHMARK_WORKLOAD) \
 		$(if $(BENCHMARK_MODEL_ID),-m $(BENCHMARK_MODEL_ID),) \
 		$(if $(filter true,$(BENCHMARK_MONITORING)),--monitoring,)
+	@echo ""
+	@echo "========================================="
+	@echo "  Generating benchmark report..."
+	@echo "========================================="
+	@$(MAKE) benchmark-report
+
+BENCHMARK_GPUS_PER_REPLICA ?= 1
+
+.PHONY: benchmark-report
+benchmark-report: ## Generate a markdown table from the latest benchmark results
+	@LATEST_DIR=$$(ls -td $(BENCHMARK_WORKSPACE)/$${USER}-*/results/$(BENCHMARK_HARNESS)-*_* 2>/dev/null | head -1); \
+	if [ -z "$$LATEST_DIR" ]; then \
+		echo "ERROR: No benchmark results found in $(BENCHMARK_WORKSPACE)"; \
+		exit 1; \
+	fi; \
+	echo "Results directory: $$LATEST_DIR"; \
+	echo ""; \
+	python3 $(CURDIR)/hack/benchmark/postprocess.py \
+		--gpus-per-replica $(BENCHMARK_GPUS_PER_REPLICA) \
+		$$LATEST_DIR
 
 BURSTY_WORKLOAD    ?= bursty.yaml
 BENCHMARK_WAIT_TIMEOUT ?= 7200

--- a/Makefile
+++ b/Makefile
@@ -387,8 +387,6 @@ benchmark-run: ## Run a single benchmark workload (set BENCHMARK_NAMESPACE=<name
 	@echo "========================================="
 	@$(MAKE) benchmark-report
 
-BENCHMARK_GPUS_PER_REPLICA ?= 1
-
 .PHONY: benchmark-report
 benchmark-report: ## Generate a markdown table from the latest benchmark results
 	@LATEST_DIR=$$(ls -td $(BENCHMARK_WORKSPACE)/$${USER}-*/results/$(BENCHMARK_HARNESS)-*_* 2>/dev/null | head -1); \
@@ -398,9 +396,7 @@ benchmark-report: ## Generate a markdown table from the latest benchmark results
 	fi; \
 	echo "Results directory: $$LATEST_DIR"; \
 	echo ""; \
-	python3 $(CURDIR)/scripts/postprocess.py \
-		--gpus-per-replica $(BENCHMARK_GPUS_PER_REPLICA) \
-		$$LATEST_DIR
+	python3 $(CURDIR)/scripts/postprocess.py $$LATEST_DIR
 
 BURSTY_WORKLOAD    ?= bursty.yaml
 BENCHMARK_WAIT_TIMEOUT ?= 7200

--- a/hack/benchmark/postprocess.py
+++ b/hack/benchmark/postprocess.py
@@ -6,15 +6,15 @@ Produces the exact table format used in docs/benchmark.md.
 
 Usage:
     # Single run:
-    python scripts/postprocess.py results/guidellm-*_1
+    python hack/benchmark/postprocess.py results/guidellm-*_1
 
     # Three runs (Run 1 | Run 2 | Run 3 | Avg):
-    python scripts/postprocess.py results/guidellm-*_1 \\
-                                   results/guidellm-*_2 \\
-                                   results/guidellm-*_3
+    python hack/benchmark/postprocess.py results/guidellm-*_1 \\
+                                          results/guidellm-*_2 \\
+                                          results/guidellm-*_3
 
     # With scenario header:
-    python scripts/postprocess.py --scenario "Prefill Heavy — Qwen/Qwen3-32B (600s)" \\
+    python hack/benchmark/postprocess.py --scenario "Prefill Heavy — Qwen/Qwen3-32B (600s)" \\
         results/guidellm-*_1 results/guidellm-*_2 results/guidellm-*_3
 """
 

--- a/hack/benchmark/postprocess.py
+++ b/hack/benchmark/postprocess.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+Post-process llm-d-benchmark results into a markdown table.
+
+Produces the exact table format used in docs/benchmark.md.
+
+Usage:
+    # Single run:
+    python hack/benchmark/postprocess.py results/guidellm-*_1
+
+    # Three runs (Run 1 | Run 2 | Run 3 | Avg):
+    python hack/benchmark/postprocess.py results/guidellm-*_1 \\
+                                          results/guidellm-*_2 \\
+                                          results/guidellm-*_3
+
+    # With scenario header and GPU count:
+    python hack/benchmark/postprocess.py --scenario "Prefill Heavy — Qwen/Qwen3-32B (600s)" \\
+        --gpus-per-replica 2 results/guidellm-*_1 results/guidellm-*_2 results/guidellm-*_3
+"""
+
+import argparse
+import json
+import os
+import sys
+from statistics import mean
+
+METRICS = [
+    "P99 TTFT (ms)",
+    "P99 ITL (ms/token)",
+    "Avg replicas",
+    "Max replicas",
+    "Avg KV cache utilization",
+    "Avg queue depth (EPP)",
+    "Error count",
+    "Avg pod startup (s)",
+    "Cost (avg replicas × GPU/hr)",
+]
+
+
+def _parse_prometheus_value(line, metric_name):
+    """Extract a float from a Prometheus exposition-format line."""
+    if not line.startswith(metric_name):
+        return None
+    rest = line[len(metric_name):]
+    if rest and rest[0] not in ("{", " "):
+        return None
+    if rest.startswith("{"):
+        close = rest.find("}")
+        if close < 0:
+            return None
+        rest = rest[close + 1:]
+    try:
+        return float(rest.strip())
+    except (ValueError, IndexError):
+        return None
+
+
+def _extract_latency(results_dir):
+    """P99 TTFT and P99 ITL from results.json."""
+    path = os.path.join(results_dir, "results.json")
+    if not os.path.isfile(path):
+        return None, None
+
+    with open(path) as f:
+        data = json.load(f)
+
+    metrics = data["benchmarks"][0]["metrics"]
+
+    def _p99(section_key):
+        section = metrics.get(section_key, {}).get("successful", {})
+        pcts = section.get("percentiles", {})
+        if isinstance(pcts, list):
+            pcts = {p["percentile"]: p["value"] for p in pcts}
+        return pcts.get("p99") or pcts.get(99) or section.get("max")
+
+    return _p99("time_to_first_token_ms"), _p99("inter_token_latency_ms")
+
+
+def _extract_error_count(results_dir):
+    """Error count from results.json."""
+    path = os.path.join(results_dir, "results.json")
+    if not os.path.isfile(path):
+        return 0
+    with open(path) as f:
+        data = json.load(f)
+    return data["benchmarks"][0]["metrics"]["request_totals"].get("errored", 0)
+
+
+def _extract_replica_stats(results_dir):
+    """Avg and max ready replicas from replica_status_timeseries.json."""
+    path = os.path.join(results_dir, "metrics", "processed",
+                        "replica_status_timeseries.json")
+    if not os.path.isfile(path):
+        return None, None
+
+    with open(path) as f:
+        data = json.load(f)
+
+    totals = []
+    for snap in data["snapshots"]:
+        ready = sum(
+            (c.get("ready_replicas", 0) or 0) for c in snap["controllers"]
+            if "decode" in c.get("name", "")
+        )
+        totals.append(ready)
+
+    if not totals:
+        return None, None
+    return mean(totals), max(totals)
+
+
+def _extract_kv_cache_avg(results_dir):
+    """Average KV cache utilization (%) from raw vLLM metrics."""
+    raw_dir = os.path.join(results_dir, "metrics", "raw")
+    if not os.path.isdir(raw_dir):
+        return None
+
+    values = []
+    for fname in os.listdir(raw_dir):
+        if not fname.endswith(".log") or "router-epp" in fname:
+            continue
+        if fname == "collection_debug.log":
+            continue
+        fpath = os.path.join(raw_dir, fname)
+        with open(fpath) as f:
+            for line in f:
+                val = _parse_prometheus_value(line.strip(),
+                                              "vllm:kv_cache_usage_perc")
+                if val is not None:
+                    values.append(val * 100)
+                    break
+
+    return mean(values) if values else None
+
+
+def _extract_queue_depth_avg(results_dir):
+    """Average EPP queue depth from raw EPP metrics."""
+    raw_dir = os.path.join(results_dir, "metrics", "raw")
+    if not os.path.isdir(raw_dir):
+        return None
+
+    values = []
+    for fname in sorted(os.listdir(raw_dir)):
+        if not fname.endswith(".log") or "router-epp" not in fname:
+            continue
+        fpath = os.path.join(raw_dir, fname)
+        with open(fpath) as f:
+            for line in f:
+                val = _parse_prometheus_value(
+                    line.strip(),
+                    "inference_extension_flow_control_queue_size")
+                if val is not None:
+                    values.append(val)
+                    break
+
+    return mean(values) if values else None
+
+
+def _extract_pod_startup_avg(results_dir):
+    """Average pod startup time (s) from pod_startup_times.json."""
+    path = os.path.join(results_dir, "metrics", "processed",
+                        "pod_startup_times.json")
+    if not os.path.isfile(path):
+        return None
+
+    with open(path) as f:
+        data = json.load(f)
+
+    times = [p["startup_seconds"] for p in data.get("pods", [])
+             if p.get("startup_seconds") is not None]
+    return mean(times) if times else None
+
+
+def _fmt(metric, value):
+    """Format a value to match the benchmark.md number style."""
+    if value is None:
+        return "?"
+
+    if metric == "P99 TTFT (ms)":
+        return f"{value:,.0f}"
+    if metric == "P99 ITL (ms/token)":
+        return f"{value:.2f}" if (value * 100) % 10 != 0 else f"{value:.1f}"
+    if metric == "Avg replicas":
+        return f"{value:.2f}"
+    if metric == "Max replicas":
+        return str(int(value))
+    if metric == "Avg KV cache utilization":
+        return f"{value:.1f}%"
+    if metric == "Avg queue depth (EPP)":
+        return f"{value:.1f}"
+    if metric == "Error count":
+        return f"{int(value):,}"
+    if metric == "Avg pod startup (s)":
+        return str(round(value))
+    if metric == "Cost (avg replicas × GPU/hr)":
+        return f"{value:.2f}"
+    return str(value)
+
+
+def process_one(results_dir, gpus_per_replica=1.0):
+    """Extract all benchmark.md metrics from one results directory."""
+    p99_ttft, p99_itl = _extract_latency(results_dir)
+    avg_rep, max_rep = _extract_replica_stats(results_dir)
+    kv_avg = _extract_kv_cache_avg(results_dir)
+    queue_avg = _extract_queue_depth_avg(results_dir)
+    startup_avg = _extract_pod_startup_avg(results_dir)
+    error_count = _extract_error_count(results_dir)
+    cost = avg_rep * gpus_per_replica if avg_rep is not None else None
+
+    raw = {
+        "P99 TTFT (ms)": p99_ttft,
+        "P99 ITL (ms/token)": p99_itl,
+        "Avg replicas": avg_rep,
+        "Max replicas": max_rep,
+        "Avg KV cache utilization": kv_avg,
+        "Avg queue depth (EPP)": queue_avg,
+        "Error count": error_count,
+        "Avg pod startup (s)": startup_avg,
+        "Cost (avg replicas × GPU/hr)": cost,
+    }
+    return raw
+
+
+def _compute_avg(runs):
+    """Compute average column across multiple runs (raw numeric values)."""
+    avg = {}
+    for m in METRICS:
+        vals = [r[m] for r in runs if r[m] is not None]
+        avg[m] = mean(vals) if vals else None
+    return avg
+
+
+def format_table(runs, labels):
+    """Render a markdown table matching the benchmark.md style."""
+    show_avg = len(runs) > 1
+    cols = list(labels)
+    data_cols = list(runs)
+
+    if show_avg:
+        cols.append("Avg")
+        data_cols.append(_compute_avg(runs))
+
+    header = "| Metric | " + " | ".join(cols) + " |"
+    sep = "|--------|" + "|".join(["------"] * len(cols)) + "|"
+
+    rows = []
+    for m in METRICS:
+        cells = [_fmt(m, run[m]) for run in data_cols]
+        rows.append(f"| {m} | " + " | ".join(cells) + " |")
+
+    return "\n".join([header, sep] + rows)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Post-process llm-d-benchmark results into a markdown table")
+    ap.add_argument("results_dirs", nargs="+",
+                    help="One or more benchmark results directories")
+    ap.add_argument("--scenario", type=str, default=None,
+                    help="Scenario heading (e.g. 'Prefill Heavy — Qwen/Qwen3-32B (600s)')")
+    ap.add_argument("--gpus-per-replica", type=float, default=1.0,
+                    help="GPUs per replica for cost calculation (default: 1)")
+    ap.add_argument("--json", action="store_true",
+                    help="Output raw JSON instead of markdown")
+    args = ap.parse_args()
+
+    runs = []
+    labels = []
+    for d in args.results_dirs:
+        if not os.path.isdir(d):
+            print(f"WARNING: {d} is not a directory, skipping", file=sys.stderr)
+            continue
+        print(f"Processing: {d}", file=sys.stderr)
+        runs.append(process_one(d, gpus_per_replica=args.gpus_per_replica))
+        labels.append(f"Run {len(runs)}")
+
+    if not runs:
+        print("ERROR: No valid results directories found", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(runs, indent=2))
+        return
+
+    print()
+    if args.scenario:
+        print(f"### {args.scenario}\n")
+    print(format_table(runs, labels))
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -13,9 +13,9 @@ Usage:
                                    results/guidellm-*_2 \\
                                    results/guidellm-*_3
 
-    # With scenario header and GPU count:
+    # With scenario header:
     python scripts/postprocess.py --scenario "Prefill Heavy — Qwen/Qwen3-32B (600s)" \\
-        --gpus-per-replica 2 results/guidellm-*_1 results/guidellm-*_2 results/guidellm-*_3
+        results/guidellm-*_1 results/guidellm-*_2 results/guidellm-*_3
 """
 
 import argparse
@@ -33,7 +33,6 @@ METRICS = [
     "Avg queue depth (EPP)",
     "Error count",
     "Avg pod startup (s)",
-    "Cost (avg replicas × GPU/hr)",
 ]
 
 
@@ -192,12 +191,10 @@ def _fmt(metric, value):
         return f"{int(value):,}"
     if metric == "Avg pod startup (s)":
         return str(round(value))
-    if metric == "Cost (avg replicas × GPU/hr)":
-        return f"{value:.2f}"
     return str(value)
 
 
-def process_one(results_dir, gpus_per_replica=1.0):
+def process_one(results_dir):
     """Extract all benchmark.md metrics from one results directory."""
     p99_ttft, p99_itl = _extract_latency(results_dir)
     avg_rep, max_rep = _extract_replica_stats(results_dir)
@@ -205,9 +202,8 @@ def process_one(results_dir, gpus_per_replica=1.0):
     queue_avg = _extract_queue_depth_avg(results_dir)
     startup_avg = _extract_pod_startup_avg(results_dir)
     error_count = _extract_error_count(results_dir)
-    cost = avg_rep * gpus_per_replica if avg_rep is not None else None
 
-    raw = {
+    return {
         "P99 TTFT (ms)": p99_ttft,
         "P99 ITL (ms/token)": p99_itl,
         "Avg replicas": avg_rep,
@@ -216,9 +212,7 @@ def process_one(results_dir, gpus_per_replica=1.0):
         "Avg queue depth (EPP)": queue_avg,
         "Error count": error_count,
         "Avg pod startup (s)": startup_avg,
-        "Cost (avg replicas × GPU/hr)": cost,
     }
-    return raw
 
 
 def _compute_avg(runs):
@@ -258,8 +252,6 @@ def main():
                     help="One or more benchmark results directories")
     ap.add_argument("--scenario", type=str, default=None,
                     help="Scenario heading (e.g. 'Prefill Heavy — Qwen/Qwen3-32B (600s)')")
-    ap.add_argument("--gpus-per-replica", type=float, default=1.0,
-                    help="GPUs per replica for cost calculation (default: 1)")
     ap.add_argument("--json", action="store_true",
                     help="Output raw JSON instead of markdown")
     args = ap.parse_args()
@@ -271,7 +263,7 @@ def main():
             print(f"WARNING: {d} is not a directory, skipping", file=sys.stderr)
             continue
         print(f"Processing: {d}", file=sys.stderr)
-        runs.append(process_one(d, gpus_per_replica=args.gpus_per_replica))
+        runs.append(process_one(d))
         labels.append(f"Run {len(runs)}")
 
     if not runs:

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -6,15 +6,15 @@ Produces the exact table format used in docs/benchmark.md.
 
 Usage:
     # Single run:
-    python hack/benchmark/postprocess.py results/guidellm-*_1
+    python scripts/postprocess.py results/guidellm-*_1
 
     # Three runs (Run 1 | Run 2 | Run 3 | Avg):
-    python hack/benchmark/postprocess.py results/guidellm-*_1 \\
-                                          results/guidellm-*_2 \\
-                                          results/guidellm-*_3
+    python scripts/postprocess.py results/guidellm-*_1 \\
+                                   results/guidellm-*_2 \\
+                                   results/guidellm-*_3
 
     # With scenario header and GPU count:
-    python hack/benchmark/postprocess.py --scenario "Prefill Heavy — Qwen/Qwen3-32B (600s)" \\
+    python scripts/postprocess.py --scenario "Prefill Heavy — Qwen/Qwen3-32B (600s)" \\
         --gpus-per-replica 2 results/guidellm-*_1 results/guidellm-*_2 results/guidellm-*_3
 """
 


### PR DESCRIPTION
## Summary

- Add `hack/benchmark/postprocess.py` that extracts metrics from `llm-d-benchmark` output folders and generates a markdown table matching the format in `docs/benchmark.md`
- Extracted metrics: P99 TTFT, P99 ITL, avg/max replicas, avg KV cache utilization, avg EPP queue depth, error count, avg pod startup, and cost
- Integrate into Makefile with a new `benchmark-report` target and auto-call after `benchmark-run`

### Usage

```bash
# Standalone — single run:
python hack/benchmark/postprocess.py results/guidellm-*_1

# Three runs (generates Run 1 | Run 2 | Run 3 | Avg columns):
python hack/benchmark/postprocess.py results/guidellm-*_1 \
                                      results/guidellm-*_2 \
                                      results/guidellm-*_3

# With scenario header and GPU count:
python hack/benchmark/postprocess.py --scenario "Prefill Heavy — Qwen/Qwen3-32B (600s)" \
    --gpus-per-replica 2 results/guidellm-*_1

# Via Makefile (auto-detects latest results):
make benchmark-report
make benchmark-report BENCHMARK_GPUS_PER_REPLICA=2

# Auto-runs after benchmark-run completes:
make benchmark-run BENCHMARK_NAMESPACE=kahila-bench \
    BENCHMARK_MODEL_ID=Qwen/Qwen3-32B \
    BENCHMARK_GPUS_PER_REPLICA=2
```

### Example output

```
| Metric | Run 1 |
|--------|------|
| P99 TTFT (ms) | 531,703 |
| P99 ITL (ms/token) | 60.78 |
| Avg replicas | 1.54 |
| Max replicas | 2 |
| Avg KV cache utilization | 55.0% |
| Avg queue depth (EPP) | 107.1 |
| Error count | 0 |
| Avg pod startup (s) | 128 |
| Cost (avg replicas × GPU/hr) | 1.54 |
```

Closes #1239



Made with [Cursor](https://cursor.com)