### PR TITLE
feat: always enable HTTP/2 and set NextProtos for ALPN

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,8 +138,6 @@ func main() {
 		"The directory that contains the metrics server certificate.")
 	flag.String("metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
 	flag.String("metrics-cert-key", "tls.key", "The name of the metrics key file.")
-	flag.Bool("enable-http2", false,
-		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.String("watch-namespace", "",
 		"Namespace to watch for updates. If unspecified, all namespaces are watched.")
 
@@ -223,20 +221,10 @@ func main() {
 	// the saturation engine goroutine constructs its locator.
 	locator.SetKEDAEnabled(kedaEnabled)
 
-	// if the enable-http2 flag is false (the default), http/2 should be disabled
-	// due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
-
-	var tlsOpts []func(*tls.Config)
-	if !cfg.EnableHTTP2() {
-		tlsOpts = append(tlsOpts, disableHTTP2)
+	tlsOpts := []func(*tls.Config){
+		func(c *tls.Config) {
+			c.NextProtos = []string{"h2", "http/1.1"}
+		},
 	}
 
 	// Create watchers for metrics and webhooks certificates

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,7 +53,6 @@ type infrastructureConfig struct {
 	retryPeriod          time.Duration
 	restTimeout          time.Duration
 	secureMetrics        bool
-	enableHTTP2          bool
 	watchNamespace       string
 	loggerVerbosity      int
 	optimizationInterval time.Duration
@@ -197,14 +196,6 @@ func (c *Config) SecureMetrics() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.infrastructure.secureMetrics
-}
-
-// EnableHTTP2 returns whether HTTP/2 is enabled.
-// Thread-safe.
-func (c *Config) EnableHTTP2() bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.infrastructure.enableHTTP2
 }
 
 // WatchNamespace returns the namespace to watch (empty = all namespaces).
@@ -674,7 +665,6 @@ func NewTestConfig() *Config {
 			retryPeriod:          10 * time.Second,
 			restTimeout:          60 * time.Second,
 			secureMetrics:        false,
-			enableHTTP2:          false,
 			watchNamespace:       "",
 			loggerVerbosity:      0,
 			optimizationInterval: 15 * time.Second,

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -20,7 +20,6 @@ var flagBindings = map[string]string{
 	"LEADER_ELECTION_RETRY_PERIOD":   "leader-election-retry-period",
 	"REST_CLIENT_TIMEOUT":            "rest-client-timeout",
 	"METRICS_SECURE":                 "metrics-secure",
-	"ENABLE_HTTP2":                   "enable-http2",
 	"WATCH_NAMESPACE":                "watch-namespace",
 	"V":                              "v",
 	"WEBHOOK_CERT_PATH":              "webhook-cert-path",
@@ -72,7 +71,6 @@ func loadConfig(cfg *Config, flagSet *flag.FlagSet, configFilePath string) error
 	v.SetDefault("LEADER_ELECTION_RETRY_PERIOD", 10*time.Second)
 	v.SetDefault("REST_CLIENT_TIMEOUT", 60*time.Second)
 	v.SetDefault("METRICS_SECURE", true)
-	v.SetDefault("ENABLE_HTTP2", false)
 	v.SetDefault("WATCH_NAMESPACE", "")
 	v.SetDefault("V", 0)
 	v.SetDefault("WEBHOOK_CERT_PATH", "")
@@ -120,7 +118,6 @@ func loadConfig(cfg *Config, flagSet *flag.FlagSet, configFilePath string) error
 		retryPeriod:          v.GetDuration("LEADER_ELECTION_RETRY_PERIOD"),
 		restTimeout:          v.GetDuration("REST_CLIENT_TIMEOUT"),
 		secureMetrics:        v.GetBool("METRICS_SECURE"),
-		enableHTTP2:          v.GetBool("ENABLE_HTTP2"),
 		watchNamespace:       v.GetString("WATCH_NAMESPACE"),
 		loggerVerbosity:      v.GetInt("V"),
 		optimizationInterval: v.GetDuration("GLOBAL_OPT_INTERVAL"),

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -34,6 +34,7 @@ func CreateTLSConfig(cfg *config.Config) (*tls.Config, error) {
 		InsecureSkipVerify: insecureSkipVerify,
 		ServerName:         serverName,
 		MinVersion:         tls.VersionTLS12, // Enforce minimum TLS version - https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/security_and_compliance/tls-security-profiles#:~:text=requires%20a%20minimum-,TLS%20version%20of%201.2,-.
+		NextProtos:         []string{"h2", "http/1.1"},
 	}
 
 	if insecureSkipVerify {


### PR DESCRIPTION
## Summary
- Remove the `--enable-http2` flag and always enable HTTP/2 with explicit NextProtos `["h2", "http/1.1"]`
- Set NextProtos on the Prometheus client TLS config for proper ALPN negotiation
- CVE-2023-44487 (HTTP/2 Rapid Reset) is fixed in Go 1.21.3+, the flag was a workaround that is no longer needed. This repo uses Go 1.25.0.

## Changes
- `cmd/main.go`: Remove `--enable-http2` flag, replace `disableHTTP2` conditional with always-on NextProtos
- `internal/config/config.go`: Remove `enableHTTP2` field and `EnableHTTP2()` getter
- `internal/config/loader.go`: Remove `ENABLE_HTTP2` env var mapping and default
- `internal/utils/tls.go`: Add `NextProtos` to Prometheus client TLS config

## Context
Starting with OCP 5.0 (GA October 2026), all TLS endpoints must explicitly negotiate protocols via ALPN. Disabling HTTP/2 degrades performance and prevents proper ALPN negotiation. The vulnerability that motivated the flag (CVE-2023-44487) has been fixed in the Go standard library since 1.21.3, and this repo uses Go 1.25.0.

## Test plan
- [x] All existing tests pass
- [x] Build passes
- [x] Config tests pass (enableHTTP2 field removed)