### PR TITLE
engine: add structured per-cycle log lines (analyzer-result, scaling-decision)

### DIFF
--- a/docs/developer-guide/cycle-log.md
+++ b/docs/developer-guide/cycle-log.md
@@ -98,6 +98,8 @@ the saturation V2 analyzer sets one of these values:
 | `P2-hist` | k2 came from the **historical** rolling average |
 | `P3-k2` | k2 was **derived** from deployment parameters (vLLM model args) |
 | `P4-k1` | k2 was unavailable; **fell back** to k1 (memory-bound capacity) |
+| `no-data` | no ready replicas, no stored record, no compatible variant — capacity is 0 this cycle (normal for newly deployed variants) |
+| `error` | K2 priority not in known set — indicates an unlabelled code path; should not occur in normal operation |
 
 The `P1-obs`–`P4-k1` values reflect the representative replica for the variant
 — specifically the replica whose effective capacity equals the lower median
@@ -106,9 +108,16 @@ reason means live inference data is available and the capacity estimate is
 high-confidence; a `P4-k1` reason means no compute-bound signal was available
 for any replica and the estimate is conservative.
 
-The throughput analyzer sets `T1-ols`, `T2-pinned`, or `T2-default` to
-indicate which fitting tier produced the capacity estimate. Other analyzers may
-set their own reason values or leave `reason` empty.
+The throughput analyzer sets one of these values:
+
+| Reason | Meaning |
+|---|---|
+| `T1-ols` | capacity from Tier-1 OLS fit (observation window ready) |
+| `T2-pinned` | capacity from Tier-2 constrained OLS with a prior fitted B |
+| `T2-default` | capacity from Tier-2 constrained OLS with the default baseline B (cold start) |
+| `T2-failed` | both tiers failed — all replicas idle or no usable ITL signal; variant skipped this cycle |
+
+Other analyzers may set their own reason values or leave `reason` empty.
 
 ---
 

--- a/docs/developer-guide/cycle-log.md
+++ b/docs/developer-guide/cycle-log.md
@@ -41,7 +41,7 @@ optimizer actually receives.
 | `modelID` | WVA model ID (unique within a namespace) |
 | `namespace` | Kubernetes namespace |
 | `analyzer` | Analyzer name, e.g. `"saturation"`, `"throughput"` |
-| `supply` | Total anticipated token supply across ready replicas |
+| `supply` | Total token supply across ready replicas (readyCount × perReplicaCapacity) |
 | `demand` | Total observed token demand |
 | `util` | `demand / supply`; > 1.0 means the model is over capacity |
 | `rc` | Required capacity signal (post-threshold): > 0 triggers scale-up |

--- a/docs/developer-guide/cycle-log.md
+++ b/docs/developer-guide/cycle-log.md
@@ -1,0 +1,151 @@
+# WVA Cycle Log
+
+The WVA saturation engine emits two structured INFO log lines per reconcile
+cycle per model. These lines are the primary observability instrument for
+understanding what the analyzer and optimizer computed without enabling
+verbose debug logging.
+
+---
+
+## Log lines
+
+### `analyzer-result`
+
+Emitted once per analyzer that ran for a model, immediately after the
+universal threshold post-step has been applied. The values reflect what the
+optimizer actually receives.
+
+```json
+{
+  "level": "info",
+  "msg": "analyzer-result",
+  "modelID": "my-model",
+  "namespace": "default",
+  "analyzer": "saturation",
+  "supply": 658534,
+  "demand": 1041047,
+  "util": 1.58,
+  "rc": 0,
+  "sc": 50000,
+  "variants": [
+    {"name": "primary", "prc": 1152000, "cost": 10, "label": "P3-k2"},
+    {"name": "v2",      "prc":  403391, "cost":  5, "label": "P1-obs"}
+  ]
+}
+```
+
+| Field | Description |
+|---|---|
+| `modelID` | WVA model ID (unique within a namespace) |
+| `namespace` | Kubernetes namespace |
+| `analyzer` | Analyzer name, e.g. `"saturation"`, `"throughput"` |
+| `supply` | Total anticipated token supply across ready replicas |
+| `demand` | Total observed token demand |
+| `util` | `demand / supply`; > 1.0 means the model is over capacity |
+| `rc` | Required capacity signal (post-threshold): > 0 triggers scale-up |
+| `sc` | Spare capacity signal (post-threshold): > 0 permits scale-down |
+| `variants[].name` | Variant name |
+| `variants[].prc` | Per-replica capacity in analyzer units (tokens for saturation) |
+| `variants[].cost` | Relative cost weight used by the optimizer |
+| `variants[].label` | How the variant's capacity was computed (see below) |
+
+If an analyzer does not compute per-variant capacity, `variants` is an empty
+array. Multiple `analyzer-result` lines appear when more than one analyzer is
+enabled; each has the same `modelID`/`namespace` and its own `analyzer` field.
+
+### `scaling-decision`
+
+Emitted once per model after the optimizer has produced its final per-variant
+replica targets.
+
+```json
+{
+  "level": "info",
+  "msg": "scaling-decision",
+  "modelID": "my-model",
+  "namespace": "default",
+  "decisions": [
+    {"name": "primary", "curr": 1, "tgt": 2, "action": "ScaleUp"},
+    {"name": "v2",      "curr": 1, "tgt": 1, "action": "NoChange"}
+  ]
+}
+```
+
+| Field | Description |
+|---|---|
+| `modelID` | WVA model ID |
+| `namespace` | Kubernetes namespace |
+| `decisions[].name` | Variant name |
+| `decisions[].curr` | Current replica count at the time of this cycle |
+| `decisions[].tgt` | Target replica count chosen by the optimizer |
+| `decisions[].action` | `ScaleUp`, `ScaleDown`, or `NoChange` |
+
+---
+
+## Capacity label values (`label` field)
+
+The `label` field in `analyzer-result` variants is set by each analyzer to
+describe how it computed the variant's per-replica capacity. It is free text;
+the saturation V2 analyzer sets one of four values based on its k2 priority
+chain:
+
+| Label | Meaning |
+|---|---|
+| `P1-obs` | k2 came from **observed** tokens-in-use (queue was saturated) |
+| `P2-hist` | k2 came from the **historical** rolling average |
+| `P3-k2` | k2 was **derived** from deployment parameters (vLLM model args) |
+| `P4-k1` | k2 was unavailable; **fell back** to k1 (memory-bound capacity) |
+
+The label reflects the representative replica for the variant — specifically
+the replica whose effective capacity equals the lower median across all ready
+replicas (the same replica that determined `prc`). A `P1-obs` label means live
+inference data is available and the capacity estimate is high-confidence; a
+`P4-k1` label means no compute-bound signal was available for any replica and
+the estimate is conservative.
+
+Other analyzers (e.g. the throughput analyzer) may set their own label values
+or leave `label` empty.
+
+---
+
+## Grep patterns
+
+```bash
+# All analyzer results for a specific model
+kubectl logs <pod> | grep '"msg":"analyzer-result"' | grep '"modelID":"my-model"'
+
+# Saturation analyzer only
+kubectl logs <pod> | grep '"msg":"analyzer-result"' | grep '"analyzer":"saturation"'
+
+# Scaling decisions only (scale-up events)
+kubectl logs <pod> | grep '"msg":"scaling-decision"' | grep '"action":"ScaleUp"'
+
+# Full cycle for one model (both lines)
+kubectl logs <pod> | grep -E '"analyzer-result"|"scaling-decision"' | grep '"modelID":"my-model"'
+```
+
+---
+
+## Ordering and timing
+
+Within a single reconcile cycle for one model:
+
+1. One `analyzer-result` line per enabled analyzer (saturation first, then
+   any registered non-saturation analyzers in registration order).
+2. One `scaling-decision` line after the optimizer has processed all models
+   in the cycle.
+
+The two line types are not atomically adjacent in the log — other models'
+`analyzer-result` lines may appear between a model's last `analyzer-result`
+and its `scaling-decision`. Filter by `modelID` and `namespace` when
+correlating them.
+
+---
+
+## Enabling the log
+
+These lines are emitted at INFO level and appear in the default controller
+log output. No feature flag or configuration change is required.
+
+The existing `"V2 saturation analysis completed"` and
+`"Applied saturation decision"` lines remain unchanged.

--- a/docs/developer-guide/cycle-log.md
+++ b/docs/developer-guide/cycle-log.md
@@ -27,9 +27,11 @@ optimizer actually receives.
   "util": 1.58,
   "rc": 0,
   "sc": 50000,
+  "scaleUpThreshold": 1.1,
+  "scaleDownBoundary": 0.7,
   "variants": [
-    {"name": "primary", "prc": 1152000, "cost": 10, "label": "P3-k2"},
-    {"name": "v2",      "prc":  403391, "cost":  5, "label": "P1-obs"}
+    {"name": "primary", "prc": 1152000, "reason": "P3-k2"},
+    {"name": "v2",      "prc":  403391, "reason": "P1-obs"}
   ]
 }
 ```
@@ -44,10 +46,11 @@ optimizer actually receives.
 | `util` | `demand / supply`; > 1.0 means the model is over capacity |
 | `rc` | Required capacity signal (post-threshold): > 0 triggers scale-up |
 | `sc` | Spare capacity signal (post-threshold): > 0 permits scale-down |
+| `scaleUpThreshold` | Scale-up threshold resolved for this analyzer (from config) |
+| `scaleDownBoundary` | Scale-down boundary resolved for this analyzer (from config) |
 | `variants[].name` | Variant name |
 | `variants[].prc` | Per-replica capacity in analyzer units (tokens for saturation) |
-| `variants[].cost` | Relative cost weight used by the optimizer |
-| `variants[].label` | How the variant's capacity was computed (see below) |
+| `variants[].reason` | How the variant's capacity was computed (see below) |
 
 If an analyzer does not compute per-variant capacity, `variants` is an empty
 array. Multiple `analyzer-result` lines appear when more than one analyzer is
@@ -82,29 +85,30 @@ replica targets.
 
 ---
 
-## Capacity label values (`label` field)
+## Reason values (`reason` field)
 
-The `label` field in `analyzer-result` variants is set by each analyzer to
+The `reason` field in `analyzer-result` variants is set by each analyzer to
 describe how it computed the variant's per-replica capacity. It is free text;
-the saturation V2 analyzer sets one of four values based on its k2 priority
-chain:
+the saturation V2 analyzer sets one of these values:
 
-| Label | Meaning |
+| Reason | Meaning |
 |---|---|
+| `P0-store` | capacity came from the **capacity store** (no live replicas) |
 | `P1-obs` | k2 came from **observed** tokens-in-use (queue was saturated) |
 | `P2-hist` | k2 came from the **historical** rolling average |
 | `P3-k2` | k2 was **derived** from deployment parameters (vLLM model args) |
 | `P4-k1` | k2 was unavailable; **fell back** to k1 (memory-bound capacity) |
 
-The label reflects the representative replica for the variant — specifically
-the replica whose effective capacity equals the lower median across all ready
-replicas (the same replica that determined `prc`). A `P1-obs` label means live
-inference data is available and the capacity estimate is high-confidence; a
-`P4-k1` label means no compute-bound signal was available for any replica and
-the estimate is conservative.
+The `P1-obs`–`P4-k1` values reflect the representative replica for the variant
+— specifically the replica whose effective capacity equals the lower median
+across all ready replicas (the same replica that determined `prc`). A `P1-obs`
+reason means live inference data is available and the capacity estimate is
+high-confidence; a `P4-k1` reason means no compute-bound signal was available
+for any replica and the estimate is conservative.
 
-Other analyzers (e.g. the throughput analyzer) may set their own label values
-or leave `label` empty.
+The throughput analyzer sets `T1-ols`, `T2-pinned`, or `T2-default` to
+indicate which fitting tier produced the capacity estimate. Other analyzers may
+set their own reason values or leave `reason` empty.
 
 ---
 
@@ -146,6 +150,3 @@ correlating them.
 
 These lines are emitted at INFO level and appear in the default controller
 log output. No feature flag or configuration change is required.
-
-The existing `"V2 saturation analysis completed"` and
-`"Applied saturation decision"` lines remain unchanged.

--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -374,3 +374,11 @@ on the `enableLimiter` flag in `SaturationScalingConfig`:
 
 Both optimizers are stateless and selected per-cycle from the engine's
 `optimizer` field.
+
+## Observability
+
+The engine emits two structured INFO log lines per reconcile cycle per model —
+one per analyzer (after the threshold post-step) and one after the optimizer
+returns. See [cycle-log.md](cycle-log.md) for field schemas, grep patterns,
+and an explanation of the `CapacityLabel` values set by the saturation V2
+analyzer.

--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -380,5 +380,4 @@ Both optimizers are stateless and selected per-cycle from the engine's
 The engine emits two structured INFO log lines per reconcile cycle per model —
 one per analyzer (after the threshold post-step) and one after the optimizer
 returns. See [cycle-log.md](cycle-log.md) for field schemas, grep patterns,
-and an explanation of the `CapacityLabel` values set by the saturation V2
-analyzer.
+and an explanation of the `reason` values set by each analyzer.

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -168,7 +168,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	if rec := a.capacityStore.Get(namespace, modelID, rm.VariantName); rec != nil {
 		vllmParams = rec.VLLMParams
 	}
-	k2 := a.computeK2(
+	k2, k2Priority := a.computeK2(
 		modelID, rm.AcceleratorName,
 		gpuCount,
 		rm.QueueLength, rm.TokensInUse,
@@ -210,6 +210,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
 		MemoryBoundCapacity:   k1,
 		ComputeBoundCapacity:  k2,
+		K2Priority:            k2Priority,
 		EffectiveCapacity:     effectiveCapacity,
 		IsSaturated:           isSaturated,
 		ReplicaDemand:         replicaDemand,
@@ -259,6 +260,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
 		TotalKvCapacityTokens: effectiveCapacity, // synthetic: store-derived
 		MemoryBoundCapacity:   effectiveCapacity,
 		ComputeBoundCapacity:  effectiveCapacity,
+		K2Priority:            4,
 		EffectiveCapacity:     effectiveCapacity,
 		IsSaturated:           isSaturated,
 		ReplicaDemand:         replicaDemand,
@@ -270,6 +272,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
 // 2. Historical → rolling average from previous observations
 // 3. Derived (from deployment args) → formula-based estimate
 // 4. Fallback → k1 (memory-bound only)
+// Returns the k2 value and the priority level (1–4) that produced it.
 func (a *SaturationAnalyzer) computeK2(
 	modelID, accelerator string,
 	gpuCount int,
@@ -278,7 +281,7 @@ func (a *SaturationAnalyzer) computeK2(
 	queueThreshold float64,
 	vllmParams *VLLMEngineParams,
 	k1 int64,
-) int64 {
+) (int64, int) {
 	outputBucket := classifyOutputLength(avgOutput)
 	historyKey := fmt.Sprintf("%s|%s|%d|%s", modelID, accelerator, gpuCount, outputBucket)
 
@@ -293,7 +296,7 @@ func (a *SaturationAnalyzer) computeK2(
 		}
 		ra.Add(float64(k2Observed))
 		a.mu.Unlock()
-		return k2Observed
+		return k2Observed, 1
 	}
 
 	// Priority 2: Historical — lock must cover Average() since Add() mutates
@@ -305,16 +308,16 @@ func (a *SaturationAnalyzer) computeK2(
 	}
 	a.mu.Unlock()
 	if histAvg > 0 {
-		return int64(histAvg)
+		return int64(histAvg), 2
 	}
 
 	// Priority 3: Derived from deployment args
 	if k2Derived := estimateCapacityFromParams(vllmParams, avgInput, avgOutput); k2Derived > 0 {
-		return k2Derived
+		return k2Derived, 3
 	}
 
 	// Priority 4: Fallback to k1
-	return k1
+	return k1, 4
 }
 
 // aggregateByVariant groups replica capacities by variant and computes
@@ -398,6 +401,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			TotalCapacity:      totalCapacity,
 			TotalDemand:        totalDemand,
 			Utilization:        utilization,
+			CapacityLabel:      k2SourceLabel(replicas),
 		}
 		result = append(result, vc)
 	}
@@ -634,6 +638,28 @@ func estimateSchedulerQueueDemand(
 	}
 
 	return schedulerQueueDemand{total: total, byRole: byRole}
+}
+
+// k2SourceLabel returns the K2Priority label for the lower-median replica by
+// EffectiveCapacity. Sorts a copy and picks index (n-1)/2, which always
+// resolves to an actual replica — no average is taken, so even-length slices
+// never produce a value that matches no element.
+// Returns "" when replicas is empty.
+func k2SourceLabel(replicas []ReplicaCapacity) string {
+	if len(replicas) == 0 {
+		return ""
+	}
+	sorted := make([]ReplicaCapacity, len(replicas))
+	copy(sorted, replicas)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].EffectiveCapacity < sorted[j].EffectiveCapacity
+	})
+	medIdx := (len(sorted) - 1) / 2
+	labels := map[int]string{1: "P1-obs", 2: "P2-hist", 3: "P3-k2", 4: "P4-k1"}
+	if label, ok := labels[sorted[medIdx].K2Priority]; ok {
+		return label
+	}
+	return ""
 }
 
 // median returns the median value from a sorted slice of int64 values.

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -385,6 +385,8 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			// No own record — try cross-variant estimation from a compatible variant
 			perReplicaCapacity = float64(rec.EffectiveCapacity)
 			capacityLabel = "P0-store"
+		} else {
+			capacityLabel = "no-data"
 		}
 
 		totalCapacity := float64(readyCount) * perReplicaCapacity
@@ -662,7 +664,7 @@ func k2SourceLabel(replicas []ReplicaCapacity) string {
 	if label, ok := labels[sorted[medIdx].K2Priority]; ok {
 		return label
 	}
-	return ""
+	return "error"
 }
 
 // median returns the median value from a sorted slice of int64 values.

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -260,7 +260,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
 		TotalKvCapacityTokens: effectiveCapacity, // synthetic: store-derived
 		MemoryBoundCapacity:   effectiveCapacity,
 		ComputeBoundCapacity:  effectiveCapacity,
-		K2Priority:            4,
+		K2Priority:            k2SrcFallback,
 		EffectiveCapacity:     effectiveCapacity,
 		IsSaturated:           isSaturated,
 		ReplicaDemand:         replicaDemand,
@@ -281,7 +281,7 @@ func (a *SaturationAnalyzer) computeK2(
 	queueThreshold float64,
 	vllmParams *VLLMEngineParams,
 	k1 int64,
-) (int64, int) {
+) (int64, k2Source) {
 	outputBucket := classifyOutputLength(avgOutput)
 	historyKey := fmt.Sprintf("%s|%s|%d|%s", modelID, accelerator, gpuCount, outputBucket)
 
@@ -296,7 +296,7 @@ func (a *SaturationAnalyzer) computeK2(
 		}
 		ra.Add(float64(k2Observed))
 		a.mu.Unlock()
-		return k2Observed, 1
+		return k2Observed, k2SrcObserved
 	}
 
 	// Priority 2: Historical — lock must cover Average() since Add() mutates
@@ -308,16 +308,16 @@ func (a *SaturationAnalyzer) computeK2(
 	}
 	a.mu.Unlock()
 	if histAvg > 0 {
-		return int64(histAvg), 2
+		return int64(histAvg), k2SrcHistorical
 	}
 
 	// Priority 3: Derived from deployment args
 	if k2Derived := estimateCapacityFromParams(vllmParams, avgInput, avgOutput); k2Derived > 0 {
-		return k2Derived, 3
+		return k2Derived, k2SrcDerived
 	}
 
 	// Priority 4: Fallback to k1
-	return k1, 4
+	return k1, k2SrcFallback
 }
 
 // aggregateByVariant groups replica capacities by variant and computes
@@ -380,13 +380,13 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			// No ready replicas — use stored capacity, enhanced with k2 derivation
 			// for deployment-derived records when workload data is available.
 			perReplicaCapacity = a.estimateStoredCapacity(rec, modelID, kvCacheThreshold, modelAvgInput, modelAvgOutput)
-			capacityLabel = "P0-store"
+			capacityLabel = satReasonP0Store
 		} else if rec := a.lookupCompatibleCapacity(namespace, modelID, vs.VariantName, accelerator, vs.GPUsPerReplica); rec != nil {
 			// No own record — try cross-variant estimation from a compatible variant
 			perReplicaCapacity = float64(rec.EffectiveCapacity)
-			capacityLabel = "P0-store"
+			capacityLabel = satReasonP0Store
 		} else {
-			capacityLabel = "no-data"
+			capacityLabel = satReasonNoData
 		}
 
 		totalCapacity := float64(readyCount) * perReplicaCapacity
@@ -660,8 +660,7 @@ func k2SourceLabel(replicas []ReplicaCapacity) string {
 		return sorted[i].EffectiveCapacity < sorted[j].EffectiveCapacity
 	})
 	medIdx := (len(sorted) - 1) / 2
-	labels := map[int]string{1: "P1-obs", 2: "P2-hist", 3: "P3-k2", 4: "P4-k1"}
-	if label, ok := labels[sorted[medIdx].K2Priority]; ok {
+	if label, ok := k2Labels[sorted[medIdx].K2Priority]; ok {
 		return label
 	}
 	return "error"

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -363,6 +363,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			readyCount = 0
 		}
 
+		var capacityLabel string
 		if len(replicas) > 0 {
 			// Use median effective capacity from ready pods
 			capacities := make([]int64, 0, len(replicas))
@@ -374,13 +375,16 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			if accelerator == "" {
 				accelerator = replicas[0].AcceleratorName
 			}
+			capacityLabel = k2SourceLabel(replicas)
 		} else if rec := a.capacityStore.Get(namespace, modelID, vs.VariantName); rec != nil && rec.EffectiveCapacity > 0 {
 			// No ready replicas — use stored capacity, enhanced with k2 derivation
 			// for deployment-derived records when workload data is available.
 			perReplicaCapacity = a.estimateStoredCapacity(rec, modelID, kvCacheThreshold, modelAvgInput, modelAvgOutput)
+			capacityLabel = "P0-store"
 		} else if rec := a.lookupCompatibleCapacity(namespace, modelID, vs.VariantName, accelerator, vs.GPUsPerReplica); rec != nil {
 			// No own record — try cross-variant estimation from a compatible variant
 			perReplicaCapacity = float64(rec.EffectiveCapacity)
+			capacityLabel = "P0-store"
 		}
 
 		totalCapacity := float64(readyCount) * perReplicaCapacity
@@ -390,7 +394,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			utilization = totalDemand / totalCapacity
 		}
 
-		vc := interfaces.VariantCapacity{
+		result = append(result, interfaces.VariantCapacity{
 			VariantName:        vs.VariantName,
 			AcceleratorName:    accelerator,
 			Cost:               cost,
@@ -401,9 +405,8 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			TotalCapacity:      totalCapacity,
 			TotalDemand:        totalDemand,
 			Utilization:        utilization,
-			CapacityLabel:      k2SourceLabel(replicas),
-		}
-		result = append(result, vc)
+			Reason:             capacityLabel,
+		})
 	}
 
 	return result

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -1386,4 +1386,34 @@ var _ = Describe("aggregateByVariant capacity Reason", func() {
 		Expect(result.VariantCapacities).To(HaveLen(1))
 		Expect(result.VariantCapacities[0].Reason).To(Equal("P0-store"))
 	})
+
+	It("sets Reason to no-data when variant has zero replicas and no store or compatible record", func() {
+		store := NewCapacityKnowledgeStore()
+		a := NewSaturationAnalyzer(store)
+
+		input := interfaces.AnalyzerInput{
+			ModelID:        "m",
+			Namespace:      "ns",
+			ReplicaMetrics: nil,
+			VariantStates: []interfaces.VariantReplicaState{
+				{VariantName: "v1", CurrentReplicas: 0, PendingReplicas: 0},
+			},
+			Config: &config.SaturationScalingConfig{KvCacheThreshold: 0.9, KvSpareTrigger: 0.2, QueueLengthThreshold: 5},
+		}
+		result, err := a.Analyze(context.Background(), input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.VariantCapacities).To(HaveLen(1))
+		Expect(result.VariantCapacities[0].Reason).To(Equal("no-data"))
+	})
+})
+
+var _ = Describe("k2SourceLabel", func() {
+	It("returns error when K2Priority is not in the known set", func() {
+		replicas := []ReplicaCapacity{{K2Priority: 0, EffectiveCapacity: 100}}
+		Expect(k2SourceLabel(replicas)).To(Equal("error"))
+	})
+
+	It("returns empty string when replicas slice is empty", func() {
+		Expect(k2SourceLabel(nil)).To(Equal(""))
+	})
 })

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -1360,3 +1360,30 @@ var _ = Describe("SaturationScalingConfig ApplyDefaults before Validate", func()
 		Expect(cfg.Priority).To(BeNumerically(">", 0))
 	})
 })
+
+var _ = Describe("aggregateByVariant capacity Reason", func() {
+	It("sets Reason to P0-store when no live replicas but a capacity store record exists", func() {
+		store := NewCapacityKnowledgeStore()
+		store.Update("ns", "m", "v1", CapacityRecord{
+			AcceleratorName:   "A100",
+			EffectiveCapacity: 50000,
+			LearnedFrom:       learnedFromLive,
+		})
+		a := NewSaturationAnalyzer(store)
+
+		input := interfaces.AnalyzerInput{
+			ModelID:   "m",
+			Namespace: "ns",
+			// No ReplicaMetrics — store path will fire.
+			ReplicaMetrics: nil,
+			VariantStates: []interfaces.VariantReplicaState{
+				{VariantName: "v1", CurrentReplicas: 0, PendingReplicas: 0},
+			},
+			Config: &config.SaturationScalingConfig{KvCacheThreshold: 0.9, KvSpareTrigger: 0.2, QueueLengthThreshold: 5},
+		}
+		result, err := a.Analyze(context.Background(), input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.VariantCapacities).To(HaveLen(1))
+		Expect(result.VariantCapacities[0].Reason).To(Equal("P0-store"))
+	})
+})

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -1384,7 +1384,7 @@ var _ = Describe("aggregateByVariant capacity Reason", func() {
 		result, err := a.Analyze(context.Background(), input)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.VariantCapacities).To(HaveLen(1))
-		Expect(result.VariantCapacities[0].Reason).To(Equal("P0-store"))
+		Expect(result.VariantCapacities[0].Reason).To(Equal(satReasonP0Store))
 	})
 
 	It("sets Reason to no-data when variant has zero replicas and no store or compatible record", func() {
@@ -1403,7 +1403,7 @@ var _ = Describe("aggregateByVariant capacity Reason", func() {
 		result, err := a.Analyze(context.Background(), input)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.VariantCapacities).To(HaveLen(1))
-		Expect(result.VariantCapacities[0].Reason).To(Equal("no-data"))
+		Expect(result.VariantCapacities[0].Reason).To(Equal(satReasonNoData))
 	})
 })
 

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -3,6 +3,29 @@ package saturation_v2
 // learnedFromLive indicates a capacity record was derived from live metrics.
 const learnedFromLive = "live"
 
+// k2Source identifies which priority level produced the compute-bound capacity
+// estimate for a replica.
+type k2Source int
+
+const (
+	k2SrcObserved   k2Source = iota + 1 // queue saturated: tokensInUse
+	k2SrcHistorical                     // rolling average from prior observations
+	k2SrcDerived                        // estimated from deployment args
+	k2SrcFallback                       // fallback to k1 (memory-bound)
+)
+
+var k2Labels = map[k2Source]string{
+	k2SrcObserved:   "P1-obs",
+	k2SrcHistorical: "P2-hist",
+	k2SrcDerived:    "P3-k2",
+	k2SrcFallback:   "P4-k1",
+}
+
+const (
+	satReasonP0Store = "P0-store" // capacity from store or compatible-variant record; no live replicas
+	satReasonNoData  = "no-data"  // no live replicas and no store record
+)
+
 // ReplicaCapacity holds the per-replica capacity breakdown computed by
 // the V2 saturation analyzer. It is internal to the analyzer and not
 // part of the public interfaces package.
@@ -12,10 +35,10 @@ type ReplicaCapacity struct {
 	AcceleratorName       string
 	TokensInUse           int64
 	TotalKvCapacityTokens int64
-	MemoryBoundCapacity   int64 // k1: KV-cache-limited capacity
-	ComputeBoundCapacity  int64 // k2: compute/scheduling-limited capacity
-	K2Priority            int   // how k2 was computed: 1=observed, 2=history, 3=derived, 4=fallback
-	EffectiveCapacity     int64 // min(k1, k2)
+	MemoryBoundCapacity   int64    // k1: KV-cache-limited capacity
+	ComputeBoundCapacity  int64    // k2: compute/scheduling-limited capacity
+	K2Priority            k2Source // how k2 was computed
+	EffectiveCapacity     int64    // min(k1, k2)
 	IsSaturated           bool
 	ReplicaDemand         int64 // tokensInUse + queueLength * avgInputTokens
 }

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -14,6 +14,7 @@ type ReplicaCapacity struct {
 	TotalKvCapacityTokens int64
 	MemoryBoundCapacity   int64 // k1: KV-cache-limited capacity
 	ComputeBoundCapacity  int64 // k2: compute/scheduling-limited capacity
+	K2Priority            int   // how k2 was computed: 1=observed, 2=history, 3=derived, 4=fallback
 	EffectiveCapacity     int64 // min(k1, k2)
 	IsSaturated           bool
 	ReplicaDemand         int64 // tokensInUse + queueLength * avgInputTokens

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -256,7 +256,7 @@ func (a *ThroughputAnalyzer) Analyze(
 		// upward → systematic under-provisioning. Supply counting (computeVariantSupply,
 		// computeDemand) uses the unfiltered variantMetrics to include booting replicas.
 		healthyMetrics := filterHealthyForShape(variantMetrics)
-		model, ok := a.resolveITLModel(ctx, state, healthyMetrics, input.Namespace, input.ModelID, variantName)
+		model, reason, ok := a.resolveITLModel(ctx, state, healthyMetrics, input.Namespace, input.ModelID, variantName)
 		if !ok {
 			ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("throughput analyzer: no ITL model available, skipping variant",
 				"namespace", input.Namespace,
@@ -337,6 +337,7 @@ func (a *ThroughputAnalyzer) Analyze(
 			TotalCapacity:      totalCapacity,
 			TotalDemand:        demand,
 			Utilization:        safeDivide(demand, totalCapacity),
+			Reason:             reason,
 		})
 	}
 
@@ -460,7 +461,7 @@ func (a *ThroughputAnalyzer) getOrCreateVariantState(key string) *variantState {
 // is extended to iterate variants with state but no current replica metrics.
 //
 // Must be called with a.mu held.
-func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variantState, metrics []interfaces.ReplicaMetrics, namespace, modelID, variantName string) (ITLModel, bool) {
+func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variantState, metrics []interfaces.ReplicaMetrics, namespace, modelID, variantName string) (ITLModel, string, bool) {
 	// Tier 1: OLS fit.
 	if state.observationWindow.Ready() {
 		obs := state.observationWindow.Observations()
@@ -471,7 +472,7 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 			)
 			state.lastFittedB = model.B
 			state.hasFittedB = true
-			return model, true
+			return model, "T1-ols", true
 		}
 		ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("throughput analyzer: tier-1 OLS fit failed, trying tier-2",
 			"namespace", namespace, "modelID", modelID, "variant", variantName,
@@ -485,8 +486,10 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 	// when replicas have spread k* values — it is the same least-squares criterion
 	// as tier-1 OLS but with B pinned instead of fitted.
 	baselineB := DefaultBaselineITLSec
+	tier2Label := "T2-default"
 	if state.hasFittedB {
 		baselineB = state.lastFittedB
+		tier2Label = "T2-pinned"
 	}
 	var numerator, sumK2 float64
 	var n float64
@@ -504,10 +507,10 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 				"namespace", namespace, "modelID", modelID, "variant", variantName,
 				"A", A, "B", baselineB, "replicas", int(n),
 			)
-			return ITLModel{A: A, B: baselineB}, true
+			return ITLModel{A: A, B: baselineB}, tier2Label, true
 		}
 	}
-	return ITLModel{}, false
+	return ITLModel{}, "", false
 }
 
 // computeDemand aggregates λ_dec (decode token demand in tokens/sec) across replicas.

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -472,7 +472,7 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 			)
 			state.lastFittedB = model.B
 			state.hasFittedB = true
-			return model, "T1-ols", true
+			return model, itlReasonT1OLS, true
 		}
 		ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("throughput analyzer: tier-1 OLS fit failed, trying tier-2",
 			"namespace", namespace, "modelID", modelID, "variant", variantName,
@@ -486,10 +486,10 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 	// when replicas have spread k* values — it is the same least-squares criterion
 	// as tier-1 OLS but with B pinned instead of fitted.
 	baselineB := DefaultBaselineITLSec
-	tier2Label := "T2-default"
+	tier2Label := itlReasonT2Default
 	if state.hasFittedB {
 		baselineB = state.lastFittedB
-		tier2Label = "T2-pinned"
+		tier2Label = itlReasonT2Pinned
 	}
 	var numerator, sumK2 float64
 	var n float64
@@ -510,7 +510,7 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 			return ITLModel{A: A, B: baselineB}, tier2Label, true
 		}
 	}
-	return ITLModel{}, "T2-failed", false
+	return ITLModel{}, itlReasonT2Failed, false
 }
 
 // computeDemand aggregates λ_dec (decode token demand in tokens/sec) across replicas.

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -510,7 +510,7 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 			return ITLModel{A: A, B: baselineB}, tier2Label, true
 		}
 	}
-	return ITLModel{}, "", false
+	return ITLModel{}, "T2-failed", false
 }
 
 // computeDemand aggregates λ_dec (decode token demand in tokens/sec) across replicas.

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -421,6 +421,20 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(state.TotalSupply).To(BeNumerically("~", muSat, muSat*0.10))
 			Expect(state.Demand).To(BeNumerically("~", 1000.0, 1.0))
 		})
+
+		It("sets Reason to T1-ols when tier-1 OLS fit succeeds", func() {
+			buildReadyWindow()
+
+			input := interfaces.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica(5)},
+			}
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.VariantCapacities).To(HaveLen(1))
+			Expect(result.VariantCapacities[0].Reason).To(Equal("T1-ols"))
+		})
 	})
 
 	Describe("Analyze — tier-2 single-point estimation", func() {
@@ -430,7 +444,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		//   A_est  = (0.06075 - 0.006) / 0.75 = 0.073
 		//   ITL_sat ≈ 0.068  →  μ_sat ≈ 2782 tok/s (same scenario as tier-1)
 
-		tier2Replica := func(k, arrivalRate float64) interfaces.ReplicaMetrics {
+		tier2Replica := func(k, arrivalRate float64) interfaces.ReplicaMetrics { //nolint:unparam
 			return interfaces.ReplicaMetrics{
 				VariantName:           "v1",
 				KvCacheUsage:          k,
@@ -463,6 +477,56 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// supply/demand inequality that the engine interprets as RC>0.
 			Expect(result.TotalDemand).To(BeNumerically(">", result.TotalAnticipatedSupply))
 			Expect(result.RequiredCapacity).To(Equal(0.0))
+		})
+
+		It("sets Reason to T2-default when no prior tier-1 fit exists", func() {
+			// Single observation → window not ready; no prior fit → T2-default.
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{tier2Replica(0.75, 0)})
+
+			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: []interfaces.ReplicaMetrics{tier2Replica(0.75, 5)},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.VariantCapacities).To(HaveLen(1))
+			Expect(result.VariantCapacities[0].Reason).To(Equal("T2-default"))
+		})
+
+		It("sets Reason to T2-pinned when a prior tier-1 fit has set lastFittedB", func() {
+			// Inject 10 on-line points to make the OLS window ready (same params as tier2Replica).
+			const trueA, trueB = 0.073, 0.006
+			t1kValues := []float64{0.20, 0.30, 0.40, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80}
+			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", 5000, 200, 0.1, 1024000, trueB, t1kValues)
+			onLine := interfaces.ReplicaMetrics{
+				VariantName: "v1", KvUsageInstant: 0.75, KvCacheUsage: 0.75,
+				AvgITL: trueA*0.75 + trueB, AvgInputTokens: 5000, AvgOutputTokens: 200,
+				PrefixCacheHitRate: 0.1, TotalKvCapacityTokens: 1024000, ArrivalRate: 5,
+			}
+			_, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: []interfaces.ReplicaMetrics{onLine},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			st, _ := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(st.HasFittedB).To(BeTrue(), "T1 must have fired to set lastFittedB")
+
+			// Clear the window to force tier-2; lastFittedB is preserved.
+			analyzer.mu.Lock()
+			if s, ok := analyzer.variantStates[variantKey(namespace, modelID, "v1")]; ok {
+				s.observationWindow.Clear()
+			}
+			analyzer.mu.Unlock()
+
+			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: []interfaces.ReplicaMetrics{tier2Replica(0.75, 5)},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.VariantCapacities).To(HaveLen(1))
+			Expect(result.VariantCapacities[0].Reason).To(Equal("T2-pinned"))
 		})
 	})
 

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -528,6 +528,29 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(result.VariantCapacities).To(HaveLen(1))
 			Expect(result.VariantCapacities[0].Reason).To(Equal("T2-pinned"))
 		})
+
+		It("resolveITLModel returns T2-failed when all replicas are idle (KvUsageInstant == 0)", func() {
+			// Single Observe with idle metrics to create variant state, then Analyze
+			// with idle replicas so both tiers fail — tier-2 needs KvUsageInstant > 0.
+			idleMetrics := interfaces.ReplicaMetrics{
+				VariantName: "v1", KvUsageInstant: 0, KvCacheUsage: 0,
+				AvgITL: 0.006, AvgInputTokens: 5000, AvgOutputTokens: 200,
+				PrefixCacheHitRate: 0.1, TotalKvCapacityTokens: 1024000,
+			}
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{idleMetrics})
+
+			_, reason, ok := analyzer.resolveITLModel(ctx,
+				func() *variantState {
+					analyzer.mu.Lock()
+					defer analyzer.mu.Unlock()
+					return analyzer.variantStates[variantKey(namespace, modelID, "v1")]
+				}(),
+				[]interfaces.ReplicaMetrics{idleMetrics},
+				namespace, modelID, "v1",
+			)
+			Expect(ok).To(BeFalse())
+			Expect(reason).To(Equal("T2-failed"))
+		})
 	})
 
 	Describe("Analyze — idle replicas produce no signal", func() {

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -433,7 +433,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.VariantCapacities).To(HaveLen(1))
-			Expect(result.VariantCapacities[0].Reason).To(Equal("T1-ols"))
+			Expect(result.VariantCapacities[0].Reason).To(Equal(itlReasonT1OLS))
 		})
 	})
 
@@ -490,7 +490,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.VariantCapacities).To(HaveLen(1))
-			Expect(result.VariantCapacities[0].Reason).To(Equal("T2-default"))
+			Expect(result.VariantCapacities[0].Reason).To(Equal(itlReasonT2Default))
 		})
 
 		It("sets Reason to T2-pinned when a prior tier-1 fit has set lastFittedB", func() {
@@ -526,7 +526,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.VariantCapacities).To(HaveLen(1))
-			Expect(result.VariantCapacities[0].Reason).To(Equal("T2-pinned"))
+			Expect(result.VariantCapacities[0].Reason).To(Equal(itlReasonT2Pinned))
 		})
 
 		It("resolveITLModel returns T2-failed when all replicas are idle (KvUsageInstant == 0)", func() {
@@ -549,7 +549,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				namespace, modelID, "v1",
 			)
 			Expect(ok).To(BeFalse())
-			Expect(reason).To(Equal("T2-failed"))
+			Expect(reason).To(Equal(itlReasonT2Failed))
 		})
 	})
 

--- a/internal/engines/analyzers/throughput/constants.go
+++ b/internal/engines/analyzers/throughput/constants.go
@@ -109,4 +109,11 @@ const (
 	// window is cleared (shape change or threshold reached) so it is always bound to
 	// the current window's lifetime.
 	DefaultGPSMismatchClearThreshold = 3
+
+	// itlReason* are the values set on VariantCapacity.Reason by resolveITLModel.
+	// They appear in the "analyzer-result" structured log line.
+	itlReasonT1OLS     = "T1-ols"     // tier-1: OLS fit from live observations
+	itlReasonT2Default = "T2-default" // tier-2: constrained OLS with default B baseline
+	itlReasonT2Pinned  = "T2-pinned"  // tier-2: constrained OLS with previously fitted B
+	itlReasonT2Failed  = "T2-failed"  // all paths exhausted; no model for this cycle
 )

--- a/internal/engines/pipeline/optimizer_interfaces.go
+++ b/internal/engines/pipeline/optimizer_interfaces.go
@@ -19,12 +19,14 @@ import (
 // to populate RoleSpare per role and initialize picker-local demand.
 // The original Result values are never mutated.
 type NamedAnalyzerResult struct {
-	Name      string
-	Result    *interfaces.AnalyzerResult
-	Score     float64            // per-analyzer weight from AnalyzerScoreConfig; used for fair-share priority
-	Remaining float64            // mutable remaining required capacity; P-scope for disaggregated, model-scope otherwise
-	Spare     float64            // mutable remaining spare capacity; model-scope (non-disaggregated only)
-	RoleSpare map[string]float64 // per-role mutable spare; set by initRoleState; nil for non-disaggregated
+	Name              string
+	Result            *interfaces.AnalyzerResult
+	Score             float64            // per-analyzer weight from AnalyzerScoreConfig; used for fair-share priority
+	Remaining         float64            // mutable remaining required capacity; P-scope for disaggregated, model-scope otherwise
+	Spare             float64            // mutable remaining spare capacity; model-scope (non-disaggregated only)
+	RoleSpare         map[string]float64 // per-role mutable spare; set by initRoleState; nil for non-disaggregated
+	ScaleUpThreshold  float64            // resolved scale-up threshold used to compute RC
+	ScaleDownBoundary float64            // resolved scale-down boundary used to compute SC
 }
 
 // ModelScalingRequest bundles the analyzer result with variant state for one model.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -863,6 +863,7 @@ func (e *Engine) optimizeV2(
 	// Stage 2: Compute GPU constraints and call optimizer
 	optimizer, constraints := e.selectV2Optimizer(ctx, requests)
 	allDecisions := optimizer.Optimize(ctx, requests, constraints)
+	logScalingDecisions(ctx, requests, allDecisions)
 
 	logger.Info("V2 optimizer produced decisions",
 		"optimizer", optimizer.Name(),

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -105,19 +105,6 @@ func (e *Engine) runAnalyzersAndScore(
 	satUp, satDown := resolveThresholds(interfaces.SaturationAnalyzerName, config)
 	applyUniversalThreshold(baseResult, satUp, satDown)
 
-	// Single Info line for the V2 saturation analysis, emitted after the
-	// post-step so RequiredCapacity/SpareCapacity hold the real values scaling
-	// uses (they are zero in the raw analyzer result; see runV2AnalysisOnly).
-	logger.Info("V2 saturation analysis completed",
-		"modelID", modelID,
-		"totalSupply", baseResult.TotalSupply,
-		"totalDemand", baseResult.TotalDemand,
-		"utilization", baseResult.Utilization,
-		"requiredCapacity", baseResult.RequiredCapacity,
-		"spareCapacity", baseResult.SpareCapacity,
-		"scaleUpThreshold", satUp,
-		"scaleDownBoundary", satDown)
-
 	// Build AnalyzerInput once; shared by all non-saturation analyzers.
 	// Note: &config has had saturation's per-entry threshold overrides applied
 	// (the loop above). Non-saturation analyzers therefore receive the
@@ -163,6 +150,9 @@ func (e *Engine) runAnalyzersAndScore(
 			Remaining: result.RequiredCapacity,
 			Spare:     result.SpareCapacity,
 		})
+	}
+	for _, nr := range namedResults {
+		logAnalyzerResult(ctx, modelID, namespace, nr)
 	}
 	return namedResults, nil
 }
@@ -363,4 +353,84 @@ func (e *Engine) collectV2ModelRequest(
 		Priority:        config.Priority,
 		Disaggregated:   disaggregated,
 	}, nil
+}
+
+// logAnalyzerResult emits one INFO "analyzer-result" line for a single named
+// analyzer result. Called for every analyzer that ran in a model's reconcile
+// cycle, after the universal threshold post-step has been applied.
+func logAnalyzerResult(ctx context.Context, modelID, namespace string, nr pipeline.NamedAnalyzerResult) {
+	if nr.Result == nil {
+		return
+	}
+	logger := ctrl.LoggerFrom(ctx)
+
+	type variantEntry struct {
+		Name  string  `json:"name"`
+		PRC   float64 `json:"prc"`
+		Cost  float64 `json:"cost"`
+		Label string  `json:"label,omitempty"`
+	}
+	variants := make([]variantEntry, 0, len(nr.Result.VariantCapacities))
+	for _, vc := range nr.Result.VariantCapacities {
+		variants = append(variants, variantEntry{
+			Name:  vc.VariantName,
+			PRC:   vc.PerReplicaCapacity,
+			Cost:  vc.Cost,
+			Label: vc.CapacityLabel,
+		})
+	}
+
+	logger.Info("analyzer-result",
+		"modelID", modelID,
+		"namespace", namespace,
+		"analyzer", nr.Name,
+		"supply", nr.Result.TotalSupply,
+		"demand", nr.Result.TotalDemand,
+		"util", nr.Result.Utilization,
+		"rc", nr.Result.RequiredCapacity,
+		"sc", nr.Result.SpareCapacity,
+		"variants", variants,
+	)
+}
+
+// logScalingDecisions emits one INFO "scaling-decision" line per model after
+// the optimizer has produced per-variant decisions.
+func logScalingDecisions(
+	ctx context.Context,
+	modelRequests []pipeline.ModelScalingRequest,
+	decisions []interfaces.VariantDecision,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	type modelKey struct{ ns, modelID string }
+	type decisionEntry struct {
+		Name   string `json:"name"`
+		Curr   int    `json:"curr"`
+		Tgt    int    `json:"tgt"`
+		Action string `json:"action"`
+	}
+
+	grouped := make(map[modelKey][]decisionEntry, len(modelRequests))
+	for _, d := range decisions {
+		k := modelKey{d.Namespace, d.ModelID}
+		grouped[k] = append(grouped[k], decisionEntry{
+			Name:   d.VariantName,
+			Curr:   d.CurrentReplicas,
+			Tgt:    d.TargetReplicas,
+			Action: string(d.Action),
+		})
+	}
+
+	for _, req := range modelRequests {
+		k := modelKey{req.Namespace, req.ModelID}
+		entries := grouped[k]
+		if len(entries) == 0 {
+			continue
+		}
+		logger.Info("scaling-decision",
+			"modelID", req.ModelID,
+			"namespace", req.Namespace,
+			"decisions", entries,
+		)
+	}
 }

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -365,18 +365,16 @@ func logAnalyzerResult(ctx context.Context, modelID, namespace string, nr pipeli
 	logger := ctrl.LoggerFrom(ctx)
 
 	type variantEntry struct {
-		Name  string  `json:"name"`
-		PRC   float64 `json:"prc"`
-		Cost  float64 `json:"cost"`
-		Label string  `json:"label,omitempty"`
+		Name   string  `json:"name"`
+		PRC    float64 `json:"prc"`
+		Reason string  `json:"reason,omitempty"`
 	}
 	variants := make([]variantEntry, 0, len(nr.Result.VariantCapacities))
 	for _, vc := range nr.Result.VariantCapacities {
 		variants = append(variants, variantEntry{
-			Name:  vc.VariantName,
-			PRC:   vc.PerReplicaCapacity,
-			Cost:  vc.Cost,
-			Label: vc.CapacityLabel,
+			Name:   vc.VariantName,
+			PRC:    vc.PerReplicaCapacity,
+			Reason: vc.Reason,
 		})
 	}
 

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -124,11 +124,13 @@ func (e *Engine) runAnalyzersAndScore(
 	// Collect per-analyzer results. Saturation is first; each non-saturation
 	// analyzer is run, calibrated with its resolved thresholds, and appended.
 	namedResults := []pipeline.NamedAnalyzerResult{{
-		Name:      interfaces.SaturationAnalyzerName,
-		Result:    baseResult,
-		Score:     scoreForAnalyzer(interfaces.SaturationAnalyzerName, config),
-		Remaining: baseResult.RequiredCapacity,
-		Spare:     baseResult.SpareCapacity,
+		Name:              interfaces.SaturationAnalyzerName,
+		Result:            baseResult,
+		Score:             scoreForAnalyzer(interfaces.SaturationAnalyzerName, config),
+		Remaining:         baseResult.RequiredCapacity,
+		Spare:             baseResult.SpareCapacity,
+		ScaleUpThreshold:  satUp,
+		ScaleDownBoundary: satDown,
 	}}
 	for _, entry := range e.analyzersSnapshot {
 		if entry.name == interfaces.SaturationAnalyzerName {
@@ -144,11 +146,13 @@ func (e *Engine) runAnalyzersAndScore(
 		up, down := resolveThresholds(entry.name, config)
 		applyUniversalThreshold(result, up, down)
 		namedResults = append(namedResults, pipeline.NamedAnalyzerResult{
-			Name:      entry.name,
-			Result:    result,
-			Score:     scoreForAnalyzer(entry.name, config),
-			Remaining: result.RequiredCapacity,
-			Spare:     result.SpareCapacity,
+			Name:              entry.name,
+			Result:            result,
+			Score:             scoreForAnalyzer(entry.name, config),
+			Remaining:         result.RequiredCapacity,
+			Spare:             result.SpareCapacity,
+			ScaleUpThreshold:  up,
+			ScaleDownBoundary: down,
 		})
 	}
 	for _, nr := range namedResults {
@@ -387,6 +391,8 @@ func logAnalyzerResult(ctx context.Context, modelID, namespace string, nr pipeli
 		"util", nr.Result.Utilization,
 		"rc", nr.Result.RequiredCapacity,
 		"sc", nr.Result.SpareCapacity,
+		"scaleUpThreshold", nr.ScaleUpThreshold,
+		"scaleDownBoundary", nr.ScaleDownBoundary,
 		"variants", variants,
 	)
 }

--- a/internal/engines/saturation/engine_v2_log_test.go
+++ b/internal/engines/saturation/engine_v2_log_test.go
@@ -1,0 +1,137 @@
+package saturation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+func zapObserverCtx(t *testing.T) (context.Context, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.InfoLevel)
+	ctx := logr.NewContext(context.Background(), zapr.NewLogger(zap.New(core)))
+	return ctx, logs
+}
+
+func TestLogAnalyzerResult_EmitsRequiredFields(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+
+	nr := pipeline.NamedAnalyzerResult{
+		Name: "saturation",
+		Result: &interfaces.AnalyzerResult{
+			TotalSupply:      100000,
+			TotalDemand:      80000,
+			Utilization:      0.8,
+			RequiredCapacity: 0,
+			SpareCapacity:    20000,
+			VariantCapacities: []interfaces.VariantCapacity{
+				{
+					VariantName:        "primary",
+					PerReplicaCapacity: 50000,
+					Cost:               10,
+					CapacityLabel:      "P2-hist",
+				},
+			},
+		},
+	}
+
+	logAnalyzerResult(ctx, "mymodel", "ns", nr)
+
+	require.Equal(t, 1, logs.Len())
+	entry := logs.All()[0]
+	assert.Equal(t, "analyzer-result", entry.Message)
+
+	fields := entry.ContextMap()
+	for _, key := range []string{"modelID", "namespace", "analyzer", "supply", "demand", "util", "rc", "sc", "variants"} {
+		assert.Contains(t, fields, key, "missing field %q", key)
+	}
+	assert.Equal(t, "mymodel", fields["modelID"])
+	assert.Equal(t, "ns", fields["namespace"])
+	assert.Equal(t, "saturation", fields["analyzer"])
+}
+
+func TestLogAnalyzerResult_NilResultSkipped(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+
+	logAnalyzerResult(ctx, "m", "ns", pipeline.NamedAnalyzerResult{
+		Name:   "saturation",
+		Result: nil,
+	})
+
+	assert.Equal(t, 0, logs.Len(), "nil result should emit no log line")
+}
+
+func TestLogAnalyzerResult_EmptyVariants(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+
+	nr := pipeline.NamedAnalyzerResult{
+		Name: "throughput",
+		Result: &interfaces.AnalyzerResult{
+			TotalSupply:       0,
+			TotalDemand:       0,
+			RequiredCapacity:  15000,
+			VariantCapacities: []interfaces.VariantCapacity{},
+		},
+	}
+
+	logAnalyzerResult(ctx, "m", "ns", nr)
+
+	require.Equal(t, 1, logs.Len())
+	entry := logs.All()[0]
+	assert.Equal(t, "analyzer-result", entry.Message)
+	assert.Contains(t, entry.ContextMap(), "variants")
+}
+
+func TestLogScalingDecisions_EmitsPerModel(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+
+	requests := []pipeline.ModelScalingRequest{
+		{ModelID: "model-a", Namespace: "ns"},
+		{ModelID: "model-b", Namespace: "ns"},
+	}
+	decisions := []interfaces.VariantDecision{
+		{ModelID: "model-a", Namespace: "ns", VariantName: "v1", CurrentReplicas: 1, TargetReplicas: 2, Action: interfaces.ActionScaleUp},
+		{ModelID: "model-a", Namespace: "ns", VariantName: "v2", CurrentReplicas: 1, TargetReplicas: 1, Action: interfaces.ActionNoChange},
+		{ModelID: "model-b", Namespace: "ns", VariantName: "v1", CurrentReplicas: 2, TargetReplicas: 1, Action: interfaces.ActionScaleDown},
+	}
+
+	logScalingDecisions(ctx, requests, decisions)
+
+	require.Equal(t, 2, logs.Len(), "expected one log line per model")
+	msgs := map[string]bool{}
+	for _, e := range logs.All() {
+		assert.Equal(t, "scaling-decision", e.Message)
+		modelID, _ := e.ContextMap()["modelID"].(string)
+		msgs[modelID] = true
+	}
+	assert.True(t, msgs["model-a"], "expected log for model-a")
+	assert.True(t, msgs["model-b"], "expected log for model-b")
+}
+
+func TestLogScalingDecisions_NoDecisionsSkipsModel(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+
+	requests := []pipeline.ModelScalingRequest{
+		{ModelID: "model-a", Namespace: "ns"},
+		{ModelID: "model-b", Namespace: "ns"},
+	}
+	// Only model-a has a decision; model-b has none.
+	decisions := []interfaces.VariantDecision{
+		{ModelID: "model-a", Namespace: "ns", VariantName: "v1", Action: interfaces.ActionNoChange},
+	}
+
+	logScalingDecisions(ctx, requests, decisions)
+
+	require.Equal(t, 1, logs.Len(), "model with no decisions should emit no log line")
+	assert.Equal(t, "model-a", logs.All()[0].ContextMap()["modelID"])
+}

--- a/internal/engines/saturation/engine_v2_log_test.go
+++ b/internal/engines/saturation/engine_v2_log_test.go
@@ -2,6 +2,7 @@ package saturation
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -39,7 +40,7 @@ func TestLogAnalyzerResult_EmitsRequiredFields(t *testing.T) {
 					VariantName:        "primary",
 					PerReplicaCapacity: 50000,
 					Cost:               10,
-					CapacityLabel:      "P2-hist",
+					Reason:             "P2-hist",
 				},
 			},
 		},
@@ -58,6 +59,14 @@ func TestLogAnalyzerResult_EmitsRequiredFields(t *testing.T) {
 	assert.Equal(t, "mymodel", fields["modelID"])
 	assert.Equal(t, "ns", fields["namespace"])
 	assert.Equal(t, "saturation", fields["analyzer"])
+
+	// Verify variants entries contain "label" but not "cost".
+	b, err := json.Marshal(fields["variants"])
+	require.NoError(t, err)
+	variantsJSON := string(b)
+	assert.Contains(t, variantsJSON, `"reason"`, "variants entry must include reason field")
+	assert.Contains(t, variantsJSON, "P2-hist", "label value must be present")
+	assert.NotContains(t, variantsJSON, `"cost"`, "cost must not appear in variants entry")
 }
 
 func TestLogAnalyzerResult_NilResultSkipped(t *testing.T) {

--- a/internal/engines/saturation/engine_v2_log_test.go
+++ b/internal/engines/saturation/engine_v2_log_test.go
@@ -28,7 +28,9 @@ func TestLogAnalyzerResult_EmitsRequiredFields(t *testing.T) {
 	ctx, logs := zapObserverCtx(t)
 
 	nr := pipeline.NamedAnalyzerResult{
-		Name: "saturation",
+		Name:              "saturation",
+		ScaleUpThreshold:  1.2,
+		ScaleDownBoundary: 0.7,
 		Result: &interfaces.AnalyzerResult{
 			TotalSupply:      100000,
 			TotalDemand:      80000,
@@ -53,14 +55,14 @@ func TestLogAnalyzerResult_EmitsRequiredFields(t *testing.T) {
 	assert.Equal(t, "analyzer-result", entry.Message)
 
 	fields := entry.ContextMap()
-	for _, key := range []string{"modelID", "namespace", "analyzer", "supply", "demand", "util", "rc", "sc", "variants"} {
+	for _, key := range []string{"modelID", "namespace", "analyzer", "supply", "demand", "util", "rc", "sc", "scaleUpThreshold", "scaleDownBoundary", "variants"} {
 		assert.Contains(t, fields, key, "missing field %q", key)
 	}
 	assert.Equal(t, "mymodel", fields["modelID"])
 	assert.Equal(t, "ns", fields["namespace"])
 	assert.Equal(t, "saturation", fields["analyzer"])
 
-	// Verify variants entries contain "label" but not "cost".
+	// Verify variants entries contain "reason" but not "cost".
 	b, err := json.Marshal(fields["variants"])
 	require.NoError(t, err)
 	variantsJSON := string(b)

--- a/internal/interfaces/analyzer.go
+++ b/internal/interfaces/analyzer.go
@@ -137,6 +137,11 @@ type VariantCapacity struct {
 	// For saturation V2: median(effectiveCapacity) in tokens across ready replicas.
 	PerReplicaCapacity float64
 
+	// CapacityLabel is a free-text label set by the analyzer to describe how
+	// the variant's per-replica capacity was computed. Empty for analyzers that
+	// do not set it. Saturation V2 uses "P1-obs", "P2-hist", "P3-k2", "P4-k1".
+	CapacityLabel string
+
 	// TotalCapacity is ReplicaCount × PerReplicaCapacity.
 	TotalCapacity float64
 

--- a/internal/interfaces/analyzer.go
+++ b/internal/interfaces/analyzer.go
@@ -137,10 +137,10 @@ type VariantCapacity struct {
 	// For saturation V2: median(effectiveCapacity) in tokens across ready replicas.
 	PerReplicaCapacity float64
 
-	// CapacityLabel is a free-text label set by the analyzer to describe how
-	// the variant's per-replica capacity was computed. Empty for analyzers that
+	// Reason is a free-text string set by the analyzer to describe how the
+	// variant's per-replica capacity was computed. Empty for analyzers that
 	// do not set it. Saturation V2 uses "P1-obs", "P2-hist", "P3-k2", "P4-k1".
-	CapacityLabel string
+	Reason string
 
 	// TotalCapacity is ReplicaCount × PerReplicaCapacity.
 	TotalCapacity float64

--- a/internal/interfaces/analyzer.go
+++ b/internal/interfaces/analyzer.go
@@ -139,7 +139,9 @@ type VariantCapacity struct {
 
 	// Reason is a free-text string set by the analyzer to describe how the
 	// variant's per-replica capacity was computed. Empty for analyzers that
-	// do not set it. Saturation V2 uses "P1-obs", "P2-hist", "P3-k2", "P4-k1".
+	// do not set it. Saturation V2 uses "P0-store", "P1-obs", "P2-hist",
+	// "P3-k2", "P4-k1", "no-data", "error". Throughput uses "T1-ols",
+	// "T2-pinned", "T2-default", "T2-failed".
 	Reason string
 
 	// TotalCapacity is ReplicaCount × PerReplicaCapacity.


### PR DESCRIPTION
## Summary

- Adds `"analyzer-result"` INFO line per analyzer per model per cycle,
  emitted after the universal threshold post-step. Fields: modelID, namespace,
  analyzer, supply, demand, util, rc, sc, scaleUpThreshold, scaleDownBoundary,
  variants[]{name, prc, reason}.
- Adds `"scaling-decision"` INFO line per model after the optimizer returns.
  Fields: modelID, namespace, decisions[]{name, curr, tgt, action}.
- Adds `Reason string` to `interfaces.VariantCapacity` — free-text label set
  by each analyzer describing how per-replica capacity was computed.
- Adds `ScaleUpThreshold`/`ScaleDownBoundary` to `pipeline.NamedAnalyzerResult`
  so the resolved thresholds are logged alongside the signals they produced.

Closes the Log A and Log B items in #1317. Supersedes #1277.

## Documentation

See `docs/developer-guide/cycle-log.md` for full field schemas, reason value
reference for each analyzer, grep patterns, and ordering/timing notes.

## Test plan
- [ ] `make test` — all pass (unit tests in `engine_v2_log_test.go`,
  `saturation_v2/analyzer_test.go`, `throughput/analyzer_test.go`)
- [ ] `make lint` — 0 issues
- [ ] `go build ./...` — clean
- [ ] `gofmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)