### PR TITLE
feat: add SGLang inference-engine backend support

### DIFF
--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -148,23 +148,25 @@ per-pod query in this codebase.
 
 ---
 
-#### QueryVLLMRequestRate (`vllm_request_rate`)
+#### QueryRequestRate (`request_rate`)
 
 ```promql
 sum by (pod) (rate(vllm:request_generation_tokens_count{namespace="...",model_name="..."}[1m]))
 ```
 
-**What it measures:** vLLM-side request completion rate per pod (req/s), derived from the
-generation tokens histogram `_count` counter (increments once per completed request).
+**What it measures:** Engine-side request completion rate per pod (req/s), derived from the
+generation tokens histogram `_count` counter (increments once per completed request). Engine-
+agnostic — the vLLM example is shown above; the SGLang variant reads
+`sglang:generation_tokens_histogram_count`.
 
 **TA notation:** fallback λ_req — used when `ArrivalRate == 0` for all pods (EPP not deployed).
-The analyzer computes `λ_dec_fallback = Σ VLLMRequestRate_r × AvgOutputTokens_r`.
+The analyzer computes `λ_dec_fallback = Σ RequestRate_r × AvgOutputTokens_r`.
 
-**ReplicaMetrics field:** `VLLMRequestRate`
+**ReplicaMetrics field:** `RequestRate`
 
 **Note:** This also serves as a throughput proxy weight for histogram averaging. When computing
 variant-average IL, OL, and prefix hit rate across replicas, each replica is weighted by its
-`VLLMRequestRate` to prevent low-throughput replicas from distorting the shape estimate.
+`RequestRate` to prevent low-throughput replicas from distorting the shape estimate.
 
 **Important:** This measures *completed* (served) requests, not *arriving* requests. It
 undercounts when requests are queued in the scheduler. Use `ArrivalRate` (primary) first;
@@ -188,7 +190,7 @@ these fields directly rather than registering duplicate queries.
 | Q (scheduler queue size) | `SchedulerQueueMetrics.QueueSize` (model-level) | `QuerySchedulerQueueSize` | `RegisterSaturationQueries` |
 
 **λ_dec primary:** `Σ ArrivalRate_r × AvgOutputTokens_r` across all replicas (EPP deployed).  
-**λ_dec fallback:** `Σ VLLMRequestRate_r × AvgOutputTokens_r` (EPP absent, all ArrivalRate == 0).
+**λ_dec fallback:** `Σ RequestRate_r × AvgOutputTokens_r` (EPP absent, all ArrivalRate == 0).
 
 **Note on arrival rate:** `ArrivalRate` comes from `QuerySchedulerDispatchRate` which is per-pod,
 namespaced, and model-scoped — correctly isolating traffic to a specific variant. The TA sums
@@ -203,7 +205,7 @@ namespace filtering limitation of the scheduler metric.
 |---|---|---|---|---|
 | `QueryGenerationTokenRate` | vLLM | `sum by (pod)` | 1m rate | μ_dec^obs per pod (observability) |
 | `QueryKvUsageInstant` | vLLM | `max by (pod)` | instant | k* (no max_over_time) |
-| `QueryVLLMRequestRate` | vLLM | `sum by (pod)` | 1m rate | Fallback λ_req; histogram weight |
+| `QueryRequestRate` | vLLM | `sum by (pod)` | 1m rate | Fallback λ_req; histogram weight |
 | `TotalKvCapacityTokens` | `KvCacheConfigInfo` labels | derived | static | KV_max = blocks × block_size |
 | `AvgITL` | `QueryAvgITL` | `max by (pod)` | 1m rate | ITL_obs for OLS calibration |
 | `AvgOutputTokens` | `QueryAvgOutputTokens` | `max by (pod)` | 5m rate | OL for KV_req and λ_dec |
@@ -233,14 +235,14 @@ internal/engines/analyzers/throughput/
 
 **Query Registration (`internal/collector/registration/throughput_analyzer.go`)**  
 Registers three PromQL templates exclusive to the throughput analyzer:
-`QueryGenerationTokenRate`, `QueryKvUsageInstant`, `QueryVLLMRequestRate`.
+`QueryGenerationTokenRate`, `QueryKvUsageInstant`, `QueryRequestRate`.
 `RegisterThroughputAnalyzerQueries` must be called once at startup alongside
 `RegisterSaturationQueries` and `RegisterQueueingModelQueries`.
 
 **Metrics Collector (`internal/collector/replica_metrics.go`)**  
 Populates all `interfaces.ReplicaMetrics` fields in a single `Refresh()` call covering all
 12 registered queries. The three TA-exclusive fields are:
-`GenerationTokenRate`, `KvUsageInstant`, `VLLMRequestRate`.
+`GenerationTokenRate`, `KvUsageInstant`, `RequestRate`.
 The remaining TA fields (`TotalKvCapacityTokens`, `AvgITL`, `AvgOutputTokens`, `AvgInputTokens`,
 `PrefixCacheHitRate`, `ArrivalRate`) are populated by saturation and queueing model queries.
 
@@ -292,7 +294,7 @@ On leader failover the incoming leader starts with an empty analyzer. During war
   │                                                                               │
   │  []ReplicaMetrics (replicas of variant v)                                     │
   │        │                                                                      │
-  │        ├─(IL, OL, H%) [VLLMRequestRate-weighted]──► ShapeTracker              │
+  │        ├─(IL, OL, H%) [RequestRate-weighted]──► ShapeTracker              │
   │        │                                               │                      │
   │        │                                         KVreq, IL_eff                │
   │        │                                         shape change──► Window.Clear │
@@ -307,7 +309,7 @@ On leader failover the incoming leader starts with an empty analyzer. During war
   │        │                                        [ITL(k_sat) = A·k_sat + B]    │
   │        │                                        → μ_dec_sat, perReplicaSupply │
   │        │                                                                      │
-  │        ├─(ArrivalRate / VLLMRequestRate)─────► computeDemand                  │
+  │        ├─(ArrivalRate / RequestRate)─────► computeDemand                  │
   │        │                                         → λ_dec, isEPP               │
   │        │                                                                      │
   │        └─(GPS_obs, k*, KV_max)──────────────► checkVariantGPSMismatch         │
@@ -339,7 +341,7 @@ On leader failover the incoming leader starts with an empty analyzer. During war
 └──────┬─────┘
        │ vllm:request_generation_tokens_sum      (QueryGenerationTokenRate   → GenerationTokenRate)
        │ vllm:kv_cache_usage_perc                (QueryKvUsageInstant          → KvUsageInstant)
-       │ vllm:request_generation_tokens_count    (QueryVLLMRequestRate       → VLLMRequestRate)
+       │ vllm:request_generation_tokens_count    (QueryRequestRate           → RequestRate)
        │ vllm:cache_config_info                  (QueryCacheConfigInfo       → TotalKvCapacityTokens)
        │ vllm:inter_token_latency_seconds_*      (QueryAvgITL               → AvgITL)
        │ vllm:request_generation_tokens_*        (QueryAvgOutputTokens       → AvgOutputTokens)
@@ -362,7 +364,7 @@ On leader failover the incoming leader starts with an empty analyzer. During war
 │    ObservationWindow → (k*, ITL) pairs                   │
 │    ITLModel (tier-1 OLS or tier-2 constrained)           │
 │    supply: μ_dec_sat = k_sat×KV_max / KVreq / ITL(k_sat) │
-│    demand: EPP primary → vLLM fallback → k*-local        │
+│    demand: EPP primary → engine fallback → k*-local      │
 │                                                          │
 │  model-level:                                            │
 │    + queue demand from QueueSize / (factor×ITL)          │
@@ -457,16 +459,16 @@ If EPP is present but all `AvgOutputTokens == 0` (warm-up: scheduler is dispatch
 requests but no generation tokens have completed yet), this path yields zero and the
 cascade falls through. `isEPP` remains true so the engine is aware EPP is deployed.
 
-**2. vLLM fallback**  
-When EPP is absent **or** EPP is present but yielded zero (warm-up), and `VLLMRequestRate > 0`:
+**2. Engine-rate fallback**  
+When EPP is absent **or** EPP is present but yielded zero (warm-up), and `RequestRate > 0`:
 ```
-λ_dec = Σ VLLMRequestRate_r × AvgOutputTokens_r
+λ_dec = Σ RequestRate_r × AvgOutputTokens_r
 ```
-Same structure as primary but using the vLLM-side completion rate. The vLLM rate counts
+Same structure as primary but using the engine-side completion rate. The engine rate counts
 only served (completed) requests and undercounts arriving demand under load.
 
 **3. k\*-based local** (scale-up only)  
-When EPP and vLLM both yield zero (EPP absent or warm-up; vLLM rate also zero), demand
+When EPP and the engine rate both yield zero (EPP absent or warm-up; engine rate also zero), demand
 is derived from the current KV utilization:
 ```
 λ_local = Σ_r  k_r* × KV_max_r / KVreq / ITL(k_r*)

--- a/docs/proposals/sglang-backend.md
+++ b/docs/proposals/sglang-backend.md
@@ -1,0 +1,192 @@
+# Proposal: SGLang Inference-Engine Backend Support
+
+**Authors:** [TBD]
+**Status:** Draft
+**Created:** 2026-06-26
+**Last Updated:** 2026-06-26
+
+---
+
+## Problem Statement
+
+The Workload Variant Autoscaler (WVA) is currently hard-wired to a single inference
+engine: **vLLM**. Every signal WVA consumes to make a scaling decision assumes vLLM's
+Prometheus metric names and vLLM's deployment CLI flags. There is no abstraction for
+"which engine is this variant running" — the engine identity is implicit and everywhere
+assumed to be vLLM.
+
+[SGLang](https://github.com/sgl-project/sglang) is a high-performance LLM serving engine
+that is a first-class member of the llm-d ecosystem (llm-d supports both `--backend vllm`
+and `--backend sglang`). Operators who run SGLang model servers cannot use WVA today: the
+collector queries `vllm:*` metric names that SGLang pods never emit, so WVA sees no load
+and never scales.
+
+This proposal introduces an **inference-engine backend** dimension to WVA and adds SGLang
+as the second supported engine, alongside vLLM, without changing existing vLLM behavior.
+
+## Goals
+
+- Introduce a backend/engine abstraction (`vllm`, `sglang`) that WVA can detect per variant.
+- Make metric collection and deployment-argument parsing engine-aware.
+- Add SGLang as a fully supported engine for the core autoscaling signal
+  (KV-cache utilization, queue depth, token throughput, latency, capacity).
+- **Zero behavior change for existing vLLM deployments.** vLLM remains the default and its
+  query/registration names are unchanged.
+
+## Non-Goals
+
+- Auto-tuning SGLang-specific server arguments.
+- P/D-disaggregation-specific SGLang metrics (prefill/decode transfer queues, etc.).
+- Per-pod mixed-engine *within a single variant* (a variant is assumed to run one engine).
+- Changing the queueing-model tuner math; only its metric inputs become engine-aware.
+
+## Background: where vLLM is assumed today
+
+WVA bakes vLLM into four distinct layers:
+
+| # | Layer | Location | vLLM-specific detail |
+|---|-------|----------|----------------------|
+| 1 | Metric name constants | `internal/constants/metrics.go` | All `vllm:*` names |
+| 2 | PromQL query templates | `internal/collector/registration/*.go` | `vllm:*` names baked into templates |
+| 3 | Deployment arg parser | `internal/engines/analyzers/saturation_v2/deployment_parser.go` | `ParseVLLMArgs`, vLLM CLI flags |
+| 4 | KV-cache config gauge | `vllm:cache_config_info` (consumed in `replica_metrics.go` / `capacity_store.go`) | vLLM info-gauge → token capacity |
+
+The query layer already has a clean seam: queries are registered as named
+`source.QueryTemplate`s in a `QueryList` and refreshed by name. What is missing is a way to
+register and select an *engine-specific* variant of each query.
+
+## Design
+
+### Engine identity and detection
+
+A new package `internal/inferenceengine` defines the engine enum and a detector:
+
+```go
+type Engine string
+
+const (
+    EngineVLLM   Engine = "vllm"
+    EngineSGLang Engine = "sglang"
+)
+
+// Detect inspects a scale target's leader pod template (container images, commands,
+// and args) and returns the inference engine it runs. Defaults to EngineVLLM when no
+// SGLang signal is present, preserving existing behavior.
+func Detect(st scaletarget.ScaleTargetAccessor) Engine
+```
+
+Detection is **conservative**: a variant is treated as SGLang only when a strong signal is
+present (container image contains `sglang`, or the command/args invoke
+`sglang.launch_server` / `sglang serve`). Everything else — including pods with no
+recognizable signal — is treated as vLLM, so no existing deployment changes behavior.
+
+Engine is a property of the *scale target* (the variant's Deployment/LWS), so it is
+detected from the same pod template WVA already parses for deployment args. No new CRD
+field is required. (A future explicit override — e.g. an annotation or a field on the
+embeddable `VariantAutoscalingConfigSpec` — can be layered on top if auto-detection proves
+insufficient.)
+
+### Engine-scoped query registration
+
+Query templates become engine-scoped. The physical registered name is derived from the
+logical name and the engine:
+
+```go
+// EngineQuery returns the physical registered query name for a logical query under a
+// given engine. vLLM keeps the bare logical name (backward compatible); other engines
+// get an "<engine>/<logical>" prefix.
+func EngineQuery(engine Engine, logical string) string
+```
+
+- `EngineQuery(EngineVLLM, "kv_cache_usage")` → `"kv_cache_usage"` (unchanged)
+- `EngineQuery(EngineSGLang, "kv_cache_usage")` → `"sglang/kv_cache_usage"`
+
+Each `Register*Queries` function additionally registers the SGLang variant of every
+**engine-specific** query. Engine-agnostic queries (the EPP/scheduler flow-control and
+dispatch-rate queries, which come from the gateway-api-inference-extension, not the engine)
+are registered once under their bare names and shared across engines.
+
+### Engine-aware collection
+
+`CollectReplicaMetrics` determines the set of engines present among a model's scale targets
+and refreshes the engine-specific queries for each present engine (plus the agnostic
+queries once). Because a vLLM pod only emits `vllm:*` series and an SGLang pod only emits
+`sglang:*` series, the per-pod results are naturally disjoint: results from each engine's
+query are merged back under the logical query name by instance key, and the existing
+per-pod consumer logic is unchanged.
+
+For single-engine models (the overwhelmingly common case) this adds no extra queries for
+vLLM and exactly one engine's queries for SGLang.
+
+### Metric mapping (vLLM → SGLang)
+
+SGLang metric names and types were taken from SGLang's metrics collector
+(`python/sglang/srt/observability/metrics_collector.py`), not from memory. SGLang labels
+its metrics with `model_name`, matching the label WVA already filters on.
+
+| Logical query | vLLM metric(s) | SGLang metric(s) | Notes |
+|---------------|----------------|------------------|-------|
+| `kv_cache_usage` / `kv_usage_instant` | `vllm:kv_cache_usage_perc` (gauge) | `sglang:token_usage` (gauge) | Both 0.0–1.0; name swap |
+| `queue_length` | `vllm:num_requests_waiting` | `sglang:num_queue_reqs` | Name swap |
+| `avg_ttft` | `vllm:time_to_first_token_seconds_{sum,count}` | `sglang:time_to_first_token_seconds_{sum,count}` | Histogram; name swap |
+| `avg_itl` | `vllm:inter_token_latency_seconds_{sum,count}` | `sglang:inter_token_latency_seconds_{sum,count}` | Histogram; name swap |
+| `avg_output_tokens` / `generation_token_rate` / `vllm_request_rate` | `vllm:request_generation_tokens_{sum,count}` | `sglang:generation_tokens_histogram_{sum,count}` | Histogram; name swap |
+| `avg_input_tokens` | `vllm:request_prompt_tokens_{sum,count}` | `sglang:prompt_tokens_histogram_{sum,count}` | Histogram; name swap |
+| `prefix_cache_hit_rate` | `vllm:prefix_cache_hits / vllm:prefix_cache_queries` | `rate(sglang:cached_tokens_total) / rate(sglang:prompt_tokens_total)` | **Structural.** SGLang also exposes `sglang:cache_hit_rate` directly, but its units (0–1 vs 0–100) are version-dependent; the token-counter ratio is unit-safe and parallels the vLLM formula |
+| `cache_config_info` (→ KV token capacity) | `vllm:cache_config_info{num_gpu_blocks,block_size}` → `num_gpu_blocks × block_size` | `sglang:max_total_num_tokens` (gauge) | **Structural.** SGLang exposes total KV token capacity directly |
+| `model_request_count` (scale-to-zero) | `vllm:request_success_total` | `sglang:num_requests_total` | Name swap |
+| `scheduler_dispatch_rate`, `scheduler_queue_size`, `scheduler_queue_bytes` | EPP `inference_extension_*` | (same) | Engine-agnostic; unchanged |
+
+### Deployment-argument mapping (vLLM → SGLang)
+
+A new `ParseSGLangArgs` mirrors `ParseVLLMArgs`, populating the same `EngineParams` struct
+(formerly `VLLMEngineParams`) so downstream capacity math is unchanged. Flag names and
+defaults were taken from SGLang's `server_args.py`.
+
+| `EngineParams` field | vLLM flag | SGLang flag | SGLang default |
+|----------------------|-----------|-------------|----------------|
+| `GpuMemoryUtilization` | `--gpu-memory-utilization` (0.9) | `--mem-fraction-static` | ~0.9 |
+| `BlockSize` | `--block-size` (16) | `--page-size` | 1 |
+| `KvCacheDtype` | `--kv-cache-dtype` | `--kv-cache-dtype` | `auto` |
+| `TensorParallelSize` | `--tensor-parallel-size` | `--tp-size` / `--tp` / `--tensor-parallel-size` | 1 |
+| `MaxNumSeqs` (max batch) | `--max-num-seqs` (256) | `--max-running-requests` | 256 (conservative placeholder when SGLang auto-derives) |
+| `MaxModelLen` | `--max-model-len` | `--context-length` | auto |
+| `MaxNumBatchedTokens` | `--max-num-batched-tokens` | `--chunked-prefill-size` / `--max-prefill-tokens` | auto |
+| `TotalKvTokensOverride` | (n/a) | `--max-total-tokens` | unset |
+| `EnforceEager` | `--enforce-eager` | `--disable-cuda-graph` | false |
+
+Engine-arg selection is done via `ParseEngineArgs(engine, scaleTarget)`, which dispatches
+to the right parser. The capacity store and the collector's max-batch-size lookup call it
+with the detected engine.
+
+## Implementation phases
+
+1. **Foundation (this PR):** `inferenceengine` package (enum + detection), SGLang metric
+   constants, SGLang query registration + `EngineQuery` resolver, engine-aware collection
+   in `CollectReplicaMetrics`, `ParseSGLangArgs` + `ParseEngineArgs`, capacity-store wiring,
+   and unit tests.
+2. **Scale-to-zero:** thread the detected engine into `CollectModelRequestCount` so SGLang
+   models use `sglang:num_requests_total`.
+3. **Validation:** e2e coverage against a real SGLang model server (kind emulator + a
+   recorded SGLang metrics fixture), Grafana dashboard labels, and docs in the user guide.
+
+## Alternatives considered
+
+- **Single template with the metric name as a parameter.** Rejected: two queries
+  (`cache_config_info`, `prefix_cache_hit_rate`) differ structurally, not just by name, so a
+  pure name substitution cannot serve both engines.
+- **Explicit engine field on the CRD instead of auto-detection.** Deferred: detection from
+  the pod template requires no operator action and no API change. An explicit override can
+  be added later without breaking the detection default.
+
+## Backward compatibility
+
+vLLM remains the default engine and all vLLM query/registration names are unchanged. A
+deployment with no SGLang signal is detected as vLLM and behaves exactly as before. The new
+collection path is identity for vLLM-only models.
+
+## References
+
+- SGLang metrics collector: `python/sglang/srt/observability/metrics_collector.py`
+- SGLang server args: `python/sglang/srt/server_args.py`
+- SGLang server arguments docs: https://docs.sglang.io/advanced_features/server_arguments.html

--- a/docs/proposals/sglang-backend.md
+++ b/docs/proposals/sglang-backend.md
@@ -130,9 +130,9 @@ its metrics with `model_name`, matching the label WVA already filters on.
 | `queue_length` | `vllm:num_requests_waiting` | `sglang:num_queue_reqs` | Name swap |
 | `avg_ttft` | `vllm:time_to_first_token_seconds_{sum,count}` | `sglang:time_to_first_token_seconds_{sum,count}` | Histogram; name swap |
 | `avg_itl` | `vllm:inter_token_latency_seconds_{sum,count}` | `sglang:inter_token_latency_seconds_{sum,count}` | Histogram; name swap |
-| `avg_output_tokens` / `generation_token_rate` / `vllm_request_rate` | `vllm:request_generation_tokens_{sum,count}` | `sglang:generation_tokens_histogram_{sum,count}` | Histogram; name swap |
+| `avg_output_tokens` / `generation_token_rate` / `request_rate` | `vllm:request_generation_tokens_{sum,count}` | `sglang:generation_tokens_histogram_{sum,count}` | Histogram; name swap |
 | `avg_input_tokens` | `vllm:request_prompt_tokens_{sum,count}` | `sglang:prompt_tokens_histogram_{sum,count}` | Histogram; name swap |
-| `prefix_cache_hit_rate` | `vllm:prefix_cache_hits / vllm:prefix_cache_queries` | `rate(sglang:cached_tokens_total) / rate(sglang:prompt_tokens_total)` | **Structural.** SGLang also exposes `sglang:cache_hit_rate` directly, but its units (0–1 vs 0–100) are version-dependent; the token-counter ratio is unit-safe and parallels the vLLM formula |
+| `prefix_cache_hit_rate` | `vllm:prefix_cache_hits / vllm:prefix_cache_queries` | `sum by(...)(rate(sglang:cached_tokens_total)) / sum by(...)(rate(sglang:prompt_tokens_total))` | **Structural.** SGLang also exposes `sglang:cache_hit_rate` directly, but its units (0–1 vs 0–100) are version-dependent; the token-counter ratio is unit-safe and parallels the vLLM formula. Each counter is summed to the per-instance key before dividing because `cached_tokens_total` carries an extra `cache_source` label, which would otherwise break one-to-one vector matching |
 | `cache_config_info` (→ KV token capacity) | `vllm:cache_config_info{num_gpu_blocks,block_size}` → `num_gpu_blocks × block_size` | `sglang:max_total_num_tokens` (gauge) | **Structural.** SGLang exposes total KV token capacity directly |
 | `model_request_count` (scale-to-zero) | `vllm:request_success_total` | `sglang:num_requests_total` | Name swap |
 | `scheduler_dispatch_rate`, `scheduler_queue_size`, `scheduler_queue_bytes` | EPP `inference_extension_*` | (same) | Engine-agnostic; unchanged |

--- a/docs/user-guide/sglang-backend.md
+++ b/docs/user-guide/sglang-backend.md
@@ -55,7 +55,7 @@ The mapping:
 | Prompt tokens / request | `vllm:request_prompt_tokens_*` | `sglang:prompt_tokens_histogram_*` |
 | Generation tokens / request | `vllm:request_generation_tokens_*` | `sglang:generation_tokens_histogram_*` |
 | Prefix-cache hit rate | `vllm:prefix_cache_hits / _queries` | `sglang:cached_tokens_total / sglang:prompt_tokens_total` |
-| Request count (scale-to-zero) | `vllm:request_success_total` | `sglang:num_requests_total` |
+| Request count (scale-to-zero) | `vllm:request_success_total` | `sglang:num_requests_total` *(not yet enabled — see Caveats)* |
 
 > Make sure your Prometheus (or VictoriaMetrics) scrapes the SGLang pods' `/metrics`
 > endpoint, the same way you scrape vLLM. WVA only consumes metrics that are
@@ -85,6 +85,14 @@ map onto the same internal parameters as their vLLM counterparts:
   variant's pod is not supported.
 - **Metric availability.** SGLang must be started with metrics enabled so the
   `sglang:*` series are exposed and scraped.
+- **Scale-to-zero is not yet supported for SGLang.** Although the
+  `sglang:num_requests_total` mapping exists, the scale-to-zero enforcer still
+  queries the vLLM request counter, so WVA cannot yet detect idleness for an
+  SGLang model. To avoid erroneously scaling an active SGLang model to zero, WVA
+  **automatically skips scale-to-zero enforcement for any model that runs a
+  non-vLLM engine**, even if scale-to-zero is enabled in config. Engine-aware
+  scale-to-zero is tracked as Phase 2 in the
+  [design proposal](../proposals/sglang-backend.md).
 
 ## See also
 

--- a/docs/user-guide/sglang-backend.md
+++ b/docs/user-guide/sglang-backend.md
@@ -1,0 +1,92 @@
+# SGLang Backend Support
+
+## Overview
+
+The Workload Variant Autoscaler (WVA) supports both [vLLM](https://github.com/vllm-project/vllm)
+and [SGLang](https://github.com/sgl-project/sglang) inference engines. WVA reads
+each engine's Prometheus metrics to estimate load and capacity, then drives the
+scale subresource through HPA/KEDA exactly as it does for vLLM.
+
+The inference engine is **auto-detected per variant** — you do not configure it.
+A deployment with no SGLang signal is treated as vLLM, so existing vLLM
+deployments are unaffected.
+
+## How detection works
+
+WVA inspects the variant's scale-target pod template (the Deployment/LeaderWorkerSet
+referenced by the `VariantAutoscaling`) and classifies it as SGLang when **either**:
+
+- a container image reference contains `sglang` (e.g. `lmsysorg/sglang:...`), or
+- a container command/args invoke `sglang.launch_server` / `sglang serve`
+  (including inside a `/bin/sh -c "..."` wrapper).
+
+Otherwise the variant is treated as **vLLM** (the default).
+
+No `VariantAutoscaling` field changes are required — the same CR works for either
+engine:
+
+```yaml
+apiVersion: autoscaling/v1alpha1
+kind: VariantAutoscaling
+metadata:
+  name: my-sglang-variant
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-sglang-decode      # a Deployment running `python -m sglang.launch_server ...`
+  modelID: meta-llama/Llama-3.1-8B-Instruct
+  maxReplicas: 8
+```
+
+## Metrics
+
+WVA requires the same autoscaling signals from either engine. SGLang exposes them
+under `sglang:*` metric names (labeled with `model_name`, which WVA filters on).
+The mapping:
+
+| Signal | vLLM | SGLang |
+|--------|------|--------|
+| KV-cache utilization (0–1) | `vllm:kv_cache_usage_perc` | `sglang:token_usage` |
+| Queue depth | `vllm:num_requests_waiting` | `sglang:num_queue_reqs` |
+| Total KV-cache token capacity | derived from `vllm:cache_config_info` | `sglang:max_total_num_tokens` |
+| Time to first token | `vllm:time_to_first_token_seconds` | `sglang:time_to_first_token_seconds` |
+| Inter-token latency | `vllm:inter_token_latency_seconds` | `sglang:inter_token_latency_seconds` |
+| Prompt tokens / request | `vllm:request_prompt_tokens_*` | `sglang:prompt_tokens_histogram_*` |
+| Generation tokens / request | `vllm:request_generation_tokens_*` | `sglang:generation_tokens_histogram_*` |
+| Prefix-cache hit rate | `vllm:prefix_cache_hits / _queries` | `sglang:cached_tokens_total / sglang:prompt_tokens_total` |
+| Request count (scale-to-zero) | `vllm:request_success_total` | `sglang:num_requests_total` |
+
+> Make sure your Prometheus (or VictoriaMetrics) scrapes the SGLang pods' `/metrics`
+> endpoint, the same way you scrape vLLM. WVA only consumes metrics that are
+> actually present in your monitoring backend.
+
+## Serving-flag mapping
+
+When a variant has no live metrics yet (e.g. a freshly created or scaled-to-zero
+variant), WVA estimates capacity from the deployment's serving flags. SGLang flags
+map onto the same internal parameters as their vLLM counterparts:
+
+| Parameter | vLLM flag | SGLang flag |
+|-----------|-----------|-------------|
+| GPU memory fraction | `--gpu-memory-utilization` | `--mem-fraction-static` |
+| Max concurrent requests | `--max-num-seqs` | `--max-running-requests` |
+| KV page/block size | `--block-size` | `--page-size` |
+| Tensor parallelism | `--tensor-parallel-size` | `--tp-size` / `--tp` |
+| Total KV token capacity | (n/a) | `--max-total-tokens` |
+| Context length | `--max-model-len` | `--context-length` |
+| Eager / no CUDA graph | `--enforce-eager` | `--disable-cuda-graph` |
+
+## Caveats
+
+- **vLLM remains the default.** Detection is conservative: anything without a clear
+  SGLang signal is treated as vLLM.
+- **A variant runs a single engine.** Mixing vLLM and SGLang containers within one
+  variant's pod is not supported.
+- **Metric availability.** SGLang must be started with metrics enabled so the
+  `sglang:*` series are exposed and scraped.
+
+## See also
+
+- Design proposal: [`docs/proposals/sglang-backend.md`](../proposals/sglang-backend.md)
+- SGLang server arguments: <https://docs.sglang.io/advanced_features/server_arguments.html>

--- a/internal/collector/engine_queries.go
+++ b/internal/collector/engine_queries.go
@@ -1,0 +1,105 @@
+package collector
+
+import (
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+)
+
+// engineSpecificReplicaQueries are the logical query names collected per replica
+// whose metric source is the inference engine (vLLM/SGLang). Each is refreshed
+// once per present engine and merged back under its logical name.
+var engineSpecificReplicaQueries = []string{
+	registration.QueryKvCacheUsage,
+	registration.QueryQueueLength,
+	registration.QueryCacheConfigInfo,
+	registration.QueryAvgOutputTokens,
+	registration.QueryAvgInputTokens,
+	registration.QueryPrefixCacheHitRate,
+	registration.QueryAvgTTFT,
+	registration.QueryAvgITL,
+	registration.QueryGenerationTokenRate,
+	registration.QueryKvUsageInstant,
+	registration.QueryVLLMRequestRate,
+}
+
+// agnosticReplicaQueries are the logical query names collected per replica whose
+// metric source is engine-independent (the EPP inference scheduler). They are
+// refreshed once and shared across engines.
+var agnosticReplicaQueries = []string{
+	registration.QuerySchedulerDispatchRate,
+}
+
+// buildEngineQueryList returns the physical query names to refresh for the given
+// set of present engines: each agnostic query once, plus each engine-specific
+// query for every present engine. For a single-engine vLLM model this is exactly
+// the agnostic queries plus the bare engine-specific names (unchanged behavior).
+func buildEngineQueryList(engines []inferenceengine.Engine, engineSpecific, agnostic []string) []string {
+	queries := make([]string, 0, len(agnostic)+len(engineSpecific)*len(engines))
+	queries = append(queries, agnostic...)
+	for _, logical := range engineSpecific {
+		for _, eng := range engines {
+			queries = append(queries, registration.EngineQuery(eng, logical))
+		}
+	}
+	return queries
+}
+
+// mergeEngineResults re-keys engine-specific query results under their logical
+// names so downstream per-pod processing is engine-agnostic.
+//
+//   - Single engine: the physical result is aliased to the logical name (a no-op
+//     for vLLM, where physical == logical; a rename for SGLang). The physical key
+//     is left in place so engine-specific consumers (e.g. the SGLang cache-config
+//     pass) can still read it.
+//   - Multiple engines: the per-engine series are concatenated into a new result
+//     under the logical name. Series are disjoint by pod, so concatenation is safe.
+func mergeEngineResults(results map[string]*source.MetricResult, engines []inferenceengine.Engine, logicalNames []string) {
+	if len(engines) == 1 {
+		eng := engines[0]
+		for _, logical := range logicalNames {
+			phys := registration.EngineQuery(eng, logical)
+			if phys == logical {
+				continue // vLLM: already keyed by logical name.
+			}
+			if r := results[phys]; r != nil {
+				r.QueryName = logical
+				results[logical] = r
+			}
+		}
+		return
+	}
+
+	for _, logical := range logicalNames {
+		var merged *source.MetricResult
+		for _, eng := range engines {
+			r := results[registration.EngineQuery(eng, logical)]
+			if r == nil {
+				continue
+			}
+			if merged == nil {
+				merged = &source.MetricResult{QueryName: logical, CollectedAt: r.CollectedAt}
+			}
+			merged.Values = append(merged.Values, r.Values...)
+			if merged.Error == nil && r.Error != nil {
+				merged.Error = r.Error
+			}
+			if !r.CollectedAt.IsZero() && (merged.CollectedAt.IsZero() || r.CollectedAt.Before(merged.CollectedAt)) {
+				merged.CollectedAt = r.CollectedAt
+			}
+		}
+		if merged != nil {
+			results[logical] = merged
+		}
+	}
+}
+
+// containsEngine reports whether the engine set includes the given engine.
+func containsEngine(engines []inferenceengine.Engine, target inferenceengine.Engine) bool {
+	for _, e := range engines {
+		if e == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/collector/engine_queries.go
+++ b/internal/collector/engine_queries.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"slices"
+
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
@@ -9,6 +11,13 @@ import (
 // engineSpecificReplicaQueries are the logical query names collected per replica
 // whose metric source is the inference engine (vLLM/SGLang). Each is refreshed
 // once per present engine and merged back under its logical name.
+//
+// This is the per-replica subset of registration.EngineSpecificQueries (the
+// authoritative list of engine-specific logical queries). Every entry here MUST
+// also appear there — TestEngineSpecificReplicaQueriesSubset enforces it so the
+// two lists cannot drift. It intentionally omits registration.QueryModelRequestCount,
+// which is engine-specific but a scale-to-zero query (collected on demand by the
+// enforcer, not per replica in this collector).
 var engineSpecificReplicaQueries = []string{
 	registration.QueryKvCacheUsage,
 	registration.QueryQueueLength,
@@ -20,7 +29,7 @@ var engineSpecificReplicaQueries = []string{
 	registration.QueryAvgITL,
 	registration.QueryGenerationTokenRate,
 	registration.QueryKvUsageInstant,
-	registration.QueryVLLMRequestRate,
+	registration.QueryRequestRate,
 }
 
 // agnosticReplicaQueries are the logical query names collected per replica whose
@@ -72,6 +81,7 @@ func mergeEngineResults(results map[string]*source.MetricResult, engines []infer
 
 	for _, logical := range logicalNames {
 		var merged *source.MetricResult
+		var firstErr error
 		for _, eng := range engines {
 			r := results[registration.EngineQuery(eng, logical)]
 			if r == nil {
@@ -81,14 +91,22 @@ func mergeEngineResults(results map[string]*source.MetricResult, engines []infer
 				merged = &source.MetricResult{QueryName: logical, CollectedAt: r.CollectedAt}
 			}
 			merged.Values = append(merged.Values, r.Values...)
-			if merged.Error == nil && r.Error != nil {
-				merged.Error = r.Error
+			if firstErr == nil && r.Error != nil {
+				firstErr = r.Error
 			}
 			if !r.CollectedAt.IsZero() && (merged.CollectedAt.IsZero() || r.CollectedAt.Before(merged.CollectedAt)) {
 				merged.CollectedAt = r.CollectedAt
 			}
 		}
 		if merged != nil {
+			// Only surface an error when NO engine produced any series. A partial
+			// success — one engine errored (e.g. transient timeout) while another
+			// returned values — must not mark the merged result errored, or the
+			// downstream HasError() checks would discard the healthy engine's pods
+			// and blackhole scaling for the whole mixed-engine model.
+			if len(merged.Values) == 0 {
+				merged.Error = firstErr
+			}
 			results[logical] = merged
 		}
 	}
@@ -96,10 +114,5 @@ func mergeEngineResults(results map[string]*source.MetricResult, engines []infer
 
 // containsEngine reports whether the engine set includes the given engine.
 func containsEngine(engines []inferenceengine.Engine, target inferenceengine.Engine) bool {
-	for _, e := range engines {
-		if e == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(engines, target)
 }

--- a/internal/collector/engine_queries_test.go
+++ b/internal/collector/engine_queries_test.go
@@ -1,0 +1,122 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+)
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildEngineQueryList_VLLMOnly(t *testing.T) {
+	q := buildEngineQueryList([]inferenceengine.Engine{inferenceengine.EngineVLLM}, engineSpecificReplicaQueries, agnosticReplicaQueries)
+
+	// Agnostic queries appear once, engine-specific queries use their bare names.
+	if !contains(q, registration.QuerySchedulerDispatchRate) {
+		t.Errorf("expected agnostic scheduler dispatch query in %v", q)
+	}
+	if !contains(q, registration.QueryKvCacheUsage) {
+		t.Errorf("expected bare vLLM kv_cache_usage in %v", q)
+	}
+	if contains(q, "sglang/"+registration.QueryKvCacheUsage) {
+		t.Errorf("did not expect SGLang variant for vLLM-only model in %v", q)
+	}
+}
+
+func TestBuildEngineQueryList_SGLangOnly(t *testing.T) {
+	q := buildEngineQueryList([]inferenceengine.Engine{inferenceengine.EngineSGLang}, engineSpecificReplicaQueries, agnosticReplicaQueries)
+
+	if !contains(q, "sglang/"+registration.QueryKvCacheUsage) {
+		t.Errorf("expected SGLang kv_cache_usage in %v", q)
+	}
+	if contains(q, registration.QueryKvCacheUsage) {
+		t.Errorf("did not expect bare vLLM kv_cache_usage for SGLang-only model in %v", q)
+	}
+	// Agnostic query is still shared (bare).
+	if !contains(q, registration.QuerySchedulerDispatchRate) {
+		t.Errorf("expected agnostic scheduler dispatch query in %v", q)
+	}
+}
+
+func TestBuildEngineQueryList_Mixed(t *testing.T) {
+	q := buildEngineQueryList(
+		[]inferenceengine.Engine{inferenceengine.EngineVLLM, inferenceengine.EngineSGLang},
+		engineSpecificReplicaQueries, agnosticReplicaQueries)
+
+	if !contains(q, registration.QueryKvCacheUsage) || !contains(q, "sglang/"+registration.QueryKvCacheUsage) {
+		t.Errorf("expected both vLLM and SGLang kv_cache_usage in %v", q)
+	}
+	// Agnostic query appears exactly once even with multiple engines.
+	count := 0
+	for _, name := range q {
+		if name == registration.QuerySchedulerDispatchRate {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected agnostic query exactly once, got %d", count)
+	}
+}
+
+func TestMergeEngineResults_VLLMIdentity(t *testing.T) {
+	results := map[string]*source.MetricResult{
+		registration.QueryKvCacheUsage: {QueryName: registration.QueryKvCacheUsage, Values: []source.MetricValue{{Value: 0.5}}},
+	}
+	mergeEngineResults(results, []inferenceengine.Engine{inferenceengine.EngineVLLM}, engineSpecificReplicaQueries)
+
+	r := results[registration.QueryKvCacheUsage]
+	if r == nil || len(r.Values) != 1 || r.Values[0].Value != 0.5 {
+		t.Fatalf("vLLM result should be unchanged, got %+v", r)
+	}
+}
+
+func TestMergeEngineResults_SGLangRename(t *testing.T) {
+	physical := "sglang/" + registration.QueryKvCacheUsage
+	results := map[string]*source.MetricResult{
+		physical: {QueryName: physical, Values: []source.MetricValue{{Value: 0.7}}},
+	}
+	mergeEngineResults(results, []inferenceengine.Engine{inferenceengine.EngineSGLang}, engineSpecificReplicaQueries)
+
+	r := results[registration.QueryKvCacheUsage]
+	if r == nil || len(r.Values) != 1 || r.Values[0].Value != 0.7 {
+		t.Fatalf("SGLang result should be aliased to the logical name, got %+v", r)
+	}
+	if r.QueryName != registration.QueryKvCacheUsage {
+		t.Errorf("QueryName should be re-keyed to logical, got %q", r.QueryName)
+	}
+}
+
+func TestMergeEngineResults_MixedConcatenates(t *testing.T) {
+	physical := "sglang/" + registration.QueryKvCacheUsage
+	results := map[string]*source.MetricResult{
+		registration.QueryKvCacheUsage: {QueryName: registration.QueryKvCacheUsage, Values: []source.MetricValue{{Value: 0.5, Labels: map[string]string{"pod": "vllm-0"}}}},
+		physical:                       {QueryName: physical, Values: []source.MetricValue{{Value: 0.7, Labels: map[string]string{"pod": "sglang-0"}}}},
+	}
+	mergeEngineResults(results,
+		[]inferenceengine.Engine{inferenceengine.EngineVLLM, inferenceengine.EngineSGLang},
+		engineSpecificReplicaQueries)
+
+	r := results[registration.QueryKvCacheUsage]
+	if r == nil || len(r.Values) != 2 {
+		t.Fatalf("expected 2 merged values, got %+v", r)
+	}
+}
+
+func TestContainsEngine(t *testing.T) {
+	engines := []inferenceengine.Engine{inferenceengine.EngineVLLM, inferenceengine.EngineSGLang}
+	if !containsEngine(engines, inferenceengine.EngineSGLang) {
+		t.Error("expected SGLang to be present")
+	}
+	if containsEngine([]inferenceengine.Engine{inferenceengine.EngineVLLM}, inferenceengine.EngineSGLang) {
+		t.Error("did not expect SGLang to be present")
+	}
+}

--- a/internal/collector/engine_queries_test.go
+++ b/internal/collector/engine_queries_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
@@ -108,6 +109,77 @@ func TestMergeEngineResults_MixedConcatenates(t *testing.T) {
 	r := results[registration.QueryKvCacheUsage]
 	if r == nil || len(r.Values) != 2 {
 		t.Fatalf("expected 2 merged values, got %+v", r)
+	}
+}
+
+// TestEngineSpecificReplicaQueriesSubset guards against drift between the
+// collector's per-replica engine-specific query list and the authoritative
+// registration.EngineSpecificQueries. Every per-replica query must be a known
+// engine-specific query; otherwise mergeEngineResults would silently fail to
+// re-key it under its logical name for SGLang.
+func TestEngineSpecificReplicaQueriesSubset(t *testing.T) {
+	authoritative := make(map[string]bool, len(registration.EngineSpecificQueries))
+	for _, q := range registration.EngineSpecificQueries {
+		authoritative[q] = true
+	}
+	for _, q := range engineSpecificReplicaQueries {
+		if !authoritative[q] {
+			t.Errorf("engineSpecificReplicaQueries contains %q which is not in registration.EngineSpecificQueries — lists have drifted", q)
+		}
+		if !registration.IsEngineSpecific(q) {
+			t.Errorf("engineSpecificReplicaQueries contains %q but registration.IsEngineSpecific(%q) is false", q, q)
+		}
+	}
+	// QueryModelRequestCount is engine-specific but intentionally excluded from the
+	// per-replica list (it is a scale-to-zero query, not a per-replica metric).
+	if contains(engineSpecificReplicaQueries, registration.QueryModelRequestCount) {
+		t.Errorf("engineSpecificReplicaQueries should not contain the scale-to-zero query %q", registration.QueryModelRequestCount)
+	}
+}
+
+// TestMergeEngineResults_MixedPartialError verifies that when one engine errors
+// but another returns values, the merged result is NOT marked errored — otherwise
+// the downstream HasError() checks would discard the healthy engine's pods and
+// blackhole scaling for the whole mixed-engine model.
+func TestMergeEngineResults_MixedPartialError(t *testing.T) {
+	physical := "sglang/" + registration.QueryKvCacheUsage
+	results := map[string]*source.MetricResult{
+		// vLLM succeeded with a value.
+		registration.QueryKvCacheUsage: {QueryName: registration.QueryKvCacheUsage, Values: []source.MetricValue{{Value: 0.5, Labels: map[string]string{"pod": "vllm-0"}}}},
+		// SGLang errored with no values (e.g. transient scrape timeout).
+		physical: {QueryName: physical, Error: errors.New("scrape timeout")},
+	}
+	mergeEngineResults(results,
+		[]inferenceengine.Engine{inferenceengine.EngineVLLM, inferenceengine.EngineSGLang},
+		engineSpecificReplicaQueries)
+
+	r := results[registration.QueryKvCacheUsage]
+	if r == nil {
+		t.Fatal("expected a merged result")
+	}
+	if r.HasError() {
+		t.Errorf("partial success must not be marked errored; got error %v", r.Error)
+	}
+	if len(r.Values) != 1 || r.Values[0].Value != 0.5 {
+		t.Errorf("the healthy engine's value should survive, got %+v", r.Values)
+	}
+}
+
+// TestMergeEngineResults_MixedAllErrored verifies the complement: when every
+// engine errors and no values exist, the merged result still surfaces an error.
+func TestMergeEngineResults_MixedAllErrored(t *testing.T) {
+	physical := "sglang/" + registration.QueryKvCacheUsage
+	results := map[string]*source.MetricResult{
+		registration.QueryKvCacheUsage: {QueryName: registration.QueryKvCacheUsage, Error: errors.New("vllm down")},
+		physical:                       {QueryName: physical, Error: errors.New("sglang down")},
+	}
+	mergeEngineResults(results,
+		[]inferenceengine.Engine{inferenceengine.EngineVLLM, inferenceengine.EngineSGLang},
+		engineSpecificReplicaQueries)
+
+	r := results[registration.QueryKvCacheUsage]
+	if r == nil || !r.HasError() {
+		t.Errorf("when all engines error and no values exist, merged result should carry an error; got %+v", r)
 	}
 }
 

--- a/internal/collector/registration/engine.go
+++ b/internal/collector/registration/engine.go
@@ -3,6 +3,7 @@
 // template variant registered under an engine-scoped name. Engine-agnostic
 // queries (e.g. the EPP scheduler flow-control queries) are registered once under
 // their bare logical name and shared across engines.
+
 package registration
 
 import (
@@ -13,6 +14,12 @@ import (
 // EngineSpecificQueries lists the logical query names whose metric source is the
 // inference engine (vLLM/SGLang), and which therefore have a per-engine template
 // variant. Any query not in this set is engine-agnostic and shared across engines.
+//
+// This is the authoritative list. The collector keeps a per-replica subset of it
+// (collector.engineSpecificReplicaQueries), which omits QueryModelRequestCount
+// (a scale-to-zero query). The two are kept from drifting by
+// TestEngineSpecificReplicaQueriesSubset: every entry in the collector's list
+// must appear here.
 var EngineSpecificQueries = []string{
 	QueryKvCacheUsage,
 	QueryQueueLength,
@@ -24,7 +31,7 @@ var EngineSpecificQueries = []string{
 	QueryAvgITL,
 	QueryGenerationTokenRate,
 	QueryKvUsageInstant,
-	QueryVLLMRequestRate,
+	QueryRequestRate,
 	QueryModelRequestCount,
 }
 

--- a/internal/collector/registration/engine.go
+++ b/internal/collector/registration/engine.go
@@ -1,0 +1,64 @@
+// This file makes query registration engine-aware. Each engine-specific logical
+// query (one whose metric source is the inference engine itself) has a per-engine
+// template variant registered under an engine-scoped name. Engine-agnostic
+// queries (e.g. the EPP scheduler flow-control queries) are registered once under
+// their bare logical name and shared across engines.
+package registration
+
+import (
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+)
+
+// EngineSpecificQueries lists the logical query names whose metric source is the
+// inference engine (vLLM/SGLang), and which therefore have a per-engine template
+// variant. Any query not in this set is engine-agnostic and shared across engines.
+var EngineSpecificQueries = []string{
+	QueryKvCacheUsage,
+	QueryQueueLength,
+	QueryCacheConfigInfo,
+	QueryAvgOutputTokens,
+	QueryAvgInputTokens,
+	QueryPrefixCacheHitRate,
+	QueryAvgTTFT,
+	QueryAvgITL,
+	QueryGenerationTokenRate,
+	QueryKvUsageInstant,
+	QueryVLLMRequestRate,
+	QueryModelRequestCount,
+}
+
+var engineSpecificSet = func() map[string]bool {
+	m := make(map[string]bool, len(EngineSpecificQueries))
+	for _, q := range EngineSpecificQueries {
+		m[q] = true
+	}
+	return m
+}()
+
+// IsEngineSpecific reports whether a logical query name has per-engine variants.
+func IsEngineSpecific(logical string) bool {
+	return engineSpecificSet[logical]
+}
+
+// EngineQuery returns the physical registered query name for a logical query
+// under a given engine. vLLM — and any engine-agnostic query — keeps the bare
+// logical name for backward compatibility; other engines get an
+// "<engine>/<logical>" prefix (e.g. "sglang/kv_cache_usage").
+func EngineQuery(engine inferenceengine.Engine, logical string) string {
+	if engine == inferenceengine.EngineVLLM || !IsEngineSpecific(logical) {
+		return logical
+	}
+	return engine.String() + "/" + logical
+}
+
+// registerForEngine registers a query template under the engine-scoped name for
+// the given engine. The supplied template's Name field must hold the logical
+// query name; it is rewritten to the physical name before registration.
+// engine is part of the engine-aware registration API: callers pass an explicit
+// engine so any future backend can register its own variant. Only SGLang uses
+// this path today (vLLM keeps bare logical names), hence unparam is suppressed.
+func registerForEngine(registry *source.QueryList, engine inferenceengine.Engine, tmpl source.QueryTemplate) { //nolint:unparam // see comment above
+	tmpl.Name = EngineQuery(engine, tmpl.Name)
+	registry.MustRegister(tmpl)
+}

--- a/internal/collector/registration/engine_test.go
+++ b/internal/collector/registration/engine_test.go
@@ -1,0 +1,69 @@
+package registration
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+)
+
+var _ = Describe("EngineQuery", func() {
+	It("returns the bare logical name for vLLM (backward compatible)", func() {
+		Expect(EngineQuery(inferenceengine.EngineVLLM, QueryKvCacheUsage)).To(Equal(QueryKvCacheUsage))
+	})
+
+	It("prefixes engine-specific queries for SGLang", func() {
+		Expect(EngineQuery(inferenceengine.EngineSGLang, QueryKvCacheUsage)).To(Equal("sglang/" + QueryKvCacheUsage))
+	})
+
+	It("returns the bare name for engine-agnostic queries regardless of engine", func() {
+		// Scheduler queries are not engine-specific (sourced from EPP).
+		Expect(IsEngineSpecific(QuerySchedulerDispatchRate)).To(BeFalse())
+		Expect(EngineQuery(inferenceengine.EngineSGLang, QuerySchedulerDispatchRate)).To(Equal(QuerySchedulerDispatchRate))
+	})
+})
+
+var _ = Describe("SGLang query registration", func() {
+	var registry *source.SourceRegistry
+
+	BeforeEach(func() {
+		ctx := context.Background()
+		registry = source.NewSourceRegistry()
+		metricsSource := prometheus.NewPrometheusSource(ctx, &mockPrometheusAPI{}, prometheus.DefaultPrometheusSourceConfig())
+		Expect(registry.Register("prometheus", metricsSource)).NotTo(HaveOccurred())
+		RegisterSaturationQueries(registry)
+		RegisterQueueingModelQueries(registry)
+		RegisterThroughputAnalyzerQueries(registry)
+		RegisterScaleToZeroQueries(registry)
+	})
+
+	get := func(engine inferenceengine.Engine, logical string) *source.QueryTemplate {
+		return registry.Get("prometheus").QueryList().Get(EngineQuery(engine, logical))
+	}
+
+	It("registers both vLLM and SGLang variants of engine-specific queries", func() {
+		for _, logical := range EngineSpecificQueries {
+			Expect(get(inferenceengine.EngineVLLM, logical)).NotTo(BeNil(), "missing vLLM "+logical)
+			Expect(get(inferenceengine.EngineSGLang, logical)).NotTo(BeNil(), "missing SGLang "+logical)
+		}
+	})
+
+	It("uses sglang:* metric names in SGLang templates", func() {
+		Expect(get(inferenceengine.EngineSGLang, QueryKvCacheUsage).Template).To(ContainSubstring("sglang:token_usage"))
+		Expect(get(inferenceengine.EngineSGLang, QueryQueueLength).Template).To(ContainSubstring("sglang:num_queue_reqs"))
+		Expect(get(inferenceengine.EngineSGLang, QueryCacheConfigInfo).Template).To(ContainSubstring("sglang:max_total_num_tokens"))
+		Expect(get(inferenceengine.EngineSGLang, QueryAvgTTFT).Template).To(ContainSubstring("sglang:time_to_first_token_seconds_sum"))
+		Expect(get(inferenceengine.EngineSGLang, QueryAvgITL).Template).To(ContainSubstring("sglang:inter_token_latency_seconds_sum"))
+		Expect(get(inferenceengine.EngineSGLang, QueryModelRequestCount).Template).To(ContainSubstring("sglang:num_requests_total"))
+	})
+
+	It("keeps SGLang templates free of vllm:* metric names", func() {
+		for _, logical := range EngineSpecificQueries {
+			Expect(get(inferenceengine.EngineSGLang, logical).Template).NotTo(ContainSubstring("vllm:"), "SGLang "+logical+" leaks a vllm: metric")
+		}
+	})
+})

--- a/internal/collector/registration/engine_test.go
+++ b/internal/collector/registration/engine_test.go
@@ -59,6 +59,21 @@ var _ = Describe("SGLang query registration", func() {
 		Expect(get(inferenceengine.EngineSGLang, QueryAvgTTFT).Template).To(ContainSubstring("sglang:time_to_first_token_seconds_sum"))
 		Expect(get(inferenceengine.EngineSGLang, QueryAvgITL).Template).To(ContainSubstring("sglang:inter_token_latency_seconds_sum"))
 		Expect(get(inferenceengine.EngineSGLang, QueryModelRequestCount).Template).To(ContainSubstring("sglang:num_requests_total"))
+
+		// Remaining engine-specific token/rate templates.
+		Expect(get(inferenceengine.EngineSGLang, QueryAvgOutputTokens).Template).To(ContainSubstring("sglang:generation_tokens_histogram_sum"))
+		Expect(get(inferenceengine.EngineSGLang, QueryAvgOutputTokens).Template).To(ContainSubstring("sglang:generation_tokens_histogram_count"))
+		Expect(get(inferenceengine.EngineSGLang, QueryAvgInputTokens).Template).To(ContainSubstring("sglang:prompt_tokens_histogram_sum"))
+		Expect(get(inferenceengine.EngineSGLang, QueryAvgInputTokens).Template).To(ContainSubstring("sglang:prompt_tokens_histogram_count"))
+		Expect(get(inferenceengine.EngineSGLang, QueryGenerationTokenRate).Template).To(ContainSubstring("sglang:generation_tokens_histogram_sum"))
+		Expect(get(inferenceengine.EngineSGLang, QueryRequestRate).Template).To(ContainSubstring("sglang:generation_tokens_histogram_count"))
+
+		// Prefix-cache hit rate is a ratio of two SGLang counters, each aggregated
+		// before the division so the extra cache_source label cannot break matching.
+		prefixCache := get(inferenceengine.EngineSGLang, QueryPrefixCacheHitRate).Template
+		Expect(prefixCache).To(ContainSubstring("sglang:cached_tokens_total"))
+		Expect(prefixCache).To(ContainSubstring("sglang:prompt_tokens_total"))
+		Expect(prefixCache).To(MatchRegexp(`sum by \([^)]*\) \(rate\(sglang:cached_tokens_total.*\) / sum by`))
 	})
 
 	It("keeps SGLang templates free of vllm:* metric names", func() {

--- a/internal/collector/registration/queueing_model.go
+++ b/internal/collector/registration/queueing_model.go
@@ -36,7 +36,7 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	// This follows the same pattern as scheduler flow control queries.
 	// Uses sum (not max) because dispatch rate is an additive counter — multiple
 	// series per instance should be summed. Uses rate() over 1m window for requests/sec.
-	// Groups by pod_name and port to uniquely identify each vLLM instance.
+	// Groups by pod_name and port to uniquely identify each engine instance.
 	registry.MustRegister(source.QueryTemplate{
 		Name: QuerySchedulerDispatchRate,
 		Type: source.QueryTypePromQL,
@@ -50,7 +50,7 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	// Average time-to-first-token per instance (seconds).
 	// Uses histogram rate(sum[1m]) / rate(count[1m]) over a 1m sliding window.
 	// Used by queueing model tuner as the observed TTFT for Kalman filter updates.
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-instance pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
 	registry.MustRegister(source.QueryTemplate{
 		Name:     QueryAvgTTFT,
 		Type:     source.QueryTypePromQL,
@@ -63,7 +63,7 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	// Average inter-token latency per instance (seconds).
 	// Uses histogram rate(sum[1m]) / rate(count[1m]) over a 1m sliding window.
 	// Used by queueing model tuner as the observed ITL for Kalman filter updates.
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-instance pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
 	registry.MustRegister(source.QueryTemplate{
 		Name:     QueryAvgITL,
 		Type:     source.QueryTypePromQL,
@@ -73,10 +73,11 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 			"used by queueing model tuner for parameter learning",
 	})
 
-	// Note: MaxBatchSize (max_num_seqs) is not available as a Prometheus metric from vLLM.
-	// It is sourced from the Deployment's container args using the deployment parser
-	// (see saturation_v2.ParseVLLMArgs). The collector populates ReplicaMetrics.MaxBatchSize
-	// by parsing the --max-num-seqs flag from the pod's parent Deployment spec.
+	// Note: MaxBatchSize (the max concurrent-request budget) is not available as a
+	// Prometheus metric from either engine. It is sourced from the Deployment's
+	// container args using the engine-aware deployment parser
+	// (see saturation_v2.ParseEngineArgs). The collector populates
+	// ReplicaMetrics.MaxBatchSize from --max-num-seqs (vLLM) or --max-running-requests (SGLang).
 
 	registerSGLangQueueingModelQueries(registry)
 }

--- a/internal/collector/registration/queueing_model.go
+++ b/internal/collector/registration/queueing_model.go
@@ -4,6 +4,7 @@ package registration
 
 import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 )
 
 // Query name constants for queueing model analyzer metrics.
@@ -76,4 +77,29 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	// It is sourced from the Deployment's container args using the deployment parser
 	// (see saturation_v2.ParseVLLMArgs). The collector populates ReplicaMetrics.MaxBatchSize
 	// by parsing the --max-num-seqs flag from the pod's parent Deployment spec.
+
+	registerSGLangQueueingModelQueries(registry)
+}
+
+// registerSGLangQueueingModelQueries registers the SGLang variants of the
+// engine-specific queueing-model queries. The scheduler dispatch-rate query above
+// is engine-agnostic (sourced from EPP) and is not duplicated here.
+func registerSGLangQueueingModelQueries(registry *source.QueryList) {
+	// Average time-to-first-token per instance (seconds), 1m sliding window.
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryAvgTTFT,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(sglang:time_to_first_token_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(sglang:time_to_first_token_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Average time-to-first-token per instance (seconds) (SGLang)",
+	})
+
+	// Average inter-token latency per instance (seconds), 1m sliding window.
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryAvgITL,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(sglang:inter_token_latency_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(sglang:inter_token_latency_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Average inter-token latency per instance (seconds) (SGLang)",
+	})
 }

--- a/internal/collector/registration/saturation.go
+++ b/internal/collector/registration/saturation.go
@@ -2,6 +2,7 @@ package registration
 
 import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 )
 
 // Query name constants for type-safe query references.
@@ -134,4 +135,77 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 		Description: "Total bytes queued in scheduler flow control for this model",
 	})
 
+	registerSGLangSaturationQueries(registry)
+}
+
+// registerSGLangSaturationQueries registers the SGLang variants of the
+// engine-specific saturation queries. The scheduler flow-control queries above
+// are engine-agnostic (sourced from EPP) and are not duplicated here.
+func registerSGLangSaturationQueries(registry *source.QueryList) {
+	// KV-cache token-pool utilization per instance (peak over last minute).
+	// sglang:token_usage is the 0.0-1.0 fraction equivalent of vllm:kv_cache_usage_perc.
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryKvCacheUsage,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (max_over_time(sglang:token_usage{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Peak KV cache utilization per instance (0.0-1.0) over last minute (SGLang)",
+	})
+
+	// Queue length per instance (peak over last minute).
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryQueueLength,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (max_over_time(sglang:num_queue_reqs{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Peak queue length per instance over last minute (SGLang)",
+	})
+
+	// Total KV-cache token capacity per instance.
+	//
+	// Structural difference from vLLM: SGLang exposes capacity directly via
+	// sglang:max_total_num_tokens (a model-labeled gauge), so this query can
+	// filter by model_name and returns the capacity as the value — there are no
+	// num_gpu_blocks/block_size labels. The collector converts this value into
+	// TotalKvCapacityTokens directly (see CollectReplicaMetrics).
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryCacheConfigInfo,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (sglang:max_total_num_tokens{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Total KV cache token capacity per instance (SGLang)",
+	})
+
+	// Average output (generation) tokens per completed request (5m rate).
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryAvgOutputTokens,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(sglang:generation_tokens_histogram_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(sglang:generation_tokens_histogram_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Average output tokens per completed request (5m rate) (SGLang)",
+	})
+
+	// Average input (prompt) tokens per completed request (5m rate).
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryAvgInputTokens,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(sglang:prompt_tokens_histogram_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(sglang:prompt_tokens_histogram_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Average input tokens per completed request (5m rate) (SGLang)",
+	})
+
+	// Prefix cache hit rate per instance (5m rate).
+	//
+	// Structural difference from vLLM: derived from SGLang's token counters
+	// (cached prompt tokens / total prompt tokens) rather than hit/query counters.
+	// This is unit-safe (0.0-1.0) and parallels the vLLM hits/queries formula.
+	// SGLang also exposes sglang:cache_hit_rate directly, but its units are
+	// version-dependent (0-1 vs 0-100), so the counter ratio is preferred.
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryPrefixCacheHitRate,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(sglang:cached_tokens_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(sglang:prompt_tokens_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Prefix cache hit rate per instance (0.0-1.0, 5m rate) (SGLang)",
+	})
 }

--- a/internal/collector/registration/saturation.go
+++ b/internal/collector/registration/saturation.go
@@ -28,7 +28,7 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 
 	// KV cache usage per instance (peak over last minute)
 	// Uses max_over_time to catch saturation events between scrapes
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-instance pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryKvCacheUsage,
 		Type:        source.QueryTypePromQL,
@@ -39,7 +39,7 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 
 	// Queue length per instance (peak over last minute)
 	// Uses max_over_time to catch burst traffic
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-instance pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryQueueLength,
 		Type:        source.QueryTypePromQL,
@@ -53,7 +53,7 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	// Cache config info per instance (static labels with block size and GPU blocks count)
 	// Uses max to deduplicate when multiple series exist per instance with different label combinations
 	// Used by Saturation Analyzer V2 for token capacity computation
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), llm_d_ai_variant (for direct pod-to-VA mapping), and config labels
+	// Preserves instance (IP:port for multi-instance pods), pod (for pod lookup), llm_d_ai_variant (for direct pod-to-VA mapping), and config labels
 	//
 	// NOTE: vllm:cache_config_info is an info-style metric. Unlike vLLM's regular
 	// gauges/counters, it is NOT labeled with model_name — its label set is derived
@@ -73,7 +73,7 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 
 	// Average output (generation) tokens per completed request
 	// Used for output-length-dependent k2 estimation
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-instance pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryAvgOutputTokens,
 		Type:        source.QueryTypePromQL,
@@ -84,7 +84,7 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 
 	// Average input (prompt) tokens per completed request
 	// Used in k2 derivation formula: k2 = N_max × (I + O/2)
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-instance pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryAvgInputTokens,
 		Type:        source.QueryTypePromQL,
@@ -96,7 +96,7 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	// Prefix cache hit rate per instance (5m rate)
 	// Used to reduce estimated input token demand for scheduler-queued requests.
 	// Returns 0..1 where 1 means all prefix lookups were cache hits.
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-instance pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryPrefixCacheHitRate,
 		Type:        source.QueryTypePromQL,
@@ -106,7 +106,7 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	})
 
 	// --- Scheduler flow control queries (model-level) ---
-	// These come from the llm-d inference scheduler, not vLLM pods.
+	// These come from the llm-d inference scheduler, not engine pods.
 	// They use target_model_name when available, falling back to model_name.
 	// The "or" clause handles cases where target_model_name is not set.
 	//
@@ -201,10 +201,17 @@ func registerSGLangSaturationQueries(registry *source.QueryList) {
 	// This is unit-safe (0.0-1.0) and parallels the vLLM hits/queries formula.
 	// SGLang also exposes sglang:cache_hit_rate directly, but its units are
 	// version-dependent (0-1 vs 0-100), so the counter ratio is preferred.
+	//
+	// Each counter is aggregated with sum by(...) BEFORE the division. The two
+	// counters do not share an identical label set — sglang:cached_tokens_total
+	// carries an extra cache_source label — so dividing the raw rates would leave
+	// the operator with no one-to-one matches and yield an empty vector. Summing
+	// each side down to the (instance, pod, llm_d_ai_variant) key first drops the
+	// differing labels and makes the division well-defined.
 	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
 		Name:        QueryPrefixCacheHitRate,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(sglang:cached_tokens_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(sglang:prompt_tokens_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(sglang:cached_tokens_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m])) / sum by (instance, pod, llm_d_ai_variant) (rate(sglang:prompt_tokens_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Prefix cache hit rate per instance (0.0-1.0, 5m rate) (SGLang)",
 	})

--- a/internal/collector/registration/scale_to_zero.go
+++ b/internal/collector/registration/scale_to_zero.go
@@ -85,9 +85,14 @@ func CollectModelRequestCount(
 	namespace string,
 	retentionPeriod time.Duration,
 ) (float64, error) {
-	// Defaults to vLLM for backward compatibility. Engine-aware scale-to-zero is
-	// wired via CollectModelRequestCountForEngine; see docs/proposals/sglang-backend.md
-	// (Phase 2) for threading the detected engine through the enforcer.
+	// Defaults to vLLM for backward compatibility: this queries
+	// vllm:request_success_total regardless of the model's actual engine. Engine-
+	// aware scale-to-zero is available via CollectModelRequestCountForEngine but is
+	// not yet threaded through the enforcer (see docs/proposals/sglang-backend.md
+	// Phase 2). Until it is, callers MUST NOT invoke scale-to-zero for non-vLLM
+	// models — the saturation engine gates this via scaleToZeroSupportedForEngines,
+	// since for SGLang this function would always return 0 (no vllm:* series) and
+	// the enforcer would incorrectly scale the model to zero.
 	return CollectModelRequestCountForEngine(ctx, metricsSource, inferenceengine.EngineVLLM, modelID, namespace, retentionPeriod)
 }
 

--- a/internal/collector/registration/scale_to_zero.go
+++ b/internal/collector/registration/scale_to_zero.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
@@ -48,6 +49,15 @@ func RegisterScaleToZeroQueries(sourceRegistry *source.SourceRegistry) {
 		Params:      []string{source.ParamNamespace, source.ParamModelID, ParamRetentionPeriod},
 		Description: "Total successful requests for a model over the retention period",
 	})
+
+	// SGLang variant: sglang:num_requests_total is the received-request counter.
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryModelRequestCount,
+		Type:        source.QueryTypePromQL,
+		Template:    `sum(increase(sglang:num_requests_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[{{.retentionPeriod}}]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID, ParamRetentionPeriod},
+		Description: "Total requests for a model over the retention period (SGLang)",
+	})
 }
 
 // CollectModelRequestCount collects the total number of successful requests for a model
@@ -75,6 +85,23 @@ func CollectModelRequestCount(
 	namespace string,
 	retentionPeriod time.Duration,
 ) (float64, error) {
+	// Defaults to vLLM for backward compatibility. Engine-aware scale-to-zero is
+	// wired via CollectModelRequestCountForEngine; see docs/proposals/sglang-backend.md
+	// (Phase 2) for threading the detected engine through the enforcer.
+	return CollectModelRequestCountForEngine(ctx, metricsSource, inferenceengine.EngineVLLM, modelID, namespace, retentionPeriod)
+}
+
+// CollectModelRequestCountForEngine is the engine-aware variant of
+// CollectModelRequestCount. It selects the request-count metric appropriate for
+// the given inference engine (vllm:request_success_total vs sglang:num_requests_total).
+func CollectModelRequestCountForEngine(
+	ctx context.Context,
+	metricsSource source.MetricsSource,
+	engine inferenceengine.Engine,
+	modelID string,
+	namespace string,
+	retentionPeriod time.Duration,
+) (float64, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Convert Go duration to Prometheus duration format
@@ -86,10 +113,12 @@ func CollectModelRequestCount(
 		ParamRetentionPeriod:  retentionPeriodStr,
 	}
 
+	queryName := EngineQuery(engine, QueryModelRequestCount)
+
 	// Execute the query with timing
 	startTime := time.Now()
 	results, err := metricsSource.Refresh(ctx, source.RefreshSpec{
-		Queries: []string{QueryModelRequestCount},
+		Queries: []string{queryName},
 		Params:  params,
 	})
 	duration := time.Since(startTime).Seconds()
@@ -107,7 +136,7 @@ func CollectModelRequestCount(
 	}
 
 	// Extract the result
-	result := results[QueryModelRequestCount]
+	result := results[queryName]
 	if result == nil {
 		logger.V(logging.VERBOSE).Info("No result for model request count query",
 			"model", modelID,

--- a/internal/collector/registration/scale_to_zero_test.go
+++ b/internal/collector/registration/scale_to_zero_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 )
 
@@ -322,5 +323,49 @@ var _ = Describe("CollectModelRequestCount", func() {
 
 			Expect(found).To(BeTrue(), "Should have found %s metric", constants.WVAMetricsCollectionDurationSeconds)
 		})
+	})
+})
+
+var _ = Describe("CollectModelRequestCountForEngine", func() {
+	var (
+		ctx           context.Context
+		registry      *source.SourceRegistry
+		metricsSource source.MetricsSource
+		capturedQuery string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		registry = source.NewSourceRegistry()
+		capturedQuery = ""
+		mockAPI := &mockPrometheusAPI{
+			queryFunc: func(_ context.Context, query string, _ time.Time, _ ...v1.Option) (model.Value, v1.Warnings, error) {
+				capturedQuery = query
+				return &model.Scalar{Value: model.SampleValue(7), Timestamp: model.TimeFromUnix(0)}, nil, nil
+			},
+		}
+		metricsSource = prometheus.NewPrometheusSource(ctx, mockAPI, prometheus.DefaultPrometheusSourceConfig())
+		Expect(registry.Register("prometheus", metricsSource)).NotTo(HaveOccurred())
+		RegisterScaleToZeroQueries(registry)
+	})
+
+	It("routes EngineSGLang to the sglang:num_requests_total query", func() {
+		// The SGLang request-count query is registered under the physical name
+		// sglang/model_request_count; this asserts the engine-aware routing reaches it.
+		Expect(EngineQuery(inferenceengine.EngineSGLang, QueryModelRequestCount)).To(Equal("sglang/" + QueryModelRequestCount))
+
+		count, err := CollectModelRequestCountForEngine(ctx, metricsSource, inferenceengine.EngineSGLang, "m", "ns", 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(7.0))
+		Expect(capturedQuery).To(ContainSubstring("sglang:num_requests_total"))
+		Expect(capturedQuery).NotTo(ContainSubstring("vllm:"))
+	})
+
+	It("routes EngineVLLM to the vllm:request_success_total query", func() {
+		count, err := CollectModelRequestCountForEngine(ctx, metricsSource, inferenceengine.EngineVLLM, "m", "ns", 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(7.0))
+		Expect(capturedQuery).To(ContainSubstring("vllm:request_success_total"))
+		Expect(capturedQuery).NotTo(ContainSubstring("sglang:"))
 	})
 })

--- a/internal/collector/registration/sglang_integration_test.go
+++ b/internal/collector/registration/sglang_integration_test.go
@@ -1,0 +1,82 @@
+package registration
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+)
+
+// This integration test drives the real PrometheusSource end to end through the
+// registered SGLang query templates: it builds each engine's KV-usage query from
+// its template + params, executes it against a mock Prometheus that only answers
+// the engine-appropriate metric name, and asserts the value flows back. It proves
+// the SGLang templates are registered, parameter-substituted, and queryable —
+// and that the vLLM path is unchanged.
+var _ = Describe("SGLang query path (integration)", func() {
+	var registry *source.SourceRegistry
+
+	// vector returns a single-sample PromQL vector result with the given value.
+	vector := func(val float64) model.Value {
+		return model.Vector{&model.Sample{
+			Metric:    model.Metric{"instance": "10.0.0.1:8000", "pod": "server-0", "model_name": "m"},
+			Value:     model.SampleValue(val),
+			Timestamp: model.Now(),
+		}}
+	}
+
+	// newSource wires a PrometheusSource whose mock answers `vllm:kv_cache_usage_perc`
+	// with 0.50 and `sglang:token_usage` with 0.85, and everything else empty.
+	newSource := func() {
+		ctx := context.Background()
+		registry = source.NewSourceRegistry()
+		mock := &mockPrometheusAPI{
+			queryFunc: func(_ context.Context, query string, _ time.Time, _ ...v1.Option) (model.Value, v1.Warnings, error) {
+				switch {
+				case strings.Contains(query, "vllm:kv_cache_usage_perc"):
+					return vector(0.50), nil, nil
+				case strings.Contains(query, "sglang:token_usage"):
+					return vector(0.85), nil, nil
+				default:
+					return model.Vector{}, nil, nil
+				}
+			},
+		}
+		Expect(registry.Register("prometheus", prometheus.NewPrometheusSource(ctx, mock, prometheus.DefaultPrometheusSourceConfig()))).NotTo(HaveOccurred())
+		RegisterSaturationQueries(registry)
+	}
+
+	refresh := func(engine inferenceengine.Engine) *source.MetricResult {
+		name := EngineQuery(engine, QueryKvCacheUsage)
+		results, err := registry.Get("prometheus").Refresh(context.Background(), source.RefreshSpec{
+			Queries: []string{name},
+			Params:  map[string]string{source.ParamNamespace: "ns", source.ParamModelID: "m"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return results[name]
+	}
+
+	BeforeEach(newSource)
+
+	It("executes the SGLang KV-usage template and returns sglang:token_usage", func() {
+		res := refresh(inferenceengine.EngineSGLang)
+		Expect(res).NotTo(BeNil())
+		Expect(res.HasError()).To(BeFalse())
+		Expect(res.FirstValue().Value).To(BeNumerically("~", 0.85, 1e-9))
+	})
+
+	It("keeps the vLLM KV-usage template working (unchanged behavior)", func() {
+		res := refresh(inferenceengine.EngineVLLM)
+		Expect(res).NotTo(BeNil())
+		Expect(res.HasError()).To(BeFalse())
+		Expect(res.FirstValue().Value).To(BeNumerically("~", 0.50, 1e-9))
+	})
+})

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -6,6 +6,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
@@ -138,5 +139,39 @@ func RegisterThroughputAnalyzerQueries(sourceRegistry *source.SourceRegistry) {
 		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "vLLM request completion rate per pod (req/s); fallback for λ_dec when EPP metrics are unavailable",
+	})
+
+	registerSGLangThroughputAnalyzerQueries(registry)
+}
+
+// registerSGLangThroughputAnalyzerQueries registers the SGLang variants of the
+// throughput-analyzer queries. SGLang exposes generation tokens via the
+// generation_tokens_histogram series and KV utilization via token_usage.
+func registerSGLangThroughputAnalyzerQueries(registry *source.QueryList) {
+	// Per-pod observed generation (decode) token rate (tokens/sec), 1m rate.
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryGenerationTokenRate,
+		Type:        source.QueryTypePromQL,
+		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(sglang:generation_tokens_histogram_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Observed generation (decode) token rate per pod (tokens/sec), proxy for μ_dec^obs (SGLang)",
+	})
+
+	// Per-pod instantaneous KV cache utilization (0.0-1.0), no max_over_time.
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryKvUsageInstant,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (sglang:token_usage{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Instantaneous KV cache utilization per pod (0.0-1.0), used as k* in the ITL model (SGLang)",
+	})
+
+	// Per-pod request completion rate (req/s) from the generation histogram count.
+	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
+		Name:        QueryVLLMRequestRate,
+		Type:        source.QueryTypePromQL,
+		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(sglang:generation_tokens_histogram_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Request completion rate per pod (req/s); fallback for λ_dec when EPP metrics are unavailable (SGLang)",
 	})
 }

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -53,18 +53,20 @@ const (
 	// Source: vllm:kv_cache_usage_perc (gauge)
 	QueryKvUsageInstant = "kv_usage_instant"
 
-	// QueryVLLMRequestRate is the query name for the vLLM-side request completion
+	// QueryRequestRate is the query name for the engine-side request completion
 	// rate per pod (req/s), derived from the generation tokens histogram count.
+	// It is engine-agnostic: the vLLM variant reads
+	// vllm:request_generation_tokens_count and the SGLang variant reads
+	// sglang:generation_tokens_histogram_count.
 	//
 	// Used as a fallback for λ_dec estimation when EPP/scheduler metrics are
 	// unavailable (ArrivalRate == 0 for all pods). Per variant V, the analyzer computes:
-	//   λ_dec_vllm = Σ_{r∈V}(VLLMRequestRate_r × AvgOutputTokens_r)
+	//   λ_dec_fallback = Σ_{r∈V}(RequestRate_r × AvgOutputTokens_r)
 	//
 	// Note: measures completed requests (served demand), not arriving requests.
 	// It undercounts when requests are queued in the scheduler. Use
 	// ArrivalRate (via QuerySchedulerDispatchRate) as the primary demand source.
-	// Source: vllm:request_generation_tokens_count (histogram _count counter)
-	QueryVLLMRequestRate = "vllm_request_rate"
+	QueryRequestRate = "request_rate"
 )
 
 // RegisterThroughputAnalyzerQueries registers the three TA-exclusive queries.
@@ -73,7 +75,7 @@ const (
 // Registered queries:
 //   - QueryGenerationTokenRate — μ_dec^obs: observed decode token rate per pod
 //   - QueryKvUsageInstant      — k*: instantaneous KV cache utilization per pod
-//   - QueryVLLMRequestRate     — fallback λ_req: completion rate per pod when EPP absent
+//   - QueryRequestRate     — fallback λ_req: completion rate per pod when EPP absent
 //
 // Additional TA inputs are read from interfaces.ReplicaMetrics fields populated by
 // RegisterSaturationQueries (TotalKvCapacityTokens, AvgOutputTokens, AvgInputTokens,
@@ -90,7 +92,7 @@ const (
 //
 // Per variant V (summed over that variant's replicas only):
 // λ_dec primary:  Σ_{r∈V}(ArrivalRate_r × AvgOutputTokens_r)     [EPP deployed]
-// λ_dec fallback: Σ_{r∈V}(VLLMRequestRate_r × AvgOutputTokens_r) [EPP absent]
+// λ_dec fallback: Σ_{r∈V}(RequestRate_r × AvgOutputTokens_r) [EPP absent]
 func RegisterThroughputAnalyzerQueries(sourceRegistry *source.SourceRegistry) {
 	metricsSource := sourceRegistry.Get("prometheus")
 	if metricsSource == nil {
@@ -130,11 +132,11 @@ func RegisterThroughputAnalyzerQueries(sourceRegistry *source.SourceRegistry) {
 	// Derived from the generation tokens histogram _count (increments once per
 	// completed request). Used as a fallback for λ_dec when EPP/scheduler metrics
 	// are unavailable; per variant V, the analyzer falls back to:
-	//   λ_dec_vllm = Σ_{r∈V}(VLLMRequestRate_r × AvgOutputTokens_r)
+	//   λ_dec_fallback = Σ_{r∈V}(RequestRate_r × AvgOutputTokens_r)
 	// Preserves instance (IP:port for composite key), pod (for pod lookup),
 	// and llm_d_ai_variant (for direct pod-to-VA mapping).
 	registry.MustRegister(source.QueryTemplate{
-		Name:        QueryVLLMRequestRate,
+		Name:        QueryRequestRate,
 		Type:        source.QueryTypePromQL,
 		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
@@ -168,7 +170,7 @@ func registerSGLangThroughputAnalyzerQueries(registry *source.QueryList) {
 
 	// Per-pod request completion rate (req/s) from the generation histogram count.
 	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
-		Name:        QueryVLLMRequestRate,
+		Name:        QueryRequestRate,
 		Type:        source.QueryTypePromQL,
 		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(sglang:generation_tokens_histogram_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},

--- a/internal/collector/registration/throughput_analyzer_test.go
+++ b/internal/collector/registration/throughput_analyzer_test.go
@@ -46,7 +46,7 @@ var _ = Describe("RegisterThroughputAnalyzerQueries", func() {
 			expectedQueries := []string{
 				QueryGenerationTokenRate,
 				QueryKvUsageInstant,
-				QueryVLLMRequestRate,
+				QueryRequestRate,
 			}
 			for _, name := range expectedQueries {
 				q := queryList.Get(name)
@@ -80,8 +80,8 @@ var _ = Describe("RegisterThroughputAnalyzerQueries", func() {
 			Expect(rendered).To(ContainSubstring(`model_name="test-model"`))
 		})
 
-		It("should build QueryVLLMRequestRate with 1m window over token count", func() {
-			rendered, err := queryList.Build(QueryVLLMRequestRate, map[string]string{
+		It("should build QueryRequestRate with 1m window over token count", func() {
+			rendered, err := queryList.Build(QueryRequestRate, map[string]string{
 				source.ParamNamespace: "test-ns",
 				source.ParamModelID:   "test-model",
 			})

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -32,7 +32,7 @@ limitations under the License.
 //	    podName = value.Labels["pod_name"]
 //	}
 //
-// vLLM metrics are typically scraped via a PodMonitor or ServiceMonitor that
+// Engine metrics are typically scraped via a PodMonitor or ServiceMonitor that
 // applies the Prometheus operator's default target-relabeling, which produces
 // a "pod" label. Some scrape configurations (e.g., raw Prometheus scrape jobs,
 // kube-state-metrics–style configs) instead expose the pod identity as
@@ -348,6 +348,25 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	// is identical to the previous fixed query list.
 	engines := inferenceengine.Present(scaleTargets)
 
+	// Log the engine detected for each scale target, plus the resolved engine set.
+	// inferenceengine.Detect defaults to vLLM when a leader pod template is nil or
+	// unresolvable, or when an SGLang image/command isn't matched — so a misdetected
+	// SGLang variant silently gets vllm:* queries and emits nothing. Logging the
+	// per-target engine lets operators tell "wrong engine detected" apart from
+	// "engine correct, but no metrics".
+	if debug := logger.V(logging.DEBUG); debug.Enabled() {
+		for key, st := range scaleTargets {
+			debug.Info("Detected inference engine for scale target",
+				"scaleTarget", key, "engine", inferenceengine.Detect(st).String())
+		}
+		engineNames := make([]string, len(engines))
+		for i, e := range engines {
+			engineNames[i] = e.String()
+		}
+		debug.Info("Resolved inference engines for model",
+			"modelID", modelID, "namespace", namespace, "engines", engineNames)
+	}
+
 	// Refresh all Prometheus-sourced queries:
 	// - Saturation: KV cache, queue length, cache config, prefix cache hit rate
 	// - Shared (saturation + queueing model): avg input tokens, avg output tokens
@@ -413,7 +432,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		// Throughput analyzer fields
 		generationTokenRate float64
 		kvUsageInstant      float64
-		vllmRequestRate     float64
+		requestRate         float64
 	}
 
 	// trackMetricFreshness determines the freshness status of metrics in podMetricData
@@ -676,7 +695,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QuerySchedulerDispatchRate]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				// The scheduler metric has pod_name and port labels to identify the vLLM instance.
+				// The scheduler metric has pod_name and port labels to identify the engine instance.
 				// Build a composite key: pod_name:port to support multiple instances per pod.
 				podName := value.Labels["pod_name"]
 				port := value.Labels["port"]
@@ -811,8 +830,8 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 	}
 
-	// Process vLLM request completion rate (req/s) — throughput analyzer fallback λ_req
-	if result := results[registration.QueryVLLMRequestRate]; result != nil {
+	// Process engine request completion rate (req/s) — throughput analyzer fallback λ_req
+	if result := results[registration.QueryRequestRate]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
 				instanceKey, _, _ := c.buildInstanceKey(ctx, namespace, value.Labels)
@@ -823,7 +842,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 					continue // skip pods the KV/queue queries didn't see (scrape skew)
 				}
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 {
-					podData[instanceKey].vllmRequestRate = value.Value
+					podData[instanceKey].requestRate = value.Value
 				}
 			}
 		}
@@ -944,7 +963,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			tokensInUse = int64(rounded)
 		}
 
-		// Look up MaxBatchSize from the scale target's vLLM args via the VA's ScaleTargetRef
+		// Look up MaxBatchSize from the scale target's engine args via the VA's ScaleTargetRef
 		var maxBatchSize int64
 		if va, ok := variantAutoscalings[variantKey]; ok && va != nil {
 			key := utils.GetNamespacedKey(namespace, va.Spec.ScaleTargetRef.Name)
@@ -954,7 +973,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 
 		if (data.hasKv || data.hasQueue) && !data.hasArrivalRate {
-			logger.Info("Pod has vLLM metrics but no dispatch rate — possible pod/pod_name label mismatch", "pod", podName, "model", modelID, "namespace", namespace)
+			logger.Info("Pod has engine metrics but no dispatch rate — possible pod/pod_name label mismatch", "pod", podName, "model", modelID, "namespace", namespace)
 		}
 
 		metric := interfaces.ReplicaMetrics{
@@ -979,7 +998,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			AvgITL:                data.avgITL,
 			GenerationTokenRate:   data.generationTokenRate,
 			KvUsageInstant:        data.kvUsageInstant,
-			VLLMRequestRate:       data.vllmRequestRate,
+			RequestRate:           data.requestRate,
 			Metadata: &interfaces.ReplicaMetricsMetadata{
 				CollectedAt:     collectedAt,
 				Age:             0, // Fresh
@@ -1006,7 +1025,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 
 // CollectSchedulerQueueMetrics collects model-level queue metrics from the
 // llm-d inference scheduler flow control layer. These metrics are not per-pod
-// but per-model, representing requests queued upstream before reaching vLLM.
+// but per-model, representing requests queued upstream before reaching the engine.
 // Returns nil (not an error) when flow control metrics are unavailable.
 func (c *ReplicaMetricsCollector) CollectSchedulerQueueMetrics(
 	ctx context.Context,

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -60,6 +60,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller/indexers"
 	saturation_v2 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/saturation_v2"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
@@ -340,25 +341,19 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		source.ParamNamespace: namespace,
 	}
 
+	// Determine which inference engines this model's variants run. Engine-specific
+	// queries are refreshed once per present engine (vLLM pods emit vllm:* series,
+	// SGLang pods emit sglang:* series — the per-pod results are disjoint and are
+	// merged back under the logical query name below). For vLLM-only models this
+	// is identical to the previous fixed query list.
+	engines := inferenceengine.Present(scaleTargets)
+
 	// Refresh all Prometheus-sourced queries:
 	// - Saturation: KV cache, queue length, cache config, prefix cache hit rate
 	// - Shared (saturation + queueing model): avg input tokens, avg output tokens
 	// - Queueing model: scheduler dispatch rate, avg TTFT, avg ITL
-	// - Throughput analyzer: generation token rate, instantaneous KV usage (k*), vLLM request rate
-	queries := []string{
-		registration.QueryKvCacheUsage,
-		registration.QueryQueueLength,
-		registration.QueryCacheConfigInfo,
-		registration.QueryAvgOutputTokens,
-		registration.QueryAvgInputTokens,
-		registration.QueryPrefixCacheHitRate,
-		registration.QuerySchedulerDispatchRate,
-		registration.QueryAvgTTFT,
-		registration.QueryAvgITL,
-		registration.QueryGenerationTokenRate,
-		registration.QueryKvUsageInstant,
-		registration.QueryVLLMRequestRate,
-	}
+	// - Throughput analyzer: generation token rate, instantaneous KV usage (k*), request rate
+	queries := buildEngineQueryList(engines, engineSpecificReplicaQueries, agnosticReplicaQueries)
 
 	// Execute the query with timing
 	startTime := time.Now()
@@ -378,6 +373,13 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		metrics.IncMetricsCollectionErrors(constants.QueryTypeCacheConfig, reason)
 		return nil, fmt.Errorf("failed to refresh replica metrics: %w", err)
 	}
+
+	// Re-key engine-specific results under their logical query names so the per-pod
+	// processing below is engine-agnostic. For SGLang-only models this renames the
+	// "sglang/<query>" results to "<query>"; for mixed-engine models it concatenates
+	// the per-engine series. The structural cache-config difference is handled by a
+	// dedicated SGLang pass after the vLLM cache-config block.
+	mergeEngineResults(results, engines, engineSpecificReplicaQueries)
 
 	// podMetricData holds per-pod metric values and timestamps
 	type podMetricData struct {
@@ -557,6 +559,43 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 					"pod", podName,
 					"numGpuBlocks", data.numGpuBlocks,
 					"blockSize", data.blockSize)
+			}
+		}
+	}
+
+	// Process SGLang cache config (structural difference from vLLM).
+	//
+	// SGLang exposes total KV-cache token capacity directly via
+	// sglang:max_total_num_tokens (the value), rather than as
+	// num_gpu_blocks/block_size labels. We map the capacity onto the existing
+	// numGpuBlocks × blockSize computation by setting blockSize = 1 and
+	// numGpuBlocks = capacity, so the downstream TotalKvCapacityTokens math is
+	// unchanged. Only runs when an SGLang variant is present for this model.
+	if containsEngine(engines, inferenceengine.EngineSGLang) {
+		sglangCacheKey := registration.EngineQuery(inferenceengine.EngineSGLang, registration.QueryCacheConfigInfo)
+		if result := results[sglangCacheKey]; result != nil && !result.HasError() {
+			for _, value := range result.Values {
+				instanceKey, podName, _ := c.buildInstanceKey(ctx, namespace, value.Labels)
+				if instanceKey == "" {
+					continue
+				}
+				data := podData[instanceKey]
+				if data == nil {
+					// Not seen by the model-scoped KV/queue queries — skip.
+					continue
+				}
+				capacity := int64(value.Value)
+				if capacity > 0 {
+					data.numGpuBlocks = capacity
+					data.blockSize = 1
+					data.hasCacheConfig = true
+					data.cacheConfigTimestamp = value.Timestamp
+				}
+
+				logger.V(logging.DEBUG).Info("SGLang cache config metric",
+					"instanceKey", instanceKey,
+					"pod", podName,
+					"totalKvCapacityTokens", capacity)
 			}
 		}
 	}
@@ -791,12 +830,13 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	}
 
 	// Pre-compute MaxBatchSize per scale target from container args.
-	// MaxBatchSize (--max-num-seqs) is not a Prometheus metric; it is parsed
-	// from the Deployment/LWS spec using the vLLM argument parser.
+	// MaxBatchSize is not a Prometheus metric; it is parsed from the Deployment/LWS
+	// spec using the argument parser for the variant's detected engine
+	// (vLLM --max-num-seqs / SGLang --max-running-requests).
 	// Map key is scale target key (namespace/name).
 	scaleTargetMaxBatchSize := make(map[string]int64, len(scaleTargets))
 	for key, scaleTarget := range scaleTargets {
-		params := saturation_v2.ParseVLLMArgs(scaleTarget)
+		params := saturation_v2.ParseEngineArgs(inferenceengine.Detect(scaleTarget), scaleTarget)
 		scaleTargetMaxBatchSize[key] = params.MaxNumSeqs
 	}
 

--- a/internal/collector/replica_metrics_test.go
+++ b/internal/collector/replica_metrics_test.go
@@ -19,12 +19,14 @@ package collector
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,6 +40,15 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+// Shared test literals (extracted to satisfy goconst across the new SGLang cases).
+const (
+	sglangScaleTargetKey = "test-ns/sglang-decode"
+	mixedVLLMPodName     = "vllm-0"
+	testServerContainer  = "server"
+	sglangVariantLabel   = "va-sglang"
+	sglangKVUsageKey     = "sglang/kv_cache_usage"
 )
 
 // mockMetricsSource is a mock implementation of source.MetricsSource for testing
@@ -564,7 +575,7 @@ func TestCollectReplicaMetrics_ErrorMetrics(t *testing.T) {
 
 // TestCollectReplicaMetrics_ThroughputKeyMerge verifies that when the KV-cache
 // query and the throughput queries (GenerationTokenRate, KvUsageInstant,
-// VLLMRequestRate) return results for the same pod, they merge into a single
+// RequestRate) return results for the same pod, they merge into a single
 // ReplicaMetrics entry with all fields non-zero.
 //
 // Before the Bug A fix, throughput loops used the bare pod name as the podData
@@ -607,7 +618,7 @@ func TestCollectReplicaMetrics_ThroughputKeyMerge(t *testing.T) {
 						{Labels: podLabels, Value: 0.50, Timestamp: ts},
 					},
 				},
-				"vllm_request_rate": {
+				"request_rate": {
 					Values: []source.MetricValue{
 						{Labels: podLabels, Value: 7.0, Timestamp: ts},
 					},
@@ -641,11 +652,234 @@ func TestCollectReplicaMetrics_ThroughputKeyMerge(t *testing.T) {
 	if m.KvUsageInstant == 0 {
 		t.Errorf("KvUsageInstant is zero — throughput key merge failed")
 	}
-	if m.VLLMRequestRate == 0 {
-		t.Errorf("VLLMRequestRate is zero — throughput key merge failed")
+	if m.RequestRate == 0 {
+		t.Errorf("RequestRate is zero — throughput key merge failed")
 	}
 	if m.KvCacheUsage == 0 {
 		t.Errorf("KvCacheUsage is zero — KV cache result not merged")
+	}
+}
+
+// TestCollectReplicaMetrics_SGLangCacheConfig verifies the SGLang cache-config
+// pass: SGLang exposes total KV-cache token capacity directly via
+// sglang:max_total_num_tokens (queried as sglang/cache_config_info), and the
+// collector must surface that value as ReplicaMetrics.TotalKvCapacityTokens —
+// unlike vLLM, which derives capacity from num_gpu_blocks × block_size.
+func TestCollectReplicaMetrics_SGLangCacheConfig(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	podLabels := map[string]string{
+		"pod":                               "sglang-pod-0",
+		"instance":                          "10.0.0.3:8000",
+		constants.VariantLabelPrometheusKey: sglangVariantLabel,
+	}
+	ts := time.Now()
+	const capacity = 100000.0
+
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			// Physical SGLang keys. The KV query makes the pod discoverable;
+			// cache_config_info carries the directly-exposed token capacity.
+			return map[string]*source.MetricResult{
+				sglangKVUsageKey: {
+					Values: []source.MetricValue{{Labels: podLabels, Value: 0.85, Timestamp: ts}},
+				},
+				"sglang/cache_config_info": {
+					Values: []source.MetricValue{{Labels: podLabels, Value: capacity, Timestamp: ts}},
+				},
+			}, nil
+		},
+	}
+
+	// An SGLang scale target so inferenceengine.Present detects SGLang and the
+	// collector runs the SGLang cache-config pass.
+	sglangTarget := scaletarget.NewDeploymentAccessor(&appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: testServerContainer, Image: "lmsysorg/sglang:latest"}},
+				},
+			},
+		},
+	})
+
+	collector := NewReplicaMetricsCollector(mockSource, k8sClient, nil, nil)
+	results, err := collector.CollectReplicaMetrics(
+		context.Background(),
+		"test-model",
+		"test-ns",
+		map[string]scaletarget.ScaleTargetAccessor{sglangScaleTargetKey: sglangTarget},
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil,
+		make(map[string]float64),
+	)
+	if err != nil {
+		t.Fatalf("CollectReplicaMetrics: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 ReplicaMetrics entry, got %d", len(results))
+	}
+	if got := results[0].TotalKvCapacityTokens; got != int64(capacity) {
+		t.Errorf("TotalKvCapacityTokens = %d, want %d (from sglang:max_total_num_tokens)", got, int64(capacity))
+	}
+}
+
+// TestCollectReplicaMetrics_SGLangPrefixCacheHitRate verifies the SGLang
+// prefix-cache-hit-rate value flows end-to-end (through mergeEngineResults
+// re-keying) into ReplicaMetrics.PrefixCacheHitRate, and that a NaN ratio
+// (0/0 when prompt_tokens_total has not increased) is dropped to 0 rather than
+// poisoning the field.
+func TestCollectReplicaMetrics_SGLangPrefixCacheHitRate(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	podLabels := map[string]string{
+		"pod":                               "sglang-pod-0",
+		"instance":                          "10.0.0.4:8000",
+		constants.VariantLabelPrometheusKey: sglangVariantLabel,
+	}
+	sglangTarget := scaletarget.NewDeploymentAccessor(&appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: testServerContainer, Image: "lmsysorg/sglang:latest"}},
+				},
+			},
+		},
+	})
+
+	cases := []struct {
+		name string
+		hit  float64
+		want float64
+	}{
+		{"valid ratio flows into PrefixCacheHitRate", 0.3, 0.3},
+		{"NaN ratio (0/0) is dropped to 0", math.NaN(), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			ts := time.Now()
+			mockSource := &mockMetricsSource{
+				refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+					return map[string]*source.MetricResult{
+						// KV query makes the pod discoverable.
+						sglangKVUsageKey: {
+							Values: []source.MetricValue{{Labels: podLabels, Value: 0.85, Timestamp: ts}},
+						},
+						"sglang/prefix_cache_hit_rate": {
+							Values: []source.MetricValue{{Labels: podLabels, Value: tc.hit, Timestamp: ts}},
+						},
+					}, nil
+				},
+			}
+			collector := NewReplicaMetricsCollector(mockSource, k8sClient, nil, nil)
+			results, err := collector.CollectReplicaMetrics(
+				context.Background(), "test-model", "test-ns",
+				map[string]scaletarget.ScaleTargetAccessor{sglangScaleTargetKey: sglangTarget},
+				make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+				nil, make(map[string]float64),
+			)
+			if err != nil {
+				t.Fatalf("CollectReplicaMetrics: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 ReplicaMetrics entry, got %d", len(results))
+			}
+			if got := results[0].PrefixCacheHitRate; got != tc.want {
+				t.Errorf("PrefixCacheHitRate = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCollectReplicaMetrics_MixedEngine drives the mixed vLLM+SGLang collection
+// path end-to-end: both engines' series are merged under the logical names, and
+// each pod must get its capacity from its own engine's source — the SGLang
+// cache-config pass (capacity = sglang:max_total_num_tokens) must not corrupt the
+// vLLM pod's num_gpu_blocks × block_size capacity, and vice versa.
+func TestCollectReplicaMetrics_MixedEngine(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ts := time.Now()
+
+	vllmPod := map[string]string{"pod": mixedVLLMPodName, "instance": "10.0.1.1:8000", constants.VariantLabelPrometheusKey: "va-vllm"}
+	sglangPod := map[string]string{"pod": "sglang-0", "instance": "10.0.2.1:8000", constants.VariantLabelPrometheusKey: sglangVariantLabel}
+	vllmCacheLabels := map[string]string{"pod": mixedVLLMPodName, "instance": "10.0.1.1:8000", "num_gpu_blocks": "1000", "block_size": "16"}
+
+	const sglangCapacity = 100000.0
+
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			return map[string]*source.MetricResult{
+				// vLLM uses the bare logical keys.
+				"kv_cache_usage":    {Values: []source.MetricValue{{Labels: vllmPod, Value: 0.5, Timestamp: ts}}},
+				"cache_config_info": {Values: []source.MetricValue{{Labels: vllmCacheLabels, Value: 1, Timestamp: ts}}},
+				// SGLang uses the engine-scoped physical keys.
+				sglangKVUsageKey:           {Values: []source.MetricValue{{Labels: sglangPod, Value: 0.85, Timestamp: ts}}},
+				"sglang/cache_config_info": {Values: []source.MetricValue{{Labels: sglangPod, Value: sglangCapacity, Timestamp: ts}}},
+			}, nil
+		},
+	}
+
+	target := func(image string) scaletarget.ScaleTargetAccessor {
+		return scaletarget.NewDeploymentAccessor(&appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: testServerContainer, Image: image}}},
+				},
+			},
+		})
+	}
+
+	collector := NewReplicaMetricsCollector(mockSource, k8sClient, nil, nil)
+	results, err := collector.CollectReplicaMetrics(
+		context.Background(), "test-model", "test-ns",
+		map[string]scaletarget.ScaleTargetAccessor{
+			"test-ns/vllm-decode": target("vllm/vllm-openai:latest"),
+			sglangScaleTargetKey:  target("lmsysorg/sglang:latest"),
+		},
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil, make(map[string]float64),
+	)
+	if err != nil {
+		t.Fatalf("CollectReplicaMetrics: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 ReplicaMetrics entries (one per engine), got %d", len(results))
+	}
+
+	byPod := make(map[string]int64, 2)
+	for _, m := range results {
+		byPod[m.PodName] = m.TotalKvCapacityTokens
+	}
+	if got := byPod[mixedVLLMPodName]; got != 1000*16 {
+		t.Errorf("vLLM pod TotalKvCapacityTokens = %d, want %d (num_gpu_blocks × block_size)", got, 1000*16)
+	}
+	if got := byPod["sglang-0"]; got != int64(sglangCapacity) {
+		t.Errorf("SGLang pod TotalKvCapacityTokens = %d, want %d (sglang:max_total_num_tokens)", got, int64(sglangCapacity))
 	}
 }
 

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -68,6 +68,62 @@ const (
 	VLLMPrefixCacheQueries = "vllm:prefix_cache_queries"
 )
 
+// SGLang Input Metrics
+// These metric names are used to query SGLang inference engine metrics from Prometheus.
+// Names and types were taken from SGLang's metrics collector
+// (python/sglang/srt/observability/metrics_collector.py). SGLang labels its metrics
+// with model_name, matching the label WVA filters on. See docs/proposals/sglang-backend.md.
+const (
+	// SGLangNumRunningReqs is the number of running requests (gauge).
+	// SGLang equivalent of vllm:num_requests_running.
+	SGLangNumRunningReqs = "sglang:num_running_reqs"
+
+	// SGLangNumQueueReqs is the number of requests in the waiting queue (gauge).
+	// SGLang equivalent of vllm:num_requests_waiting.
+	SGLangNumQueueReqs = "sglang:num_queue_reqs"
+
+	// SGLangTokenUsage is the KV-cache token-pool utilization as a fraction 0.0-1.0 (gauge).
+	// SGLang equivalent of vllm:kv_cache_usage_perc.
+	SGLangTokenUsage = "sglang:token_usage"
+
+	// SGLangMaxTotalNumTokens is the total KV-cache token capacity (gauge).
+	// SGLang exposes capacity directly, unlike vLLM which derives it from
+	// vllm:cache_config_info (num_gpu_blocks x block_size).
+	SGLangMaxTotalNumTokens = "sglang:max_total_num_tokens"
+
+	// SGLangTimeToFirstTokenSecondsSum/Count are the TTFT histogram parts.
+	// SGLang equivalent of vllm:time_to_first_token_seconds_{sum,count}.
+	SGLangTimeToFirstTokenSecondsSum   = "sglang:time_to_first_token_seconds_sum"
+	SGLangTimeToFirstTokenSecondsCount = "sglang:time_to_first_token_seconds_count"
+
+	// SGLangInterTokenLatencySecondsSum/Count are the inter-token-latency histogram parts.
+	// SGLang equivalent of vllm:inter_token_latency_seconds_{sum,count}.
+	SGLangInterTokenLatencySecondsSum   = "sglang:inter_token_latency_seconds_sum"
+	SGLangInterTokenLatencySecondsCount = "sglang:inter_token_latency_seconds_count"
+
+	// SGLangPromptTokensHistogramSum/Count are the prompt-token histogram parts.
+	// SGLang equivalent of vllm:request_prompt_tokens_{sum,count}.
+	SGLangPromptTokensHistogramSum   = "sglang:prompt_tokens_histogram_sum"
+	SGLangPromptTokensHistogramCount = "sglang:prompt_tokens_histogram_count"
+
+	// SGLangGenerationTokensHistogramSum/Count are the generation-token histogram parts.
+	// SGLang equivalent of vllm:request_generation_tokens_{sum,count}.
+	SGLangGenerationTokensHistogramSum   = "sglang:generation_tokens_histogram_sum"
+	SGLangGenerationTokensHistogramCount = "sglang:generation_tokens_histogram_count"
+
+	// SGLangCachedTokensTotal is a counter of prompt tokens served from the prefix cache.
+	// Used with SGLangPromptTokensTotal to compute the prefix cache hit rate, the
+	// unit-safe analog of vllm:prefix_cache_hits / vllm:prefix_cache_queries.
+	SGLangCachedTokensTotal = "sglang:cached_tokens_total"
+
+	// SGLangPromptTokensTotal is a counter of total prompt tokens.
+	SGLangPromptTokensTotal = "sglang:prompt_tokens_total"
+
+	// SGLangNumRequestsTotal is a counter of received requests.
+	// SGLang equivalent of vllm:request_success_total (used for scale-to-zero).
+	SGLangNumRequestsTotal = "sglang:num_requests_total"
+)
+
 // llm-d Inference Scheduler Flow Control Metrics
 // These metrics come from the Gateway API Inference Extension EPP (Endpoint Picker)
 // flow control layer, not from vLLM pods. They are model-scoped (not per-pod).

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -91,24 +91,36 @@ const (
 	// vllm:cache_config_info (num_gpu_blocks x block_size).
 	SGLangMaxTotalNumTokens = "sglang:max_total_num_tokens"
 
-	// SGLangTimeToFirstTokenSecondsSum/Count are the TTFT histogram parts.
-	// SGLang equivalent of vllm:time_to_first_token_seconds_{sum,count}.
-	SGLangTimeToFirstTokenSecondsSum   = "sglang:time_to_first_token_seconds_sum"
+	// SGLangTimeToFirstTokenSecondsSum is the sum part of the TTFT histogram.
+	// SGLang equivalent of vllm:time_to_first_token_seconds_sum.
+	SGLangTimeToFirstTokenSecondsSum = "sglang:time_to_first_token_seconds_sum"
+
+	// SGLangTimeToFirstTokenSecondsCount is the count part of the TTFT histogram.
+	// SGLang equivalent of vllm:time_to_first_token_seconds_count.
 	SGLangTimeToFirstTokenSecondsCount = "sglang:time_to_first_token_seconds_count"
 
-	// SGLangInterTokenLatencySecondsSum/Count are the inter-token-latency histogram parts.
-	// SGLang equivalent of vllm:inter_token_latency_seconds_{sum,count}.
-	SGLangInterTokenLatencySecondsSum   = "sglang:inter_token_latency_seconds_sum"
+	// SGLangInterTokenLatencySecondsSum is the sum part of the inter-token-latency histogram.
+	// SGLang equivalent of vllm:inter_token_latency_seconds_sum.
+	SGLangInterTokenLatencySecondsSum = "sglang:inter_token_latency_seconds_sum"
+
+	// SGLangInterTokenLatencySecondsCount is the count part of the inter-token-latency histogram.
+	// SGLang equivalent of vllm:inter_token_latency_seconds_count.
 	SGLangInterTokenLatencySecondsCount = "sglang:inter_token_latency_seconds_count"
 
-	// SGLangPromptTokensHistogramSum/Count are the prompt-token histogram parts.
-	// SGLang equivalent of vllm:request_prompt_tokens_{sum,count}.
-	SGLangPromptTokensHistogramSum   = "sglang:prompt_tokens_histogram_sum"
+	// SGLangPromptTokensHistogramSum is the sum part of the prompt-token histogram.
+	// SGLang equivalent of vllm:request_prompt_tokens_sum.
+	SGLangPromptTokensHistogramSum = "sglang:prompt_tokens_histogram_sum"
+
+	// SGLangPromptTokensHistogramCount is the count part of the prompt-token histogram.
+	// SGLang equivalent of vllm:request_prompt_tokens_count.
 	SGLangPromptTokensHistogramCount = "sglang:prompt_tokens_histogram_count"
 
-	// SGLangGenerationTokensHistogramSum/Count are the generation-token histogram parts.
-	// SGLang equivalent of vllm:request_generation_tokens_{sum,count}.
-	SGLangGenerationTokensHistogramSum   = "sglang:generation_tokens_histogram_sum"
+	// SGLangGenerationTokensHistogramSum is the sum part of the generation-token histogram.
+	// SGLang equivalent of vllm:request_generation_tokens_sum.
+	SGLangGenerationTokensHistogramSum = "sglang:generation_tokens_histogram_sum"
+
+	// SGLangGenerationTokensHistogramCount is the count part of the generation-token histogram.
+	// SGLang equivalent of vllm:request_generation_tokens_count.
 	SGLangGenerationTokensHistogramCount = "sglang:generation_tokens_histogram_count"
 
 	// SGLangCachedTokensTotal is a counter of prompt tokens served from the prefix cache.

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -164,9 +164,9 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	k1 := int64(float64(rm.TotalKvCapacityTokens) * config.KvCacheThreshold)
 
 	// k2: compute-bound capacity
-	var vllmParams *VLLMEngineParams
+	var engineParams *EngineParams
 	if rec := a.capacityStore.Get(namespace, modelID, rm.VariantName); rec != nil {
-		vllmParams = rec.VLLMParams
+		engineParams = rec.EngineParams
 	}
 	k2, k2Priority := a.computeK2(
 		modelID, rm.AcceleratorName,
@@ -174,7 +174,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		rm.QueueLength, rm.TokensInUse,
 		rm.AvgOutputTokens, rm.AvgInputTokens,
 		config.QueueLengthThreshold,
-		vllmParams,
+		engineParams,
 		k1,
 	)
 
@@ -185,11 +185,11 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 
 	isSaturated := replicaDemand >= effectiveCapacity
 
-	// Update capacity store with live data, preserving VLLMParams from any
+	// Update capacity store with live data, preserving EngineParams from any
 	// existing record (parsed from deployment args and needed for FindCompatible).
-	var existingParams *VLLMEngineParams
-	if existing := a.capacityStore.Get(namespace, modelID, rm.VariantName); existing != nil && existing.VLLMParams != nil {
-		existingParams = existing.VLLMParams
+	var existingParams *EngineParams
+	if existing := a.capacityStore.Get(namespace, modelID, rm.VariantName); existing != nil && existing.EngineParams != nil {
+		existingParams = existing.EngineParams
 	}
 	a.capacityStore.Update(namespace, modelID, rm.VariantName, CapacityRecord{
 		AcceleratorName:       rm.AcceleratorName,
@@ -198,7 +198,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		BlockSize:             rm.BlockSize,
 		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
 		EffectiveCapacity:     effectiveCapacity,
-		VLLMParams:            existingParams,
+		EngineParams:          existingParams,
 		LearnedFrom:           learnedFromLive,
 	})
 
@@ -279,7 +279,7 @@ func (a *SaturationAnalyzer) computeK2(
 	queueLen int, tokensInUse int64,
 	avgOutput, avgInput float64,
 	queueThreshold float64,
-	vllmParams *VLLMEngineParams,
+	engineParams *EngineParams,
 	k1 int64,
 ) (int64, k2Source) {
 	outputBucket := classifyOutputLength(avgOutput)
@@ -312,7 +312,7 @@ func (a *SaturationAnalyzer) computeK2(
 	}
 
 	// Priority 3: Derived from deployment args
-	if k2Derived := estimateCapacityFromParams(vllmParams, avgInput, avgOutput); k2Derived > 0 {
+	if k2Derived := estimateCapacityFromParams(engineParams, avgInput, avgOutput); k2Derived > 0 {
 		return k2Derived, k2SrcDerived
 	}
 
@@ -462,17 +462,17 @@ func (a *SaturationAnalyzer) aggregateByRole(
 }
 
 // lookupCompatibleCapacity searches the capacity store for a record from
-// another variant with matching hardware and vLLM parameters. This enables
+// another variant with matching hardware and engine parameters. This enables
 // capacity estimation for zero-replica variants that have no prior data.
 // The search is cross-namespace since capacity depends on hardware + config,
 // not namespace.
 func (a *SaturationAnalyzer) lookupCompatibleCapacity(namespace, modelID, variantName, accelerator string, gpuCount int) *CapacityRecord {
-	// Get VLLMParams for this variant (from deployment-derived record)
+	// Get EngineParams for this variant (from deployment-derived record)
 	rec := a.capacityStore.Get(namespace, modelID, variantName)
-	if rec == nil || rec.VLLMParams == nil {
+	if rec == nil || rec.EngineParams == nil {
 		return nil
 	}
-	return a.capacityStore.FindCompatible(modelID, accelerator, gpuCount, rec.VLLMParams)
+	return a.capacityStore.FindCompatible(modelID, accelerator, gpuCount, rec.EngineParams)
 }
 
 // estimateStoredCapacity returns a capacity estimate for a zero-replica variant
@@ -496,8 +496,8 @@ func (a *SaturationAnalyzer) estimateStoredCapacity(rec *CapacityRecord, modelID
 	}
 
 	// For deployment-derived records, try k2 derivation with workload data
-	if rec.VLLMParams != nil && modelAvgOutput > 0 {
-		if derived := estimateCapacityFromParams(rec.VLLMParams, modelAvgInput, modelAvgOutput); derived > 0 {
+	if rec.EngineParams != nil && modelAvgOutput > 0 {
+		if derived := estimateCapacityFromParams(rec.EngineParams, modelAvgInput, modelAvgOutput); derived > 0 {
 			bounded := derived
 
 			// Bound by own k1 if TotalKvCapacityTokens is known (num_gpu_blocks_override)
@@ -509,7 +509,7 @@ func (a *SaturationAnalyzer) estimateStoredCapacity(rec *CapacityRecord, modelID
 			}
 
 			// Bound by compatible variant's live EffectiveCapacity (already min(k1,k2))
-			if compatible := a.capacityStore.FindCompatible(modelID, rec.AcceleratorName, rec.GpuCount, rec.VLLMParams); compatible != nil && compatible.LearnedFrom == learnedFromLive && compatible.EffectiveCapacity > 0 {
+			if compatible := a.capacityStore.FindCompatible(modelID, rec.AcceleratorName, rec.GpuCount, rec.EngineParams); compatible != nil && compatible.LearnedFrom == learnedFromLive && compatible.EffectiveCapacity > 0 {
 				if compatible.EffectiveCapacity < bounded {
 					bounded = compatible.EffectiveCapacity
 				}
@@ -528,7 +528,7 @@ func (a *SaturationAnalyzer) estimateStoredCapacity(rec *CapacityRecord, modelID
 // Used by computeK2 (Priority 3) for per-replica estimation and by
 // estimateStoredCapacity for zero-replica variants with model-level workload averages.
 // Returns 0 if estimation is not possible.
-func estimateCapacityFromParams(params *VLLMEngineParams, avgInput, avgOutput float64) int64 {
+func estimateCapacityFromParams(params *EngineParams, avgInput, avgOutput float64) int64 {
 	if params == nil || params.EffectiveMaxBatchedTokens <= 0 || avgOutput <= 0 {
 		return 0
 	}
@@ -582,7 +582,7 @@ type schedulerQueueDemand struct {
 // in the llm-d inference scheduler's flow control layer, with per-role
 // attribution for P/D disaggregated models.
 //
-// These requests have not yet reached any vLLM pod, so we estimate their
+// These requests have not yet reached any engine pod, so we estimate their
 // token footprint using two independent signals:
 //
 //	inputTokens = max(queueBytes / BytesPerToken, queueSize * avgInputTokens)
@@ -597,8 +597,9 @@ type schedulerQueueDemand struct {
 //
 // The prefix cache hit rate reduces expected input token KV demand because
 // a fraction of prompt tokens will hit the prefix cache and reuse existing
-// KV blocks. This does NOT apply to the local vLLM queue (num_requests_waiting)
-// because those requests have not yet had prefix cache lookup performed.
+// KV blocks. This does NOT apply to the local engine queue
+// (vllm:num_requests_waiting / sglang:num_queue_reqs) because those requests
+// have not yet had prefix cache lookup performed.
 func estimateSchedulerQueueDemand(
 	sq *interfaces.SchedulerQueueMetrics,
 	replicaMetrics []interfaces.ReplicaMetrics,

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -176,7 +176,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 			store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
 				AcceleratorName: "H100",
 				GpuCount:        1,
-				VLLMParams: &VLLMEngineParams{
+				EngineParams: &EngineParams{
 					EffectiveMaxBatchedTokens: 2048,
 					MaxNumSeqs:                256,
 					ChunkedPrefillEnabled:     true,
@@ -293,7 +293,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				AcceleratorName:   "A100",
 				GpuCount:          1,
 				EffectiveCapacity: 8192, // conservative fallback from LoadFromDeployment
-				VLLMParams: &VLLMEngineParams{
+				EngineParams: &EngineParams{
 					EffectiveMaxBatchedTokens: 8192,
 					MaxNumSeqs:                256,
 				},
@@ -328,7 +328,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should bound k2 estimate by compatible variant's live EffectiveCapacity", func() {
 			// variant-b is a new deployment on the same H100 hardware as variant-a
-			defaultParams := &VLLMEngineParams{
+			defaultParams := &EngineParams{
 				GpuMemoryUtilization:      0.9,
 				BlockSize:                 16,
 				KvCacheDtype:              "auto",
@@ -340,7 +340,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				AcceleratorName:   "H100",
 				GpuCount:          1,
 				EffectiveCapacity: 8192,
-				VLLMParams:        defaultParams,
+				EngineParams:      defaultParams,
 				LearnedFrom:       "deployment",
 			})
 
@@ -350,7 +350,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 50000,
 				EffectiveCapacity:     40000, // observed min(k1, k2) = 40000
-				VLLMParams:            defaultParams,
+				EngineParams:          defaultParams,
 				LearnedFrom:           "live",
 			})
 
@@ -382,7 +382,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				GpuCount:              1,
 				EffectiveCapacity:     8192,
 				TotalKvCapacityTokens: 30000, // from num_gpu_blocks_override
-				VLLMParams: &VLLMEngineParams{
+				EngineParams: &EngineParams{
 					EffectiveMaxBatchedTokens: 8192,
 					MaxNumSeqs:                256,
 					NumGpuBlocksOverride:      1875,
@@ -421,7 +421,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				AcceleratorName:   "H100",
 				GpuCount:          1,
 				EffectiveCapacity: 8192,
-				VLLMParams: &VLLMEngineParams{
+				EngineParams: &EngineParams{
 					EffectiveMaxBatchedTokens: 8192,
 					MaxNumSeqs:                256,
 				},
@@ -445,7 +445,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 	Describe("estimateCapacityFromParams", func() {
 		It("should compute k2 from B, S, I, O", func() {
-			params := &VLLMEngineParams{
+			params := &EngineParams{
 				EffectiveMaxBatchedTokens: 4096,
 				MaxNumSeqs:                256,
 			}
@@ -456,7 +456,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 		})
 
 		It("should cap N_steady at MaxNumSeqs", func() {
-			params := &VLLMEngineParams{
+			params := &EngineParams{
 				EffectiveMaxBatchedTokens: 8192,
 				MaxNumSeqs:                64,
 			}
@@ -467,7 +467,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 		})
 
 		It("should return 0 when avgOutput is 0", func() {
-			params := &VLLMEngineParams{
+			params := &EngineParams{
 				EffectiveMaxBatchedTokens: 8192,
 				MaxNumSeqs:                256,
 			}

--- a/internal/engines/analyzers/saturation_v2/capacity_store.go
+++ b/internal/engines/analyzers/saturation_v2/capacity_store.go
@@ -21,8 +21,8 @@ type CapacityRecord struct {
 	BlockSize             int64
 	TotalKvCapacityTokens int64
 	EffectiveCapacity     int64
-	VLLMParams            *VLLMEngineParams // parsed deployment params for k2 derivation
-	LearnedFrom           string            // "live", "deployment", "annotation"
+	EngineParams          *EngineParams // parsed deployment params for k2 derivation
+	LearnedFrom           string        // "live", "deployment", "annotation"
 	LearnedAt             time.Time
 }
 
@@ -32,7 +32,7 @@ type CapacityRecord struct {
 // deployments before any live metrics are available.
 //
 // For cross-variant estimation, use FindCompatible which searches for records
-// from other variants with matching hardware and vLLM parameters.
+// from other variants with matching hardware and engine parameters.
 type CapacityKnowledgeStore struct {
 	mu      sync.RWMutex
 	records map[string]*CapacityRecord
@@ -81,9 +81,10 @@ func (s *CapacityKnowledgeStore) IsStale(namespace, modelID, variantName string)
 	return time.Since(rec.LearnedAt) > CapacityStalenessTimeout
 }
 
-// LoadFromScaleTarget parses vLLM args from a scale target and stores an
-// estimated capacity record for the variant. It does NOT overwrite an
-// existing "live" record — scale target-derived data is a fallback only.
+// LoadFromScaleTarget parses the engine args from a scale target (dispatching by
+// detected engine via ParseEngineArgs) and stores an estimated capacity record for
+// the variant. It does NOT overwrite an existing "live" record — scale
+// target-derived data is a fallback only.
 func (s *CapacityKnowledgeStore) LoadFromScaleTarget(namespace, modelID, variantName, accelerator string, gpuCount int, scaleTarget scaletarget.ScaleTargetAccessor) {
 	if scaleTarget == nil {
 		return
@@ -103,7 +104,7 @@ func (s *CapacityKnowledgeStore) LoadFromScaleTarget(namespace, modelID, variant
 	record := &CapacityRecord{
 		AcceleratorName: accelerator,
 		GpuCount:        gpuCount,
-		VLLMParams:      &params,
+		EngineParams:    &params,
 		LearnedFrom:     "deployment", // same for deployment and LWS
 		LearnedAt:       time.Now(),
 	}
@@ -148,13 +149,13 @@ func (s *CapacityKnowledgeStore) EvictStale(timeout time.Duration) int {
 
 // FindCompatible searches across all namespaces for a capacity record from
 // another variant with matching configuration: same model, accelerator type,
-// GPU count, and compatible vLLM parameters (as defined by IsCapacityCompatible).
-// Capacity is a property of hardware + vLLM config, not namespace, so
+// GPU count, and compatible engine parameters (as defined by IsCapacityCompatible).
+// Capacity is a property of hardware + engine config, not namespace, so
 // cross-namespace matching is intentional.
 //
 // Returns the best match (preferring "live" records over "deployment"/"lws" records),
 // or nil if no compatible record exists.
-func (s *CapacityKnowledgeStore) FindCompatible(modelID, accelerator string, gpuCount int, params *VLLMEngineParams) *CapacityRecord {
+func (s *CapacityKnowledgeStore) FindCompatible(modelID, accelerator string, gpuCount int, params *EngineParams) *CapacityRecord {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -171,8 +172,8 @@ func (s *CapacityKnowledgeStore) FindCompatible(modelID, accelerator string, gpu
 			continue
 		}
 
-		// Must have compatible vLLM parameters
-		if rec.VLLMParams == nil || !rec.VLLMParams.IsCapacityCompatible(params) {
+		// Must have compatible engine parameters
+		if rec.EngineParams == nil || !rec.EngineParams.IsCapacityCompatible(params) {
 			continue
 		}
 

--- a/internal/engines/analyzers/saturation_v2/capacity_store.go
+++ b/internal/engines/analyzers/saturation_v2/capacity_store.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
@@ -98,7 +99,7 @@ func (s *CapacityKnowledgeStore) LoadFromScaleTarget(namespace, modelID, variant
 		return
 	}
 
-	params := ParseVLLMArgs(scaleTarget)
+	params := ParseEngineArgs(inferenceengine.Detect(scaleTarget), scaleTarget)
 	record := &CapacityRecord{
 		AcceleratorName: accelerator,
 		GpuCount:        gpuCount,
@@ -107,11 +108,14 @@ func (s *CapacityKnowledgeStore) LoadFromScaleTarget(namespace, modelID, variant
 		LearnedAt:       time.Now(),
 	}
 
-	// If num_gpu_blocks_override is set, we can estimate k1
+	// If num_gpu_blocks_override is set (vLLM), we can estimate k1.
 	if params.NumGpuBlocksOverride > 0 {
 		record.NumGpuBlocks = params.NumGpuBlocksOverride
 		record.BlockSize = params.BlockSize
 		record.TotalKvCapacityTokens = params.NumGpuBlocksOverride * params.BlockSize
+	} else if params.TotalKvTokensOverride > 0 {
+		// SGLang exposes total KV token capacity directly via --max-total-tokens.
+		record.TotalKvCapacityTokens = params.TotalKvTokensOverride
 	}
 
 	// Provide a conservative capacity estimate so that brand-new variants

--- a/internal/engines/analyzers/saturation_v2/capacity_store_test.go
+++ b/internal/engines/analyzers/saturation_v2/capacity_store_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -62,18 +63,47 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 	})
 
 	Describe("LoadFromScaleTarget", func() {
-		It("should populate VLLMParams from deployment args", func() {
+		It("should populate EngineParams from deployment args", func() {
 			deploy := makeTestDeployment("--gpu-memory-utilization=0.85", "--max-num-batched-tokens=4096")
 			store.LoadFromScaleTarget("ns-1", "model-a", "variant-a100", "A100", 2, scaletarget.NewDeploymentAccessor(deploy))
 
 			got := store.Get("ns-1", "model-a", "variant-a100")
 			Expect(got).NotTo(BeNil())
-			Expect(got.VLLMParams).NotTo(BeNil())
-			Expect(got.VLLMParams.GpuMemoryUtilization).To(Equal(0.85))
-			Expect(got.VLLMParams.MaxNumBatchedTokens).To(Equal(int64(4096)))
+			Expect(got.EngineParams).NotTo(BeNil())
+			Expect(got.EngineParams.GpuMemoryUtilization).To(Equal(0.85))
+			Expect(got.EngineParams.MaxNumBatchedTokens).To(Equal(int64(4096)))
 			Expect(got.AcceleratorName).To(Equal("A100"))
 			Expect(got.GpuCount).To(Equal(2))
 			Expect(got.LearnedFrom).To(Equal("deployment"))
+		})
+
+		It("should populate SGLang EngineParams and TotalKvCapacityTokens from --max-total-tokens", func() {
+			// SGLang is detected from the launch command; --max-total-tokens maps to
+			// TotalKvTokensOverride and is used as the total KV capacity directly
+			// (vLLM's num_gpu_blocks path must not be taken).
+			deploy := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:    "sglang",
+								Image:   "lmsysorg/sglang:latest",
+								Command: []string{"python3", "-m", "sglang.launch_server"},
+								Args:    []string{"--mem-fraction-static=0.85", "--max-total-tokens=100000"},
+							}},
+						},
+					},
+				},
+			}
+			store.LoadFromScaleTarget("ns-1", "model-a", "variant-sglang", "H100", 1, scaletarget.NewDeploymentAccessor(deploy))
+
+			got := store.Get("ns-1", "model-a", "variant-sglang")
+			Expect(got).NotTo(BeNil())
+			Expect(got.EngineParams).NotTo(BeNil())
+			Expect(got.EngineParams.Engine).To(Equal(inferenceengine.EngineSGLang))
+			Expect(got.EngineParams.TotalKvTokensOverride).To(Equal(int64(100000)))
+			Expect(got.TotalKvCapacityTokens).To(Equal(int64(100000)))
+			Expect(got.NumGpuBlocks).To(Equal(int64(0)))
 		})
 
 		It("should not overwrite live data with deployment data", func() {
@@ -196,8 +226,8 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 	})
 
 	Describe("FindCompatible", func() {
-		defaultParams := func() *VLLMEngineParams {
-			p := defaultVLLMEngineParams()
+		defaultParams := func() *EngineParams {
+			p := defaultEngineParams()
 			resolveEffectiveMaxBatchedTokens(&p)
 			return &p
 		}
@@ -209,7 +239,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 32000,
 				EffectiveCapacity:     28000,
-				VLLMParams:            params,
+				EngineParams:          params,
 				LearnedFrom:           "live",
 			})
 
@@ -226,7 +256,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 32000,
 				EffectiveCapacity:     28000,
-				VLLMParams:            params,
+				EngineParams:          params,
 				LearnedFrom:           "live",
 			})
 
@@ -242,7 +272,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 32000,
 				EffectiveCapacity:     28000,
-				VLLMParams:            params,
+				EngineParams:          params,
 				LearnedFrom:           "live",
 			})
 
@@ -251,14 +281,14 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 			Expect(found).To(BeNil())
 		})
 
-		It("should not match across different vLLM parameters", func() {
+		It("should not match across different engine parameters", func() {
 			params1 := defaultParams()
 			store.Update("ns-1", "model-a", "variant-h100-high-util", CapacityRecord{
 				AcceleratorName:       "H100",
 				GpuCount:              1,
 				TotalKvCapacityTokens: 32000,
 				EffectiveCapacity:     28000,
-				VLLMParams:            params1,
+				EngineParams:          params1,
 				LearnedFrom:           "live",
 			})
 
@@ -276,7 +306,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 32000,
 				EffectiveCapacity:     28000,
-				VLLMParams:            params,
+				EngineParams:          params,
 				LearnedFrom:           "live",
 			})
 
@@ -293,7 +323,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 32000,
 				EffectiveCapacity:     28000,
-				VLLMParams:            params,
+				EngineParams:          params,
 				LearnedFrom:           "live",
 			})
 
@@ -310,7 +340,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 30000,
 				EffectiveCapacity:     25000,
-				VLLMParams:            params,
+				EngineParams:          params,
 				LearnedFrom:           "deployment",
 			})
 			store.Update("ns-1", "model-a", "variant-h100-live", CapacityRecord{
@@ -318,7 +348,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 32000,
 				EffectiveCapacity:     28000,
-				VLLMParams:            params,
+				EngineParams:          params,
 				LearnedFrom:           "live",
 			})
 
@@ -333,7 +363,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 			store.Update("ns-1", "model-a", "variant-h100-empty", CapacityRecord{
 				AcceleratorName:       "H100",
 				GpuCount:              1,
-				VLLMParams:            params,
+				EngineParams:          params,
 				EffectiveCapacity:     0,
 				TotalKvCapacityTokens: 0,
 				LearnedFrom:           "deployment",
@@ -349,7 +379,7 @@ var _ = Describe("CapacityKnowledgeStore", func() {
 				GpuCount:              1,
 				TotalKvCapacityTokens: 32000,
 				EffectiveCapacity:     28000,
-				VLLMParams:            defaultParams(),
+				EngineParams:          defaultParams(),
 				LearnedFrom:           "live",
 			})
 

--- a/internal/engines/analyzers/saturation_v2/deployment_parser.go
+++ b/internal/engines/analyzers/saturation_v2/deployment_parser.go
@@ -7,21 +7,30 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
-// VLLMEngineParams holds vLLM configuration parameters parsed from a
+// VLLMEngineParams holds inference-engine configuration parameters parsed from a
 // Deployment/LWS's container args and environment variables. These are used
 // to derive compute-bound capacity (k2) when no live metrics are available.
+//
+// Despite the name, this struct is the shared engine-params type for all
+// supported engines: ParseVLLMArgs populates it from vLLM flags and
+// ParseSGLangArgs populates it from SGLang flags (mapped onto the same fields).
 type VLLMEngineParams struct {
 	GpuMemoryUtilization  float64 // default: 0.9
-	BlockSize             int64   // default: 16
+	BlockSize             int64   // default: 16 (vLLM block size / SGLang page size)
 	KvCacheDtype          string  // default: "auto"
 	TensorParallelSize    int     // default: 1
-	NumGpuBlocksOverride  int64   // default: 0 (not set)
+	NumGpuBlocksOverride  int64   // default: 0 (not set) — vLLM only
 	MaxNumBatchedTokens   int64   // default: 0 (auto)
-	MaxNumSeqs            int64   // default: 256
-	MaxModelLen           int64   // default: 0 (auto)
-	EnforceEager          bool    // default: false
-	IsV1Engine            bool    // VLLM_USE_V1 env detection (default: true since v0.8)
+	MaxNumSeqs            int64   // default: 256 (vLLM --max-num-seqs / SGLang --max-running-requests)
+	MaxModelLen           int64   // default: 0 (auto) (vLLM --max-model-len / SGLang --context-length)
+	EnforceEager          bool    // default: false (vLLM --enforce-eager / SGLang --disable-cuda-graph)
+	IsV1Engine            bool    // VLLM_USE_V1 env detection (default: true since v0.8); always true for SGLang
 	ChunkedPrefillEnabled bool    // true for V1, or --enable-chunked-prefill
+
+	// TotalKvTokensOverride is the explicit total KV-cache token capacity, when the
+	// engine exposes it as a deployment flag (SGLang --max-total-tokens). 0 = unset.
+	// vLLM has no equivalent flag and uses NumGpuBlocksOverride instead.
+	TotalKvTokensOverride int64
 
 	// EffectiveMaxBatchedTokens is the resolved per-step token budget used
 	// for k2 derivation. It is computed after parsing all other fields.
@@ -154,8 +163,17 @@ func normalizeKey(key string) string {
 	return strings.ReplaceAll(key, "-", "_")
 }
 
-// parseArgs walks the argument list and populates params.
+// parseArgs walks the argument list and populates params using the vLLM flag mapping.
 func parseArgs(args []string, params *VLLMEngineParams) {
+	parseArgsWith(args, params, applyParam)
+}
+
+// parseArgsWith walks the argument list and applies each normalized --key/value
+// pair via the supplied apply function. It is shared by the vLLM and SGLang
+// parsers, which differ only in their per-flag mapping (applyParam vs
+// applySGLangParam). Boolean flags (no following value) are passed with an empty
+// value string.
+func parseArgsWith(args []string, params *VLLMEngineParams, apply func(key, value string, params *VLLMEngineParams)) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if !strings.HasPrefix(arg, "--") {
@@ -177,7 +195,7 @@ func parseArgs(args []string, params *VLLMEngineParams) {
 			// Otherwise it's a boolean flag (no value)
 		}
 
-		applyParam(key, value, params)
+		apply(key, value, params)
 	}
 }
 

--- a/internal/engines/analyzers/saturation_v2/deployment_parser.go
+++ b/internal/engines/analyzers/saturation_v2/deployment_parser.go
@@ -4,17 +4,25 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
-// VLLMEngineParams holds inference-engine configuration parameters parsed from a
+// EngineParams holds inference-engine configuration parameters parsed from a
 // Deployment/LWS's container args and environment variables. These are used
 // to derive compute-bound capacity (k2) when no live metrics are available.
 //
-// Despite the name, this struct is the shared engine-params type for all
-// supported engines: ParseVLLMArgs populates it from vLLM flags and
-// ParseSGLangArgs populates it from SGLang flags (mapped onto the same fields).
-type VLLMEngineParams struct {
+// It is the shared engine-params type for all supported engines: ParseVLLMArgs
+// populates it from vLLM flags and ParseSGLangArgs populates it from SGLang flags
+// (mapped onto the same fields). Field comments note the per-engine flag mapping.
+type EngineParams struct {
+	// Engine records which inference engine produced these params (set by the
+	// parser: EngineVLLM for ParseVLLMArgs, EngineSGLang for ParseSGLangArgs).
+	// IsCapacityCompatible compares it so a capacity record learned for one engine
+	// is never reused as the zero-replica estimate for a different engine serving
+	// the same model on the same hardware.
+	Engine inferenceengine.Engine
+
 	GpuMemoryUtilization  float64 // default: 0.9
 	BlockSize             int64   // default: 16 (vLLM block size / SGLang page size)
 	KvCacheDtype          string  // default: "auto"
@@ -37,11 +45,12 @@ type VLLMEngineParams struct {
 	EffectiveMaxBatchedTokens int64
 }
 
-// defaultVLLMEngineParams returns VLLMEngineParams with vLLM defaults
+// defaultEngineParams returns EngineParams with vLLM defaults
 // as of vLLM v0.8+. If vLLM changes its defaults in a future version,
 // these values should be updated accordingly.
-func defaultVLLMEngineParams() VLLMEngineParams {
-	return VLLMEngineParams{
+func defaultEngineParams() EngineParams {
+	return EngineParams{
+		Engine:                inferenceengine.EngineVLLM,
 		GpuMemoryUtilization:  0.9,
 		BlockSize:             16,
 		KvCacheDtype:          "auto",
@@ -61,8 +70,8 @@ func defaultVLLMEngineParams() VLLMEngineParams {
 //   - Shell commands: ["/bin/sh", "-c", "vllm serve model --arg=val"]
 //   - Boolean flags: --enforce-eager (no value)
 //   - VLLM_USE_V1 environment variable for V1 engine detection
-func ParseVLLMArgs(scaleTarget scaletarget.ScaleTargetAccessor) VLLMEngineParams {
-	params := defaultVLLMEngineParams()
+func ParseVLLMArgs(scaleTarget scaletarget.ScaleTargetAccessor) EngineParams {
+	params := defaultEngineParams()
 	if scaleTarget == nil {
 		resolveEffectiveMaxBatchedTokens(&params)
 		return params
@@ -164,7 +173,7 @@ func normalizeKey(key string) string {
 }
 
 // parseArgs walks the argument list and populates params using the vLLM flag mapping.
-func parseArgs(args []string, params *VLLMEngineParams) {
+func parseArgs(args []string, params *EngineParams) {
 	parseArgsWith(args, params, applyParam)
 }
 
@@ -173,7 +182,7 @@ func parseArgs(args []string, params *VLLMEngineParams) {
 // parsers, which differ only in their per-flag mapping (applyParam vs
 // applySGLangParam). Boolean flags (no following value) are passed with an empty
 // value string.
-func parseArgsWith(args []string, params *VLLMEngineParams, apply func(key, value string, params *VLLMEngineParams)) {
+func parseArgsWith(args []string, params *EngineParams, apply func(key, value string, params *EngineParams)) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if !strings.HasPrefix(arg, "--") {
@@ -199,11 +208,11 @@ func parseArgsWith(args []string, params *VLLMEngineParams, apply func(key, valu
 	}
 }
 
-// applyParam sets the corresponding VLLMEngineParams field from a
+// applyParam sets the corresponding EngineParams field from a
 // normalized key and its string value. Parse errors are silently ignored
 // and the default value is preserved — this is intentional graceful
 // degradation since deployment args are operator-controlled.
-func applyParam(key, value string, params *VLLMEngineParams) {
+func applyParam(key, value string, params *EngineParams) {
 	switch key {
 	case "gpu_memory_utilization":
 		if v, err := strconv.ParseFloat(value, 64); err == nil {
@@ -242,19 +251,21 @@ func applyParam(key, value string, params *VLLMEngineParams) {
 	}
 }
 
-// IsCapacityCompatible checks whether two VLLMEngineParams configurations
+// IsCapacityCompatible checks whether two EngineParams configurations
 // would produce equivalent per-replica capacity (both k1 and k2).
 // Used by CapacityKnowledgeStore.FindCompatible to identify variants
 // whose stored capacity can be reused for zero-replica estimation.
-func (p *VLLMEngineParams) IsCapacityCompatible(other *VLLMEngineParams) bool {
+func (p *EngineParams) IsCapacityCompatible(other *EngineParams) bool {
 	if p == nil || other == nil {
 		return false
 	}
-	return p.GpuMemoryUtilization == other.GpuMemoryUtilization &&
+	return p.Engine == other.Engine &&
+		p.GpuMemoryUtilization == other.GpuMemoryUtilization &&
 		p.BlockSize == other.BlockSize &&
 		p.KvCacheDtype == other.KvCacheDtype &&
 		p.TensorParallelSize == other.TensorParallelSize &&
 		p.NumGpuBlocksOverride == other.NumGpuBlocksOverride &&
+		p.TotalKvTokensOverride == other.TotalKvTokensOverride &&
 		p.EffectiveMaxBatchedTokens == other.EffectiveMaxBatchedTokens
 }
 
@@ -267,7 +278,7 @@ func (p *VLLMEngineParams) IsCapacityCompatible(other *VLLMEngineParams) bool {
 //  3. V0 engine with chunked prefill → 2048 (vLLM V0 default since v0.6.5)
 //  4. Unchunked prefill → max(MaxModelLen, 2048)
 //  5. Fallback → 2048
-func resolveEffectiveMaxBatchedTokens(params *VLLMEngineParams) {
+func resolveEffectiveMaxBatchedTokens(params *EngineParams) {
 	if params.MaxNumBatchedTokens > 0 {
 		params.EffectiveMaxBatchedTokens = params.MaxNumBatchedTokens
 		return

--- a/internal/engines/analyzers/saturation_v2/deployment_parser_test.go
+++ b/internal/engines/analyzers/saturation_v2/deployment_parser_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -209,71 +210,110 @@ var _ = Describe("ParseVLLMArgs", func() {
 
 var _ = Describe("IsCapacityCompatible", func() {
 	It("should return true for identical default params", func() {
-		p1 := defaultVLLMEngineParams()
+		p1 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p1)
-		p2 := defaultVLLMEngineParams()
+		p2 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p2)
 		Expect(p1.IsCapacityCompatible(&p2)).To(BeTrue())
 	})
 
 	It("should return false when GpuMemoryUtilization differs", func() {
-		p1 := defaultVLLMEngineParams()
+		p1 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p1)
-		p2 := defaultVLLMEngineParams()
+		p2 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p2)
 		p2.GpuMemoryUtilization = 0.5
 		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
 	})
 
 	It("should return false when BlockSize differs", func() {
-		p1 := defaultVLLMEngineParams()
+		p1 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p1)
-		p2 := defaultVLLMEngineParams()
+		p2 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p2)
 		p2.BlockSize = 32
 		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
 	})
 
 	It("should return false when KvCacheDtype differs", func() {
-		p1 := defaultVLLMEngineParams()
+		p1 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p1)
-		p2 := defaultVLLMEngineParams()
+		p2 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p2)
 		p2.KvCacheDtype = "fp8"
 		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
 	})
 
 	It("should return false when TensorParallelSize differs", func() {
-		p1 := defaultVLLMEngineParams()
+		p1 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p1)
-		p2 := defaultVLLMEngineParams()
+		p2 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p2)
 		p2.TensorParallelSize = 4
 		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
 	})
 
 	It("should return false when EffectiveMaxBatchedTokens differs", func() {
-		p1 := defaultVLLMEngineParams()
+		p1 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p1)
-		p2 := defaultVLLMEngineParams()
+		p2 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p2)
 		p2.EffectiveMaxBatchedTokens = 4096
 		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
 	})
 
+	It("should return false when the Engine differs (no cross-engine capacity reuse)", func() {
+		// Same model on the same hardware served by two engines must not share a
+		// capacity record: vLLM and SGLang derive KV capacity from different sources.
+		p1 := defaultEngineParams() // Engine == EngineVLLM
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultSGLangEngineParams() // Engine == EngineSGLang
+		// Force every other capacity field equal so only Engine distinguishes them.
+		p2.GpuMemoryUtilization = p1.GpuMemoryUtilization
+		p2.BlockSize = p1.BlockSize
+		p2.KvCacheDtype = p1.KvCacheDtype
+		p2.TensorParallelSize = p1.TensorParallelSize
+		p2.NumGpuBlocksOverride = p1.NumGpuBlocksOverride
+		p2.TotalKvTokensOverride = p1.TotalKvTokensOverride
+		resolveEffectiveMaxBatchedTokens(&p2)
+		p2.EffectiveMaxBatchedTokens = p1.EffectiveMaxBatchedTokens
+
+		Expect(p1.Engine).NotTo(Equal(p2.Engine))
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
+	})
+
+	It("should treat same-engine parsed params as Engine-compatible", func() {
+		p1 := ParseEngineArgs(inferenceengine.EngineSGLang, scaletarget.NewDeploymentAccessor(makeTestDeployment()))
+		p2 := ParseEngineArgs(inferenceengine.EngineSGLang, scaletarget.NewDeploymentAccessor(makeTestDeployment()))
+		Expect(p1.Engine).To(Equal(inferenceengine.EngineSGLang))
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeTrue())
+	})
+
+	It("should return false when TotalKvTokensOverride differs", func() {
+		// Two SGLang variants differing only in --max-total-tokens must NOT be
+		// treated as capacity-compatible: the override directly sets KV capacity.
+		p1 := defaultEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p2)
+		p1.TotalKvTokensOverride = 100000
+		p2.TotalKvTokensOverride = 200000
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
+	})
+
 	It("should return false when either param is nil", func() {
-		p1 := defaultVLLMEngineParams()
+		p1 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p1)
 		Expect(p1.IsCapacityCompatible(nil)).To(BeFalse())
 
-		var p2 *VLLMEngineParams
+		var p2 *EngineParams
 		Expect(p2.IsCapacityCompatible(&p1)).To(BeFalse())
 	})
 
 	It("should ignore non-capacity fields like MaxNumSeqs and MaxModelLen", func() {
-		p1 := defaultVLLMEngineParams()
+		p1 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p1)
-		p2 := defaultVLLMEngineParams()
+		p2 := defaultEngineParams()
 		resolveEffectiveMaxBatchedTokens(&p2)
 		p2.MaxNumSeqs = 512
 		p2.MaxModelLen = 16384

--- a/internal/engines/analyzers/saturation_v2/sglang_parser.go
+++ b/internal/engines/analyzers/saturation_v2/sglang_parser.go
@@ -9,19 +9,20 @@ import (
 
 // ParseEngineArgs parses a scale target's container args using the parser
 // appropriate for the given inference engine, returning the shared
-// VLLMEngineParams. It dispatches to ParseSGLangArgs for SGLang and ParseVLLMArgs
+// EngineParams. It dispatches to ParseSGLangArgs for SGLang and ParseVLLMArgs
 // otherwise (the default), so existing vLLM behavior is unchanged.
-func ParseEngineArgs(engine inferenceengine.Engine, scaleTarget scaletarget.ScaleTargetAccessor) VLLMEngineParams {
+func ParseEngineArgs(engine inferenceengine.Engine, scaleTarget scaletarget.ScaleTargetAccessor) EngineParams {
 	if engine == inferenceengine.EngineSGLang {
 		return ParseSGLangArgs(scaleTarget)
 	}
 	return ParseVLLMArgs(scaleTarget)
 }
 
-// defaultSGLangEngineParams returns VLLMEngineParams with SGLang defaults.
+// defaultSGLangEngineParams returns EngineParams with SGLang defaults.
 // Flag defaults were taken from SGLang's server_args.py.
-func defaultSGLangEngineParams() VLLMEngineParams {
-	return VLLMEngineParams{
+func defaultSGLangEngineParams() EngineParams {
+	return EngineParams{
+		Engine:               inferenceengine.EngineSGLang,
 		GpuMemoryUtilization: 0.9, // --mem-fraction-static default
 		BlockSize:            1,   // --page-size default
 		KvCacheDtype:         "auto",
@@ -41,7 +42,7 @@ func defaultSGLangEngineParams() VLLMEngineParams {
 //   - hyphen/underscore normalization
 //   - shell commands: ["/bin/sh", "-c", "python -m sglang.launch_server ..."]
 //   - boolean flags: --disable-cuda-graph (no value)
-func ParseSGLangArgs(scaleTarget scaletarget.ScaleTargetAccessor) VLLMEngineParams {
+func ParseSGLangArgs(scaleTarget scaletarget.ScaleTargetAccessor) EngineParams {
 	params := defaultSGLangEngineParams()
 	if scaleTarget == nil {
 		resolveEffectiveMaxBatchedTokens(&params)
@@ -65,11 +66,11 @@ func ParseSGLangArgs(scaleTarget scaletarget.ScaleTargetAccessor) VLLMEnginePara
 	return params
 }
 
-// applySGLangParam sets the corresponding VLLMEngineParams field from a
+// applySGLangParam sets the corresponding EngineParams field from a
 // normalized SGLang flag key and its string value. Parse errors are silently
 // ignored and the default value is preserved (graceful degradation), matching
 // the vLLM parser's behavior.
-func applySGLangParam(key, value string, params *VLLMEngineParams) {
+func applySGLangParam(key, value string, params *EngineParams) {
 	switch key {
 	case "mem_fraction_static":
 		if v, err := strconv.ParseFloat(value, 64); err == nil {

--- a/internal/engines/analyzers/saturation_v2/sglang_parser.go
+++ b/internal/engines/analyzers/saturation_v2/sglang_parser.go
@@ -1,0 +1,117 @@
+package saturation_v2
+
+import (
+	"strconv"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+// ParseEngineArgs parses a scale target's container args using the parser
+// appropriate for the given inference engine, returning the shared
+// VLLMEngineParams. It dispatches to ParseSGLangArgs for SGLang and ParseVLLMArgs
+// otherwise (the default), so existing vLLM behavior is unchanged.
+func ParseEngineArgs(engine inferenceengine.Engine, scaleTarget scaletarget.ScaleTargetAccessor) VLLMEngineParams {
+	if engine == inferenceengine.EngineSGLang {
+		return ParseSGLangArgs(scaleTarget)
+	}
+	return ParseVLLMArgs(scaleTarget)
+}
+
+// defaultSGLangEngineParams returns VLLMEngineParams with SGLang defaults.
+// Flag defaults were taken from SGLang's server_args.py.
+func defaultSGLangEngineParams() VLLMEngineParams {
+	return VLLMEngineParams{
+		GpuMemoryUtilization: 0.9, // --mem-fraction-static default
+		BlockSize:            1,   // --page-size default
+		KvCacheDtype:         "auto",
+		TensorParallelSize:   1,
+		// SGLang auto-derives --max-running-requests from available memory when
+		// unset; 256 is a conservative placeholder that underestimates capacity
+		// (safe: it biases toward scale-up rather than overload).
+		MaxNumSeqs:            256,
+		IsV1Engine:            true, // SGLang has a single (V1-style) engine
+		ChunkedPrefillEnabled: true, // chunked prefill is on by default
+	}
+}
+
+// ParseSGLangArgs scans a Deployment/LWS's containers for SGLang CLI arguments
+// and returns the parsed parameters. It mirrors ParseVLLMArgs:
+//   - --key=value and --key value argument formats
+//   - hyphen/underscore normalization
+//   - shell commands: ["/bin/sh", "-c", "python -m sglang.launch_server ..."]
+//   - boolean flags: --disable-cuda-graph (no value)
+func ParseSGLangArgs(scaleTarget scaletarget.ScaleTargetAccessor) VLLMEngineParams {
+	params := defaultSGLangEngineParams()
+	if scaleTarget == nil {
+		resolveEffectiveMaxBatchedTokens(&params)
+		return params
+	}
+
+	podTemplateSpec := scaleTarget.GetLeaderPodTemplateSpec()
+	if podTemplateSpec == nil || len(podTemplateSpec.Spec.Containers) == 0 {
+		resolveEffectiveMaxBatchedTokens(&params)
+		return params
+	}
+
+	for _, container := range podTemplateSpec.Spec.Containers {
+		// collectArgs and the --key/--key=value parsing loop are shared with the
+		// vLLM parser; only the per-flag mapping (applySGLangParam) differs.
+		allArgs := collectArgs(container.Command, container.Args)
+		parseArgsWith(allArgs, &params, applySGLangParam)
+	}
+
+	resolveEffectiveMaxBatchedTokens(&params)
+	return params
+}
+
+// applySGLangParam sets the corresponding VLLMEngineParams field from a
+// normalized SGLang flag key and its string value. Parse errors are silently
+// ignored and the default value is preserved (graceful degradation), matching
+// the vLLM parser's behavior.
+func applySGLangParam(key, value string, params *VLLMEngineParams) {
+	switch key {
+	case "mem_fraction_static":
+		if v, err := strconv.ParseFloat(value, 64); err == nil {
+			params.GpuMemoryUtilization = v
+		}
+	case "page_size":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.BlockSize = v
+		}
+	case "kv_cache_dtype":
+		params.KvCacheDtype = value
+	case "tp_size", "tensor_parallel_size", "tp":
+		if v, err := strconv.Atoi(value); err == nil {
+			params.TensorParallelSize = v
+		}
+	case "max_running_requests":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.MaxNumSeqs = v
+		}
+	case "max_total_tokens":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.TotalKvTokensOverride = v
+		}
+	case "context_length":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.MaxModelLen = v
+		}
+	case "max_prefill_tokens":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.MaxNumBatchedTokens = v
+		}
+	case "chunked_prefill_size":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			if v > 0 {
+				params.MaxNumBatchedTokens = v
+				params.ChunkedPrefillEnabled = true
+			} else {
+				// SGLang uses --chunked-prefill-size=-1 to disable chunked prefill.
+				params.ChunkedPrefillEnabled = false
+			}
+		}
+	case "disable_cuda_graph":
+		params.EnforceEager = true
+	}
+}

--- a/internal/engines/analyzers/saturation_v2/sglang_parser_test.go
+++ b/internal/engines/analyzers/saturation_v2/sglang_parser_test.go
@@ -65,6 +65,14 @@ var _ = Describe("ParseSGLangArgs", func() {
 			Expect(params.EnforceEager).To(BeTrue())
 		})
 
+		It("should map --max-prefill-tokens to the per-step token budget", func() {
+			deploy := makeTestDeployment("--max-prefill-tokens=16384")
+			params := ParseSGLangArgs(scaletarget.NewDeploymentAccessor(deploy))
+			Expect(params.MaxNumBatchedTokens).To(Equal(int64(16384)))
+			// With an explicit batched-token budget, it is used verbatim.
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(16384)))
+		})
+
 		It("should set the per-step token budget from --chunked-prefill-size", func() {
 			deploy := makeTestDeployment("--chunked-prefill-size=4096")
 			params := ParseSGLangArgs(scaletarget.NewDeploymentAccessor(deploy))

--- a/internal/engines/analyzers/saturation_v2/sglang_parser_test.go
+++ b/internal/engines/analyzers/saturation_v2/sglang_parser_test.go
@@ -1,0 +1,130 @@
+package saturation_v2
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+var _ = Describe("ParseSGLangArgs", func() {
+
+	Describe("Default values", func() {
+		It("should return SGLang defaults when no args are provided", func() {
+			deploy := makeTestDeployment() // no args
+			params := ParseSGLangArgs(scaletarget.NewDeploymentAccessor(deploy))
+
+			Expect(params.GpuMemoryUtilization).To(Equal(0.9))
+			Expect(params.BlockSize).To(Equal(int64(1))) // page-size default
+			Expect(params.KvCacheDtype).To(Equal("auto"))
+			Expect(params.TensorParallelSize).To(Equal(1))
+			Expect(params.MaxNumSeqs).To(Equal(int64(256)))
+			Expect(params.TotalKvTokensOverride).To(Equal(int64(0)))
+			Expect(params.EnforceEager).To(BeFalse())
+			Expect(params.IsV1Engine).To(BeTrue())
+			Expect(params.ChunkedPrefillEnabled).To(BeTrue())
+		})
+	})
+
+	Describe("SGLang flag mapping", func() {
+		It("should parse all known SGLang capacity flags", func() {
+			deploy := makeTestDeployment(
+				"--mem-fraction-static=0.85",
+				"--page-size=16",
+				"--kv-cache-dtype=fp8_e4m3",
+				"--tp-size=4",
+				"--max-running-requests=512",
+				"--max-total-tokens=131072",
+				"--context-length=8192",
+			)
+			params := ParseSGLangArgs(scaletarget.NewDeploymentAccessor(deploy))
+
+			Expect(params.GpuMemoryUtilization).To(Equal(0.85))
+			Expect(params.BlockSize).To(Equal(int64(16)))
+			Expect(params.KvCacheDtype).To(Equal("fp8_e4m3"))
+			Expect(params.TensorParallelSize).To(Equal(4))
+			Expect(params.MaxNumSeqs).To(Equal(int64(512)))
+			Expect(params.TotalKvTokensOverride).To(Equal(int64(131072)))
+			Expect(params.MaxModelLen).To(Equal(int64(8192)))
+		})
+
+		It("should accept --tp and --tensor-parallel-size aliases", func() {
+			Expect(ParseSGLangArgs(scaletarget.NewDeploymentAccessor(
+				makeTestDeployment("--tp", "8"))).TensorParallelSize).To(Equal(8))
+			Expect(ParseSGLangArgs(scaletarget.NewDeploymentAccessor(
+				makeTestDeployment("--tensor-parallel-size=2"))).TensorParallelSize).To(Equal(2))
+		})
+
+		It("should treat --disable-cuda-graph as enforce-eager (boolean flag)", func() {
+			deploy := makeTestDeployment("--disable-cuda-graph")
+			params := ParseSGLangArgs(scaletarget.NewDeploymentAccessor(deploy))
+			Expect(params.EnforceEager).To(BeTrue())
+		})
+
+		It("should set the per-step token budget from --chunked-prefill-size", func() {
+			deploy := makeTestDeployment("--chunked-prefill-size=4096")
+			params := ParseSGLangArgs(scaletarget.NewDeploymentAccessor(deploy))
+			Expect(params.MaxNumBatchedTokens).To(Equal(int64(4096)))
+			Expect(params.ChunkedPrefillEnabled).To(BeTrue())
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(4096)))
+		})
+
+		It("should disable chunked prefill when --chunked-prefill-size=-1", func() {
+			deploy := makeTestDeployment("--chunked-prefill-size=-1", "--context-length=4096")
+			params := ParseSGLangArgs(scaletarget.NewDeploymentAccessor(deploy))
+			Expect(params.ChunkedPrefillEnabled).To(BeFalse())
+			// Unchunked prefill falls back to max(MaxModelLen, 2048).
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(4096)))
+		})
+	})
+
+	Describe("Shell command parsing", func() {
+		It("should parse SGLang args from a shell command string", func() {
+			deploy := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "sglang",
+									Command: []string{"/bin/sh", "-c", "python3 -m sglang.launch_server --model-path m --mem-fraction-static=0.8 --max-running-requests 128"},
+								},
+							},
+						},
+					},
+				},
+			}
+			params := ParseSGLangArgs(scaletarget.NewDeploymentAccessor(deploy))
+			Expect(params.GpuMemoryUtilization).To(Equal(0.8))
+			Expect(params.MaxNumSeqs).To(Equal(int64(128)))
+		})
+	})
+
+	Describe("Nil scale target", func() {
+		It("should return defaults for a nil scale target", func() {
+			params := ParseSGLangArgs(nil)
+			Expect(params.GpuMemoryUtilization).To(Equal(0.9))
+			Expect(params.MaxNumSeqs).To(Equal(int64(256)))
+		})
+	})
+})
+
+var _ = Describe("ParseEngineArgs", func() {
+	It("should dispatch to the SGLang parser for EngineSGLang", func() {
+		deploy := makeTestDeployment("--max-running-requests=64")
+		params := ParseEngineArgs(inferenceengine.EngineSGLang, scaletarget.NewDeploymentAccessor(deploy))
+		Expect(params.MaxNumSeqs).To(Equal(int64(64)))
+		Expect(params.BlockSize).To(Equal(int64(1))) // SGLang page-size default
+	})
+
+	It("should dispatch to the vLLM parser for EngineVLLM", func() {
+		deploy := makeTestDeployment("--max-num-seqs=64")
+		params := ParseEngineArgs(inferenceengine.EngineVLLM, scaletarget.NewDeploymentAccessor(deploy))
+		Expect(params.MaxNumSeqs).To(Equal(int64(64)))
+		Expect(params.BlockSize).To(Equal(int64(16))) // vLLM block-size default
+	})
+})

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -175,7 +175,7 @@ func (a *ThroughputAnalyzer) Observe(
 //
 // Demand per variant is estimated in priority order:
 //  1. EPP primary: Σ ArrivalRate × AvgOutputTokens (when ArrivalRate > 0 on any replica).
-//  2. vLLM fallback: VLLMRequestRate × avgOL (when EPP absent but vLLM rate is nonzero).
+//  2. Engine-rate fallback: RequestRate × avgOL (when EPP absent but the engine completion rate is nonzero).
 //  3. k*-based local: Σ k_r* × KV_max_r / KVreq / ITL(k_r*) (scale-up only; no EPP needed).
 //
 // Scheduler queue demand (QueueSize / (DefaultQueueDrainFactor × ITL(k_sat))) is added
@@ -277,7 +277,7 @@ func (a *ThroughputAnalyzer) Analyze(
 		}
 
 		demand, isEPP := computeDemand(variantMetrics)
-		// k*-based local demand: when EPP and vLLM rate are both absent, or when
+		// k*-based local demand: when EPP and the engine completion rate are both absent, or when
 		// EPP is present but yields zero usable demand (warm-up, no completions yet),
 		// derive demand from observed KV utilization so a busy replica is not
 		// mis-classified as idle and spuriously scaled down.
@@ -516,7 +516,7 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 // computeDemand aggregates λ_dec (decode token demand in tokens/sec) across replicas.
 //
 // Primary path (EPP deployed): Σ ArrivalRate_r × AvgOutputTokens_r.
-// Fallback path (EPP absent): Σ VLLMRequestRate_r × AvgOutputTokens_r.
+// Fallback path (EPP absent): Σ RequestRate_r × AvgOutputTokens_r.
 //
 // Both paths use the per-replica product rather than sumRate × avgOL to avoid
 // averaging-the-averages: replicas with higher throughput contribute proportionally
@@ -524,9 +524,9 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 //
 // Returns (λ_dec, isEPP). isEPP is true when at least one replica reports ArrivalRate > 0.
 // When EPP is present but yields zero usable demand (warm-up: ArrivalRate > 0 but
-// AvgOutputTokens == 0), the function falls through to the vLLM proxy so the caller
-// can use computeLocalDemand when both paths yield zero. isEPP still reflects "EPP
-// present" so the anyEPP tracking in Analyze is unaffected.
+// AvgOutputTokens == 0), the function falls through to the engine request-rate proxy
+// so the caller can use computeLocalDemand when both paths yield zero. isEPP still
+// reflects "EPP present" so the anyEPP tracking in Analyze is unaffected.
 func computeDemand(metrics []interfaces.ReplicaMetrics) (float64, bool) {
 	var lambdaDec float64
 	var isEPP bool
@@ -542,20 +542,20 @@ func computeDemand(metrics []interfaces.ReplicaMetrics) (float64, bool) {
 		return lambdaDec, isEPP // EPP present and gave usable demand
 	}
 	// EPP absent, OR EPP present but zero usable demand (warm-up, no completions yet):
-	// fall through to the vLLM request-rate proxy.
-	// Σ VLLMRequestRate_r × AvgOutputTokens_r mirrors the EPP formula structure and
+	// fall through to the engine request-rate proxy.
+	// Σ RequestRate_r × AvgOutputTokens_r mirrors the EPP formula structure and
 	// correctly weights each replica's OL by its own throughput.
 	var lambdaDecFallback float64
 	for _, m := range metrics {
-		if m.VLLMRequestRate > 0 && m.AvgOutputTokens > 0 {
-			lambdaDecFallback += m.VLLMRequestRate * m.AvgOutputTokens
+		if m.RequestRate > 0 && m.AvgOutputTokens > 0 {
+			lambdaDecFallback += m.RequestRate * m.AvgOutputTokens
 		}
 	}
 	return lambdaDecFallback, isEPP // isEPP still reflects "EPP present"
 }
 
 // computeLocalDemand estimates decode token demand from per-replica k* observations
-// when the EPP ArrivalRate and vLLM request rate are both unavailable.
+// when the EPP ArrivalRate and the engine request rate are both unavailable.
 //
 //	λ_local = Σ_r (k_r* × KV_max_r / KVreq) / ITL(k_r*)
 //
@@ -630,10 +630,10 @@ func groupByVariant(metrics []interfaces.ReplicaMetrics) map[string][]interfaces
 	return groups
 }
 
-// averageShapeMetrics computes the VLLMRequestRate-weighted mean IL, OL, and
+// averageShapeMetrics computes the RequestRate-weighted mean IL, OL, and
 // prefix hit rate across a slice of replica metrics. Replicas with zero or
 // negative IL or OL are excluded. When all eligible replicas have zero
-// VLLMRequestRate, falls back to an unweighted mean.
+// RequestRate, falls back to an unweighted mean.
 func averageShapeMetrics(metrics []interfaces.ReplicaMetrics) (il, ol, hitRate float64) {
 	var sumIL, sumOL, sumHitRate float64 // weighted accumulators
 	var sumILu, sumOLu, sumHRu float64   // unweighted fallback
@@ -646,11 +646,11 @@ func averageShapeMetrics(metrics []interfaces.ReplicaMetrics) (il, ol, hitRate f
 		sumILu += m.AvgInputTokens
 		sumOLu += m.AvgOutputTokens
 		sumHRu += m.PrefixCacheHitRate
-		if m.VLLMRequestRate > 0 {
-			sumIL += m.VLLMRequestRate * m.AvgInputTokens
-			sumOL += m.VLLMRequestRate * m.AvgOutputTokens
-			sumHitRate += m.VLLMRequestRate * m.PrefixCacheHitRate
-			totalWeight += m.VLLMRequestRate
+		if m.RequestRate > 0 {
+			sumIL += m.RequestRate * m.AvgInputTokens
+			sumOL += m.RequestRate * m.AvgOutputTokens
+			sumHitRate += m.RequestRate * m.PrefixCacheHitRate
+			totalWeight += m.RequestRate
 		}
 	}
 	if count == 0 {

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -215,7 +215,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(result.Namespace).To(Equal(namespace))
 		})
 
-		It("returns zero signal when demand is zero (no ArrivalRate or VLLMRequestRate set)", func() {
+		It("returns zero signal when demand is zero (no ArrivalRate or RequestRate set)", func() {
 			metrics := makeMetrics("v1", 3, 0.20, 0.10)
 			input := interfaces.AnalyzerInput{
 				ModelID:        modelID,
@@ -338,7 +338,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("returns zero SpareCapacity when EPP is not deployed (ArrivalRate==0)", func() {
 			buildReadyWindow()
 
-			// ArrivalRate=0, VLLMRequestRate=0 → isEPP=false → no scale-down signal
+			// ArrivalRate=0, RequestRate=0 → isEPP=false → no scale-down signal
 			replica := baseReplica(0)
 			input := interfaces.AnalyzerInput{
 				ModelID:        modelID,
@@ -895,7 +895,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				{VariantName: "v1", KvCacheUsage: 0.95, KvUsageInstant: 0.95,
 					AvgITL: A*0.95 + B, AvgInputTokens: il, AvgOutputTokens: ol,
 					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
-					// ArrivalRate=0, VLLMRequestRate=0 → EPP absent
+					// ArrivalRate=0, RequestRate=0 → EPP absent
 				},
 				{VariantName: "v1", KvCacheUsage: 0.95, KvUsageInstant: 0.95,
 					AvgITL: A*0.95 + B, AvgInputTokens: il, AvgOutputTokens: ol,
@@ -933,7 +933,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("emits zero RequiredCapacity when OL is below the decode-dominated threshold", func() {
 			// OL=5 < DefaultMinDecodeOLForLocalDemand(20): the k*-based formula must not fire.
-			// EPP and vLLM paths are also absent (no ArrivalRate, no VLLMRequestRate).
+			// EPP and vLLM paths are also absent (no ArrivalRate, no RequestRate).
 			// Expected: demand=0, RC=0, SC=0.
 			const lowOL = 5.0
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, lowOL, prefix, kvMax, B, kValues)
@@ -947,7 +947,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				AvgOutputTokens:       lowOL,
 				PrefixCacheHitRate:    prefix,
 				TotalKvCapacityTokens: kvMax,
-				// ArrivalRate=0, VLLMRequestRate=0
+				// ArrivalRate=0, RequestRate=0
 			}
 			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
@@ -1304,14 +1304,14 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		})
 	})
 
-	Describe("averageShapeMetrics — VLLMRequestRate-weighted averaging", func() {
-		It("returns rate-weighted mean when replicas have different VLLMRequestRates", func() {
+	Describe("averageShapeMetrics — RequestRate-weighted averaging", func() {
+		It("returns rate-weighted mean when replicas have different RequestRates", func() {
 			// r1: rate=1, IL=1000, OL=200, hr=0.1
 			// r2: rate=3, IL=3000, OL=600, hr=0.5
 			// Weighted: IL=(1*1000+3*3000)/4=2500, OL=(1*200+3*600)/4=500, hr=(1*0.1+3*0.5)/4=0.4
 			metrics := []interfaces.ReplicaMetrics{
-				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, VLLMRequestRate: 1},
-				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, VLLMRequestRate: 3},
+				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, RequestRate: 1},
+				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, RequestRate: 3},
 			}
 			il, ol, hr := averageShapeMetrics(metrics)
 			Expect(il).To(BeNumerically("~", 2500.0, 1e-9))
@@ -1319,10 +1319,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(hr).To(BeNumerically("~", 0.4, 1e-9))
 		})
 
-		It("falls back to unweighted mean when all VLLMRequestRates are zero", func() {
+		It("falls back to unweighted mean when all RequestRates are zero", func() {
 			metrics := []interfaces.ReplicaMetrics{
-				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, VLLMRequestRate: 0},
-				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, VLLMRequestRate: 0},
+				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, RequestRate: 0},
+				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, RequestRate: 0},
 			}
 			il, ol, hr := averageShapeMetrics(metrics)
 			Expect(il).To(BeNumerically("~", 2000.0, 1e-9))
@@ -1334,8 +1334,8 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// r1 has rate=0: contributes only to unweighted fallback
 			// r2 has rate=2: drives the weighted result entirely
 			metrics := []interfaces.ReplicaMetrics{
-				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, VLLMRequestRate: 0},
-				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, VLLMRequestRate: 2},
+				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, RequestRate: 0},
+				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, RequestRate: 2},
 			}
 			il, ol, hr := averageShapeMetrics(metrics)
 			Expect(il).To(BeNumerically("~", 3000.0, 1e-9))

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -46,6 +46,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/common"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/executor"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
@@ -616,22 +617,10 @@ func (e *Engine) optimizeV1(
 		// not per role group. In P/D deployments, scaling prefill to zero while
 		// keeping decode (or vice versa) makes the model non-functional — both
 		// stages must scale together.
-		if len(modelDecisions) > 0 {
-			if !hasMinReplicasAboveZero(data.variantStates) {
-				scaleToZeroConfig := e.Config.ScaleToZeroConfigForNamespace(namespace)
-				scaledToZero := e.ScaleToZeroEnforcer.EnforcePolicyOnDecisions(
-					ctx, modelID, namespace,
-					modelDecisions, scaleToZeroConfig, "v1-saturation",
-				)
-				if scaledToZero {
-					logger.Info("Scale-to-zero enforcement applied",
-						"modelID", modelID)
-				}
-			} else {
-				logger.V(logging.DEBUG).Info("Skipping scale-to-zero enforcement: variant has minReplicas > 0",
-					"modelID", modelID)
-			}
-		}
+		e.applyScaleToZeroEnforcement(
+			ctx, modelID, namespace, "v1-saturation",
+			modelDecisions, data.scaleTargets, data.variantStates,
+		)
 
 		allDecisions = append(allDecisions, modelDecisions...)
 	}
@@ -816,6 +805,10 @@ func (e *Engine) optimizeV2(
 	requests := make([]pipeline.ModelScalingRequest, 0, len(modelGroups))
 	// modelReplicaMetrics collects per-model replica metrics for KV token enrichment
 	modelReplicaMetrics := make(map[string][]interfaces.ReplicaMetrics)
+	// modelScaleTargets carries each model's scale targets into stage 3, where
+	// applyScaleToZeroEnforcement needs them to gate the enforcer. Captured here
+	// because data.scaleTargets is only in scope during this collection loop.
+	modelScaleTargets := make(map[string]map[string]scaletarget.ScaleTargetAccessor)
 
 	for groupKey, modelVAs := range modelGroups {
 		modelID := modelVAs[0].Spec.ModelID
@@ -861,6 +854,7 @@ func (e *Engine) optimizeV2(
 
 		requests = append(requests, *req)
 		modelReplicaMetrics[modelID] = data.replicaMetrics
+		modelScaleTargets[utils.GetNamespacedKey(namespace, modelID)] = data.scaleTargets
 	}
 
 	if len(requests) == 0 {
@@ -879,23 +873,12 @@ func (e *Engine) optimizeV2(
 
 	// Stage 3: Apply enforcer per-model (directly on decisions)
 	for _, req := range requests {
-		// Skip scale-to-zero enforcement if any variant has minReplicas > 0
-		if hasMinReplicasAboveZero(req.VariantStates) {
-			logger.V(logging.DEBUG).Info("Skipping scale-to-zero enforcement (V2): variant has minReplicas > 0",
-				"modelID", req.ModelID)
-			continue
-		}
-
-		scaleToZeroConfig := e.Config.ScaleToZeroConfigForNamespace(req.Namespace)
-
-		scaledToZero := e.ScaleToZeroEnforcer.EnforcePolicyOnDecisions(
-			ctx, req.ModelID, req.Namespace,
-			allDecisions, scaleToZeroConfig, optimizer.Name(),
+		e.applyScaleToZeroEnforcement(
+			ctx, req.ModelID, req.Namespace, optimizer.Name(),
+			allDecisions,
+			modelScaleTargets[utils.GetNamespacedKey(req.Namespace, req.ModelID)],
+			req.VariantStates,
 		)
-		if scaledToZero {
-			logger.Info("Scale-to-zero enforcement applied (V2)",
-				"modelID", req.ModelID)
-		}
 	}
 
 	// Stage 4: Enrich decisions with KV cache token data from replicaMetrics.
@@ -1150,6 +1133,70 @@ func hasMinReplicasAboveZero(states []interfaces.VariantReplicaState) bool {
 		}
 	}
 	return false
+}
+
+// scaleToZeroSupportedForEngines reports whether scale-to-zero enforcement is safe
+// for a model running the given set of scale targets. Scale-to-zero relies on
+// CollectModelRequestCount, which is currently hardcoded to vLLM's request counter
+// (vllm:request_success_total); routing the per-engine counter through the enforcer
+// is the deferred Phase 2 work (see docs/proposals/sglang-backend.md). For any
+// non-vLLM engine that counter returns 0, which the enforcer would misread as
+// "no traffic" and scale the model to zero. Until the engine is threaded through,
+// scale-to-zero is skipped for models that run a non-vLLM engine.
+func scaleToZeroSupportedForEngines(scaleTargets map[string]scaletarget.ScaleTargetAccessor) bool {
+	for _, eng := range inferenceengine.Present(scaleTargets) {
+		if eng != inferenceengine.EngineVLLM {
+			return false
+		}
+	}
+	return true
+}
+
+// applyScaleToZeroEnforcement runs scale-to-zero / minimum-replica enforcement for a
+// single model's decisions, unless a safety gate skips it:
+//   - the model runs a non-vLLM engine — CollectModelRequestCount is hardcoded to
+//     vLLM's request counter, so an active SGLang model would falsely read as idle
+//     and be zeroed (see scaleToZeroSupportedForEngines); or
+//   - any variant declares minReplicas > 0 (hasMinReplicasAboveZero).
+//
+// Decisions are mutated in place; returns true if the model was scaled to zero.
+//
+// All three optimize paths (V1, V2, queueing-model) funnel their enforcement through
+// this one method so the gate lives in a single place — a caller cannot accidentally
+// invoke the enforcer ungated, and one test (engine_scale_to_zero_enforce_test.go)
+// locks the gate down for every path.
+func (e *Engine) applyScaleToZeroEnforcement(
+	ctx context.Context,
+	modelID, namespace, optimizerName string,
+	decisions []interfaces.VariantDecision,
+	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
+	variantStates []interfaces.VariantReplicaState,
+) bool {
+	if len(decisions) == 0 {
+		return false
+	}
+	logger := ctrl.LoggerFrom(ctx)
+
+	if !scaleToZeroSupportedForEngines(scaleTargets) {
+		logger.V(logging.DEBUG).Info("Skipping scale-to-zero enforcement: model runs a non-vLLM engine; engine-aware request counting is not yet wired through the enforcer (see docs/proposals/sglang-backend.md Phase 2)",
+			"modelID", modelID, "optimizer", optimizerName)
+		return false
+	}
+	if hasMinReplicasAboveZero(variantStates) {
+		logger.V(logging.DEBUG).Info("Skipping scale-to-zero enforcement: variant has minReplicas > 0",
+			"modelID", modelID, "optimizer", optimizerName)
+		return false
+	}
+
+	scaleToZeroConfig := e.Config.ScaleToZeroConfigForNamespace(namespace)
+	scaledToZero := e.ScaleToZeroEnforcer.EnforcePolicyOnDecisions(
+		ctx, modelID, namespace, decisions, scaleToZeroConfig, optimizerName,
+	)
+	if scaledToZero {
+		logger.Info("Scale-to-zero enforcement applied",
+			"modelID", modelID, "optimizer", optimizerName)
+	}
+	return scaledToZero
 }
 
 // normalizeRole maps empty and "both" roles to the same canonical key so that

--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -11,6 +11,8 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
 // optimizeQueueingModel runs the queueing model-based analysis path.
@@ -36,6 +38,10 @@ func (e *Engine) optimizeQueueingModel(
 
 	// Stage 1: Collect ModelScalingRequests for all models
 	requests := make([]pipeline.ModelScalingRequest, 0, len(modelGroups))
+	// modelScaleTargets carries each model's scale targets into stage 3, where
+	// applyScaleToZeroEnforcement needs them to gate the enforcer. Captured here
+	// because data.scaleTargets is only in scope during this collection loop.
+	modelScaleTargets := make(map[string]map[string]scaletarget.ScaleTargetAccessor)
 
 	for groupKey, modelVAs := range modelGroups {
 		modelID := modelVAs[0].Spec.ModelID
@@ -80,6 +86,7 @@ func (e *Engine) optimizeQueueingModel(
 			}},
 			VariantStates: data.variantStates,
 		})
+		modelScaleTargets[utils.GetNamespacedKey(namespace, modelID)] = data.scaleTargets
 	}
 
 	if len(requests) == 0 {
@@ -94,18 +101,16 @@ func (e *Engine) optimizeQueueingModel(
 		"decisionCount", len(allDecisions),
 		"modelCount", len(requests))
 
-	// Stage 3: Apply enforcer per-model (directly on decisions)
+	// Stage 3: Apply enforcer per-model (directly on decisions). Routed through the
+	// shared gate so a non-vLLM (e.g. SGLang) model is not falsely zeroed — the
+	// queueing-model path previously enforced ungated (see applyScaleToZeroEnforcement).
 	for _, req := range requests {
-		scaleToZeroConfig := e.Config.ScaleToZeroConfigForNamespace(req.Namespace)
-
-		scaledToZero := e.ScaleToZeroEnforcer.EnforcePolicyOnDecisions(
-			ctx, req.ModelID, req.Namespace,
-			allDecisions, scaleToZeroConfig, e.optimizer.Name(),
+		e.applyScaleToZeroEnforcement(
+			ctx, req.ModelID, req.Namespace, e.optimizer.Name(),
+			allDecisions,
+			modelScaleTargets[utils.GetNamespacedKey(req.Namespace, req.ModelID)],
+			req.VariantStates,
 		)
-		if scaledToZero {
-			logger.Info("Scale-to-zero enforcement applied (queueing-model)",
-				"modelID", req.ModelID)
-		}
 	}
 
 	return allDecisions

--- a/internal/engines/saturation/engine_scale_to_zero_enforce_test.go
+++ b/internal/engines/saturation/engine_scale_to_zero_enforce_test.go
@@ -1,0 +1,112 @@
+package saturation
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+// applyScaleToZeroEnforcement is the single seam every optimize path (V1, V2,
+// queueing-model) routes its enforcement through. These specs drive that seam with
+// a real, idle (request count 0) Enforcer and assert the gate's outcome end-to-end:
+// an SGLang model is left untouched while an otherwise-identical vLLM model is zeroed.
+// The vLLM case is the canary — it proves the SGLang case isn't passing simply because
+// the enforcer never ran; inverting the engine gate would flip both and fail here.
+var _ = Describe("applyScaleToZeroEnforcement", func() {
+	const (
+		modelID   = "test-model"
+		namespace = "test-ns"
+	)
+
+	var ctx = context.Background()
+
+	target := func(image string) scaletarget.ScaleTargetAccessor {
+		return scaletarget.NewDeploymentAccessor(&appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "server", Image: image}},
+					},
+				},
+			},
+		})
+	}
+
+	// engineWithIdleEnforcer builds an Engine whose enforcer always reads zero
+	// traffic and whose config enables scale-to-zero for the test model — so the
+	// enforcer will zero any model it is actually allowed to act on.
+	engineWithIdleEnforcer := func() *Engine {
+		cfg := config.NewTestConfig()
+		cfg.UpdateScaleToZeroConfigForNamespace(namespace, config.ScaleToZeroConfigData{
+			modelID: {EnableScaleToZero: ptrTo(true), RetentionPeriod: "10m"},
+		})
+		return &Engine{
+			Config: cfg,
+			ScaleToZeroEnforcer: pipeline.NewEnforcer(
+				func(context.Context, string, string, time.Duration) (float64, error) {
+					return 0, nil // idle: enforcer would scale to zero unless gated off
+				},
+			),
+		}
+	}
+
+	decisions := func() []interfaces.VariantDecision {
+		return []interfaces.VariantDecision{
+			{VariantName: "v1", ModelID: modelID, Namespace: namespace, Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 2},
+		}
+	}
+
+	It("zeroes an idle all-vLLM model (canary: the enforcer does run when ungated)", func() {
+		e := engineWithIdleEnforcer()
+		d := decisions()
+		scaledToZero := e.applyScaleToZeroEnforcement(ctx, modelID, namespace, "v1-saturation",
+			d, map[string]scaletarget.ScaleTargetAccessor{"a": target("vllm/vllm-openai:latest")}, nil)
+		Expect(scaledToZero).To(BeTrue())
+		Expect(d[0].TargetReplicas).To(Equal(0))
+	})
+
+	It("does NOT zero an idle SGLang model (engine gate skips the enforcer)", func() {
+		e := engineWithIdleEnforcer()
+		d := decisions()
+		scaledToZero := e.applyScaleToZeroEnforcement(ctx, modelID, namespace, "v2-saturation",
+			d, map[string]scaletarget.ScaleTargetAccessor{"a": target("lmsysorg/sglang:latest")}, nil)
+		Expect(scaledToZero).To(BeFalse())
+		Expect(d[0].TargetReplicas).To(Equal(2), "SGLang model must not be scaled to zero by the vLLM-hardcoded counter")
+	})
+
+	It("does NOT zero a mixed vLLM+SGLang model", func() {
+		e := engineWithIdleEnforcer()
+		d := decisions()
+		scaledToZero := e.applyScaleToZeroEnforcement(ctx, modelID, namespace, "queueing-model",
+			d, map[string]scaletarget.ScaleTargetAccessor{
+				"a": target("vllm/vllm-openai:latest"),
+				"b": target("lmsysorg/sglang:latest"),
+			}, nil)
+		Expect(scaledToZero).To(BeFalse())
+		Expect(d[0].TargetReplicas).To(Equal(2))
+	})
+
+	It("does NOT zero a vLLM model whose variant declares minReplicas > 0", func() {
+		e := engineWithIdleEnforcer()
+		d := decisions()
+		min := 1
+		scaledToZero := e.applyScaleToZeroEnforcement(ctx, modelID, namespace, "v1-saturation",
+			d, map[string]scaletarget.ScaleTargetAccessor{"a": target("vllm/vllm-openai:latest")},
+			[]interfaces.VariantReplicaState{{VariantName: "v1", MinReplicas: &min}})
+		Expect(scaledToZero).To(BeFalse())
+		Expect(d[0].TargetReplicas).To(Equal(2))
+	})
+})
+
+// ptrTo returns a pointer to v. Local helper so this file stays self-contained.
+func ptrTo[T any](v T) *T { return &v }

--- a/internal/engines/saturation/engine_scale_to_zero_gate_test.go
+++ b/internal/engines/saturation/engine_scale_to_zero_gate_test.go
@@ -1,0 +1,52 @@
+package saturation
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+// scaleToZeroSupportedForEngines is the safety gate that prevents an active
+// non-vLLM model from being scaled to zero by the vLLM-hardcoded request counter
+// (see CollectModelRequestCount). These specs lock in its behavior: only an
+// all-vLLM (or empty/unknown) target set may be scaled to zero.
+var _ = Describe("scaleToZeroSupportedForEngines", func() {
+	target := func(image string) scaletarget.ScaleTargetAccessor {
+		return scaletarget.NewDeploymentAccessor(&appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "server", Image: image}},
+					},
+				},
+			},
+		})
+	}
+	vllm := target("vllm/vllm-openai:latest")
+	sglang := target("lmsysorg/sglang:latest")
+
+	It("supports scale-to-zero for an all-vLLM model", func() {
+		Expect(scaleToZeroSupportedForEngines(
+			map[string]scaletarget.ScaleTargetAccessor{"a": vllm, "b": vllm})).To(BeTrue())
+	})
+
+	It("supports scale-to-zero for an empty or nil target set (defaults to vLLM)", func() {
+		Expect(scaleToZeroSupportedForEngines(nil)).To(BeTrue())
+		Expect(scaleToZeroSupportedForEngines(
+			map[string]scaletarget.ScaleTargetAccessor{})).To(BeTrue())
+	})
+
+	It("gates scale-to-zero off when any variant runs SGLang", func() {
+		Expect(scaleToZeroSupportedForEngines(
+			map[string]scaletarget.ScaleTargetAccessor{"a": sglang})).To(BeFalse())
+	})
+
+	It("gates scale-to-zero off for a mixed vLLM+SGLang model", func() {
+		Expect(scaleToZeroSupportedForEngines(
+			map[string]scaletarget.ScaleTargetAccessor{"a": vllm, "b": sglang})).To(BeFalse())
+	})
+})

--- a/internal/inferenceengine/engine.go
+++ b/internal/inferenceengine/engine.go
@@ -8,6 +8,7 @@
 package inferenceengine
 
 import (
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -67,20 +68,14 @@ func isSGLangContainer(c *corev1.Container) bool {
 	// Join command + args into a single lowercase string so we catch both the
 	// argv form (["python", "-m", "sglang.launch_server", ...]) and the shell
 	// form (["/bin/sh", "-c", "python -m sglang.launch_server ..."]).
-	var b strings.Builder
-	for _, tok := range c.Command {
-		b.WriteString(tok)
-		b.WriteByte(' ')
-	}
-	for _, tok := range c.Args {
-		b.WriteString(tok)
-		b.WriteByte(' ')
-	}
-	cmd := strings.ToLower(b.String())
+	cmd := strings.ToLower(strings.Join(slices.Concat(c.Command, c.Args), " "))
 
+	// Match only the documented launch forms. A bare "-m sglang" prefix is
+	// intentionally not matched: it is broader than the contract (it would also
+	// match "-m sglang_bench" and similar), and the two forms below already cover
+	// every supported SGLang launch.
 	return strings.Contains(cmd, "sglang.launch_server") ||
-		strings.Contains(cmd, "sglang serve") ||
-		strings.Contains(cmd, "-m sglang")
+		strings.Contains(cmd, "sglang serve")
 }
 
 // Present returns the deterministically-ordered set of distinct engines detected

--- a/internal/inferenceengine/engine.go
+++ b/internal/inferenceengine/engine.go
@@ -1,0 +1,107 @@
+// Package inferenceengine identifies which LLM inference engine (vLLM, SGLang)
+// a scale target runs. WVA's metric collection and deployment-argument parsing
+// are engine-specific, so the engine must be known before queries are built.
+//
+// Detection is conservative: a variant is treated as SGLang only when a strong
+// signal is present in its pod template. Everything else — including pods with no
+// recognizable signal — defaults to vLLM, preserving WVA's historical behavior.
+package inferenceengine
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+// Engine identifies an LLM inference engine.
+type Engine string
+
+const (
+	// EngineVLLM is the vLLM inference engine. It is the default when no other
+	// engine is detected, so existing deployments are unaffected.
+	EngineVLLM Engine = "vllm"
+
+	// EngineSGLang is the SGLang inference engine.
+	EngineSGLang Engine = "sglang"
+)
+
+// String returns the engine identifier (e.g. "vllm").
+func (e Engine) String() string {
+	return string(e)
+}
+
+// Detect inspects a scale target's leader pod template (container images,
+// commands, and args) and returns the inference engine it runs. It defaults to
+// EngineVLLM when the scale target is nil, has no pod template, or carries no
+// SGLang signal.
+func Detect(st scaletarget.ScaleTargetAccessor) Engine {
+	if st == nil {
+		return EngineVLLM
+	}
+	return detectFromPodTemplate(st.GetLeaderPodTemplateSpec())
+}
+
+// detectFromPodTemplate returns the engine implied by a pod template, defaulting
+// to EngineVLLM.
+func detectFromPodTemplate(tmpl *corev1.PodTemplateSpec) Engine {
+	if tmpl == nil {
+		return EngineVLLM
+	}
+	for i := range tmpl.Spec.Containers {
+		if isSGLangContainer(&tmpl.Spec.Containers[i]) {
+			return EngineSGLang
+		}
+	}
+	return EngineVLLM
+}
+
+// isSGLangContainer reports whether a container runs an SGLang server, based on
+// its image reference or launch command/args.
+func isSGLangContainer(c *corev1.Container) bool {
+	if strings.Contains(strings.ToLower(c.Image), "sglang") {
+		return true
+	}
+
+	// Join command + args into a single lowercase string so we catch both the
+	// argv form (["python", "-m", "sglang.launch_server", ...]) and the shell
+	// form (["/bin/sh", "-c", "python -m sglang.launch_server ..."]).
+	var b strings.Builder
+	for _, tok := range c.Command {
+		b.WriteString(tok)
+		b.WriteByte(' ')
+	}
+	for _, tok := range c.Args {
+		b.WriteString(tok)
+		b.WriteByte(' ')
+	}
+	cmd := strings.ToLower(b.String())
+
+	return strings.Contains(cmd, "sglang.launch_server") ||
+		strings.Contains(cmd, "sglang serve") ||
+		strings.Contains(cmd, "-m sglang")
+}
+
+// Present returns the deterministically-ordered set of distinct engines detected
+// across a collection of scale targets. vLLM is ordered first when present. When
+// the input is empty, it returns just EngineVLLM so callers always query at least
+// the default engine.
+func Present(scaleTargets map[string]scaletarget.ScaleTargetAccessor) []Engine {
+	seen := make(map[Engine]bool, 2)
+	for _, st := range scaleTargets {
+		seen[Detect(st)] = true
+	}
+	if len(seen) == 0 {
+		return []Engine{EngineVLLM}
+	}
+
+	// Deterministic order: vLLM first, then SGLang.
+	engines := make([]Engine, 0, len(seen))
+	for _, e := range []Engine{EngineVLLM, EngineSGLang} {
+		if seen[e] {
+			engines = append(engines, e)
+		}
+	}
+	return engines
+}

--- a/internal/inferenceengine/engine_test.go
+++ b/internal/inferenceengine/engine_test.go
@@ -48,8 +48,21 @@ func TestDetect(t *testing.T) {
 			want:      EngineSGLang,
 		},
 		{
+			name:      "SGLang serve subcommand",
+			container: corev1.Container{Name: "server", Image: "registry.example.com/serving:1.0", Command: []string{"sglang", "serve", "m"}},
+			want:      EngineSGLang,
+		},
+		{
 			name:      "no signal defaults to vLLM",
 			container: corev1.Container{Name: "server", Image: "registry.example.com/serving:1.0", Command: []string{"serve"}},
+			want:      EngineVLLM,
+		},
+		{
+			// Guard against the dropped over-broad "-m sglang" substring: a module
+			// whose name merely starts with "sglang" (e.g. a benchmark harness) must
+			// NOT be detected as an SGLang server.
+			name:      "-m sglang_bench is not an SGLang server (false-positive guard)",
+			container: corev1.Container{Name: "server", Image: "registry.example.com/serving:1.0", Command: []string{"python", "-m", "sglang_bench", "--model", "m"}},
 			want:      EngineVLLM,
 		},
 	}

--- a/internal/inferenceengine/engine_test.go
+++ b/internal/inferenceengine/engine_test.go
@@ -1,0 +1,120 @@
+package inferenceengine
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+func deploymentWith(container corev1.Container) scaletarget.ScaleTargetAccessor {
+	return scaletarget.NewDeploymentAccessor(&appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{container},
+				},
+			},
+		},
+	})
+}
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name      string
+		container corev1.Container
+		want      Engine
+	}{
+		{
+			name:      "vLLM image",
+			container: corev1.Container{Name: "server", Image: "vllm/vllm-openai:latest", Command: []string{"vllm", "serve", "m"}},
+			want:      EngineVLLM,
+		},
+		{
+			name:      "SGLang image",
+			container: corev1.Container{Name: "server", Image: "lmsysorg/sglang:v0.5.9-cu130-runtime"},
+			want:      EngineSGLang,
+		},
+		{
+			name:      "SGLang launch_server in args (argv form)",
+			container: corev1.Container{Name: "server", Image: "registry.example.com/serving:1.0", Command: []string{"python", "-m", "sglang.launch_server", "--model-path", "m"}},
+			want:      EngineSGLang,
+		},
+		{
+			name:      "SGLang launch_server in shell command",
+			container: corev1.Container{Name: "server", Command: []string{"/bin/sh", "-c", "python3 -m sglang.launch_server --model-path m --tp 2"}},
+			want:      EngineSGLang,
+		},
+		{
+			name:      "no signal defaults to vLLM",
+			container: corev1.Container{Name: "server", Image: "registry.example.com/serving:1.0", Command: []string{"serve"}},
+			want:      EngineVLLM,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Detect(deploymentWith(tt.container)); got != tt.want {
+				t.Errorf("Detect() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectNilAndEmpty(t *testing.T) {
+	if got := Detect(nil); got != EngineVLLM {
+		t.Errorf("Detect(nil) = %q, want %q", got, EngineVLLM)
+	}
+	empty := scaletarget.NewDeploymentAccessor(&appsv1.Deployment{})
+	if got := Detect(empty); got != EngineVLLM {
+		t.Errorf("Detect(empty) = %q, want %q", got, EngineVLLM)
+	}
+}
+
+func TestPresent(t *testing.T) {
+	vllm := deploymentWith(corev1.Container{Name: "s", Image: "vllm/vllm-openai"})
+	sglang := deploymentWith(corev1.Container{Name: "s", Image: "lmsysorg/sglang"})
+
+	tests := []struct {
+		name    string
+		targets map[string]scaletarget.ScaleTargetAccessor
+		want    []Engine
+	}{
+		{
+			name:    "empty defaults to vLLM",
+			targets: nil,
+			want:    []Engine{EngineVLLM},
+		},
+		{
+			name:    "vLLM only",
+			targets: map[string]scaletarget.ScaleTargetAccessor{"a": vllm},
+			want:    []Engine{EngineVLLM},
+		},
+		{
+			name:    "SGLang only",
+			targets: map[string]scaletarget.ScaleTargetAccessor{"a": sglang},
+			want:    []Engine{EngineSGLang},
+		},
+		{
+			name:    "mixed is vLLM-first deterministic",
+			targets: map[string]scaletarget.ScaleTargetAccessor{"a": sglang, "b": vllm},
+			want:    []Engine{EngineVLLM, EngineSGLang},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Present(tt.targets)
+			if len(got) != len(tt.want) {
+				t.Fatalf("Present() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("Present()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -135,13 +135,14 @@ type ReplicaMetrics struct {
 	// Zero when metrics are unavailable.
 	KvUsageInstant float64
 
-	// VLLMRequestRate is the vLLM-side request completion rate on this replica (req/s).
-	// Derived from rate(vllm:request_generation_tokens_count[1m]) per pod.
+	// RequestRate is the engine-side request completion rate on this replica (req/s).
+	// Engine-agnostic: derived per pod from rate(vllm:request_generation_tokens_count[1m])
+	// for vLLM and rate(sglang:generation_tokens_histogram_count[1m]) for SGLang.
 	// TA notation: fallback λ_req — used when ArrivalRate == 0 (EPP not deployed).
-	// λ_dec_fallback = sum(VLLMRequestRate) × avg(AvgOutputTokens).
+	// λ_dec_fallback = sum(RequestRate) × avg(AvgOutputTokens).
 	// Measures completed requests only; undercounts when requests queue in the scheduler.
 	// Zero when metrics are unavailable.
-	VLLMRequestRate float64
+	RequestRate float64
 }
 
 // ReplicaMetricsMetadata contains freshness information for replica metrics

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -187,14 +187,14 @@ func InitMetrics(registry prometheus.Registerer) error {
 	kvCacheTokensUsed = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVAKvCacheTokensUsed,
-			Help: "Total KV cache tokens currently in use across all replicas of a variant (sum of vLLM TokensInUse).",
+			Help: "Total KV cache tokens currently in use across all replicas of a variant (sum of per-replica TokensInUse).",
 		},
 		satModelLabels,
 	)
 	kvCacheTokensCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVAKvCacheTokensCapacity,
-			Help: "Total KV cache token capacity across all replicas of a variant (sum of vLLM TotalKvCapacityTokens).",
+			Help: "Total KV cache token capacity across all replicas of a variant (sum of per-replica TotalKvCapacityTokens).",
 		},
 		satModelLabels,
 	)

--- a/internal/utils/scaletarget/accessor.go
+++ b/internal/utils/scaletarget/accessor.go
@@ -30,7 +30,7 @@ type ScaleTargetAccessor interface {
 	// GetLeaderPodTemplateSpec returns the pod template for the leader/primary pod.
 	// For Deployment: the single pod template.
 	// For LWS: the leader template (falls back to worker template if not set).
-	// Use this for: vLLM args extraction (leader starts the API server),
+	// Use this for: engine args extraction (leader starts the API server),
 	// metrics port discovery, pod label matching.
 	GetLeaderPodTemplateSpec() *corev1.PodTemplateSpec
 

--- a/test/e2e/fixtures/sglang_emulator_builder.go
+++ b/test/e2e/fixtures/sglang_emulator_builder.go
@@ -1,0 +1,187 @@
+package fixtures
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	// sglangEmulatorImage is a CPU-only image used to run the synthetic SGLang
+	// metrics emitter. A real SGLang server needs a GPU; this emitter instead
+	// serves the sglang:* Prometheus metrics WVA consumes, so the engine-aware
+	// metric-collection path can be exercised in the kind-emulator environment.
+	// Not from docker.io, per the project's e2e image policy.
+	sglangEmulatorImage = "registry.access.redhat.com/ubi9/python-311:latest"
+	sglangScriptSuffix  = "-sglang-script"
+)
+
+// sglangEmitterScript is served at :8000/metrics. Counters grow with elapsed time
+// so rate()/increase() are non-zero; gauges hold a fixed saturated operating
+// point. The served model name is read from the MODEL env var so it matches the
+// VariantAutoscaling's modelID.
+const sglangEmitterScript = `import os, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+START = time.time()
+MODEL = os.environ.get("MODEL", "sglang-emulator-model")
+
+def render():
+    el = max(time.time() - START, 0.001)
+    L = 'model_name="%s"' % MODEL
+    out = []
+    def s(n, v):
+        out.append('%s{%s} %r' % (n, L, float(v)))
+    s("sglang:num_running_reqs", 5)
+    s("sglang:num_queue_reqs", 3)
+    s("sglang:token_usage", 0.85)
+    s("sglang:max_total_num_tokens", 100000)
+    s("sglang:num_requests_total", 2 * el)
+    s("sglang:prompt_tokens_total", 1000 * el)
+    s("sglang:cached_tokens_total", 300 * el)
+    s("sglang:time_to_first_token_seconds_count", 2 * el)
+    s("sglang:time_to_first_token_seconds_sum", 1.0 * el)
+    s("sglang:inter_token_latency_seconds_count", 200 * el)
+    s("sglang:inter_token_latency_seconds_sum", 4.0 * el)
+    s("sglang:prompt_tokens_histogram_count", 2 * el)
+    s("sglang:prompt_tokens_histogram_sum", 1000 * el)
+    s("sglang:generation_tokens_histogram_count", 2 * el)
+    s("sglang:generation_tokens_histogram_sum", 500 * el)
+    return ("\n".join(out) + "\n").encode()
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.startswith("/metrics"):
+            b = render()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(b)))
+            self.end_headers()
+            self.wfile.write(b)
+        else:
+            self.send_response(200); self.end_headers(); self.wfile.write(b"ok\n")
+    def log_message(self, *a):
+        pass
+
+print("sglang-emulator serving :8000/metrics for %s" % MODEL, flush=True)
+HTTPServer(("0.0.0.0", 8000), H).serve_forever()
+`
+
+// CreateSGLangEmulator deploys a synthetic SGLang model server: a CPU-only pod
+// that serves sglang:* metrics and whose launch command is a faithful
+// "python -m sglang.launch_server ..." line, so WVA's engine detection classifies
+// it as SGLang. It creates a ConfigMap ("<name>-sglang-script") and a Deployment
+// ("<name>-decode").
+//
+// Pair it with CreateService/EnsureServiceMonitor (appLabel "<name>-decode") and a
+// VariantAutoscaling whose ScaleTargetRef.Name is "<name>-decode". vaName is
+// stamped as the llm-d.ai/variant pod label for metric attribution (pass "" to
+// skip). The emitted metrics carry model_name == modelID.
+func CreateSGLangEmulator(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, modelID, vaName string) error {
+	appLabel := name + decodeNameSuffix
+	cmName := name + sglangScriptSuffix
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: namespace,
+			Labels:    map[string]string{"test-resource": defaultTestResourceLabelValue},
+		},
+		Data: map[string]string{"serve.py": sglangEmitterScript},
+	}
+	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("create sglang configmap %s: %w", cmName, err)
+	}
+
+	labels := map[string]string{
+		"app":                       appLabel,
+		"llm-d.ai/inferenceServing": defaultLabelValueTrue,
+		"test-resource":             defaultTestResourceLabelValue,
+	}
+	if vaName != "" {
+		labels["llm-d.ai/variant"] = vaName
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: appLabel, Namespace: namespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "sglang",
+							Image: sglangEmulatorImage,
+							// Faithful SGLang launch line: WVA's inferenceengine.Detect
+							// sees "sglang.launch_server" and ParseSGLangArgs reads these
+							// flags. serve.py ignores the extra argv.
+							Command: []string{"python3", "-u", "/app/serve.py"},
+							Args: []string{
+								"sglang.launch_server",
+								"--model-path=" + modelID,
+								"--mem-fraction-static=0.85",
+								"--max-running-requests=512",
+								"--page-size=16",
+								"--tp-size=1",
+								"--max-total-tokens=100000",
+								"--context-length=8192",
+								"--disable-cuda-graph",
+							},
+							Env: []corev1.EnvVar{{Name: "MODEL", Value: modelID}},
+							Ports: []corev1.ContainerPort{
+								{Name: defaultServicePortName, ContainerPort: defaultModelServiceContainerPort, Protocol: corev1.ProtocolTCP},
+							},
+							VolumeMounts: []corev1.VolumeMount{{Name: "script", MountPath: "/app"}},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "script",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if _, err := k8sClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("create sglang deployment %s: %w", appLabel, err)
+	}
+	return nil
+}
+
+// DeleteSGLangEmulator removes the emulator Deployment and ConfigMap. Idempotent;
+// ignores NotFound.
+func DeleteSGLangEmulator(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name string) error {
+	appLabel := name + decodeNameSuffix
+	if err := k8sClient.AppsV1().Deployments(namespace).Delete(ctx, appLabel, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("delete sglang deployment %s: %w", appLabel, err)
+	}
+	if err := k8sClient.CoreV1().ConfigMaps(namespace).Delete(ctx, name+sglangScriptSuffix, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("delete sglang configmap %s: %w", name+sglangScriptSuffix, err)
+	}
+	return nil
+}

--- a/test/e2e/fixtures/sglang_emulator_builder.go
+++ b/test/e2e/fixtures/sglang_emulator_builder.go
@@ -45,7 +45,11 @@ def render():
     s("sglang:max_total_num_tokens", 100000)
     s("sglang:num_requests_total", 2 * el)
     s("sglang:prompt_tokens_total", 1000 * el)
-    s("sglang:cached_tokens_total", 300 * el)
+    # cached_tokens_total carries an extra cache_source label (as real SGLang does),
+    # so its label set differs from prompt_tokens_total. The prefix-cache-hit-rate
+    # query must aggregate this label away before dividing; emitting it here keeps
+    # the e2e a genuine regression guard for that PromQL.
+    out.append('sglang:cached_tokens_total{%s,cache_source="radix_cache"} %r' % (L, float(300 * el)))
     s("sglang:time_to_first_token_seconds_count", 2 * el)
     s("sglang:time_to_first_token_seconds_sum", 1.0 * el)
     s("sglang:inter_token_latency_seconds_count", 200 * el)

--- a/test/e2e/sglang_backend_test.go
+++ b/test/e2e/sglang_backend_test.go
@@ -21,7 +21,7 @@ import (
 // This exercises the same code path as vLLM, only with SGLang metric names and
 // flags. It runs in the kind-emulator environment (cfg.UseSimulator); a real
 // SGLang server requires a GPU.
-var _ = Describe("SGLang backend", Ordered, func() {
+var _ = Describe("SGLang backend", Label("smoke", "full"), Ordered, func() {
 	const (
 		baseName = "e2e-sglang"
 		vaName   = "e2e-sglang-va"
@@ -68,6 +68,13 @@ var _ = Describe("SGLang backend", Ordered, func() {
 			// collected the SGLang metrics (vLLM queries would return nothing here).
 			g.Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).NotTo(BeNil(),
 				"WVA should compute a desired replica count from sglang:* metrics")
+			// Assert an actual scale-up rather than just a non-nil count: static
+			// arg-based capacity estimation alone would still produce a value even
+			// if engine routing were broken. The fixture emits a saturated operating
+			// point (token_usage=0.85, num_queue_reqs=3), so a correctly routed
+			// SGLang collection must drive the variant above a single replica.
+			g.Expect(*va.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically(">", 1),
+				"saturated sglang:* metrics should drive a scale-up above 1 replica")
 		}).WithTimeout(time.Duration(cfg.EventuallyExtendedSec) * time.Second).
 			WithPolling(time.Duration(cfg.PollIntervalSlowSec) * time.Second).
 			Should(Succeed())

--- a/test/e2e/sglang_backend_test.go
+++ b/test/e2e/sglang_backend_test.go
@@ -1,0 +1,75 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	variantautoscalingv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
+)
+
+// SGLang backend e2e: deploys a synthetic SGLang model server (CPU-only emitter of
+// sglang:* metrics, launched with a faithful `sglang.launch_server` command),
+// wires Prometheus scraping, and creates a VariantAutoscaling for it. It asserts
+// that WVA — with no engine configuration — detects SGLang, collects the sglang:*
+// metrics, and reconciles the variant to a desired allocation.
+//
+// This exercises the same code path as vLLM, only with SGLang metric names and
+// flags. It runs in the kind-emulator environment (cfg.UseSimulator); a real
+// SGLang server requires a GPU.
+var _ = Describe("SGLang backend", Ordered, func() {
+	const (
+		baseName = "e2e-sglang"
+		vaName   = "e2e-sglang-va"
+		// decodeSuffix mirrors the fixtures' "<base>-decode" naming convention.
+		decodeSuffix = "-decode"
+		// sglangEmulatorPort is the container/Service port the emitter serves on.
+		sglangEmulatorPort = 8000
+	)
+	var (
+		ctx      = context.Background()
+		appLabel = baseName + decodeSuffix
+		modelID  = "e2ewva/sglang-model"
+	)
+
+	BeforeAll(func() {
+		if !cfg.UseSimulator {
+			Skip("SGLang e2e uses a CPU-only metrics emitter; it runs in the kind-emulator environment (UseSimulator=true)")
+		}
+
+		By("Deploying the synthetic SGLang model server")
+		Expect(fixtures.CreateSGLangEmulator(ctx, k8sClient, cfg.LLMDNamespace, baseName, modelID, vaName)).To(Succeed())
+		DeferCleanup(func() { _ = fixtures.DeleteSGLangEmulator(ctx, k8sClient, cfg.LLMDNamespace, baseName) })
+
+		By("Exposing it via a Service and ServiceMonitor")
+		Expect(fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, baseName, appLabel, sglangEmulatorPort)).To(Succeed())
+		DeferCleanup(func() { _ = fixtures.DeleteService(ctx, k8sClient, cfg.LLMDNamespace, baseName) })
+		Expect(fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, cfg.LLMDNamespace, baseName, appLabel)).To(Succeed())
+		DeferCleanup(func() { _ = fixtures.DeleteServiceMonitor(ctx, crClient, cfg.MonitoringNS, baseName) })
+
+		By("Creating a VariantAutoscaling targeting the SGLang deployment")
+		Expect(fixtures.CreateVariantAutoscalingWithDefaults(
+			ctx, crClient, cfg.LLMDNamespace, vaName, appLabel, modelID, cfg.AcceleratorType, cfg.ControllerInstance,
+		)).To(Succeed())
+		DeferCleanup(func() { _ = fixtures.DeleteVariantAutoscaling(ctx, crClient, cfg.LLMDNamespace, vaName) })
+	})
+
+	It("detects SGLang and reconciles the variant from sglang:* metrics", func() {
+		Eventually(func(g Gomega) {
+			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+			g.Expect(crClient.Get(ctx, client.ObjectKey{Namespace: cfg.LLMDNamespace, Name: vaName}, va)).To(Succeed())
+			// WVA sets status conditions once it has reconciled the variant...
+			g.Expect(va.Status.Conditions).NotTo(BeEmpty(), "WVA should set status conditions for the SGLang variant")
+			// ...and computes a desired allocation, which is only possible if it
+			// collected the SGLang metrics (vLLM queries would return nothing here).
+			g.Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).NotTo(BeNil(),
+				"WVA should compute a desired replica count from sglang:* metrics")
+		}).WithTimeout(time.Duration(cfg.EventuallyExtendedSec) * time.Second).
+			WithPolling(time.Duration(cfg.PollIntervalSlowSec) * time.Second).
+			Should(Succeed())
+	})
+})


### PR DESCRIPTION
WVA is currently hard-wired to **vLLM**: every signal it collects assumes vLLM's
Prometheus metric names (`vllm:*`) and vLLM's deployment CLI flags. Operators
running **SGLang** model servers therefore can't use WVA at all — the collector
queries `vllm:*` series that SGLang pods never emit, so WVA sees no load and never
scales. This PR adds SGLang as a first-class inference-engine backend alongside
vLLM, with **zero behavior change for existing vLLM deployments**.

## Proposed Changes

- :gift: **Add SGLang as a second supported inference engine.** New
  `internal/inferenceengine` package detects the engine per variant from the pod
  spec (container image / launch command), defaulting to vLLM when no SGLang
  signal is present. Adds SGLang Prometheus metric constants and an SGLang
  deployment-arg parser (`ParseSGLangArgs` / `ParseEngineArgs`).
- :gift: **Engine-scoped metric queries.** Each engine-specific query now has an
  SGLang PromQL variant registered alongside the vLLM one (`EngineQuery` resolver;
  vLLM keeps its bare names). Includes the two *structural* differences, not just
  name swaps: KV-cache capacity via `sglang:max_total_num_tokens`, and prefix-cache
  hit rate via `sglang:cached_tokens_total / sglang:prompt_tokens_total`.
- :gift: **Engine-aware collection.** `CollectReplicaMetrics` detects the engines
  present for a model, refreshes the right query variants per engine, and merges
  per-engine results back under their logical names so per-pod processing stays
  engine-agnostic.
- :broom: **Refactor for reuse.** The vLLM arg-parse loop is extracted into a
  shared `parseArgsWith` helper used by both engines; the existing engine-params
  struct is reused (new `TotalKvTokensOverride` field for SGLang `--max-total-tokens`).
- :book: **Proposal doc** `docs/proposals/sglang-backend.md` with the full
  vLLM↔SGLang metric and CLI-flag mapping (sourced from SGLang's
  `observability/metrics_collector.py` and `server_args.py`).

vLLM remains the default and **all vLLM query/registration names are unchanged**,
so a deployment with no SGLang signal behaves exactly as before.

### Pre-review Checklist

- [x] **E2E tests** for any new behavior — `test/e2e/sglang_backend_test.go` plus a
  reusable fixture `test/e2e/fixtures/sglang_emulator_builder.go` (a CPU-only
  SGLang metrics emitter, launched with a faithful `sglang.launch_server` command):
  deploys it, wires a `ServiceMonitor`, creates a `VariantAutoscaling`, and asserts
  WVA detects SGLang and reconciles the variant from `sglang:*` metrics. Runs under
  `make test-e2e-*` (kind-emulator), like the rest of the e2e suite. Also covered by
  unit tests (detection, arg parsing, query registration, result merging) and an
  integration test that executes the registered SGLang template through the
  Prometheus source.
- [x] **Docs** for user-facing impact — `docs/user-guide/sglang-backend.md`
  (detection, metric/flag mapping, caveats). A guide in `llm-d/llm-d` is an optional
  follow-up (see Docs below).
- [x] **Proposal PR** for any new enhancement — `docs/proposals/sglang-backend.md`
  is included in this PR.

**Release Note**

```release-note
WVA now supports SGLang model servers in addition to vLLM. The inference engine is
auto-detected per variant from the deployment's pod spec (container image and launch
command), and SGLang's Prometheus metrics and serving flags are mapped onto WVA's
autoscaling signals (KV-cache utilization, queue depth, token throughput, latency,
and capacity).
```

**Docs**

<!-- Follow-up user-facing docs (separate PR in llm-d/llm-d):
- guide: https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling
- architecture: https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling
-->
TODO: link a follow-up docs/guide PR in llm-d/llm-d for SGLang backend usage.
