### PR TITLE
feat(config): allow opt-in plain HTTP Prometheus endpoints

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -421,15 +422,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Always validate TLS configuration since HTTPS is required
+	// Validate Prometheus transport configuration before creating the client.
 	if err := utils.ValidateTLSConfig(cfg); err != nil {
-		setupLog.Error(err, "TLS configuration validation failed - HTTPS is required")
+		setupLog.Error(err, "Prometheus transport configuration validation failed")
 		os.Exit(1)
 	}
 
 	setupLog.Info("Initializing Prometheus client",
 		"address", cfg.PrometheusBaseURL(),
-		"tlsEnabled", true,
+		"tlsEnabled", strings.HasPrefix(cfg.PrometheusBaseURL(), "https://"),
+		"allowHTTP", cfg.PrometheusAllowHTTP(),
 	)
 
 	// Create Prometheus client with TLS support

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -430,7 +429,7 @@ func main() {
 
 	setupLog.Info("Initializing Prometheus client",
 		"address", cfg.PrometheusBaseURL(),
-		"tlsEnabled", strings.HasPrefix(cfg.PrometheusBaseURL(), "https://"),
+		"tlsEnabled", utils.IsHTTPS(cfg.PrometheusBaseURL()),
 		"allowHTTP", cfg.PrometheusAllowHTTP(),
 	)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -427,8 +428,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	promURL, _ := url.Parse(cfg.PrometheusBaseURL()) // already validated above
 	setupLog.Info("Initializing Prometheus client",
-		"address", cfg.PrometheusBaseURL(),
+		"address", promURL.Redacted(),
 		"tlsEnabled", utils.IsHTTPS(cfg.PrometheusBaseURL()),
 		"allowHTTP", cfg.PrometheusAllowHTTP(),
 	)

--- a/docs/developer-guide/prometheus.md
+++ b/docs/developer-guide/prometheus.md
@@ -136,9 +136,11 @@ spec:
 - If your Prometheus is only reachable over plain HTTP (e.g. `kube-prometheus-stack`'s
   default in-cluster service), set `PROMETHEUS_ALLOW_HTTP=true` and use an
   `http://` `PROMETHEUS_BASE_URL` instead of standing up a TLS-terminating proxy.
-  This cannot be combined with `PROMETHEUS_TLS_INSECURE_SKIP_VERIFY`, any
-  `PROMETHEUS_CA_CERT_PATH`/client cert settings, or bearer token auth — WVA
-  refuses to start if those are set alongside a plain HTTP URL.
+  This cannot be combined with `PROMETHEUS_TLS_INSECURE_SKIP_VERIFY`,
+  `PROMETHEUS_SERVER_NAME`, any `PROMETHEUS_CA_CERT_PATH`/client cert settings, or
+  bearer token auth — WVA refuses to start if those are set alongside a plain HTTP
+  URL. Note that credentials and metrics are sent in cleartext, so use this only
+  on a trusted network (dev/test or a secured in-cluster path).
 
 ### PromQL Injection Prevention
 

--- a/docs/developer-guide/prometheus.md
+++ b/docs/developer-guide/prometheus.md
@@ -54,6 +54,7 @@ spec:
 | Variable | Required | Description | Default |
 |----------|----------|-------------|---------|
 | `PROMETHEUS_BASE_URL` | Yes | Prometheus server URL (HTTPS only in production) | - |
+| `PROMETHEUS_ALLOW_HTTP` | No | Allow a plain `http://` `PROMETHEUS_BASE_URL` (dev/test only; cannot be combined with TLS settings or bearer token auth) | `false` |
 | `PROMETHEUS_TLS_INSECURE_SKIP_VERIFY` | No | Skip TLS certificate verification (dev/test only) | `false` |
 | `PROMETHEUS_CA_CERT_PATH` | No | Path to CA certificate for TLS verification | - |
 | `PROMETHEUS_CLIENT_CERT_PATH` | No | Path to client certificate for mutual TLS | - |
@@ -132,6 +133,12 @@ spec:
   export PROMETHEUS_BASE_URL=https://127.0.0.1:9091
   export PROMETHEUS_TLS_INSECURE_SKIP_VERIFY=true
   ```
+- If your Prometheus is only reachable over plain HTTP (e.g. `kube-prometheus-stack`'s
+  default in-cluster service), set `PROMETHEUS_ALLOW_HTTP=true` and use an
+  `http://` `PROMETHEUS_BASE_URL` instead of standing up a TLS-terminating proxy.
+  This cannot be combined with `PROMETHEUS_TLS_INSECURE_SKIP_VERIFY`, any
+  `PROMETHEUS_CA_CERT_PATH`/client cert settings, or bearer token auth — WVA
+  refuses to start if those are set alongside a plain HTTP URL.
 
 ### PromQL Injection Prevention
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -169,6 +169,7 @@ func loadConfig(cfg *Config, flagSet *flag.FlagSet, configFilePath string) error
 	cfg.prometheus.bearerToken = v.GetString("PROMETHEUS_BEARER_TOKEN")
 	cfg.prometheus.tokenPath = v.GetString("PROMETHEUS_TOKEN_PATH")
 	cfg.prometheus.insecureSkipVerify = v.GetBool("PROMETHEUS_TLS_INSECURE_SKIP_VERIFY")
+	cfg.prometheus.allowHTTP = v.GetBool("PROMETHEUS_ALLOW_HTTP")
 	cfg.prometheus.caCertPath = v.GetString("PROMETHEUS_CA_CERT_PATH")
 	cfg.prometheus.clientCertPath = v.GetString("PROMETHEUS_CLIENT_CERT_PATH")
 	cfg.prometheus.clientKeyPath = v.GetString("PROMETHEUS_CLIENT_KEY_PATH")

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -44,6 +44,30 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.OptimizationInterval() != 60*time.Second {
 		t.Errorf("Expected OptimizationInterval default 60s, got %v", cfg.OptimizationInterval())
 	}
+	if cfg.PrometheusAllowHTTP() {
+		t.Error("Expected PrometheusAllowHTTP default to be false")
+	}
+}
+
+func TestLoad_PrometheusAllowHTTPFromEnv(t *testing.T) {
+	_ = os.Setenv("PROMETHEUS_BASE_URL", "http://prometheus-env:9090")
+	_ = os.Setenv("PROMETHEUS_ALLOW_HTTP", "true")
+	defer func() {
+		_ = os.Unsetenv("PROMETHEUS_BASE_URL")
+		_ = os.Unsetenv("PROMETHEUS_ALLOW_HTTP")
+	}()
+
+	cfg, err := Load(nil, "")
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if cfg.PrometheusBaseURL() != "http://prometheus-env:9090" {
+		t.Errorf("Expected Prometheus BaseURL from env, got %q", cfg.PrometheusBaseURL())
+	}
+	if !cfg.PrometheusAllowHTTP() {
+		t.Error("Expected PrometheusAllowHTTP to be true from env")
+	}
 }
 
 func TestLoad_FlagsPrecedence(t *testing.T) {

--- a/internal/config/prometheus.go
+++ b/internal/config/prometheus.go
@@ -12,6 +12,7 @@ type prometheusConfig struct {
 	bearerToken        string
 	tokenPath          string
 	insecureSkipVerify bool
+	allowHTTP          bool
 	caCertPath         string
 	clientCertPath     string
 	clientKeyPath      string
@@ -94,6 +95,14 @@ func (c *Config) PrometheusInsecureSkipVerify() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.prometheus.insecureSkipVerify
+}
+
+// PrometheusAllowHTTP returns whether plain HTTP connections to Prometheus are allowed.
+// Thread-safe.
+func (c *Config) PrometheusAllowHTTP() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.prometheus.allowHTTP
 }
 
 // PrometheusCACertPath returns the Prometheus CA certificate path.

--- a/internal/utils/prometheus_transport.go
+++ b/internal/utils/prometheus_transport.go
@@ -21,7 +21,7 @@ func CreatePrometheusTransport(cfg *config.Config) (http.RoundTripper, error) {
 	// Clone the default transport to get all the good defaults
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 
-	if strings.HasPrefix(cfg.PrometheusBaseURL(), "https://") {
+	if IsHTTPS(cfg.PrometheusBaseURL()) {
 		tlsConfig, err := CreateTLSConfig(cfg)
 		if err != nil {
 			return nil, err
@@ -72,7 +72,7 @@ func CreatePrometheusClientConfig(cfg *config.Config) (*api.Config, error) {
 	return clientConfig, nil
 }
 
-// bearerTokenRoundTripper adds bearer token authentication to HTTPS requests
+// bearerTokenRoundTripper adds bearer token authentication to HTTP and HTTPS requests
 type bearerTokenRoundTripper struct {
 	base  http.RoundTripper
 	token string

--- a/internal/utils/prometheus_transport.go
+++ b/internal/utils/prometheus_transport.go
@@ -72,14 +72,18 @@ func CreatePrometheusClientConfig(cfg *config.Config) (*api.Config, error) {
 	return clientConfig, nil
 }
 
-// bearerTokenRoundTripper adds bearer token authentication to HTTP and HTTPS requests
+// bearerTokenRoundTripper adds bearer token authentication to HTTPS requests.
+// The header is only set for https:// requests to prevent credential leakage
+// if a redirect leads to a plain http:// endpoint.
 type bearerTokenRoundTripper struct {
 	base  http.RoundTripper
 	token string
 }
 
-// RoundTrip adds the Authorization header with bearer token
+// RoundTrip adds the Authorization header for HTTPS requests only.
 func (b *bearerTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", "Bearer "+b.token)
+	if req.URL.Scheme == "https" {
+		req.Header.Set("Authorization", "Bearer "+b.token)
+	}
 	return b.base.RoundTrip(req)
 }

--- a/internal/utils/prometheus_transport.go
+++ b/internal/utils/prometheus_transport.go
@@ -13,24 +13,27 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
-// CreatePrometheusTransport creates a custom HTTPS transport for Prometheus client with TLS support.
-// TLS is always enabled for HTTPS-only support with configurable certificate validation.
+// CreatePrometheusTransport creates a custom transport for the Prometheus client.
+// TLS configuration is only applied for https:// endpoints; plain http://
+// endpoints (allowed only when PROMETHEUS_ALLOW_HTTP is set, see ValidateTLSConfig)
+// use the default transport unmodified.
 func CreatePrometheusTransport(cfg *config.Config) (http.RoundTripper, error) {
 	// Clone the default transport to get all the good defaults
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 
-	// Configure TLS (always required for HTTPS-only support)
-	tlsConfig, err := CreateTLSConfig(cfg)
-	if err != nil {
-		return nil, err
+	if strings.HasPrefix(cfg.PrometheusBaseURL(), "https://") {
+		tlsConfig, err := CreateTLSConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig = tlsConfig
+		ctrl.Log.V(logging.VERBOSE).Info("TLS configuration applied to Prometheus HTTPS transport")
 	}
-	transport.TLSClientConfig = tlsConfig
-	ctrl.Log.V(logging.VERBOSE).Info("TLS configuration applied to Prometheus HTTPS transport")
 
 	return transport, nil
 }
 
-// CreatePrometheusClientConfig creates a complete Prometheus client configuration with HTTPS support.
+// CreatePrometheusClientConfig creates a complete Prometheus client configuration.
 // Supports both direct bearer tokens and token files for flexible authentication.
 func CreatePrometheusClientConfig(cfg *config.Config) (*api.Config, error) {
 	clientConfig := &api.Config{

--- a/internal/utils/prometheus_transport.go
+++ b/internal/utils/prometheus_transport.go
@@ -82,7 +82,7 @@ type bearerTokenRoundTripper struct {
 
 // RoundTrip adds the Authorization header for HTTPS requests only.
 func (b *bearerTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.URL.Scheme == "https" {
+	if req.URL.Scheme == schemeHTTPS {
 		req.Header.Set("Authorization", "Bearer "+b.token)
 	}
 	return b.base.RoundTrip(req)

--- a/internal/utils/prometheus_transport.go
+++ b/internal/utils/prometheus_transport.go
@@ -40,7 +40,7 @@ func CreatePrometheusClientConfig(cfg *config.Config) (*api.Config, error) {
 		Address: cfg.PrometheusBaseURL(),
 	}
 
-	// Create custom HTTPS transport with TLS support
+	// Create the custom transport; TLS is applied only for https:// endpoints.
 	transport, err := CreatePrometheusTransport(cfg)
 	if err != nil {
 		return nil, err

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -15,7 +15,7 @@ import (
 )
 
 // IsHTTPS reports whether rawURL uses the https scheme.
-// It uses url.Parse so the comparison is case-insensitive per RFC 3986.
+// url.Parse normalizes scheme to lowercase, so the comparison is case-insensitive.
 func IsHTTPS(rawURL string) bool {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -105,6 +105,9 @@ func ValidateTLSConfig(cfg *config.Config) error {
 	case "https":
 		// Continue with the HTTPS-specific validation below.
 	case "http":
+		if u.User != nil {
+			return fmt.Errorf("refusing to use Prometheus URL with embedded credentials %q; use PROMETHEUS_BEARER_TOKEN or PROMETHEUS_TOKEN_PATH instead", u.Redacted())
+		}
 		if !allowHTTP {
 			return fmt.Errorf("plain HTTP Prometheus URL %q is not allowed; set PROMETHEUS_ALLOW_HTTP=true to permit http:// endpoints", baseURL)
 		}
@@ -114,7 +117,7 @@ func ValidateTLSConfig(cfg *config.Config) error {
 		if insecureSkipVerify || caCertPath != "" || clientCertPath != "" || clientKeyPath != "" || cfg.PrometheusServerName() != "" {
 			return fmt.Errorf("TLS-related settings are not supported with plain HTTP Prometheus URL %q; remove them or use an https:// URL", baseURL)
 		}
-		ctrl.Log.Info("Plain HTTP Prometheus endpoint allowed by configuration", "address", baseURL)
+		ctrl.Log.Info("Plain HTTP Prometheus endpoint allowed by configuration", "address", u.Redacted())
 		return nil
 	default:
 		return fmt.Errorf("unsupported Prometheus URL scheme %q in %q; expected http or https", u.Scheme, baseURL)

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -71,8 +71,9 @@ func CreateTLSConfig(cfg *config.Config) (*tls.Config, error) {
 	return config, nil
 }
 
-// ValidateTLSConfig validates TLS configuration.
-// Ensures HTTPS is used and certificate files exist when verification is enabled.
+// ValidateTLSConfig validates the Prometheus transport configuration.
+// Ensures the URL scheme is supported, and that certificate files exist when
+// HTTPS verification is enabled.
 func ValidateTLSConfig(cfg *config.Config) error {
 	if cfg == nil {
 		return errors.New("config is nil")
@@ -80,14 +81,33 @@ func ValidateTLSConfig(cfg *config.Config) error {
 
 	baseURL := cfg.PrometheusBaseURL()
 	insecureSkipVerify := cfg.PrometheusInsecureSkipVerify()
+	allowHTTP := cfg.PrometheusAllowHTTP()
 	caCertPath := cfg.PrometheusCACertPath()
 	clientCertPath := cfg.PrometheusClientCertPath()
 	clientKeyPath := cfg.PrometheusClientKeyPath()
 
-	// Validate that the URL uses HTTPS (TLS is always required)
 	u, err := url.Parse(baseURL)
-	if err != nil || u.Scheme != "https" {
-		return fmt.Errorf("HTTPS is required - URL must use https:// scheme: %s", baseURL)
+	if err != nil {
+		return fmt.Errorf("invalid Prometheus URL %q: %w", baseURL, err)
+	}
+
+	switch u.Scheme {
+	case "https":
+		// Continue with the HTTPS-specific validation below.
+	case "http":
+		if !allowHTTP {
+			return fmt.Errorf("plain HTTP Prometheus URL %q is not allowed; set PROMETHEUS_ALLOW_HTTP=true to permit http:// endpoints", baseURL)
+		}
+		if cfg.PrometheusBearerToken() != "" || cfg.PrometheusTokenPath() != "" {
+			return fmt.Errorf("refusing to send bearer token authentication over plain HTTP Prometheus URL %q", baseURL)
+		}
+		if insecureSkipVerify || caCertPath != "" || clientCertPath != "" || clientKeyPath != "" || cfg.PrometheusServerName() != "" {
+			return fmt.Errorf("TLS-related settings are not supported with plain HTTP Prometheus URL %q; remove them or use an https:// URL", baseURL)
+		}
+		ctrl.Log.Info("Plain HTTP Prometheus endpoint allowed by configuration", "address", baseURL)
+		return nil
+	default:
+		return fmt.Errorf("unsupported Prometheus URL scheme %q in %q; expected http or https", u.Scheme, baseURL)
 	}
 
 	// If InsecureSkipVerify is true, we don't need to validate certificate files

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -14,6 +14,8 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
+const schemeHTTPS = "https"
+
 // IsHTTPS reports whether rawURL uses the https scheme.
 // url.Parse normalizes scheme to lowercase, so the comparison is case-insensitive.
 func IsHTTPS(rawURL string) bool {
@@ -21,7 +23,7 @@ func IsHTTPS(rawURL string) bool {
 	if err != nil {
 		return false
 	}
-	return u.Scheme == "https"
+	return u.Scheme == schemeHTTPS
 }
 
 // CreateTLSConfig creates a TLS configuration from getter-based Prometheus config.
@@ -102,7 +104,7 @@ func ValidateTLSConfig(cfg *config.Config) error {
 	}
 
 	switch u.Scheme {
-	case "https":
+	case schemeHTTPS:
 		// Continue with the HTTPS-specific validation below.
 	case "http":
 		if u.User != nil {

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -14,7 +14,10 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
-const schemeHTTPS = "https"
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
 
 // IsHTTPS reports whether rawURL uses the https scheme.
 // url.Parse normalizes the scheme to lowercase before comparison, so HTTPS:// is treated the same as https://.
@@ -103,13 +106,18 @@ func ValidateTLSConfig(cfg *config.Config) error {
 		return fmt.Errorf("invalid Prometheus URL %q: %w", baseURL, err)
 	}
 
+	// Reject credentials embedded in the URL for any scheme: they leak through
+	// process listings, config dumps, redirect Referer headers, and any log that
+	// doesn't redact the URL — even over TLS. Use PROMETHEUS_BEARER_TOKEN or
+	// PROMETHEUS_TOKEN_PATH (over https) instead.
+	if u.User != nil {
+		return fmt.Errorf("refusing to use Prometheus URL with embedded credentials %q; use PROMETHEUS_BEARER_TOKEN or PROMETHEUS_TOKEN_PATH instead", u.Redacted())
+	}
+
 	switch u.Scheme {
 	case schemeHTTPS:
 		// Continue with the HTTPS-specific validation below.
-	case "http":
-		if u.User != nil {
-			return fmt.Errorf("refusing to use Prometheus URL with embedded credentials %q; use PROMETHEUS_BEARER_TOKEN or PROMETHEUS_TOKEN_PATH instead", u.Redacted())
-		}
+	case schemeHTTP:
 		if !allowHTTP {
 			return fmt.Errorf("plain HTTP Prometheus URL %q is not allowed; set PROMETHEUS_ALLOW_HTTP=true to permit http:// endpoints", baseURL)
 		}

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -17,7 +17,7 @@ import (
 const schemeHTTPS = "https"
 
 // IsHTTPS reports whether rawURL uses the https scheme.
-// url.Parse normalizes scheme to lowercase, so the comparison is case-insensitive.
+// url.Parse normalizes the scheme to lowercase before comparison, so HTTPS:// is treated the same as https://.
 func IsHTTPS(rawURL string) bool {
 	u, err := url.Parse(rawURL)
 	if err != nil {

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -14,8 +14,18 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
+// IsHTTPS reports whether rawURL uses the https scheme.
+// It uses url.Parse so the comparison is case-insensitive per RFC 3986.
+func IsHTTPS(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "https"
+}
+
 // CreateTLSConfig creates a TLS configuration from getter-based Prometheus config.
-// TLS is always enabled for HTTPS-only support. The configuration supports:
+// TLS is applied only for https:// endpoints. The configuration supports:
 // - Server certificate validation via CA certificate
 // - Mutual TLS authentication via client certificates
 // - Insecure certificate verification (development/testing only)

--- a/internal/utils/tls_test.go
+++ b/internal/utils/tls_test.go
@@ -242,7 +242,7 @@ func TestValidateTLSConfig(t *testing.T) {
 		{
 			name: "HTTP URL with embedded credentials - should fail",
 			promConfig: testConfigFromEnv(t, map[string]string{
-				"PROMETHEUS_BASE_URL": "http://user:pass@prometheus:9090",
+				"PROMETHEUS_BASE_URL":  "http://user:pass@prometheus:9090",
 				envPrometheusAllowHTTP: "true",
 			}),
 			expectError: true,

--- a/internal/utils/tls_test.go
+++ b/internal/utils/tls_test.go
@@ -264,6 +264,37 @@ func TestValidateTLSConfig(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "HTTPS URL with embedded credentials - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL": "https://user:pass@prometheus:9090",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTPS URL with missing CA cert - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":     "https://prometheus:9090",
+				"PROMETHEUS_CA_CERT_PATH": t.TempDir() + "/missing-ca.crt",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTPS URL with missing client cert - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":         "https://prometheus:9090",
+				"PROMETHEUS_CLIENT_CERT_PATH": t.TempDir() + "/missing-client.crt",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTPS URL with missing client key - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":        "https://prometheus:9090",
+				"PROMETHEUS_CLIENT_KEY_PATH": t.TempDir() + "/missing-client.key",
+			}),
+			expectError: true,
+		},
+		{
 			name: "TLS with insecure skip verify",
 			promConfig: testConfigFromEnv(t, map[string]string{
 				"PROMETHEUS_BASE_URL":                 "https://prometheus:9090",

--- a/internal/utils/tls_test.go
+++ b/internal/utils/tls_test.go
@@ -23,6 +23,7 @@ func testConfigFromEnv(t *testing.T, env map[string]string) *config.Config {
 		"PROMETHEUS_BEARER_TOKEN",
 		"PROMETHEUS_TOKEN_PATH",
 		"PROMETHEUS_TLS_INSECURE_SKIP_VERIFY",
+		"PROMETHEUS_ALLOW_HTTP",
 		"PROMETHEUS_CA_CERT_PATH",
 		"PROMETHEUS_CLIENT_CERT_PATH",
 		"PROMETHEUS_CLIENT_KEY_PATH",
@@ -146,9 +147,42 @@ func TestValidateTLSConfig(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "HTTP URL - should fail",
+			name: "HTTP URL without opt-in - should fail",
 			promConfig: testConfigFromEnv(t, map[string]string{
 				"PROMETHEUS_BASE_URL": "http://prometheus:9090",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTP URL with opt-in - should pass",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":   "http://prometheus:9090",
+				"PROMETHEUS_ALLOW_HTTP": "true",
+			}),
+			expectError: false,
+		},
+		{
+			name: "HTTP URL with opt-in and CA cert - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":     "http://prometheus:9090",
+				"PROMETHEUS_ALLOW_HTTP":   "true",
+				"PROMETHEUS_CA_CERT_PATH": "/tmp/ca.crt",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTP URL with opt-in and bearer token - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":     "http://prometheus:9090",
+				"PROMETHEUS_ALLOW_HTTP":   "true",
+				"PROMETHEUS_BEARER_TOKEN": "secret",
+			}),
+			expectError: true,
+		},
+		{
+			name: "unsupported URL scheme - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL": "ftp://prometheus:9090",
 			}),
 			expectError: true,
 		},

--- a/internal/utils/tls_test.go
+++ b/internal/utils/tls_test.go
@@ -64,6 +64,26 @@ func testConfigFromEnv(t *testing.T, env map[string]string) *config.Config {
 	return cfg
 }
 
+func TestIsHTTPS(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   bool
+	}{
+		{"https scheme", "https://prometheus:9090", true},
+		{"HTTPS uppercase scheme", "HTTPS://prometheus:9090", true},
+		{"http scheme", "http://prometheus:9090", false},
+		{"empty string", "", false},
+		{"invalid url", "://bad", false},
+		{"no scheme", "prometheus:9090", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsHTTPS(tt.rawURL))
+		})
+	}
+}
+
 func TestCreateTLSConfig(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -207,6 +227,23 @@ func TestValidateTLSConfig(t *testing.T) {
 				"PROMETHEUS_BASE_URL":         "http://prometheus:9090",
 				envPrometheusAllowHTTP:        "true",
 				"PROMETHEUS_CLIENT_CERT_PATH": "/tmp/client.crt",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTP URL with opt-in and client key path - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":        "http://prometheus:9090",
+				envPrometheusAllowHTTP:       "true",
+				"PROMETHEUS_CLIENT_KEY_PATH": "/tmp/client.key",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTP URL with embedded credentials - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL": "http://user:pass@prometheus:9090",
+				envPrometheusAllowHTTP: "true",
 			}),
 			expectError: true,
 		},

--- a/internal/utils/tls_test.go
+++ b/internal/utils/tls_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"crypto/tls"
+	"net/http"
 	"os"
 	"testing"
 
@@ -9,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const envPrometheusAllowHTTP = "PROMETHEUS_ALLOW_HTTP"
 
 func init() {
 	// Initialize logger for tests
@@ -23,7 +27,7 @@ func testConfigFromEnv(t *testing.T, env map[string]string) *config.Config {
 		"PROMETHEUS_BEARER_TOKEN",
 		"PROMETHEUS_TOKEN_PATH",
 		"PROMETHEUS_TLS_INSECURE_SKIP_VERIFY",
-		"PROMETHEUS_ALLOW_HTTP",
+		envPrometheusAllowHTTP,
 		"PROMETHEUS_CA_CERT_PATH",
 		"PROMETHEUS_CLIENT_CERT_PATH",
 		"PROMETHEUS_CLIENT_KEY_PATH",
@@ -156,8 +160,8 @@ func TestValidateTLSConfig(t *testing.T) {
 		{
 			name: "HTTP URL with opt-in - should pass",
 			promConfig: testConfigFromEnv(t, map[string]string{
-				"PROMETHEUS_BASE_URL":   "http://prometheus:9090",
-				"PROMETHEUS_ALLOW_HTTP": "true",
+				"PROMETHEUS_BASE_URL":  "http://prometheus:9090",
+				envPrometheusAllowHTTP: "true",
 			}),
 			expectError: false,
 		},
@@ -165,7 +169,7 @@ func TestValidateTLSConfig(t *testing.T) {
 			name: "HTTP URL with opt-in and CA cert - should fail",
 			promConfig: testConfigFromEnv(t, map[string]string{
 				"PROMETHEUS_BASE_URL":     "http://prometheus:9090",
-				"PROMETHEUS_ALLOW_HTTP":   "true",
+				envPrometheusAllowHTTP:    "true",
 				"PROMETHEUS_CA_CERT_PATH": "/tmp/ca.crt",
 			}),
 			expectError: true,
@@ -174,8 +178,44 @@ func TestValidateTLSConfig(t *testing.T) {
 			name: "HTTP URL with opt-in and bearer token - should fail",
 			promConfig: testConfigFromEnv(t, map[string]string{
 				"PROMETHEUS_BASE_URL":     "http://prometheus:9090",
-				"PROMETHEUS_ALLOW_HTTP":   "true",
+				envPrometheusAllowHTTP:    "true",
 				"PROMETHEUS_BEARER_TOKEN": "secret",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTP URL with opt-in and token path - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":   "http://prometheus:9090",
+				envPrometheusAllowHTTP:  "true",
+				"PROMETHEUS_TOKEN_PATH": "/var/run/secrets/token",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTP URL with opt-in and insecure skip verify - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":                 "http://prometheus:9090",
+				envPrometheusAllowHTTP:                "true",
+				"PROMETHEUS_TLS_INSECURE_SKIP_VERIFY": "true",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTP URL with opt-in and client cert path - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":         "http://prometheus:9090",
+				envPrometheusAllowHTTP:        "true",
+				"PROMETHEUS_CLIENT_CERT_PATH": "/tmp/client.crt",
+			}),
+			expectError: true,
+		},
+		{
+			name: "HTTP URL with opt-in and server name - should fail",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":    "http://prometheus:9090",
+				envPrometheusAllowHTTP:   "true",
+				"PROMETHEUS_SERVER_NAME": "prometheus.example.com",
 			}),
 			expectError: true,
 		},
@@ -211,6 +251,57 @@ func TestValidateTLSConfig(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreatePrometheusTransport(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		// expectCustomTLS is true when CreateTLSConfig should have been called
+		// (i.e. the URL is https://). CreateTLSConfig always sets MinVersion to
+		// tls.VersionTLS12, so we use that as a sentinel to distinguish our
+		// custom TLS config from any TLS config the cloned default transport
+		// may carry for h2 support (which has MinVersion == 0).
+		expectCustomTLS bool
+	}{
+		{
+			name: "http with opt-in - custom TLS config should not be applied",
+			env: map[string]string{
+				"PROMETHEUS_BASE_URL":  "http://prometheus:9090",
+				envPrometheusAllowHTTP: "true",
+			},
+			expectCustomTLS: false,
+		},
+		{
+			name: "https - custom TLS config should be applied",
+			env: map[string]string{
+				"PROMETHEUS_BASE_URL": "https://prometheus:9090",
+			},
+			expectCustomTLS: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfigFromEnv(t, tt.env)
+			rt, err := CreatePrometheusTransport(cfg)
+			require.NoError(t, err)
+			require.NotNil(t, rt)
+
+			transport, ok := rt.(*http.Transport)
+			require.True(t, ok, "expected *http.Transport")
+
+			if tt.expectCustomTLS {
+				// CreateTLSConfig always enforces MinVersion: tls.VersionTLS12.
+				require.NotNil(t, transport.TLSClientConfig)
+				assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+			} else if transport.TLSClientConfig != nil {
+				// TLSClientConfig may be non-nil (cloned from DefaultTransport for h2
+				// support), but our custom MinVersion must NOT be set.
+				assert.NotEqual(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1074

## Proposed Changes

- :gift: Add new feature

- Add `PROMETHEUS_ALLOW_HTTP` (default `false`) to opt in to a plain `http://` `PROMETHEUS_BASE_URL`.
- `ValidateTLSConfig` now branches on URL scheme: `https://` keeps existing validation; `http://` requires the new flag and explicitly rejects being combined with bearer-token auth or any TLS-specific setting (CA cert, client cert, `insecureSkipVerify`, server name) to avoid a false sense of security; any other scheme is rejected outright.
- `CreatePrometheusTransport` only builds/attaches a `tls.Config` for `https://` endpoints — plain HTTP uses the default transport unmodified.
- Updated the "Initializing Prometheus client" startup log to report the actual `tlsEnabled`/`allowHTTP` state instead of a hardcoded `tlsEnabled: true`.
- Documented the new variable in `docs/developer-guide/prometheus.md` (env var reference table + a dev/testing note in Security Considerations).

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — this only affects local config validation/transport setup, no new e2e coverage added; let me know if you'd like one added for an HTTP-Prometheus scenario
- [x] **Docs PR** for any user-facing impact — updated `docs/developer-guide/prometheus.md` in this PR
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — this is a small, additive opt-in flag; happy to write a proposal if maintainers want one

**Release Note**

```release-note
Add `PROMETHEUS_ALLOW_HTTP` to allow connecting to a plain `http://` Prometheus endpoint. Disabled by default; cannot be combined with TLS settings or bearer token auth.
```

**Docs**

Updated `docs/developer-guide/prometheus.md` (env var table + Security Considerations section) in this PR.

## How tested

- `go build ./...` and `go vet ./...` clean.
- `go test ./internal/config/... ./internal/utils/...` passes, including new cases:
  - `TestValidateTLSConfig`: HTTP without opt-in (fail), HTTP with opt-in (pass), HTTP + CA cert (fail), HTTP + bearer token (fail), unsupported scheme (fail)
  - `TestLoad_PrometheusAllowHTTPFromEnv`: confirms the env var loads correctly
- `make test` run locally: the only failure is a pre-existing, unrelated flaky case in `internal/engines/analyzers/throughput/itl_model_test.go`, confirmed present on `main` without this change.
- Could not run `make lint` locally — `golangci-lint` panics in this environment on a Go toolchain version mismatch (`file requires newer Go version go1.26 (application built with go1.25)`), unrelated to this diff; `gofmt`/`go vet` are clean.

## Notes

I'm aware a prior PR (#1075) attempted this same issue and went stale from inactivity after a maintainer review (not rejection) — addressed similarly here but reimplemented independently rather than reusing that diff.
