### PR TITLE
fix: suppress repeated VariantAutoscaling deprecation warnings in tests

### DIFF
--- a/test/e2e/fixtures/va_builder.go
+++ b/test/e2e/fixtures/va_builder.go
@@ -134,6 +134,12 @@ func buildVariantAutoscaling(namespace, name, deploymentName, modelID, accelerat
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
+			// Pre-acknowledge the deprecation warning so the controller does not
+			// emit it repeatedly during e2e tests (it fires once per VA object
+			// absent this annotation, which would spam logs on every test cycle).
+			Annotations: map[string]string{
+				"llm-d.ai/deprecation-warned": "true",
+			},
 		},
 		Spec: variantautoscalingv1alpha1.VariantAutoscalingSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{


### PR DESCRIPTION
Fixes #1365 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🧹Pre-set "llm-d.ai/deprecation-warned": "true" in the single private factory buildVariantAutoscaling that all e2e VA helpers delegate to. The annotation signals to the controller that the deprecation notice has already been acknowledged, so the block is skipped from the very first reconcile.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
