### PR TITLE
fix: exclude KEDA-generated HPAs from the collector's managed-HPA index

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -102,6 +102,11 @@ const (
 	LeaderWorkerSetKind       = "LeaderWorkerSet"
 	LeaderWorkerSetAPIVersion = "leaderworkerset.x-k8s.io/v1"
 
+	// KEDA ScaledObject identity, used to recognize the HPA KEDA generates per
+	// ScaledObject (the child HPA inherits the ScaledObject's annotations).
+	ScaledObjectKind     = "ScaledObject"
+	ScaledObjectAPIGroup = "keda.sh"
+
 	// K8s Events
 	K8SEventScaledUp                  = "ScaledUp"
 	K8SEventScaledDown                = "ScaledDown"

--- a/internal/controller/indexers/hpa.go
+++ b/internal/controller/indexers/hpa.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -26,6 +27,14 @@ func scaleTargetKindSupported(kind string) bool {
 func HPAByScaleTargetIndexFunc(o client.Object) []string {
 	hpa := o.(*autoscalingv2.HorizontalPodAutoscaler)
 	if !annotations.IsManaged(hpa) {
+		return nil
+	}
+	// Exclude KEDA-generated child HPAs. KEDA creates an HPA per ScaledObject and
+	// propagates the ScaledObject's annotations (including llm-d.ai/managed) onto it,
+	// so the child HPA looks managed too. The ScaledObject is the real managed scaler;
+	// indexing its child HPA would make the locator match two managed scalers for one
+	// target and fail with "ambiguous scale target".
+	if utils.IsOwnedByKEDAScaledObject(hpa) {
 		return nil
 	}
 	ref := hpa.Spec.ScaleTargetRef

--- a/internal/controller/indexers/hpa_index_test.go
+++ b/internal/controller/indexers/hpa_index_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2025.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package indexers
 
 import (

--- a/internal/controller/indexers/hpa_index_test.go
+++ b/internal/controller/indexers/hpa_index_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexers
+
+import (
+	"testing"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+)
+
+// A KEDA-generated HPA inherits the ScaledObject's llm-d.ai/managed annotation
+// (kedacore/keda#5468). It must NOT be indexed as a managed scaler, or the
+// collector's locator sees two managed scalers for one target and fails with
+// "ambiguous scale target". Regression for #1333.
+func TestHPAByScaleTargetIndexFunc_SkipsKEDAOwnedHPA(t *testing.T) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "keda-hpa-my-model",
+			Namespace:   "inference",
+			Annotations: map[string]string{annotations.Managed: "true"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: constants.ScaledObjectAPIGroup + "/v1alpha1",
+				Kind:       constants.ScaledObjectKind,
+				Name:       "my-model",
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: constants.DeploymentKind,
+				Name: "my-model",
+			},
+		},
+	}
+
+	if got := HPAByScaleTargetIndexFunc(hpa); got != nil {
+		t.Errorf("KEDA-owned managed HPA must not be indexed, got %v", got)
+	}
+
+	// Sanity: a managed HPA that is NOT owned by a ScaledObject is still indexed.
+	hpa.OwnerReferences = nil
+	if got := HPAByScaleTargetIndexFunc(hpa); len(got) != 1 {
+		t.Errorf("managed non-KEDA HPA should be indexed, got %v", got)
+	}
+}

--- a/internal/coordinator/selection.go
+++ b/internal/coordinator/selection.go
@@ -5,19 +5,11 @@ import (
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 )
-
-// scaledObjectGroup is the API group reported on OwnerReferences for KEDA
-// ScaledObjects, used to recognize KEDA-generated HPAs.
-const scaledObjectGroup = "keda.sh"
-
-// scaledObjectKind is the OwnerReference Kind reported by KEDA for the HPA
-// it generates per ScaledObject.
-const scaledObjectKind = "ScaledObject"
 
 // IsHPAUnderControl reports whether an HPA is under Coordinator control.
 //
@@ -42,7 +34,7 @@ func IsHPAUnderControl(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
 	if hpaHasWVADesiredReplicasMetric(hpa) {
 		return false
 	}
-	if isOwnedByKEDAScaledObject(hpa) {
+	if utils.IsOwnedByKEDAScaledObject(hpa) {
 		return false
 	}
 	return true
@@ -84,24 +76,6 @@ func hpaHasWVADesiredReplicasMetric(hpa *autoscalingv2.HorizontalPodAutoscaler) 
 		}
 	}
 	return false
-}
-
-// isOwnedByKEDAScaledObject returns true if obj has a controller
-// OwnerReference whose APIVersion is in the keda.sh API group and whose
-// Kind is "ScaledObject".
-func isOwnedByKEDAScaledObject(obj metav1.Object) bool {
-	ctrl := metav1.GetControllerOf(obj)
-	if ctrl == nil {
-		return false
-	}
-	if ctrl.Kind != scaledObjectKind {
-		return false
-	}
-	// APIVersion is "<group>/<version>"; match the group prefix.
-	if i := strings.IndexByte(ctrl.APIVersion, '/'); i > 0 {
-		return ctrl.APIVersion[:i] == scaledObjectGroup
-	}
-	return ctrl.APIVersion == scaledObjectGroup
 }
 
 // scaledObjectHasWVADesiredReplicasTrigger returns true if any Prometheus

--- a/internal/coordinator/selection_test.go
+++ b/internal/coordinator/selection_test.go
@@ -52,7 +52,7 @@ func otherExternalMetric() autoscalingv2.MetricSpec {
 func kedaOwnerRef() metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: "keda.sh/v1alpha1",
-		Kind:       scaledObjectKind,
+		Kind:       constants.ScaledObjectKind,
 		Name:       "my-so",
 		UID:        "uid-1",
 		Controller: ptr.To(true),

--- a/internal/utils/keda.go
+++ b/internal/utils/keda.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+)
+
+// IsOwnedByKEDAScaledObject reports whether obj has a controller OwnerReference
+// whose APIVersion is in the keda.sh API group and whose Kind is "ScaledObject".
+//
+// KEDA generates an HPA per ScaledObject and propagates the ScaledObject's
+// annotations (including llm-d.ai/managed) onto that child HPA. Callers that scan
+// for WVA-managed scalers must exclude such KEDA-generated HPAs: the ScaledObject
+// is the managed scaler, and treating its child HPA as a second managed scaler for
+// the same target is ambiguous.
+func IsOwnedByKEDAScaledObject(obj metav1.Object) bool {
+	ctrl := metav1.GetControllerOf(obj)
+	if ctrl == nil {
+		return false
+	}
+	if ctrl.Kind != constants.ScaledObjectKind {
+		return false
+	}
+	// APIVersion is "<group>/<version>"; match the group prefix.
+	if i := strings.IndexByte(ctrl.APIVersion, '/'); i > 0 {
+		return ctrl.APIVersion[:i] == constants.ScaledObjectAPIGroup
+	}
+	return ctrl.APIVersion == constants.ScaledObjectAPIGroup
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -455,3 +455,26 @@ func extractGPUFromNodeSelectorTerm(term corev1.NodeSelectorTerm, gpuKeys []stri
 	}
 	return ""
 }
+
+// IsOwnedByKEDAScaledObject reports whether obj has a controller OwnerReference
+// whose APIVersion is in the keda.sh API group and whose Kind is "ScaledObject".
+//
+// KEDA generates an HPA per ScaledObject and propagates the ScaledObject's
+// annotations (including llm-d.ai/managed) onto that child HPA. Callers that scan
+// for WVA-managed scalers must exclude such KEDA-generated HPAs: the ScaledObject
+// is the managed scaler, and treating its child HPA as a second managed scaler for
+// the same target is ambiguous.
+func IsOwnedByKEDAScaledObject(obj metav1.Object) bool {
+	ctrl := metav1.GetControllerOf(obj)
+	if ctrl == nil {
+		return false
+	}
+	if ctrl.Kind != constants.ScaledObjectKind {
+		return false
+	}
+	// APIVersion is "<group>/<version>"; match the group prefix.
+	if i := strings.IndexByte(ctrl.APIVersion, '/'); i > 0 {
+		return ctrl.APIVersion[:i] == constants.ScaledObjectAPIGroup
+	}
+	return ctrl.APIVersion == constants.ScaledObjectAPIGroup
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -455,26 +455,3 @@ func extractGPUFromNodeSelectorTerm(term corev1.NodeSelectorTerm, gpuKeys []stri
 	}
 	return ""
 }
-
-// IsOwnedByKEDAScaledObject reports whether obj has a controller OwnerReference
-// whose APIVersion is in the keda.sh API group and whose Kind is "ScaledObject".
-//
-// KEDA generates an HPA per ScaledObject and propagates the ScaledObject's
-// annotations (including llm-d.ai/managed) onto that child HPA. Callers that scan
-// for WVA-managed scalers must exclude such KEDA-generated HPAs: the ScaledObject
-// is the managed scaler, and treating its child HPA as a second managed scaler for
-// the same target is ambiguous.
-func IsOwnedByKEDAScaledObject(obj metav1.Object) bool {
-	ctrl := metav1.GetControllerOf(obj)
-	if ctrl == nil {
-		return false
-	}
-	if ctrl.Kind != constants.ScaledObjectKind {
-		return false
-	}
-	// APIVersion is "<group>/<version>"; match the group prefix.
-	if i := strings.IndexByte(ctrl.APIVersion, '/'); i > 0 {
-		return ctrl.APIVersion[:i] == constants.ScaledObjectAPIGroup
-	}
-	return ctrl.APIVersion == constants.ScaledObjectAPIGroup
-}


### PR DESCRIPTION
Fixes #1333

## Proposed Changes

- Exclude KEDA-generated child HPAs from the collector's managed-HPA index (`HPAByScaleTargetIndexFunc`), fixing the `ambiguous scale target` failure that left annotation-mode variants stuck on the current replicas safety net fallback instead of real saturation/optimization.
- Factor the KEDA-ownership check into a shared `utils.IsOwnedByKEDAScaledObject` (with `ScaledObjectKind` /`ScaledObjectAPIGroup` constants); the Coordinator's `IsHPAUnderControl` now uses the same predicate, so there is one source of truth. 
- Add a regression test: a KEDA-owned managed HPA is not indexed; a managed non-KEDA HPA still is.

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement

This is a bug fix so no documentation / proposal pr was included and this does not introduce any new behavior.

**Release Note**

```release-note
Fixed annotation-mode discovery so the metrics collector no longer fails with "ambiguous scale target" when a managed KEDA ScaledObject's generated HPA inherits the llm-d.ai/uns real saturation/optimization for such variantsinstead of emitting only the current-replicas fallback.
```

**Docs**

No documentation change. This is a bug fix restoring intended behavior with no user facing config or usage change.

