### PR TITLE
fix(saturation): log actual analyzer mode instead of hardcoded value

### DIFF
--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -438,6 +438,7 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	//   - Queueing model: QueueingModelAnalyzer → AnalyzerResult → Optimizer.Optimize → Enforcer bridge
 	// V1 will be deprecated once V2 is fully validated.
 	// Queueing model is activated by presence of wva-queueing-model-config ConfigMap.
+	mode := modeLabelForAnalyzer(analyzerName)
 	switch analyzerName {
 	case interfaces.QueueingModelAnalyzerName:
 		allDecisions = e.optimizeQueueingModel(ctx, modelGroups, currentAllocations)
@@ -460,11 +461,25 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	e.applySaturationDecisions(ctx, allDecisions, vaMap, currentAllocations)
 
 	logger.Info("Optimization completed successfully",
-		"mode", "saturation-only",
+		"mode", mode,
 		"modelsProcessed", len(modelGroups),
 		"decisionsApplied", len(allDecisions))
 
 	return nil
+}
+
+// modeLabelForAnalyzer returns the human-readable mode label for the given
+// analyzer name, used in the "Optimization completed successfully" log entry.
+// It mirrors the analyzer selection in optimize's switch statement.
+func modeLabelForAnalyzer(analyzerName string) string {
+	switch analyzerName {
+	case interfaces.QueueingModelAnalyzerName:
+		return interfaces.QueueingModelAnalyzerName
+	case interfaces.SaturationAnalyzerName:
+		return interfaces.SaturationAnalyzerName
+	default:
+		return "saturation-only"
+	}
 }
 
 // recordEvent ensures only one event is recorded per VA in an optimization cycle.

--- a/internal/engines/saturation/mode_label_test.go
+++ b/internal/engines/saturation/mode_label_test.go
@@ -1,0 +1,31 @@
+package saturation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// TestModeLabelForAnalyzer ensures the "Optimization completed successfully" log
+// entry reports the analyzer mode that was actually selected, rather than always
+// logging "saturation-only" regardless of which path ran.
+func TestModeLabelForAnalyzer(t *testing.T) {
+	tests := []struct {
+		name         string
+		analyzerName string
+		wantMode     string
+	}{
+		{"queueing model analyzer", interfaces.QueueingModelAnalyzerName, interfaces.QueueingModelAnalyzerName},
+		{"V2 saturation analyzer", interfaces.SaturationAnalyzerName, interfaces.SaturationAnalyzerName},
+		{"unset analyzer name falls back to V1 saturation-only", "", "saturation-only"},
+		{"unrecognized analyzer name falls back to V1 saturation-only", "not-a-real-analyzer", "saturation-only"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantMode, modeLabelForAnalyzer(tt.analyzerName))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #962

## Proposed Changes

- :bug: Fix bug

- The "Optimization completed successfully" log entry in `internal/engines/saturation/engine.go` always hardcoded `mode=saturation-only`, regardless of whether the queueing-model, V2 saturation, or V1 (legacy saturation-only) analyzer path actually ran.
- Extracted `modeLabelForAnalyzer(analyzerName string) string`, which maps the resolved `analyzerName` to the same label used by the `switch` that selects the optimize path, and used it for the completion log instead of the literal string.

### Pre-review Checklist

- [x] **E2E tests** for any new behavior — N/A, this is a logging-correctness fix with no behavioral change to scaling decisions
- [ ] **Docs PR** for any user-facing impact — N/A, internal log field only
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — N/A, bug fix

**Release Note**

```release-note

```

**Docs**

N/A — internal log field, no user-facing documentation impact.

## How tested

- Added `TestModeLabelForAnalyzer` (table-driven, `internal/engines/saturation/mode_label_test.go`) covering all three modes plus the empty/unset and unrecognized fallback cases.
- `go test ./internal/engines/saturation/...` passes (61.4% coverage maintained).
- `make test` run locally: only pre-existing, unrelated failure in `internal/engines/analyzers/throughput` (a flaky degenerate-input case in `itl_model_test.go`), confirmed present on `main` without this change too.
- `gofmt`/`go vet` clean.
