### PR TITLE
feat(engine): add HPA-style stabilization of scaling recommendations

### DIFF
--- a/docs/plans/engine/stabilization.md
+++ b/docs/plans/engine/stabilization.md
@@ -47,9 +47,13 @@ pipeline, in order, matches the HPA:
    since the optimizer already decided to act.
 3. **Per-period rate policies.** `Pods` and `Percent` policies cap the change
    per `periodSeconds`, budgeting against changes already actuated within the
-   period (tracked as per-key scale events). `selectPolicy` `Max`/`Min`/
-   `Disabled` combines competing policies. Defaults: scale-up the higher of
-   `+4 pods` or `+100%` per `60s`; scale-down `-100%` per `60s`.
+   period (the period start is reconstructed as `current − added + removed`
+   using both scale-up and scale-down events, as the HPA does). `selectPolicy`
+   `Max`/`Min`/`Disabled` combines competing policies. Defaults: scale-up the
+   higher of `+4 pods` or `+100%` per `60s`; scale-down `-100%` per `60s`. The
+   magnitudes and the `300s` down window match the HPA; the `60s` period is
+   chosen for WVA's ~30s optimize cadence rather than the controller's `15s`
+   default (which would make the budget a near no-op at that cadence).
 4. **Min/max clamp** to the variant's bounds.
 
 The `Stabilizer` is long-lived and concurrency-safe; it keeps the trailing
@@ -65,8 +69,8 @@ matches the HPA: stabilize the recommendation, then let the hard bounds have the
 last word. The existing emit path (Prometheus desired-replica gauge, internal
 decision cache, CRD status patch) carries the stabilized value unchanged.
 
-Each variant is keyed `namespace/variant[/role]`, so disaggregated prefill/decode
-scale targets are damped independently.
+Each variant is keyed `namespace/model/variant[/role]`, so disaggregated
+prefill/decode scale targets are damped independently.
 
 A `stabilization-decision` structured log line is emitted per model per cycle,
 grouped like the sibling `scaling-decision` line, with `curr`, `raw`

--- a/docs/plans/engine/stabilization.md
+++ b/docs/plans/engine/stabilization.md
@@ -1,0 +1,102 @@
+# HPA-style stabilization of optimizer recommendations
+
+## Motivation
+
+The optimizer produces a fresh per-variant replica target every optimize cycle
+(~30s). Acting on those targets directly is prone to flapping: a momentary load
+spike scales up and the next cycle scales straight back down. Today WVA leans on
+a downstream HorizontalPodAutoscaler to absorb this — WVA emits a desired-replica
+metric and the HPA's own stabilization window damps it.
+
+Stabilizing inside WVA is the prerequisite for WVA ever actuating `/scale`
+directly (the 1→N range), because patching the scale subresource without a
+stabilization window would lose the damping the HPA provides today and reproduce
+the flapping. This change implements that stabilization step; direct actuation is
+a separate, later step.
+
+## Design
+
+A small, self-contained `internal/stabilization` package ports the Kubernetes
+HorizontalPodAutoscaler **configurable scaling behavior** so an operator can
+express damping the familiar HPA way.
+
+- **Config types are reused** from `k8s.io/api/autoscaling/v2`
+  (`HorizontalPodAutoscalerBehavior`, `HPAScalingRules`, `HPAScalingPolicy`).
+  Already a dependency; maps 1:1 if WVA ever generates HPAs.
+- **The algorithm is clean-room.** The upstream behavior logic lives on
+  unexported methods of `HorizontalController` in `k8s.io/kubernetes`, which is
+  not consumable as a module. The behavior is documented at
+  [configurable-scaling-behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior),
+  so it is reimplemented rather than imported. Knative's KPA was also considered
+  and rejected (wrong domain — it smooths a request/concurrency metric, not a
+  replica recommendation — and heavy Knative coupling).
+
+### Algorithm
+
+`Stabilizer.Stabilize` damps one raw recommendation for one scale target. The
+pipeline, in order, matches the HPA:
+
+1. **Trailing stabilization window.** Per key, recent raw recommendations are
+   retained. The smallest recommendation over the scale-up window is a floor
+   (scale up only once every recent recommendation agrees); the largest over the
+   scale-down window is a ceiling (scale down only after the window decays). The
+   current replica count is clamped into `[floor, ceiling]`. Default windows:
+   scale-up `0s` (immediate), scale-down `300s`.
+2. **Tolerance deadband.** A change within the configured per-direction
+   tolerance fraction of current replicas is suppressed. Default `0` (disabled),
+   since the optimizer already decided to act.
+3. **Per-period rate policies.** `Pods` and `Percent` policies cap the change
+   per `periodSeconds`, budgeting against changes already actuated within the
+   period (tracked as per-key scale events). `selectPolicy` `Max`/`Min`/
+   `Disabled` combines competing policies. Defaults: scale-up the higher of
+   `+4 pods` or `+100%` per `60s`; scale-down `-100%` per `60s`.
+4. **Min/max clamp** to the variant's bounds.
+
+The `Stabilizer` is long-lived and concurrency-safe; it keeps the trailing
+windows and rate budgets in memory, mirroring the HPA controller, which keeps
+the same state in memory on the elected leader.
+
+### Wiring
+
+The stabilizer is applied in the V2 engine's `optimizeV2`, immediately after the
+optimizer produces decisions (and the `scaling-decision` cycle log) and **before**
+the scale-to-zero / minimum-replica enforcer. This ordering is deliberate and
+matches the HPA: stabilize the recommendation, then let the hard bounds have the
+last word. The existing emit path (Prometheus desired-replica gauge, internal
+decision cache, CRD status patch) carries the stabilized value unchanged.
+
+Each variant is keyed `namespace/variant[/role]`, so disaggregated prefill/decode
+scale targets are damped independently.
+
+A `stabilization-decision` structured log line is emitted per model per cycle,
+grouped like the sibling `scaling-decision` line, with `curr`, `raw`
+(optimizer recommendation) and `final` (stabilized) per variant.
+
+### Configuration
+
+Gated by `enableStabilization` in the saturation scaling config (default
+`false`), mirroring how `enableLimiter` gates the GPU limiter. When disabled the
+engine emits the optimizer's raw recommendation exactly as before — no
+operator-facing behavior change on upgrade. When enabled, the HPA default
+behavior is applied. Exposing the full per-policy behavior through config is a
+follow-up.
+
+## Known interactions
+
+- **Double stabilization.** If a downstream HPA also stabilizes the emitted
+  metric, lag compounds. The intended contract once this is enabled is that WVA
+  owns stabilization and the HPA `behavior` is set to near-passthrough. Until
+  that is wired and documented for operators, `enableStabilization` defaults off.
+- **Scale-to-zero.** The enforcer runs after stabilization and applies
+  scale-to-zero / minimum-replica floors as a hard override, so an idle model
+  still scales to zero even if the window is holding replicas high. The trailing
+  window records the pre-enforcement recommendation; recovery from zero is
+  handled by the scale-from-zero path.
+
+## Testing
+
+`internal/stabilization` has table-driven Ginkgo specs with an injectable clock
+covering: immediate default scale-up, the 300s scale-down hold-and-release, the
+scale-up window delay, per-period Pods/Percent rate caps, `selectPolicy`
+Max/Min/Disabled, the tolerance deadband, min/max clamping, and per-key
+isolation.

--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -33,6 +33,15 @@ type SaturationScalingConfig struct {
 	// Default is false (limiter disabled).
 	EnableLimiter bool `yaml:"enableLimiter,omitempty"`
 
+	// EnableStabilization: When true, applies HPA-style stabilization (a trailing
+	// scale-down window plus per-period rate policies) to the optimizer's
+	// per-variant targets before they are emitted, damping flapping. The
+	// HorizontalPodAutoscaler defaults are used: immediate scale-up rate-limited
+	// to the higher of +4 pods or +100% per 60s, and scale-down held by a 300s
+	// stabilization window. Default is false, preserving the prior behavior of
+	// emitting the optimizer's raw recommendation each cycle.
+	EnableStabilization bool `yaml:"enableStabilization,omitempty"`
+
 	// AnalyzerName selects which saturation analyzer to use.
 	// "saturation" uses the V2 token-based analyzer.
 	// Empty string (default) uses the V1 percentage-based analyzer.
@@ -218,6 +227,9 @@ func (c *SaturationScalingConfig) Merge(override SaturationScalingConfig) {
 	}
 	if override.EnableLimiter {
 		c.EnableLimiter = override.EnableLimiter
+	}
+	if override.EnableStabilization {
+		c.EnableStabilization = override.EnableStabilization
 	}
 	if override.Priority != 0 {
 		c.Priority = override.Priority

--- a/internal/config/saturation_scaling_test.go
+++ b/internal/config/saturation_scaling_test.go
@@ -446,6 +446,19 @@ var _ = Describe("SaturationScalingConfig", func() {
 			Expect(base.ModelID).To(Equal("llama-70b"))
 			Expect(base.Namespace).To(Equal("production"))
 		})
+
+		It("should propagate EnableStabilization from the override", func() {
+			base := SaturationScalingConfig{}
+			base.Merge(SaturationScalingConfig{EnableStabilization: true})
+			Expect(base.EnableStabilization).To(BeTrue())
+		})
+
+		It("should not clear EnableStabilization already set to true", func() {
+			base := SaturationScalingConfig{EnableStabilization: true}
+			base.Merge(SaturationScalingConfig{EnableStabilization: false})
+			Expect(base.EnableStabilization).To(BeTrue(),
+				"a false override must not revert an enabled flag (matches EnableLimiter semantics)")
+		})
 	})
 
 	Context("IsV2", func() {

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -362,6 +362,20 @@ func (d *VariantDecision) ReasonCategory() DecisionReason {
 	return d.decisionReason
 }
 
+// ActionForTarget returns the scaling action implied by comparing the
+// decision's TargetReplicas to its CurrentReplicas. Pipeline stages that adjust
+// TargetReplicas use it to recompute Action consistently.
+func (d *VariantDecision) ActionForTarget() SaturationAction {
+	switch {
+	case d.TargetReplicas > d.CurrentReplicas:
+		return ActionScaleUp
+	case d.TargetReplicas < d.CurrentReplicas:
+		return ActionScaleDown
+	default:
+		return ActionNoChange
+	}
+}
+
 // Reason returns the detailed human-readable reason for this decision.
 func (d *VariantDecision) Reason() string {
 	return d.reason

--- a/internal/domain/saturation_analyzer_test.go
+++ b/internal/domain/saturation_analyzer_test.go
@@ -102,3 +102,24 @@ func TestVariantDecision_SetDecisionReason_MultipleUpdates(t *testing.T) {
 		t.Errorf("Second update: Reason() = %v, want %v", decision.Reason(), "V2 (optimizer: cost-aware, enforced)")
 	}
 }
+
+func TestVariantDecision_ActionForTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		current int
+		target  int
+		want    SaturationAction
+	}{
+		{"target above current is scale-up", 2, 5, ActionScaleUp},
+		{"target below current is scale-down", 5, 2, ActionScaleDown},
+		{"target equal to current is no-change", 3, 3, ActionNoChange},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &VariantDecision{CurrentReplicas: tt.current, TargetReplicas: tt.target}
+			if got := d.ActionForTarget(); got != tt.want {
+				t.Errorf("ActionForTarget() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/engines/pipeline/enforcer.go
+++ b/internal/engines/pipeline/enforcer.go
@@ -182,15 +182,7 @@ func (e *Enforcer) ensureMinimumReplicasOnDecisions(
 // CurrentReplicas after enforcement and refreshes its reason. SetDecisionReason
 // is the single place that writes d.Action.
 func updateDecisionAction(d *domain.VariantDecision, optimizerName, policyType string, metricsEmitter *metrics.MetricsEmitter) {
-	var action domain.SaturationAction
-	switch {
-	case d.TargetReplicas > d.CurrentReplicas:
-		action = domain.ActionScaleUp
-	case d.TargetReplicas < d.CurrentReplicas:
-		action = domain.ActionScaleDown
-	default:
-		action = domain.ActionNoChange
-	}
+	action := d.ActionForTarget()
 	// Preserve the decision's original reason category (e.g. saturation-only on
 	// the V1 path) instead of hardcoding V2, so an enforced decision is not
 	// mis-attributed in the reason metric label. Fall back to V2 if it was unset.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -47,6 +47,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/stabilization"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
@@ -149,6 +150,12 @@ type Engine struct {
 	// ScaleToZeroEnforcer applies scale-to-zero and minimum replica enforcement
 	ScaleToZeroEnforcer *pipeline.Enforcer
 
+	// stabilizer damps the optimizer's raw per-variant targets with HPA-style
+	// scaling behavior. It is long-lived so its trailing recommendation windows
+	// and per-period rate budgets persist across optimize cycles. Applied only
+	// when EnableStabilization is set in the saturation config.
+	stabilizer *stabilization.Stabilizer
+
 	// GPULimiter constrains scaling decisions based on available GPU resources.
 	// Only applied when EnableLimiter is true in the saturation config.
 	GPULimiter pipeline.Limiter
@@ -242,6 +249,7 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 		Config:                  cfg,
 		ReplicaMetricsCollector: collector.NewReplicaMetricsCollector(promSource, client, recorder, podLocator),
 		ScaleToZeroEnforcer:     pipeline.NewEnforcer(requestCountFunc),
+		stabilizer:              stabilization.New(),
 		GPULimiter:              gpuLimiter,
 		metricsRegistry:         metricsRegistry,
 		saturationV2Analyzer:    satV2,
@@ -909,6 +917,10 @@ func (e *Engine) optimizeV2(
 		"optimizer", optimizer.Name(),
 		"decisionCount", len(allDecisions),
 		"modelCount", len(requests))
+
+	// Damp the raw recommendations with HPA-style stabilization before the
+	// enforcer and emit path see them. No-op unless enabled in config.
+	e.applyStabilization(ctx, allDecisions)
 
 	// Stage 3: Apply enforcer per-model (directly on decisions)
 	for _, req := range requests {

--- a/internal/engines/saturation/stabilization.go
+++ b/internal/engines/saturation/stabilization.go
@@ -3,6 +3,7 @@ package saturation
 import (
 	"context"
 
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
@@ -29,6 +30,14 @@ func (e *Engine) applyStabilization(ctx context.Context, decisions []interfaces.
 	logger := ctrl.LoggerFrom(ctx)
 	behavior := stabilization.DefaultBehavior()
 
+	// Bound the stabilizer's per-key history to the variants live this cycle, so
+	// keys for deleted variants do not accumulate.
+	active := make(map[string]struct{}, len(decisions))
+	for i := range decisions {
+		active[stabilizationKey(&decisions[i])] = struct{}{}
+	}
+	e.stabilizer.Forget(active)
+
 	type stabilizationEntry struct {
 		Name  string `json:"name"`
 		Role  string `json:"role,omitempty"`
@@ -45,8 +54,8 @@ func (e *Engine) applyStabilization(ctx context.Context, decisions []interfaces.
 			Key:             stabilizationKey(d),
 			CurrentReplicas: int32(d.CurrentReplicas),
 			DesiredReplicas: int32(d.TargetReplicas),
-			MinReplicas:     intPtrOrZero(d.MinReplicas),
-			MaxReplicas:     intPtrOrZero(d.MaxReplicas),
+			MinReplicas:     int32(ptr.Deref(d.MinReplicas, 0)),
+			MaxReplicas:     int32(ptr.Deref(d.MaxReplicas, 0)),
 			Behavior:        behavior,
 		})
 
@@ -89,29 +98,14 @@ func stabilizationKey(d *interfaces.VariantDecision) string {
 // retargetDecision recomputes a decision's Action after stabilization changed
 // its TargetReplicas, preserving the original reason category so the decision is
 // not mis-attributed in the reason metric label.
+//
+// A nil MinReplicas/MaxReplicas is passed to the stabilizer as 0, where a zero
+// MaxReplicas means "no cap" and a zero MinReplicas means "no floor" —
+// scale-to-zero and minimum-replica enforcement remain the enforcer's job.
 func retargetDecision(d *interfaces.VariantDecision) {
-	var action interfaces.SaturationAction
-	switch {
-	case d.TargetReplicas > d.CurrentReplicas:
-		action = interfaces.ActionScaleUp
-	case d.TargetReplicas < d.CurrentReplicas:
-		action = interfaces.ActionScaleDown
-	default:
-		action = interfaces.ActionNoChange
-	}
 	category := d.ReasonCategory()
 	if category == "" {
 		category = interfaces.DecisionReasonV2
 	}
-	d.SetDecisionReason(action, category, string(category)+" (stabilized)")
-}
-
-// intPtrOrZero dereferences an optional replica bound, returning 0 when unset.
-// A zero MaxReplicas means "no cap"; a zero MinReplicas means "no floor"
-// (scale-to-zero and minimum-replica enforcement remain the enforcer's job).
-func intPtrOrZero(v *int) int32 {
-	if v == nil {
-		return 0
-	}
-	return int32(*v)
+	d.SetDecisionReason(d.ActionForTarget(), category, string(category)+" (stabilized)")
 }

--- a/internal/engines/saturation/stabilization.go
+++ b/internal/engines/saturation/stabilization.go
@@ -36,7 +36,7 @@ func (e *Engine) applyStabilization(ctx context.Context, decisions []interfaces.
 	for i := range decisions {
 		active[stabilizationKey(&decisions[i])] = struct{}{}
 	}
-	e.stabilizer.Forget(active)
+	e.stabilizer.Retain(active)
 
 	type stabilizationEntry struct {
 		Name  string `json:"name"`
@@ -54,9 +54,11 @@ func (e *Engine) applyStabilization(ctx context.Context, decisions []interfaces.
 			Key:             stabilizationKey(d),
 			CurrentReplicas: int32(d.CurrentReplicas),
 			DesiredReplicas: int32(d.TargetReplicas),
-			MinReplicas:     int32(ptr.Deref(d.MinReplicas, 0)),
-			MaxReplicas:     int32(ptr.Deref(d.MaxReplicas, 0)),
 			Behavior:        behavior,
+			// 0 means no floor / no cap: scale-to-zero and minimum-replica
+			// enforcement remain the enforcer's job, not the stabilizer's.
+			MinReplicas: int32(ptr.Deref(d.MinReplicas, 0)),
+			MaxReplicas: int32(ptr.Deref(d.MaxReplicas, 0)),
 		})
 
 		raw := d.TargetReplicas
@@ -98,10 +100,6 @@ func stabilizationKey(d *interfaces.VariantDecision) string {
 // retargetDecision recomputes a decision's Action after stabilization changed
 // its TargetReplicas, preserving the original reason category so the decision is
 // not mis-attributed in the reason metric label.
-//
-// A nil MinReplicas/MaxReplicas is passed to the stabilizer as 0, where a zero
-// MaxReplicas means "no cap" and a zero MinReplicas means "no floor" —
-// scale-to-zero and minimum-replica enforcement remain the enforcer's job.
 func retargetDecision(d *interfaces.VariantDecision) {
 	category := d.ReasonCategory()
 	if category == "" {

--- a/internal/engines/saturation/stabilization.go
+++ b/internal/engines/saturation/stabilization.go
@@ -87,10 +87,12 @@ func (e *Engine) applyStabilization(ctx context.Context, decisions []interfaces.
 	}
 }
 
-// stabilizationKey identifies a scale target across cycles. Disaggregated P/D
-// variants have one scale target per role, so the role is part of the key.
+// stabilizationKey identifies a scale target across cycles. It includes the
+// model so that, even if two models in a namespace ever expose a same-named
+// variant, their histories never collide. Disaggregated P/D variants have one
+// scale target per role, so the role is part of the key too.
 func stabilizationKey(d *interfaces.VariantDecision) string {
-	key := d.Namespace + "/" + d.VariantName
+	key := d.Namespace + "/" + d.ModelID + "/" + d.VariantName
 	if d.Role != "" {
 		key += "/" + d.Role
 	}

--- a/internal/engines/saturation/stabilization.go
+++ b/internal/engines/saturation/stabilization.go
@@ -1,0 +1,117 @@
+package saturation
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/stabilization"
+)
+
+// applyStabilization damps the optimizer's raw per-variant targets with
+// HPA-style scaling behavior before the enforcer and emit path consume them.
+// It mutates decisions in place and is a no-op unless EnableStabilization is set
+// in the global ("default") saturation config — mirroring how the GPU limiter is
+// gated. Each variant (per role, when disaggregated) is stabilized independently
+// against its own trailing recommendation window and per-period rate budget,
+// retained on the Engine's long-lived stabilizer.
+func (e *Engine) applyStabilization(ctx context.Context, decisions []interfaces.VariantDecision) {
+	if e.stabilizer == nil || len(decisions) == 0 {
+		return
+	}
+
+	cfg, ok := e.Config.SaturationConfig()["default"]
+	if !ok || !cfg.EnableStabilization {
+		return
+	}
+
+	logger := ctrl.LoggerFrom(ctx)
+	behavior := stabilization.DefaultBehavior()
+
+	type stabilizationEntry struct {
+		Name  string `json:"name"`
+		Role  string `json:"role,omitempty"`
+		Curr  int    `json:"curr"`
+		Raw   int    `json:"raw"`   // optimizer recommendation
+		Final int    `json:"final"` // after stabilization
+	}
+	type modelKey struct{ ns, modelID string }
+	grouped := make(map[modelKey][]stabilizationEntry)
+
+	for i := range decisions {
+		d := &decisions[i]
+		res := e.stabilizer.Stabilize(stabilization.Args{
+			Key:             stabilizationKey(d),
+			CurrentReplicas: int32(d.CurrentReplicas),
+			DesiredReplicas: int32(d.TargetReplicas),
+			MinReplicas:     intPtrOrZero(d.MinReplicas),
+			MaxReplicas:     intPtrOrZero(d.MaxReplicas),
+			Behavior:        behavior,
+		})
+
+		raw := d.TargetReplicas
+		final := int(res.Replicas)
+		if final != raw {
+			d.TargetReplicas = final
+			retargetDecision(d)
+		}
+
+		k := modelKey{d.Namespace, d.ModelID}
+		grouped[k] = append(grouped[k], stabilizationEntry{
+			Name:  d.VariantName,
+			Role:  d.Role,
+			Curr:  d.CurrentReplicas,
+			Raw:   raw,
+			Final: final,
+		})
+	}
+
+	for k, entries := range grouped {
+		logger.Info("stabilization-decision",
+			"modelID", k.modelID,
+			"namespace", k.ns,
+			"decisions", entries,
+		)
+	}
+}
+
+// stabilizationKey identifies a scale target across cycles. Disaggregated P/D
+// variants have one scale target per role, so the role is part of the key.
+func stabilizationKey(d *interfaces.VariantDecision) string {
+	key := d.Namespace + "/" + d.VariantName
+	if d.Role != "" {
+		key += "/" + d.Role
+	}
+	return key
+}
+
+// retargetDecision recomputes a decision's Action after stabilization changed
+// its TargetReplicas, preserving the original reason category so the decision is
+// not mis-attributed in the reason metric label.
+func retargetDecision(d *interfaces.VariantDecision) {
+	var action interfaces.SaturationAction
+	switch {
+	case d.TargetReplicas > d.CurrentReplicas:
+		action = interfaces.ActionScaleUp
+	case d.TargetReplicas < d.CurrentReplicas:
+		action = interfaces.ActionScaleDown
+	default:
+		action = interfaces.ActionNoChange
+	}
+	category := d.ReasonCategory()
+	if category == "" {
+		category = interfaces.DecisionReasonV2
+	}
+	d.SetDecisionReason(action, category, string(category)+" (stabilized)")
+}
+
+// intPtrOrZero dereferences an optional replica bound, returning 0 when unset.
+// A zero MaxReplicas means "no cap"; a zero MinReplicas means "no floor"
+// (scale-to-zero and minimum-replica enforcement remain the enforcer's job).
+func intPtrOrZero(v *int) int32 {
+	if v == nil {
+		return 0
+	}
+	return int32(*v)
+}

--- a/internal/engines/saturation/stabilization.go
+++ b/internal/engines/saturation/stabilization.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/stabilization"
 )
 
@@ -17,7 +17,7 @@ import (
 // gated. Each variant (per role, when disaggregated) is stabilized independently
 // against its own trailing recommendation window and per-period rate budget,
 // retained on the Engine's long-lived stabilizer.
-func (e *Engine) applyStabilization(ctx context.Context, decisions []interfaces.VariantDecision) {
+func (e *Engine) applyStabilization(ctx context.Context, decisions []domain.VariantDecision) {
 	if e.stabilizer == nil || len(decisions) == 0 {
 		return
 	}
@@ -91,7 +91,7 @@ func (e *Engine) applyStabilization(ctx context.Context, decisions []interfaces.
 // model so that, even if two models in a namespace ever expose a same-named
 // variant, their histories never collide. Disaggregated P/D variants have one
 // scale target per role, so the role is part of the key too.
-func stabilizationKey(d *interfaces.VariantDecision) string {
+func stabilizationKey(d *domain.VariantDecision) string {
 	key := d.Namespace + "/" + d.ModelID + "/" + d.VariantName
 	if d.Role != "" {
 		key += "/" + d.Role
@@ -102,10 +102,10 @@ func stabilizationKey(d *interfaces.VariantDecision) string {
 // retargetDecision recomputes a decision's Action after stabilization changed
 // its TargetReplicas, preserving the original reason category so the decision is
 // not mis-attributed in the reason metric label.
-func retargetDecision(d *interfaces.VariantDecision) {
+func retargetDecision(d *domain.VariantDecision) {
 	category := d.ReasonCategory()
 	if category == "" {
-		category = interfaces.DecisionReasonV2
+		category = domain.DecisionReasonV2
 	}
 	d.SetDecisionReason(d.ActionForTarget(), category, string(category)+" (stabilized)")
 }

--- a/internal/engines/saturation/stabilization_test.go
+++ b/internal/engines/saturation/stabilization_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/stabilization"
 )
 
@@ -19,23 +19,22 @@ func newStabilizationEngine(enabled bool) *Engine {
 	return &Engine{stabilizer: stabilization.New(), Config: cfg}
 }
 
-func scaleDecision(ns, name, role string, current, target int) interfaces.VariantDecision {
-	d := interfaces.VariantDecision{
-		Namespace:       ns,
+func scaleDecision(current, target int) domain.VariantDecision {
+	d := domain.VariantDecision{
+		Namespace:       "ns",
 		ModelID:         "model",
-		VariantName:     name,
-		Role:            role,
+		VariantName:     "v",
 		CurrentReplicas: current,
 		TargetReplicas:  target,
 	}
-	d.SetDecisionReason(d.ActionForTarget(), interfaces.DecisionReasonV2, "V2 (optimizer: cost-aware)")
+	d.SetDecisionReason(d.ActionForTarget(), domain.DecisionReasonV2, "V2 (optimizer: cost-aware)")
 	return d
 }
 
 var _ = Describe("applyStabilization", func() {
 	It("is a no-op when EnableStabilization is false", func() {
 		e := newStabilizationEngine(false)
-		decisions := []interfaces.VariantDecision{scaleDecision("ns", "v", "", 2, 10)}
+		decisions := []domain.VariantDecision{scaleDecision(2, 10)}
 		e.applyStabilization(context.Background(), decisions)
 		Expect(decisions[0].TargetReplicas).To(Equal(10), "raw optimizer target must pass through unchanged")
 	})
@@ -43,18 +42,18 @@ var _ = Describe("applyStabilization", func() {
 	It("damps the target and recomputes the action when enabled", func() {
 		e := newStabilizationEngine(true)
 		// Default scale-up rate caps a 2->10 spike to max(+4 pods, +100%) = 6.
-		decisions := []interfaces.VariantDecision{scaleDecision("ns", "v", "", 2, 10)}
+		decisions := []domain.VariantDecision{scaleDecision(2, 10)}
 		e.applyStabilization(context.Background(), decisions)
 		Expect(decisions[0].TargetReplicas).To(Equal(6))
-		Expect(decisions[0].Action).To(Equal(interfaces.ActionScaleUp))
+		Expect(decisions[0].Action).To(Equal(domain.ActionScaleUp))
 	})
 
 	It("leaves the decision untouched when stabilization does not change the target", func() {
 		e := newStabilizationEngine(true)
 		// current=2, desired=3 is within the default +4-pods budget, so it passes through.
-		d := scaleDecision("ns", "v", "", 2, 3)
+		d := scaleDecision(2, 3)
 		wantReason := d.Reason()
-		decisions := []interfaces.VariantDecision{d}
+		decisions := []domain.VariantDecision{d}
 		e.applyStabilization(context.Background(), decisions)
 		Expect(decisions[0].TargetReplicas).To(Equal(3), "target passes through when the stabilizer agrees")
 		Expect(decisions[0].Reason()).To(Equal(wantReason), "reason is not rewritten when no retarget occurs")
@@ -63,26 +62,26 @@ var _ = Describe("applyStabilization", func() {
 
 var _ = Describe("stabilizationKey", func() {
 	It("omits the role for non-disaggregated variants", func() {
-		Expect(stabilizationKey(&interfaces.VariantDecision{Namespace: "ns", ModelID: "m", VariantName: "v"})).To(Equal("ns/m/v"))
+		Expect(stabilizationKey(&domain.VariantDecision{Namespace: "ns", ModelID: "m", VariantName: "v"})).To(Equal("ns/m/v"))
 	})
 
 	It("includes the role for disaggregated variants", func() {
-		Expect(stabilizationKey(&interfaces.VariantDecision{Namespace: "ns", ModelID: "m", VariantName: "v", Role: "prefill"})).To(Equal("ns/m/v/prefill"))
+		Expect(stabilizationKey(&domain.VariantDecision{Namespace: "ns", ModelID: "m", VariantName: "v", Role: "prefill"})).To(Equal("ns/m/v/prefill"))
 	})
 })
 
 var _ = Describe("retargetDecision", func() {
 	It("recomputes the action from the new target", func() {
-		d := scaleDecision("ns", "v", "", 5, 10) // initially scale-up
+		d := scaleDecision(5, 10) // initially scale-up
 		d.TargetReplicas = 3
 		retargetDecision(&d)
-		Expect(d.Action).To(Equal(interfaces.ActionScaleDown))
+		Expect(d.Action).To(Equal(domain.ActionScaleDown))
 	})
 
 	It("falls back to the V2 reason category when unset", func() {
-		d := &interfaces.VariantDecision{CurrentReplicas: 5, TargetReplicas: 3}
+		d := &domain.VariantDecision{CurrentReplicas: 5, TargetReplicas: 3}
 		retargetDecision(d)
-		Expect(d.ReasonCategory()).To(Equal(interfaces.DecisionReasonV2))
-		Expect(d.Action).To(Equal(interfaces.ActionScaleDown))
+		Expect(d.ReasonCategory()).To(Equal(domain.DecisionReasonV2))
+		Expect(d.Action).To(Equal(domain.ActionScaleDown))
 	})
 })

--- a/internal/engines/saturation/stabilization_test.go
+++ b/internal/engines/saturation/stabilization_test.go
@@ -22,6 +22,7 @@ func newStabilizationEngine(enabled bool) *Engine {
 func scaleDecision(ns, name, role string, current, target int) interfaces.VariantDecision {
 	d := interfaces.VariantDecision{
 		Namespace:       ns,
+		ModelID:         "model",
 		VariantName:     name,
 		Role:            role,
 		CurrentReplicas: current,
@@ -47,15 +48,26 @@ var _ = Describe("applyStabilization", func() {
 		Expect(decisions[0].TargetReplicas).To(Equal(6))
 		Expect(decisions[0].Action).To(Equal(interfaces.ActionScaleUp))
 	})
+
+	It("leaves the decision untouched when stabilization does not change the target", func() {
+		e := newStabilizationEngine(true)
+		// current=2, desired=3 is within the default +4-pods budget, so it passes through.
+		d := scaleDecision("ns", "v", "", 2, 3)
+		wantReason := d.Reason()
+		decisions := []interfaces.VariantDecision{d}
+		e.applyStabilization(context.Background(), decisions)
+		Expect(decisions[0].TargetReplicas).To(Equal(3), "target passes through when the stabilizer agrees")
+		Expect(decisions[0].Reason()).To(Equal(wantReason), "reason is not rewritten when no retarget occurs")
+	})
 })
 
 var _ = Describe("stabilizationKey", func() {
 	It("omits the role for non-disaggregated variants", func() {
-		Expect(stabilizationKey(&interfaces.VariantDecision{Namespace: "ns", VariantName: "v"})).To(Equal("ns/v"))
+		Expect(stabilizationKey(&interfaces.VariantDecision{Namespace: "ns", ModelID: "m", VariantName: "v"})).To(Equal("ns/m/v"))
 	})
 
 	It("includes the role for disaggregated variants", func() {
-		Expect(stabilizationKey(&interfaces.VariantDecision{Namespace: "ns", VariantName: "v", Role: "prefill"})).To(Equal("ns/v/prefill"))
+		Expect(stabilizationKey(&interfaces.VariantDecision{Namespace: "ns", ModelID: "m", VariantName: "v", Role: "prefill"})).To(Equal("ns/m/v/prefill"))
 	})
 })
 

--- a/internal/engines/saturation/stabilization_test.go
+++ b/internal/engines/saturation/stabilization_test.go
@@ -1,0 +1,76 @@
+package saturation
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/stabilization"
+)
+
+func newStabilizationEngine(enabled bool) *Engine {
+	cfg := config.NewTestConfig()
+	cfg.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{
+		"default": {EnableStabilization: enabled},
+	})
+	return &Engine{stabilizer: stabilization.New(), Config: cfg}
+}
+
+func scaleDecision(ns, name, role string, current, target int) interfaces.VariantDecision {
+	d := interfaces.VariantDecision{
+		Namespace:       ns,
+		VariantName:     name,
+		Role:            role,
+		CurrentReplicas: current,
+		TargetReplicas:  target,
+	}
+	d.SetDecisionReason(d.ActionForTarget(), interfaces.DecisionReasonV2, "V2 (optimizer: cost-aware)")
+	return d
+}
+
+var _ = Describe("applyStabilization", func() {
+	It("is a no-op when EnableStabilization is false", func() {
+		e := newStabilizationEngine(false)
+		decisions := []interfaces.VariantDecision{scaleDecision("ns", "v", "", 2, 10)}
+		e.applyStabilization(context.Background(), decisions)
+		Expect(decisions[0].TargetReplicas).To(Equal(10), "raw optimizer target must pass through unchanged")
+	})
+
+	It("damps the target and recomputes the action when enabled", func() {
+		e := newStabilizationEngine(true)
+		// Default scale-up rate caps a 2->10 spike to max(+4 pods, +100%) = 6.
+		decisions := []interfaces.VariantDecision{scaleDecision("ns", "v", "", 2, 10)}
+		e.applyStabilization(context.Background(), decisions)
+		Expect(decisions[0].TargetReplicas).To(Equal(6))
+		Expect(decisions[0].Action).To(Equal(interfaces.ActionScaleUp))
+	})
+})
+
+var _ = Describe("stabilizationKey", func() {
+	It("omits the role for non-disaggregated variants", func() {
+		Expect(stabilizationKey(&interfaces.VariantDecision{Namespace: "ns", VariantName: "v"})).To(Equal("ns/v"))
+	})
+
+	It("includes the role for disaggregated variants", func() {
+		Expect(stabilizationKey(&interfaces.VariantDecision{Namespace: "ns", VariantName: "v", Role: "prefill"})).To(Equal("ns/v/prefill"))
+	})
+})
+
+var _ = Describe("retargetDecision", func() {
+	It("recomputes the action from the new target", func() {
+		d := scaleDecision("ns", "v", "", 5, 10) // initially scale-up
+		d.TargetReplicas = 3
+		retargetDecision(&d)
+		Expect(d.Action).To(Equal(interfaces.ActionScaleDown))
+	})
+
+	It("falls back to the V2 reason category when unset", func() {
+		d := &interfaces.VariantDecision{CurrentReplicas: 5, TargetReplicas: 3}
+		retargetDecision(d)
+		Expect(d.ReasonCategory()).To(Equal(interfaces.DecisionReasonV2))
+		Expect(d.Action).To(Equal(interfaces.ActionScaleDown))
+	})
+})

--- a/internal/stabilization/behavior.go
+++ b/internal/stabilization/behavior.go
@@ -1,0 +1,101 @@
+package stabilization
+
+import (
+	"time"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+)
+
+// resolvedRules is the normalized form of an HPAScalingRules for one direction,
+// with all defaults filled in.
+type resolvedRules struct {
+	window       time.Duration
+	selectPolicy autoscalingv2.ScalingPolicySelect
+	policies     []autoscalingv2.HPAScalingPolicy
+	tolerance    float64 // fraction of current replicas; 0 disables the deadband
+}
+
+// behaviorScaleUp returns the scale-up rules from a behavior, or nil if unset.
+func behaviorScaleUp(b *autoscalingv2.HorizontalPodAutoscalerBehavior) *autoscalingv2.HPAScalingRules {
+	if b == nil {
+		return nil
+	}
+	return b.ScaleUp
+}
+
+// behaviorScaleDown returns the scale-down rules from a behavior, or nil if unset.
+func behaviorScaleDown(b *autoscalingv2.HorizontalPodAutoscalerBehavior) *autoscalingv2.HPAScalingRules {
+	if b == nil {
+		return nil
+	}
+	return b.ScaleDown
+}
+
+// resolveRules fills in HPA defaults for any unset field of an HPAScalingRules.
+// A nil rules value resolves entirely to the direction's defaults.
+//
+// Scale-up defaults: no stabilization window; allow the higher of +4 pods or
+// +100% per 60s. Scale-down defaults: a 300s stabilization window; allow -100%
+// per 60s. These mirror the upstream HorizontalPodAutoscaler.
+func resolveRules(rules *autoscalingv2.HPAScalingRules, scaleUp bool) resolvedRules {
+	out := resolvedRules{selectPolicy: autoscalingv2.MaxChangePolicySelect}
+	if scaleUp {
+		out.policies = defaultScaleUpPolicies()
+	} else {
+		out.window = DefaultDownscaleStabilizationWindow
+		out.policies = defaultScaleDownPolicies()
+	}
+
+	if rules == nil {
+		return out
+	}
+
+	if rules.StabilizationWindowSeconds != nil {
+		out.window = time.Duration(*rules.StabilizationWindowSeconds) * time.Second
+	}
+	if rules.SelectPolicy != nil {
+		out.selectPolicy = *rules.SelectPolicy
+	}
+	if len(rules.Policies) > 0 {
+		out.policies = rules.Policies
+	}
+	if rules.Tolerance != nil {
+		out.tolerance = rules.Tolerance.AsApproximateFloat64()
+	}
+	return out
+}
+
+func defaultScaleUpPolicies() []autoscalingv2.HPAScalingPolicy {
+	return []autoscalingv2.HPAScalingPolicy{
+		{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 60},
+		{Type: autoscalingv2.PercentScalingPolicy, Value: 100, PeriodSeconds: 60},
+	}
+}
+
+func defaultScaleDownPolicies() []autoscalingv2.HPAScalingPolicy {
+	return []autoscalingv2.HPAScalingPolicy{
+		{Type: autoscalingv2.PercentScalingPolicy, Value: 100, PeriodSeconds: 60},
+	}
+}
+
+// DefaultBehavior returns the HorizontalPodAutoscaler default scaling behavior:
+// immediate scale-up rate-limited to the higher of +4 pods or +100% per 60s,
+// and scale-down damped by a 300s stabilization window. Callers may use it as a
+// starting point and override individual fields.
+func DefaultBehavior() *autoscalingv2.HorizontalPodAutoscalerBehavior {
+	maxSelect := autoscalingv2.MaxChangePolicySelect
+	downWindow := int32(DefaultDownscaleStabilizationWindow / time.Second)
+	upWindow := int32(0)
+	return &autoscalingv2.HorizontalPodAutoscalerBehavior{
+		ScaleUp: &autoscalingv2.HPAScalingRules{
+			StabilizationWindowSeconds: &upWindow,
+			SelectPolicy:               &maxSelect,
+			Policies:                   defaultScaleUpPolicies(),
+		},
+		ScaleDown: &autoscalingv2.HPAScalingRules{
+			StabilizationWindowSeconds: &downWindow,
+			SelectPolicy:               &maxSelect,
+			Policies:                   defaultScaleDownPolicies(),
+		},
+	}
+}

--- a/internal/stabilization/behavior.go
+++ b/internal/stabilization/behavior.go
@@ -83,18 +83,21 @@ func defaultScaleDownPolicies() []autoscalingv2.HPAScalingPolicy {
 // and scale-down damped by a 300s stabilization window. Callers may use it as a
 // starting point and override individual fields.
 func DefaultBehavior() *autoscalingv2.HorizontalPodAutoscalerBehavior {
-	maxSelect := autoscalingv2.MaxChangePolicySelect
-	downWindow := int32(DefaultDownscaleStabilizationWindow / time.Second)
+	// Each direction gets its own pointers so a caller overriding one field via
+	// dereference (e.g. *b.ScaleUp.SelectPolicy = ...) cannot corrupt the other.
+	upSelect := autoscalingv2.MaxChangePolicySelect
+	downSelect := autoscalingv2.MaxChangePolicySelect
 	upWindow := int32(0)
+	downWindow := int32(DefaultDownscaleStabilizationWindow / time.Second)
 	return &autoscalingv2.HorizontalPodAutoscalerBehavior{
 		ScaleUp: &autoscalingv2.HPAScalingRules{
 			StabilizationWindowSeconds: &upWindow,
-			SelectPolicy:               &maxSelect,
+			SelectPolicy:               &upSelect,
 			Policies:                   defaultScaleUpPolicies(),
 		},
 		ScaleDown: &autoscalingv2.HPAScalingRules{
 			StabilizationWindowSeconds: &downWindow,
-			SelectPolicy:               &maxSelect,
+			SelectPolicy:               &downSelect,
 			Policies:                   defaultScaleDownPolicies(),
 		},
 	}

--- a/internal/stabilization/behavior.go
+++ b/internal/stabilization/behavior.go
@@ -31,12 +31,19 @@ func behaviorScaleDown(b *autoscalingv2.HorizontalPodAutoscalerBehavior) *autosc
 	return b.ScaleDown
 }
 
-// resolveRules fills in HPA defaults for any unset field of an HPAScalingRules.
+// resolveRules fills in default values for any unset field of an HPAScalingRules.
 // A nil rules value resolves entirely to the direction's defaults.
 //
 // Scale-up defaults: no stabilization window; allow the higher of +4 pods or
 // +100% per 60s. Scale-down defaults: a 300s stabilization window; allow -100%
-// per 60s. These mirror the upstream HorizontalPodAutoscaler.
+// per 60s, and a Max select policy.
+//
+// The pod/percent magnitudes (4, 100%) and the 300s scale-down window match the
+// HorizontalPodAutoscaler. The policy period is 60s rather than the HPA
+// controller's 15s default because WVA's optimize loop runs every ~30s, so a 60s
+// window spans a couple of cycles whereas 15s would make the per-period budget a
+// near no-op. (The autoscaling/v2 API documentation itself states the default as
+// "per 60 seconds", while the controller's defaulting uses 15s.)
 func resolveRules(rules *autoscalingv2.HPAScalingRules, scaleUp bool) resolvedRules {
 	out := resolvedRules{selectPolicy: autoscalingv2.MaxChangePolicySelect}
 	if scaleUp {

--- a/internal/stabilization/stabilization.go
+++ b/internal/stabilization/stabilization.go
@@ -20,6 +20,7 @@ package stabilization
 import (
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -136,14 +137,19 @@ func (s *Stabilizer) Stabilize(args Args) Result {
 	up := resolveRules(behaviorScaleUp(args.Behavior), true)
 	down := resolveRules(behaviorScaleDown(args.Behavior), false)
 
-	stabilized := s.applyStabilizationWindow(args.Key, args.CurrentReplicas, args.DesiredReplicas, now, up.window, down.window)
+	// One critical section for the whole operation so concurrent calls — even on
+	// the same key — observe and update the per-key history atomically.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stabilized := s.stabilizationWindowLocked(args.Key, args.CurrentReplicas, args.DesiredReplicas, now, up.window, down.window)
 	stabilized = applyTolerance(args.CurrentReplicas, stabilized, up.tolerance, down.tolerance)
 
-	rateLimited := s.applyRatePolicies(args.Key, args.CurrentReplicas, stabilized, now, up, down)
+	rateLimited := s.ratePoliciesLocked(args.Key, args.CurrentReplicas, stabilized, now, up, down)
 
 	final := clamp(rateLimited, args.MinReplicas, args.MaxReplicas)
 
-	s.recordScaleEvent(args.Key, args.CurrentReplicas, final, now)
+	s.recordScaleEventLocked(args.Key, args.CurrentReplicas, final, now)
 
 	return Result{
 		Replicas:   final,
@@ -152,16 +158,29 @@ func (s *Stabilizer) Stabilize(args Args) Result {
 	}
 }
 
-// applyStabilizationWindow records the raw recommendation and returns the
+// Forget drops all retained history for keys not present in active. The engine
+// calls it each cycle with the keys it is about to stabilize, bounding the
+// per-key maps to the live set of scale targets (variants come and go).
+func (s *Stabilizer) Forget(active map[string]struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k := range s.recommendations {
+		if _, ok := active[k]; !ok {
+			delete(s.recommendations, k)
+			delete(s.upEvents, k)
+			delete(s.downEvents, k)
+		}
+	}
+}
+
+// stabilizationWindowLocked records the raw recommendation and returns the
 // current replica count clamped into the band [min recent (up window), max
 // recent (down window)]. The smallest recommendation over the scale-up window
 // is a floor (scale up only when every recent recommendation agrees); the
 // largest recommendation over the scale-down window is a ceiling (scale down
 // only after the window has decayed).
-func (s *Stabilizer) applyStabilizationWindow(key string, current, desired int32, now time.Time, upWindow, downWindow time.Duration) int32 {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+// stabilizationWindowLocked must be called with s.mu held.
+func (s *Stabilizer) stabilizationWindowLocked(key string, current, desired int32, now time.Time, upWindow, downWindow time.Duration) int32 {
 	upCutoff := now.Add(-upWindow)
 	downCutoff := now.Add(-downWindow)
 	pruneCutoff := now.Add(-max(upWindow, downWindow))
@@ -212,18 +231,17 @@ func applyTolerance(current, stabilized int32, upTolerance, downTolerance float6
 	return stabilized
 }
 
-// applyRatePolicies caps the per-period change permitted by the scaling
+// ratePoliciesLocked caps the per-period change permitted by the scaling
 // policies, budgeting against the changes already actuated within each policy's
 // period.
-func (s *Stabilizer) applyRatePolicies(key string, current, desired int32, now time.Time, up, down resolvedRules) int32 {
+// ratePoliciesLocked must be called with s.mu held.
+func (s *Stabilizer) ratePoliciesLocked(key string, current, desired int32, now time.Time, up, down resolvedRules) int32 {
 	if desired == current {
 		return desired
 	}
 
-	s.mu.Lock()
 	upEvents := s.upEvents[key]
 	downEvents := s.downEvents[key]
-	s.mu.Unlock()
 
 	if desired > current {
 		limit := calculateScaleUpLimit(current, upEvents, now, up)
@@ -332,33 +350,25 @@ func replicasChangePerPeriod(periodSeconds int32, events []scaleEvent, now time.
 	return sum
 }
 
-// recordScaleEvent records an actuation's replica delta so future cycles can
-// budget rate policies against it. Stale events (older than the longest policy
-// period seen, capped at the stabilization ceiling) are pruned opportunistically.
-func (s *Stabilizer) recordScaleEvent(key string, from, to int32, now time.Time) {
+// recordScaleEventLocked records an actuation's replica delta so future cycles
+// can budget rate policies against it. Events older than the stabilization
+// ceiling are pruned opportunistically. Must be called with s.mu held.
+//
+// The delta is recorded against the value this stage produced (final), so the
+// rate budget stays accurate only while stabilization is the last stage that
+// determines the actuated replica count. Any future post-stabilization clamp in
+// the V2 path must update this event instead, or the budget will desync.
+func (s *Stabilizer) recordScaleEventLocked(key string, from, to int32, now time.Time) {
 	if to == from {
 		return
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	pruneCutoff := now.Add(-maxStabilizationWindow)
+	stale := func(e scaleEvent) bool { return !e.timestamp.After(pruneCutoff) }
 	if to > from {
-		s.upEvents[key] = append(pruneEvents(s.upEvents[key], pruneCutoff), scaleEvent{timestamp: now, replicas: to - from})
+		s.upEvents[key] = append(slices.DeleteFunc(s.upEvents[key], stale), scaleEvent{timestamp: now, replicas: to - from})
 	} else {
-		s.downEvents[key] = append(pruneEvents(s.downEvents[key], pruneCutoff), scaleEvent{timestamp: now, replicas: from - to})
+		s.downEvents[key] = append(slices.DeleteFunc(s.downEvents[key], stale), scaleEvent{timestamp: now, replicas: from - to})
 	}
-}
-
-// pruneEvents drops events at or before cutoff, reusing the backing array.
-func pruneEvents(events []scaleEvent, cutoff time.Time) []scaleEvent {
-	kept := events[:0]
-	for _, e := range events {
-		if e.timestamp.After(cutoff) {
-			kept = append(kept, e)
-		}
-	}
-	return kept
 }
 
 // clamp bounds v to [min, max]. The max bound is ignored when max <= 0.

--- a/internal/stabilization/stabilization.go
+++ b/internal/stabilization/stabilization.go
@@ -13,8 +13,8 @@
 // (HorizontalPodAutoscalerBehavior, HPAScalingRules, HPAScalingPolicy) so an
 // operator expresses stabilization the familiar HPA way. The algorithm is a
 // clean-room implementation of the behavior documented at
-// https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
-// it does not import k8s.io/kubernetes, which is not consumable as a module.
+// https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior.
+// It does not import k8s.io/kubernetes, which is not consumable as a module.
 package stabilization
 
 import (
@@ -98,8 +98,8 @@ func New(opts ...Option) *Stabilizer {
 // Args is the input to a single Stabilize call for one scale target.
 type Args struct {
 	// Key uniquely identifies the scale target across cycles (e.g.
-	// "namespace/variant" or "namespace/variant/role"). History is retained
-	// per Key.
+	// "namespace/model/variant" or "namespace/model/variant/role"). History is
+	// retained per Key.
 	Key string
 	// CurrentReplicas is the scale target's current replica count.
 	CurrentReplicas int32

--- a/internal/stabilization/stabilization.go
+++ b/internal/stabilization/stabilization.go
@@ -1,0 +1,386 @@
+// Package stabilization implements HorizontalPodAutoscaler-style damping of
+// raw replica recommendations.
+//
+// The workload-variant-autoscaler optimizer produces a fresh per-variant
+// replica target every reconcile cycle. Acting on those targets directly is
+// prone to flapping: a momentary load spike scales up and the following cycle
+// scales straight back down. Kubernetes' HorizontalPodAutoscaler solves this
+// with a configurable scaling behavior — a trailing stabilization window plus
+// per-period rate policies. This package ports that behavior so WVA can damp
+// its own recommendations before they are emitted.
+//
+// The configuration types are reused verbatim from k8s.io/api/autoscaling/v2
+// (HorizontalPodAutoscalerBehavior, HPAScalingRules, HPAScalingPolicy) so an
+// operator expresses stabilization the familiar HPA way. The algorithm is a
+// clean-room implementation of the behavior documented at
+// https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+// it does not import k8s.io/kubernetes, which is not consumable as a module.
+package stabilization
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+)
+
+// DefaultDownscaleStabilizationWindow is the trailing window over which the
+// largest recent recommendation is held to damp scale-down. It matches the
+// upstream HorizontalPodAutoscaler default.
+const DefaultDownscaleStabilizationWindow = 300 * time.Second
+
+// maxStabilizationWindow bounds how long any single recommendation sample is
+// retained, matching the upstream HPA ceiling on stabilizationWindowSeconds.
+const maxStabilizationWindow = 3600 * time.Second
+
+// Clock returns the current time. It is injectable so tests can drive the
+// trailing windows deterministically.
+type Clock func() time.Time
+
+// recommendation is a single timestamped raw replica recommendation, retained
+// to compute the trailing stabilization window.
+type recommendation struct {
+	timestamp time.Time
+	replicas  int32
+}
+
+// scaleEvent records that an actuation changed the replica count by a positive
+// magnitude at a point in time. Up and down events are tracked separately, as
+// the rate policies budget each direction independently.
+type scaleEvent struct {
+	timestamp time.Time
+	replicas  int32
+}
+
+// Stabilizer damps raw replica recommendations using HPA-style scaling
+// behavior. It is safe for concurrent use and retains per-key history across
+// calls, so a single long-lived instance should be shared across reconcile
+// cycles (mirroring the HPA controller, which keeps this state in memory on the
+// elected leader).
+type Stabilizer struct {
+	now Clock
+
+	mu              sync.Mutex
+	recommendations map[string][]recommendation
+	upEvents        map[string][]scaleEvent
+	downEvents      map[string][]scaleEvent
+}
+
+// Option customizes a Stabilizer.
+type Option func(*Stabilizer)
+
+// WithClock overrides the time source. Intended for tests.
+func WithClock(c Clock) Option {
+	return func(s *Stabilizer) {
+		if c != nil {
+			s.now = c
+		}
+	}
+}
+
+// New constructs a Stabilizer with empty history.
+func New(opts ...Option) *Stabilizer {
+	s := &Stabilizer{
+		now:             time.Now,
+		recommendations: make(map[string][]recommendation),
+		upEvents:        make(map[string][]scaleEvent),
+		downEvents:      make(map[string][]scaleEvent),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Args is the input to a single Stabilize call for one scale target.
+type Args struct {
+	// Key uniquely identifies the scale target across cycles (e.g.
+	// "namespace/variant" or "namespace/variant/role"). History is retained
+	// per Key.
+	Key string
+	// CurrentReplicas is the scale target's current replica count.
+	CurrentReplicas int32
+	// DesiredReplicas is the optimizer's raw recommendation for this cycle.
+	DesiredReplicas int32
+	// MinReplicas is the hard lower bound. The result is never below it.
+	MinReplicas int32
+	// MaxReplicas is the hard upper bound. Ignored when <= 0.
+	MaxReplicas int32
+	// Behavior carries the scale-up/scale-down rules. A nil Behavior, or a nil
+	// direction within it, falls back to the HPA defaults.
+	Behavior *autoscalingv2.HorizontalPodAutoscalerBehavior
+}
+
+// Result is the outcome of a Stabilize call.
+type Result struct {
+	// Replicas is the final stabilized, rate-limited and clamped target to act
+	// on.
+	Replicas int32
+	// Stabilized is the recommendation after the trailing window and tolerance
+	// deadband, before rate policies and min/max clamping. Exposed for
+	// observability.
+	Stabilized int32
+	// Reason is a short human-readable explanation of why Replicas differs from
+	// the raw DesiredReplicas, suitable for structured logs.
+	Reason string
+}
+
+// Stabilize damps a single raw recommendation. It records the recommendation
+// for future cycles and returns the target to act on. The pipeline is, in
+// order: trailing stabilization window, tolerance deadband, per-period rate
+// policies, then min/max clamp — matching the HorizontalPodAutoscaler.
+func (s *Stabilizer) Stabilize(args Args) Result {
+	now := s.now()
+	up := resolveRules(behaviorScaleUp(args.Behavior), true)
+	down := resolveRules(behaviorScaleDown(args.Behavior), false)
+
+	stabilized := s.applyStabilizationWindow(args.Key, args.CurrentReplicas, args.DesiredReplicas, now, up.window, down.window)
+	stabilized = applyTolerance(args.CurrentReplicas, stabilized, up.tolerance, down.tolerance)
+
+	rateLimited := s.applyRatePolicies(args.Key, args.CurrentReplicas, stabilized, now, up, down)
+
+	final := clamp(rateLimited, args.MinReplicas, args.MaxReplicas)
+
+	s.recordScaleEvent(args.Key, args.CurrentReplicas, final, now)
+
+	return Result{
+		Replicas:   final,
+		Stabilized: stabilized,
+		Reason:     reason(args.DesiredReplicas, stabilized, rateLimited, final),
+	}
+}
+
+// applyStabilizationWindow records the raw recommendation and returns the
+// current replica count clamped into the band [min recent (up window), max
+// recent (down window)]. The smallest recommendation over the scale-up window
+// is a floor (scale up only when every recent recommendation agrees); the
+// largest recommendation over the scale-down window is a ceiling (scale down
+// only after the window has decayed).
+func (s *Stabilizer) applyStabilizationWindow(key string, current, desired int32, now time.Time, upWindow, downWindow time.Duration) int32 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	upCutoff := now.Add(-upWindow)
+	downCutoff := now.Add(-downWindow)
+	pruneCutoff := now.Add(-max(upWindow, downWindow))
+
+	upRec := desired   // floor for scale-up: min over the up window
+	downRec := desired // ceiling for scale-down: max over the down window
+
+	hist := s.recommendations[key]
+	kept := hist[:0]
+	for _, r := range hist {
+		if r.timestamp.Before(pruneCutoff) {
+			continue // sample older than both windows; drop it
+		}
+		kept = append(kept, r)
+		if r.timestamp.After(upCutoff) && r.replicas < upRec {
+			upRec = r.replicas
+		}
+		if r.timestamp.After(downCutoff) && r.replicas > downRec {
+			downRec = r.replicas
+		}
+	}
+	s.recommendations[key] = append(kept, recommendation{timestamp: now, replicas: desired})
+
+	rec := current
+	if rec < upRec {
+		rec = upRec
+	}
+	if rec > downRec {
+		rec = downRec
+	}
+	return rec
+}
+
+// applyTolerance suppresses a scale change whose magnitude is within the
+// per-direction tolerance fraction of the current replica count. A tolerance of
+// zero disables the deadband for that direction.
+func applyTolerance(current, stabilized int32, upTolerance, downTolerance float64) int32 {
+	if current <= 0 || stabilized == current {
+		return stabilized
+	}
+	change := math.Abs(float64(stabilized-current)) / float64(current)
+	if stabilized > current && upTolerance > 0 && change < upTolerance {
+		return current
+	}
+	if stabilized < current && downTolerance > 0 && change < downTolerance {
+		return current
+	}
+	return stabilized
+}
+
+// applyRatePolicies caps the per-period change permitted by the scaling
+// policies, budgeting against the changes already actuated within each policy's
+// period.
+func (s *Stabilizer) applyRatePolicies(key string, current, desired int32, now time.Time, up, down resolvedRules) int32 {
+	if desired == current {
+		return desired
+	}
+
+	s.mu.Lock()
+	upEvents := s.upEvents[key]
+	downEvents := s.downEvents[key]
+	s.mu.Unlock()
+
+	if desired > current {
+		limit := calculateScaleUpLimit(current, upEvents, now, up)
+		if limit < current {
+			limit = current
+		}
+		if desired > limit {
+			return limit
+		}
+		return desired
+	}
+
+	limit := calculateScaleDownLimit(current, downEvents, now, down)
+	if limit > current {
+		limit = current
+	}
+	if desired < limit {
+		return limit
+	}
+	return desired
+}
+
+// calculateScaleUpLimit returns the highest replica count scaling up may reach
+// this cycle under the configured policies.
+func calculateScaleUpLimit(current int32, upEvents []scaleEvent, now time.Time, rules resolvedRules) int32 {
+	if rules.selectPolicy == autoscalingv2.DisabledPolicySelect {
+		return current
+	}
+	// With the default Max policy select, the most permissive (highest) proposal
+	// wins; with Min select, the most conservative (lowest) wins.
+	useMin := rules.selectPolicy == autoscalingv2.MinChangePolicySelect
+	result := int32(math.MinInt32)
+	if useMin {
+		result = math.MaxInt32
+	}
+	for _, p := range rules.policies {
+		addedInPeriod := replicasChangePerPeriod(p.PeriodSeconds, upEvents, now)
+		periodStart := current - addedInPeriod
+		var proposed int32
+		switch p.Type {
+		case autoscalingv2.PodsScalingPolicy:
+			proposed = periodStart + p.Value
+		case autoscalingv2.PercentScalingPolicy:
+			proposed = int32(math.Ceil(float64(periodStart) * (1 + float64(p.Value)/100)))
+		default:
+			continue
+		}
+		if useMin {
+			result = min(result, proposed)
+		} else {
+			result = max(result, proposed)
+		}
+	}
+	return result
+}
+
+// calculateScaleDownLimit returns the lowest replica count scaling down may
+// reach this cycle under the configured policies.
+func calculateScaleDownLimit(current int32, downEvents []scaleEvent, now time.Time, rules resolvedRules) int32 {
+	if rules.selectPolicy == autoscalingv2.DisabledPolicySelect {
+		return current
+	}
+	// For scale-down the proposals are lower bounds: with the default Max policy
+	// select the most permissive (lowest) wins; with Min select the most
+	// conservative (highest) wins.
+	useMax := rules.selectPolicy == autoscalingv2.MinChangePolicySelect
+	result := int32(math.MaxInt32)
+	if useMax {
+		result = math.MinInt32
+	}
+	for _, p := range rules.policies {
+		removedInPeriod := replicasChangePerPeriod(p.PeriodSeconds, downEvents, now)
+		periodStart := current + removedInPeriod
+		var proposed int32
+		switch p.Type {
+		case autoscalingv2.PodsScalingPolicy:
+			proposed = periodStart - p.Value
+		case autoscalingv2.PercentScalingPolicy:
+			proposed = int32(float64(periodStart) * (1 - float64(p.Value)/100))
+		default:
+			continue
+		}
+		if proposed < 0 {
+			proposed = 0
+		}
+		if useMax {
+			result = max(result, proposed)
+		} else {
+			result = min(result, proposed)
+		}
+	}
+	return result
+}
+
+// replicasChangePerPeriod sums the magnitude of events newer than periodSeconds
+// ago, giving how many replicas were already added (or removed) within the
+// current policy period.
+func replicasChangePerPeriod(periodSeconds int32, events []scaleEvent, now time.Time) int32 {
+	cutoff := now.Add(-time.Duration(periodSeconds) * time.Second)
+	var sum int32
+	for _, e := range events {
+		if e.timestamp.After(cutoff) {
+			sum += e.replicas
+		}
+	}
+	return sum
+}
+
+// recordScaleEvent records an actuation's replica delta so future cycles can
+// budget rate policies against it. Stale events (older than the longest policy
+// period seen, capped at the stabilization ceiling) are pruned opportunistically.
+func (s *Stabilizer) recordScaleEvent(key string, from, to int32, now time.Time) {
+	if to == from {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pruneCutoff := now.Add(-maxStabilizationWindow)
+	if to > from {
+		s.upEvents[key] = append(pruneEvents(s.upEvents[key], pruneCutoff), scaleEvent{timestamp: now, replicas: to - from})
+	} else {
+		s.downEvents[key] = append(pruneEvents(s.downEvents[key], pruneCutoff), scaleEvent{timestamp: now, replicas: from - to})
+	}
+}
+
+// pruneEvents drops events at or before cutoff, reusing the backing array.
+func pruneEvents(events []scaleEvent, cutoff time.Time) []scaleEvent {
+	kept := events[:0]
+	for _, e := range events {
+		if e.timestamp.After(cutoff) {
+			kept = append(kept, e)
+		}
+	}
+	return kept
+}
+
+// clamp bounds v to [min, max]. The max bound is ignored when max <= 0.
+func clamp(v, min, max int32) int32 {
+	if max > 0 && v > max {
+		v = max
+	}
+	if v < min {
+		v = min
+	}
+	return v
+}
+
+func reason(desired, stabilized, rateLimited, final int32) string {
+	switch {
+	case final == desired:
+		return "no stabilization applied"
+	case final != rateLimited:
+		return fmt.Sprintf("clamped to bounds: desired=%d final=%d", desired, final)
+	case rateLimited != stabilized:
+		return fmt.Sprintf("rate-limited: desired=%d stabilized=%d final=%d", desired, stabilized, final)
+	default:
+		return fmt.Sprintf("stabilization window applied: desired=%d final=%d", desired, final)
+	}
+}

--- a/internal/stabilization/stabilization.go
+++ b/internal/stabilization/stabilization.go
@@ -245,7 +245,7 @@ func (s *Stabilizer) ratePoliciesLocked(key string, current, desired int32, now 
 	downEvents := s.downEvents[key]
 
 	if desired > current {
-		limit := calculateScaleUpLimit(current, upEvents, now, up)
+		limit := calculateScaleUpLimit(current, upEvents, downEvents, now, up)
 		if limit < current {
 			limit = current
 		}
@@ -255,7 +255,7 @@ func (s *Stabilizer) ratePoliciesLocked(key string, current, desired int32, now 
 		return desired
 	}
 
-	limit := calculateScaleDownLimit(current, downEvents, now, down)
+	limit := calculateScaleDownLimit(current, upEvents, downEvents, now, down)
 	if limit > current {
 		limit = current
 	}
@@ -265,9 +265,20 @@ func (s *Stabilizer) ratePoliciesLocked(key string, current, desired int32, now 
 	return desired
 }
 
+// periodStartReplicas reconstructs the replica count at the start of a policy
+// period: current minus what was added plus what was removed within the period.
+// Both event directions are needed — an intervening scale in the opposite
+// direction must be accounted for or the budget baseline drifts. Matches the
+// upstream HPA (current - added + removed, used for both directions).
+func periodStartReplicas(current, periodSeconds int32, upEvents, downEvents []scaleEvent, now time.Time) int32 {
+	added := replicasChangePerPeriod(periodSeconds, upEvents, now)
+	removed := replicasChangePerPeriod(periodSeconds, downEvents, now)
+	return current - added + removed
+}
+
 // calculateScaleUpLimit returns the highest replica count scaling up may reach
 // this cycle under the configured policies.
-func calculateScaleUpLimit(current int32, upEvents []scaleEvent, now time.Time, rules resolvedRules) int32 {
+func calculateScaleUpLimit(current int32, upEvents, downEvents []scaleEvent, now time.Time, rules resolvedRules) int32 {
 	if rules.selectPolicy == autoscalingv2.DisabledPolicySelect {
 		return current
 	}
@@ -279,8 +290,7 @@ func calculateScaleUpLimit(current int32, upEvents []scaleEvent, now time.Time, 
 		result = math.MaxInt32
 	}
 	for _, p := range rules.policies {
-		addedInPeriod := replicasChangePerPeriod(p.PeriodSeconds, upEvents, now)
-		periodStart := current - addedInPeriod
+		periodStart := periodStartReplicas(current, p.PeriodSeconds, upEvents, downEvents, now)
 		var proposed int32
 		switch p.Type {
 		case autoscalingv2.PodsScalingPolicy:
@@ -301,7 +311,7 @@ func calculateScaleUpLimit(current int32, upEvents []scaleEvent, now time.Time, 
 
 // calculateScaleDownLimit returns the lowest replica count scaling down may
 // reach this cycle under the configured policies.
-func calculateScaleDownLimit(current int32, downEvents []scaleEvent, now time.Time, rules resolvedRules) int32 {
+func calculateScaleDownLimit(current int32, upEvents, downEvents []scaleEvent, now time.Time, rules resolvedRules) int32 {
 	if rules.selectPolicy == autoscalingv2.DisabledPolicySelect {
 		return current
 	}
@@ -314,8 +324,7 @@ func calculateScaleDownLimit(current int32, downEvents []scaleEvent, now time.Ti
 		result = math.MinInt32
 	}
 	for _, p := range rules.policies {
-		removedInPeriod := replicasChangePerPeriod(p.PeriodSeconds, downEvents, now)
-		periodStart := current + removedInPeriod
+		periodStart := periodStartReplicas(current, p.PeriodSeconds, upEvents, downEvents, now)
 		var proposed int32
 		switch p.Type {
 		case autoscalingv2.PodsScalingPolicy:
@@ -355,10 +364,14 @@ func replicasChangePerPeriod(periodSeconds int32, events []scaleEvent, now time.
 // can budget rate policies against it. Events older than the stabilization
 // ceiling are pruned opportunistically. Must be called with s.mu held.
 //
-// The delta is recorded against the value this stage produced (final), so the
-// rate budget stays accurate only while stabilization is the last stage that
-// determines the actuated replica count. Any future post-stabilization clamp in
-// the V2 path must update this event instead, or the budget will desync.
+// The delta is recorded against the value this stage produced (final). The
+// scale-to-zero / minimum-replica enforcer runs after stabilization and may
+// override the target, so the recorded delta can differ from what is finally
+// actuated. That is acceptable: scale-to-zero is an idle override (no traffic),
+// and a minimum-replica bump only under-counts a future up-budget, making the
+// next scale-up marginally more permissive — never less safe. A future
+// post-stabilization stage that needs exact budgeting would record the event
+// itself after actuation instead.
 func (s *Stabilizer) recordScaleEventLocked(key string, from, to int32, now time.Time) {
 	if to == from {
 		return
@@ -383,6 +396,8 @@ func clamp(v, min, max int32) int32 {
 	return v
 }
 
+// reason returns a short human-readable explanation of which pipeline stage was
+// responsible for the final replica count differing from the raw desired value.
 func reason(desired, stabilized, rateLimited, final int32) string {
 	switch {
 	case final == desired:

--- a/internal/stabilization/stabilization.go
+++ b/internal/stabilization/stabilization.go
@@ -158,10 +158,11 @@ func (s *Stabilizer) Stabilize(args Args) Result {
 	}
 }
 
-// Forget drops all retained history for keys not present in active. The engine
-// calls it each cycle with the keys it is about to stabilize, bounding the
-// per-key maps to the live set of scale targets (variants come and go).
-func (s *Stabilizer) Forget(active map[string]struct{}) {
+// Retain keeps history only for the given keys, dropping every other key's
+// trailing window and rate-event budget. The engine calls it each cycle with
+// the keys it is about to stabilize, bounding the per-key maps to the live set
+// of scale targets (variants come and go).
+func (s *Stabilizer) Retain(active map[string]struct{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for k := range s.recommendations {

--- a/internal/stabilization/stabilization_test.go
+++ b/internal/stabilization/stabilization_test.go
@@ -92,6 +92,30 @@ var _ = Describe("Stabilizer", func() {
 			clock.Advance(61 * time.Second)
 			Expect(s.Stabilize(args).Replicas).To(Equal(int32(5)), "after the window passes, scale-up proceeds")
 		})
+
+		It("freezes the current count when it sits inside the historical band", func() {
+			// Both directions windowed at 60s with generous rate policies, so only
+			// the trailing band governs.
+			up := rulesFor(60, autoscalingv2.MaxChangePolicySelect, podsPolicy(1000))
+			down := rulesFor(60, autoscalingv2.MaxChangePolicySelect, podsPolicy(1000))
+			args := Args{Key: "ns/v", Behavior: behaviorFor(up, down), MinReplicas: 0, MaxReplicas: 0}
+
+			// Seed the window with 5 then 10, so the band becomes [upRec=5, downRec=10].
+			args.CurrentReplicas, args.DesiredReplicas = 5, 5
+			s.Stabilize(args)
+			clock.Advance(20 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 5, 10
+			s.Stabilize(args)
+
+			// current=8 sits inside [5,10]; desired=7 is below current but still in
+			// the band, so neither the floor nor the ceiling clamp fires.
+			clock.Advance(20 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 8, 7
+			res := s.Stabilize(args)
+			Expect(res.Stabilized).To(Equal(int32(8)), "current inside the band is held, not the desired 7")
+			Expect(res.Replicas).To(Equal(int32(8)))
+			Expect(res.Reason).To(ContainSubstring("stabilization window applied"))
+		})
 	})
 
 	Describe("rate policies", func() {
@@ -139,6 +163,46 @@ var _ = Describe("Stabilizer", func() {
 			Entry("Min picks the most conservative (highest)", autoscalingv2.MinChangePolicySelect, int32(6)),
 			Entry("Disabled holds current", autoscalingv2.DisabledPolicySelect, int32(10)),
 		)
+
+		It("grants a fresh percent budget each period for scale-down", func() {
+			down := rulesFor(0, autoscalingv2.MaxChangePolicySelect, percentPolicy(50))
+			args := Args{Key: "ns/v", Behavior: behaviorFor(nil, down), MinReplicas: 0, MaxReplicas: 100}
+
+			args.CurrentReplicas, args.DesiredReplicas = 10, 0
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(5)), "first cycle: at most -50% -> 5")
+
+			clock.Advance(10 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 5, 0
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(5)), "budget already spent this period")
+
+			clock.Advance(61 * time.Second)
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(2)), "new period: -50% of current 5 -> 2")
+		})
+
+		It("reconstructs the period start from both directions (cross-direction budgeting)", func() {
+			// Scale-up +4 pods/60s; scale-down unlimited and un-stabilized so the
+			// intervening down actuates immediately and records a down event.
+			up := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(4))
+			down := rulesFor(0, autoscalingv2.MaxChangePolicySelect, percentPolicy(100))
+			b := behaviorFor(up, down)
+			args := Args{Key: "ns/v", Behavior: b, MinReplicas: 0, MaxReplicas: 100}
+
+			// t0: 2 -> 6 (records +4 up event).
+			args.CurrentReplicas, args.DesiredReplicas = 2, 6
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(6)))
+
+			// t20: load drops, 6 -> 2 (records -4 down event).
+			clock.Advance(20 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 6, 2
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(2)))
+
+			// t40: load spikes again, 2 -> 6. Both events are still in the 60s
+			// window: periodStart = 2 - 4(added) + 4(removed) = 2, so +4 reaches 6.
+			// (Same-direction-only accounting would wrongly pin this at 2.)
+			clock.Advance(20 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 2, 6
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(6)), "cross-direction term must restore the legitimate scale-up")
+		})
 	})
 
 	Describe("tolerance deadband", func() {
@@ -157,6 +221,23 @@ var _ = Describe("Stabilizer", func() {
 			clock.Advance(time.Second)
 			args.CurrentReplicas, args.DesiredReplicas = 10, 20
 			Expect(s.Stabilize(args).Replicas).To(Equal(int32(20)), "+100% exceeds the deadband")
+		})
+
+		It("suppresses a scale-down within the down-direction tolerance", func() {
+			down := &autoscalingv2.HPAScalingRules{
+				StabilizationWindowSeconds: ptr[int32](0),
+				SelectPolicy:               ptr(autoscalingv2.MaxChangePolicySelect),
+				Policies:                   []autoscalingv2.HPAScalingPolicy{podsPolicy(1000)},
+				Tolerance:                  ptr(resource.MustParse("0.5")),
+			}
+			args := Args{Key: "ns/v", Behavior: behaviorFor(nil, down), MinReplicas: 0, MaxReplicas: 20}
+
+			args.CurrentReplicas, args.DesiredReplicas = 10, 9
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(10)), "-10% is within the 50% down deadband")
+
+			clock.Advance(time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 10, 4
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(4)), "-60% exceeds the down deadband")
 		})
 
 		It("does not suppress scale-from-zero even when a tolerance is set", func() {
@@ -261,6 +342,23 @@ var _ = Describe("Stabilizer", func() {
 			Expect(res.Stabilized).To(Equal(int32(9)), "Stabilized is the window output, before rate limiting")
 			Expect(res.Replicas).To(Equal(int32(3)), "Replicas is rate-limited to +1")
 		})
+
+		DescribeTable("Reason names the stage responsible for the final value",
+			func(args Args, want string) {
+				Expect(s.Stabilize(args).Reason).To(ContainSubstring(want))
+			},
+			Entry("unchanged target",
+				Args{Key: "ns/v", CurrentReplicas: 4, DesiredReplicas: 4, MinReplicas: 1, MaxReplicas: 10},
+				"no stabilization applied"),
+			Entry("rate-limited",
+				Args{Key: "ns/v", Behavior: behaviorFor(rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(1)), nil),
+					CurrentReplicas: 2, DesiredReplicas: 9, MinReplicas: 1, MaxReplicas: 100},
+				"rate-limited"),
+			Entry("clamped to max",
+				Args{Key: "ns/c", Behavior: behaviorFor(rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(1000)), nil),
+					CurrentReplicas: 1, DesiredReplicas: 100, MinReplicas: 1, MaxReplicas: 5},
+				"clamped to bounds"),
+		)
 	})
 })
 

--- a/internal/stabilization/stabilization_test.go
+++ b/internal/stabilization/stabilization_test.go
@@ -127,6 +127,18 @@ var _ = Describe("Stabilizer", func() {
 			Entry("Min picks the most conservative", autoscalingv2.MinChangePolicySelect, int32(14)),
 			Entry("Disabled holds current", autoscalingv2.DisabledPolicySelect, int32(10)),
 		)
+
+		DescribeTable("selectPolicy combines competing scale-down policies",
+			func(sel autoscalingv2.ScalingPolicySelect, want int32) {
+				// From 10: Pods(-4) proposes 6; Percent(-50%) proposes 5.
+				down := rulesFor(0, sel, podsPolicy(4), percentPolicy(50))
+				res := s.Stabilize(Args{Key: "ns/v", Behavior: behaviorFor(nil, down), CurrentReplicas: 10, DesiredReplicas: 1, MinReplicas: 0, MaxReplicas: 100})
+				Expect(res.Replicas).To(Equal(want))
+			},
+			Entry("Max picks the most permissive (lowest)", autoscalingv2.MaxChangePolicySelect, int32(5)),
+			Entry("Min picks the most conservative (highest)", autoscalingv2.MinChangePolicySelect, int32(6)),
+			Entry("Disabled holds current", autoscalingv2.DisabledPolicySelect, int32(10)),
+		)
 	})
 
 	Describe("tolerance deadband", func() {
@@ -145,6 +157,17 @@ var _ = Describe("Stabilizer", func() {
 			clock.Advance(time.Second)
 			args.CurrentReplicas, args.DesiredReplicas = 10, 20
 			Expect(s.Stabilize(args).Replicas).To(Equal(int32(20)), "+100% exceeds the deadband")
+		})
+
+		It("does not suppress scale-from-zero even when a tolerance is set", func() {
+			up := &autoscalingv2.HPAScalingRules{
+				StabilizationWindowSeconds: ptr[int32](0),
+				SelectPolicy:               ptr(autoscalingv2.MaxChangePolicySelect),
+				Policies:                   []autoscalingv2.HPAScalingPolicy{podsPolicy(1000)},
+				Tolerance:                  ptr(resource.MustParse("0.9")),
+			}
+			res := s.Stabilize(Args{Key: "ns/v", Behavior: behaviorFor(up, nil), CurrentReplicas: 0, DesiredReplicas: 2, MinReplicas: 0, MaxReplicas: 100})
+			Expect(res.Replicas).To(Equal(int32(2)), "current=0 must not divide-by-zero into a suppressed change")
 		})
 	})
 
@@ -185,6 +208,29 @@ var _ = Describe("Stabilizer", func() {
 
 			byA := s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 2, MinReplicas: 1, MaxReplicas: 20})
 			Expect(byA.Replicas).To(Equal(int32(8)), "key a is still held by its own window")
+		})
+	})
+
+	Describe("Forget", func() {
+		It("drops history for keys not in the active set", func() {
+			// Build a high down-window history for key a.
+			s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 8, MinReplicas: 0, MaxReplicas: 20})
+			clock.Advance(10 * time.Second)
+
+			// Forget it (only key b is active this cycle).
+			s.Forget(map[string]struct{}{"ns/b": {}})
+
+			// With its window gone, key a's scale-down is no longer held at 8.
+			got := s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 2, MinReplicas: 0, MaxReplicas: 20}).Replicas
+			Expect(got).To(Equal(int32(2)), "forgotten history must not damp the next decision")
+		})
+
+		It("retains history for keys still in the active set", func() {
+			s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 8, MinReplicas: 0, MaxReplicas: 20})
+			clock.Advance(10 * time.Second)
+			s.Forget(map[string]struct{}{"ns/a": {}})
+			got := s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 2, MinReplicas: 0, MaxReplicas: 20}).Replicas
+			Expect(got).To(Equal(int32(8)), "retained window still holds the recent max")
 		})
 	})
 

--- a/internal/stabilization/stabilization_test.go
+++ b/internal/stabilization/stabilization_test.go
@@ -203,6 +203,37 @@ var _ = Describe("Stabilizer", func() {
 			args.CurrentReplicas, args.DesiredReplicas = 2, 6
 			Expect(s.Stabilize(args).Replicas).To(Equal(int32(6)), "cross-direction term must restore the legitimate scale-up")
 		})
+
+		It("reconstructs the period start from both directions for scale-down", func() {
+			// Symmetric to the scale-up case: an intervening up event must not
+			// inflate the down period-start baseline and block a legitimate down.
+			down := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(4))
+			up := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(1000))
+			b := behaviorFor(up, down)
+			args := Args{Key: "ns/v", Behavior: b, MinReplicas: 0, MaxReplicas: 100}
+
+			// t0: 10 -> 6 (records -4 down event).
+			args.CurrentReplicas, args.DesiredReplicas = 10, 6
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(6)))
+
+			// t20: load recovers, 6 -> 10 (records +4 up event).
+			clock.Advance(20 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 6, 10
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(10)))
+
+			// t40: load drops again, 10 -> 6. periodStart = 10 - 4(added) + 4(removed)
+			// = 10, so -4 reaches 6. (Same-direction-only would inflate to 14, block at 10.)
+			clock.Advance(20 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 10, 6
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(6)), "cross-direction up event must not inflate the down baseline")
+		})
+
+		It("floors the scale-down limit to 0 when a policy would reach negative replicas", func() {
+			// Pods policy removes more than the period-start count: 3 - 10 = -7 -> 0.
+			down := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(10))
+			res := s.Stabilize(Args{Key: "ns/v", Behavior: behaviorFor(nil, down), CurrentReplicas: 3, DesiredReplicas: 0, MinReplicas: 0, MaxReplicas: 20})
+			Expect(res.Replicas).To(Equal(int32(0)), "a negative scale-down limit is floored to 0")
+		})
 	})
 
 	Describe("tolerance deadband", func() {

--- a/internal/stabilization/stabilization_test.go
+++ b/internal/stabilization/stabilization_test.go
@@ -1,0 +1,209 @@
+package stabilization
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// fakeClock is a manually advanceable time source for deterministic windows.
+type fakeClock struct{ t time.Time }
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time          { return c.t }
+func (c *fakeClock) Advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func ptr[T any](v T) *T { return &v }
+
+// behaviorFor builds a single-direction behavior for tests. Pass nil for the
+// direction that should keep its defaults.
+func behaviorFor(scaleUp, scaleDown *autoscalingv2.HPAScalingRules) *autoscalingv2.HorizontalPodAutoscalerBehavior {
+	return &autoscalingv2.HorizontalPodAutoscalerBehavior{ScaleUp: scaleUp, ScaleDown: scaleDown}
+}
+
+func rulesFor(window int32, sel autoscalingv2.ScalingPolicySelect, policies ...autoscalingv2.HPAScalingPolicy) *autoscalingv2.HPAScalingRules {
+	return &autoscalingv2.HPAScalingRules{
+		StabilizationWindowSeconds: ptr(window),
+		SelectPolicy:               ptr(sel),
+		Policies:                   policies,
+	}
+}
+
+// testPeriod is the rate-policy period used across the specs; clock advances of
+// 61s cross it to exercise per-period budgeting.
+const testPeriod int32 = 60
+
+func podsPolicy(value int32) autoscalingv2.HPAScalingPolicy {
+	return autoscalingv2.HPAScalingPolicy{Type: autoscalingv2.PodsScalingPolicy, Value: value, PeriodSeconds: testPeriod}
+}
+
+func percentPolicy(value int32) autoscalingv2.HPAScalingPolicy {
+	return autoscalingv2.HPAScalingPolicy{Type: autoscalingv2.PercentScalingPolicy, Value: value, PeriodSeconds: testPeriod}
+}
+
+var _ = Describe("Stabilizer", func() {
+	var (
+		clock *fakeClock
+		s     *Stabilizer
+	)
+
+	BeforeEach(func() {
+		clock = newFakeClock()
+		s = New(WithClock(clock.Now))
+	})
+
+	Describe("stabilization window", func() {
+		It("scales up immediately under the default behavior", func() {
+			res := s.Stabilize(Args{Key: "ns/v", CurrentReplicas: 2, DesiredReplicas: 4, MinReplicas: 1, MaxReplicas: 10})
+			Expect(res.Replicas).To(Equal(int32(4)))
+		})
+
+		It("holds scale-down for the default 300s window, then releases", func() {
+			args := Args{Key: "ns/v", MinReplicas: 1, MaxReplicas: 10}
+
+			args.CurrentReplicas, args.DesiredReplicas = 4, 4
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(4)))
+
+			clock.Advance(30 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 4, 2
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(4)), "within the down window the recent max is held")
+
+			clock.Advance(DefaultDownscaleStabilizationWindow + time.Second)
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(2)), "after the window decays the low recommendation wins")
+		})
+
+		It("delays scale-up while the up window still holds a recent low", func() {
+			up := rulesFor(60, autoscalingv2.MaxChangePolicySelect, podsPolicy(1000))
+			args := Args{Key: "ns/v", Behavior: behaviorFor(up, nil), MinReplicas: 1, MaxReplicas: 100}
+
+			args.CurrentReplicas, args.DesiredReplicas = 2, 2
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(2)))
+
+			clock.Advance(10 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 2, 5
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(2)), "the recent low (2) gates the spike")
+
+			clock.Advance(61 * time.Second)
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(5)), "after the window passes, scale-up proceeds")
+		})
+	})
+
+	Describe("rate policies", func() {
+		It("caps scale-up by a pods-per-period budget", func() {
+			up := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(2))
+			args := Args{Key: "ns/v", Behavior: behaviorFor(up, nil), MinReplicas: 1, MaxReplicas: 100}
+
+			args.CurrentReplicas, args.DesiredReplicas = 2, 10
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(4)), "first cycle adds at most 2")
+
+			clock.Advance(10 * time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 4, 10
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(4)), "budget already spent this period")
+
+			clock.Advance(61 * time.Second)
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(6)), "a new period grants a fresh +2")
+		})
+
+		It("caps scale-down by a percent-per-period budget", func() {
+			down := rulesFor(0, autoscalingv2.MaxChangePolicySelect, percentPolicy(50))
+			res := s.Stabilize(Args{Key: "ns/v", Behavior: behaviorFor(nil, down), CurrentReplicas: 10, DesiredReplicas: 2, MinReplicas: 1, MaxReplicas: 100})
+			Expect(res.Replicas).To(Equal(int32(5)), "at most -50% in one period")
+		})
+
+		DescribeTable("selectPolicy combines competing policies",
+			func(sel autoscalingv2.ScalingPolicySelect, want int32) {
+				// Pods(+4) proposes 14; Percent(+100%) proposes 20.
+				up := rulesFor(0, sel, podsPolicy(4), percentPolicy(100))
+				res := s.Stabilize(Args{Key: "ns/v", Behavior: behaviorFor(up, nil), CurrentReplicas: 10, DesiredReplicas: 100, MinReplicas: 1, MaxReplicas: 1000})
+				Expect(res.Replicas).To(Equal(want))
+			},
+			Entry("Max picks the most permissive", autoscalingv2.MaxChangePolicySelect, int32(20)),
+			Entry("Min picks the most conservative", autoscalingv2.MinChangePolicySelect, int32(14)),
+			Entry("Disabled holds current", autoscalingv2.DisabledPolicySelect, int32(10)),
+		)
+	})
+
+	Describe("tolerance deadband", func() {
+		It("suppresses changes within tolerance and allows larger ones", func() {
+			up := &autoscalingv2.HPAScalingRules{
+				StabilizationWindowSeconds: ptr[int32](0),
+				SelectPolicy:               ptr(autoscalingv2.MaxChangePolicySelect),
+				Policies:                   []autoscalingv2.HPAScalingPolicy{podsPolicy(1000)},
+				Tolerance:                  ptr(resource.MustParse("0.5")),
+			}
+			args := Args{Key: "ns/v", Behavior: behaviorFor(up, nil), MinReplicas: 1, MaxReplicas: 1000}
+
+			args.CurrentReplicas, args.DesiredReplicas = 10, 12
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(10)), "+20% is within the 50% deadband")
+
+			clock.Advance(time.Second)
+			args.CurrentReplicas, args.DesiredReplicas = 10, 20
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(20)), "+100% exceeds the deadband")
+		})
+	})
+
+	Describe("min/max clamping", func() {
+		var b *autoscalingv2.HorizontalPodAutoscalerBehavior
+
+		BeforeEach(func() {
+			// Generous policies so clamping, not rate, bounds the result.
+			up := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(1000))
+			down := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(1000))
+			b = behaviorFor(up, down)
+		})
+
+		It("clamps to maxReplicas", func() {
+			res := s.Stabilize(Args{Key: "ns/a", Behavior: b, CurrentReplicas: 1, DesiredReplicas: 100, MinReplicas: 1, MaxReplicas: 5})
+			Expect(res.Replicas).To(Equal(int32(5)))
+		})
+
+		It("clamps to minReplicas", func() {
+			res := s.Stabilize(Args{Key: "ns/b", Behavior: b, CurrentReplicas: 10, DesiredReplicas: 0, MinReplicas: 2, MaxReplicas: 20})
+			Expect(res.Replicas).To(Equal(int32(2)))
+		})
+
+		It("ignores maxReplicas when non-positive", func() {
+			up := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(1000))
+			res := s.Stabilize(Args{Key: "ns/v", Behavior: behaviorFor(up, nil), CurrentReplicas: 3, DesiredReplicas: 9, MinReplicas: 1, MaxReplicas: 0})
+			Expect(res.Replicas).To(Equal(int32(9)))
+		})
+	})
+
+	Describe("per-key isolation", func() {
+		It("keeps each scale target's history independent", func() {
+			s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 8, MinReplicas: 1, MaxReplicas: 20})
+			clock.Advance(10 * time.Second)
+
+			byB := s.Stabilize(Args{Key: "ns/b", CurrentReplicas: 8, DesiredReplicas: 2, MinReplicas: 1, MaxReplicas: 20})
+			Expect(byB.Replicas).To(Equal(int32(2)), "key b is not held by key a's window")
+
+			byA := s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 2, MinReplicas: 1, MaxReplicas: 20})
+			Expect(byA.Replicas).To(Equal(int32(8)), "key a is still held by its own window")
+		})
+	})
+
+	Describe("Result observability fields", func() {
+		It("reports the pre-rate recommendation in Stabilized", func() {
+			up := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(1))
+			res := s.Stabilize(Args{Key: "ns/v", Behavior: behaviorFor(up, nil), CurrentReplicas: 2, DesiredReplicas: 9, MinReplicas: 1, MaxReplicas: 100})
+			Expect(res.Stabilized).To(Equal(int32(9)), "Stabilized is the window output, before rate limiting")
+			Expect(res.Replicas).To(Equal(int32(3)), "Replicas is rate-limited to +1")
+		})
+	})
+})
+
+var _ = Describe("DefaultBehavior", func() {
+	It("sets immediate scale-up and a 300s scale-down window", func() {
+		b := DefaultBehavior()
+		Expect(b.ScaleUp).NotTo(BeNil())
+		Expect(b.ScaleDown).NotTo(BeNil())
+		Expect(*b.ScaleUp.StabilizationWindowSeconds).To(Equal(int32(0)))
+		Expect(*b.ScaleDown.StabilizationWindowSeconds).To(Equal(int32(DefaultDownscaleStabilizationWindow / time.Second)))
+	})
+})

--- a/internal/stabilization/stabilization_test.go
+++ b/internal/stabilization/stabilization_test.go
@@ -211,26 +211,46 @@ var _ = Describe("Stabilizer", func() {
 		})
 	})
 
-	Describe("Forget", func() {
+	Describe("Retain", func() {
 		It("drops history for keys not in the active set", func() {
 			// Build a high down-window history for key a.
 			s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 8, MinReplicas: 0, MaxReplicas: 20})
 			clock.Advance(10 * time.Second)
 
-			// Forget it (only key b is active this cycle).
-			s.Forget(map[string]struct{}{"ns/b": {}})
+			// Retain only key b this cycle.
+			s.Retain(map[string]struct{}{"ns/b": {}})
 
 			// With its window gone, key a's scale-down is no longer held at 8.
 			got := s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 2, MinReplicas: 0, MaxReplicas: 20}).Replicas
-			Expect(got).To(Equal(int32(2)), "forgotten history must not damp the next decision")
+			Expect(got).To(Equal(int32(2)), "dropped history must not damp the next decision")
 		})
 
-		It("retains history for keys still in the active set", func() {
+		It("keeps history for keys still in the active set", func() {
 			s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 8, MinReplicas: 0, MaxReplicas: 20})
 			clock.Advance(10 * time.Second)
-			s.Forget(map[string]struct{}{"ns/a": {}})
+			s.Retain(map[string]struct{}{"ns/a": {}})
 			got := s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 2, MinReplicas: 0, MaxReplicas: 20}).Replicas
 			Expect(got).To(Equal(int32(8)), "retained window still holds the recent max")
+		})
+
+		It("drops all history when the active set is empty", func() {
+			s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 8, MinReplicas: 0, MaxReplicas: 20})
+			clock.Advance(10 * time.Second)
+			s.Retain(map[string]struct{}{})
+			got := s.Stabilize(Args{Key: "ns/a", CurrentReplicas: 8, DesiredReplicas: 2, MinReplicas: 0, MaxReplicas: 20}).Replicas
+			Expect(got).To(Equal(int32(2)), "an empty active set evicts every key")
+		})
+
+		It("clears the rate-event budget so the next cycle starts fresh", func() {
+			// First cycle records an up-event: 2->6 hits the +4-pods cap.
+			up := rulesFor(0, autoscalingv2.MaxChangePolicySelect, podsPolicy(4))
+			args := Args{Key: "ns/a", Behavior: behaviorFor(up, nil), CurrentReplicas: 2, DesiredReplicas: 10, MinReplicas: 0, MaxReplicas: 100}
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(6)), "rate-limited on the first cycle")
+
+			// Evict the key, then the same period must grant a fresh +4 budget.
+			s.Retain(map[string]struct{}{"ns/b": {}})
+			args.CurrentReplicas, args.DesiredReplicas = 6, 100
+			Expect(s.Stabilize(args).Replicas).To(Equal(int32(10)), "after Retain drops the event, +4 from 6 = 10")
 		})
 	})
 

--- a/internal/stabilization/suite_test.go
+++ b/internal/stabilization/suite_test.go
@@ -1,0 +1,16 @@
+package stabilization
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+)
+
+func TestStabilization(t *testing.T) {
+	logging.NewTestLogger()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Stabilization Suite")
+}


### PR DESCRIPTION
Fixes #1352

## Proposed Changes

- :gift: Add `internal/stabilization`: a clean-room port of the Kubernetes HPA *configurable scaling behavior* (trailing window — min over the up-window / max over the down-window — plus per-period `Pods`/`Percent` rate policies with `selectPolicy`, tolerance deadband, and min/max clamp). Reuses the `autoscaling/v2` behavior types so it is configured the familiar HPA way.
- :gift: Wire stabilization into the V2 engine right after the optimizer and before the enforcer, keyed per `namespace/model/variant[/role]`, with a structured `stabilization-decision` cycle log. Gated by a new `enableStabilization` saturation-config flag, **default off**. Intended deployment contract: WVA owns stabilization, HPA `behavior` delays set to `0`.
- :broom: Extract `VariantDecision.ActionForTarget` and reuse it from both the enforcer and the stabilizer (removes a duplicated action-recompute switch).

This is the foundation for owning scale-down so the priority-weighted rescale proposal (#1238) can actuate cleanly, and a prerequisite for direct `/scale` actuation in the 1→N range. Per-policy config via the ConfigMap, direct actuation, and the V1 path are follow-ups (see #1352).

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A while default-off (no behavior change on upgrade). Covered by `internal/stabilization` unit specs and the saturation engine envtest suite; E2E will accompany enabling it by default / direct actuation.
- [ ] **Docs PR** for any user-facing impact — developer design note included (`docs/plans/engine/stabilization.md`); no user-facing impact while the flag is off. User-facing docs will accompany the per-policy config follow-up.
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — rationale tracked in #1352 and related to the rescale proposal #1238; a dedicated proposal for the operator-facing config surface is a follow-up.

**Release Note**

```release-note
Added opt-in HPA-style stabilization of WVA scaling recommendations (a trailing
scale-down window plus per-period rate policies), enabled via
`enableStabilization` in the saturation scaling config. Disabled by default.
```

**Docs**

No user-visible impact while default-off; user-facing documentation will accompany the per-policy configuration follow-up.
