### PR TITLE
fix(engine): populate V2 saturation decision metrics

### DIFF
--- a/docs/developer-guide/prometheus.md
+++ b/docs/developer-guide/prometheus.md
@@ -534,12 +534,12 @@ With WVA metrics, the value for the label `namespace` is the WVA controller name
 
 ### `wva_spare_capacity`
 - **Type**: Gauge
-- **Description**: Spare capacity from saturation analysis; >0 indicates scale-down headroom. Use the `unit` label to interpret the value: `continuous` (V2) = absolute spare in KV-cache **tokens**, `max(0, TotalSupply - TotalDemand/scaleDownBoundary)` — the companion to `wva_required_capacity`; otherwise (V1) = a 0.0-1.0 threshold-relative fraction (`kvCacheThreshold - avg KV usage`).
+- **Description**: Spare capacity; >0 indicates scale-down headroom (per-role for P/D-disaggregated models, model-level otherwise). Use the `unit` label to interpret the value: `continuous` → **token surplus** from the **Token-based analyzer** (`max(0, TotalSupply - TotalDemand/scaleDownBoundary)`); empty → a 0.0-1.0 threshold-relative fraction from the **Percentage-based analyzer** (`kvCacheThreshold - avg KV usage`).
 - **Labels**:
   - `variant_name`: Name of the variant
   - `namespace`: Kubernetes namespace
   - `model_name`: Model name served by the variant
-  - `unit`: `continuous` (V2, token value) or empty (V1, 0.0-1.0 fraction)
+  - `unit`: `continuous` (Token-based analyzer — a token magnitude) or empty (Percentage-based analyzer — 0.0-1.0 fraction)
 - **Use Case**: Track available capacity headroom to prevent saturation and optimize resource allocation
 - **Example**:
   ```
@@ -567,12 +567,12 @@ With WVA metrics, the value for the label `namespace` is the WVA controller name
 
 ### `wva_required_capacity`
 - **Type**: Gauge
-- **Description**: Required capacity; >0 indicates scale-up needed (V2: per-role for P/D-disaggregated models, model-level otherwise). Use the `unit` label to interpret the value: `binary` → 0/1 scale-up signal (V1), `continuous` → token demand (V2).
+- **Description**: Required capacity; >0 indicates scale-up needed (per-role for P/D-disaggregated models, model-level otherwise). Use the `unit` label to interpret the value: `continuous` → **token demand** from the **Token-based analyzer**; `binary` → 0/1 scale-up signal from the **Percentage-based analyzer**.
 - **Labels**:
   - `variant_name`: Name of the variant
   - `namespace`: Kubernetes namespace
   - `model_name`: Model name served by the variant
-  - `unit`: Interpretation of the value (`binary` or `continuous`)
+  - `unit`: `continuous` (Token-based analyzer — a token magnitude) or `binary` (Percentage-based analyzer — 0/1 signal)
 - **Use Case**: Identify when additional capacity is needed and understand the magnitude of demand
 - **Example**:
   ```

--- a/docs/developer-guide/prometheus.md
+++ b/docs/developer-guide/prometheus.md
@@ -534,19 +534,19 @@ With WVA metrics, the value for the label `namespace` is the WVA controller name
 
 ### `wva_spare_capacity`
 - **Type**: Gauge
-- **Description**: Per-variant spare KV-cache capacity (0.0-1.0) from saturation analysis. V1 path: threshold-relative spare (kvCacheThreshold - avg KV usage). V2 path: 1.0 - utilization.
+- **Description**: Spare capacity from saturation analysis; >0 indicates scale-down headroom. Use the `unit` label to interpret the value: `continuous` (V2) = absolute spare in KV-cache **tokens**, `max(0, TotalSupply - TotalDemand/scaleDownBoundary)` — the companion to `wva_required_capacity`; otherwise (V1) = a 0.0-1.0 threshold-relative fraction (`kvCacheThreshold - avg KV usage`).
 - **Labels**:
   - `variant_name`: Name of the variant
   - `namespace`: Kubernetes namespace
   - `model_name`: Model name served by the variant
-  - `accelerator_type`: Type of accelerator being used
+  - `unit`: `continuous` (V2, token value) or empty (V1, 0.0-1.0 fraction)
 - **Use Case**: Track available capacity headroom to prevent saturation and optimize resource allocation
 - **Example**:
   ```
   {
     "metric": {
       "__name__": "wva_spare_capacity",
-      "accelerator_type": "H100",
+      "unit": "continuous",
       "container": "manager",
       "endpoint": "https",
       "exported_namespace": "llm-d-sim-dual",
@@ -560,14 +560,14 @@ With WVA metrics, the value for the label `namespace` is the WVA controller name
     },
     "value": [
       1778846184.925,
-      "0.8"
+      "12000"
     ]
   }
   ```
 
 ### `wva_required_capacity`
 - **Type**: Gauge
-- **Description**: Model-level required capacity; >0 indicates scale-up needed. Use the `unit` label to interpret the value: `binary` → 0/1 scale-up signal (V1), `continuous` → token demand (V2).
+- **Description**: Required capacity; >0 indicates scale-up needed (V2: per-role for P/D-disaggregated models, model-level otherwise). Use the `unit` label to interpret the value: `binary` → 0/1 scale-up signal (V1), `continuous` → token demand (V2).
 - **Labels**:
   - `variant_name`: Name of the variant
   - `namespace`: Kubernetes namespace
@@ -909,8 +909,12 @@ wva_saturation_utilization
 # Variants requiring scale-up (V1 binary signal)
 wva_required_capacity{unit="binary"} > 0
 
-# Spare capacity below threshold (potential scale-up needed)
-wva_spare_capacity < 0.2
+# High utilization — scale-up likely (V1 and V2)
+wva_saturation_utilization > 0.85
+
+# Low spare capacity, V1 fractional signal only.
+# On V2 wva_spare_capacity is an absolute token count, not a 0-1 ratio — use utilization above.
+wva_spare_capacity{unit=""} < 0.2
 
 # Models processed over time
 wva_models_processed

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -166,19 +166,19 @@ const (
 	// Labels: variant_name, namespace, model_name, accelerator_type
 	WVASaturationUtilization = "wva_saturation_utilization"
 
-	// WVASpareCapacity is a gauge that tracks spare capacity from saturation analysis.
-	// >0 means scale-down headroom.
+	// WVASpareCapacity is a gauge that tracks spare capacity; >0 means scale-down
+	// headroom (per-role for P/D-disaggregated models, model-level otherwise).
 	// Value semantics differ by analyzer (use the "unit" label to distinguish):
-	//   - unit="continuous" (V2): absolute spare in KV-cache tokens
-	//   - otherwise         (V1): 0.0-1.0 threshold-relative KV-cache fraction
+	//   - unit="continuous" (Token-based analyzer):       token surplus
+	//   - unit="" (empty)   (Percentage-based analyzer): 0.0-1.0 threshold-relative fraction
 	// Labels: variant_name, namespace, model_name, unit
 	WVASpareCapacity = "wva_spare_capacity"
 
 	// WVARequiredCapacity is a gauge that tracks required capacity; >0 means scale-up
-	// needed (V2: per-role for P/D-disaggregated models, model-level otherwise).
+	// needed (per-role for P/D-disaggregated models, model-level otherwise).
 	// Value semantics differ by analyzer (use the "unit" label to distinguish):
-	//   - unit="binary"     (V1): 0.0 = no scale-up, 1.0 = scale-up needed
-	//   - unit="continuous" (V2): continuous token-based demand
+	//   - unit="continuous" (Token-based analyzer):       token demand
+	//   - unit="binary"     (Percentage-based analyzer): 0.0 = no scale-up, 1.0 = scale-up
 	// Labels: variant_name, namespace, model_name, unit
 	WVARequiredCapacity = "wva_required_capacity"
 

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -166,12 +166,16 @@ const (
 	// Labels: variant_name, namespace, model_name, accelerator_type
 	WVASaturationUtilization = "wva_saturation_utilization"
 
-	// WVASpareCapacity is a gauge that tracks per-variant spare capacity (0.0-1.0).
-	// Labels: variant_name, namespace, model_name, accelerator_type
+	// WVASpareCapacity is a gauge that tracks spare capacity from saturation analysis.
+	// >0 means scale-down headroom.
+	// Value semantics differ by analyzer (use the "unit" label to distinguish):
+	//   - unit="continuous" (V2): absolute spare in KV-cache tokens
+	//   - otherwise         (V1): 0.0-1.0 threshold-relative KV-cache fraction
+	// Labels: variant_name, namespace, model_name, unit
 	WVASpareCapacity = "wva_spare_capacity"
 
-	// WVARequiredCapacity is a gauge that tracks model-level required capacity.
-	// >0 means scale-up needed.
+	// WVARequiredCapacity is a gauge that tracks required capacity; >0 means scale-up
+	// needed (V2: per-role for P/D-disaggregated models, model-level otherwise).
 	// Value semantics differ by analyzer (use the "unit" label to distinguish):
 	//   - unit="binary"     (V1): 0.0 = no scale-up, 1.0 = scale-up needed
 	//   - unit="continuous" (V2): continuous token-based demand
@@ -223,9 +227,9 @@ const (
 	LabelScaleToZeroEnabled = "scale_to_zero_enabled"
 	LabelQueryType          = "query_type"
 	// LabelUnit distinguishes the unit of a metric value when a single metric name
-	// carries values with different semantic units. Currently applied to
-	// wva_required_capacity, whose value is either a binary scale-up signal (V1)
-	// or a continuous token-demand value (V2).
+	// carries values with different semantic units. Applied to wva_required_capacity
+	// and wva_spare_capacity, whose values are either a "binary" 0/1 signal (V1) or a
+	// "continuous" token magnitude (V2).
 	LabelUnit = "unit"
 )
 

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -248,6 +248,12 @@ func buildDecisionsWithOptimizer(
 	optimizerName string,
 ) []interfaces.VariantDecision {
 	decisions := make([]interfaces.VariantDecision, 0, len(targets))
+	// satEntry carries the model-level RequiredCapacity/SpareCapacity computed by
+	// applyUniversalThreshold; per-variant Utilization is on each VariantCapacity.
+	// These feed the saturation gauges (utilization/required/spare). SpareCapacity is
+	// additionally an input to the GPU limiter's GreedyBySaturation ordering, so setting
+	// it here also makes that ordering reflect real spare tokens on V2 (it was 0 before).
+	satEntry := saturationEntry(req.AnalyzerResults)
 	for name, target := range targets {
 		state := stateMap[name]
 		vc := vcMap[name]
@@ -285,6 +291,28 @@ func buildDecisionsWithOptimizer(
 		// SetDecisionReason is the single place that sets d.Action (avoids a
 		// redundant Action assignment in the struct literal above).
 		decision.SetDecisionReason(action, decisionReason, detailedReason)
+
+		// Observability fields consumed by RecordSaturationMetrics
+		// (wva_saturation_utilization / wva_required_capacity / wva_spare_capacity).
+		// Without these the three V2 gauges read zero. RequiredCapacity and
+		// SpareCapacity are the matched scale-up/scale-down token signals from
+		// applyUniversalThreshold; Utilization is the per-variant demand/capacity ratio.
+		// For P/D-disaggregated models use the variant's per-role capacity; otherwise
+		// fall back to the model-level totals.
+		decision.Utilization = vc.Utilization
+		if satEntry != nil {
+			reqCap, spareCap := satEntry.RequiredCapacity, satEntry.SpareCapacity
+			role := state.Role
+			if role == "" {
+				role = interfaces.RoleBoth
+			}
+			if rc, ok := satEntry.RoleCapacities[role]; ok {
+				reqCap, spareCap = rc.RequiredCapacity, rc.SpareCapacity
+			}
+			decision.RequiredCapacity = reqCap
+			decision.SpareCapacity = spareCap
+		}
+
 		decisions = append(decisions, decision)
 	}
 	return decisions

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -134,6 +134,36 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(dm["d"].SpareCapacity).To(Equal(20.0))
 		})
 
+		It("maps an empty-role variant to the \"both\" RoleCapacities entry", func() {
+			// Role "" normalizes to RoleBoth, so the "both" entry (not the model-level
+			// totals) must be used. Model-level 9999/8888 are decoys.
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				RequiredCapacity: 9999,
+				SpareCapacity:    8888,
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"both": {Role: "both", RequiredCapacity: 300, SpareCapacity: 30},
+				},
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v", Role: "", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.5},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
+					ModelID:   "model-1",
+					Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "v", Role: "", CurrentReplicas: 1},
+					},
+				}),
+			}
+
+			dm := decisionMap(optimizer.Optimize(ctx, requests, nil))
+			Expect(dm["v"].RequiredCapacity).To(Equal(300.0)) // "both" entry, not model-level 9999
+			Expect(dm["v"].SpareCapacity).To(Equal(30.0))     // "both" entry, not model-level 8888
+		})
+
 		It("should not skip variants with pending replicas", func() {
 			r := &interfaces.AnalyzerResult{
 				RequiredCapacity: 5000,

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -73,6 +73,67 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(dm["expensive"].TargetReplicas).To(Equal(1))
 		})
 
+		It("populates decision observability fields (utilization/required/spare) from the analyzer result", func() {
+			// Regression: these three feed wva_saturation_utilization / wva_required_capacity /
+			// wva_spare_capacity. If buildDecisionsWithOptimizer stops copying them, the gauges read 0.
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				RequiredCapacity: 5000,
+				SpareCapacity:    1200,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.42},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
+					ModelID:   "model-1",
+					Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "v1", CurrentReplicas: 2},
+					},
+				}),
+			}
+
+			dm := decisionMap(optimizer.Optimize(ctx, requests, nil))
+			Expect(dm["v1"].Utilization).To(Equal(0.42))
+			Expect(dm["v1"].RequiredCapacity).To(Equal(5000.0)) // model-level (no RoleCapacities)
+			Expect(dm["v1"].SpareCapacity).To(Equal(1200.0))    // tokens, companion to required
+		})
+
+		It("uses per-role required/spare capacity for P/D-disaggregated models", func() {
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				RequiredCapacity: 9999, // model-level; must NOT be used for role-scoped variants
+				SpareCapacity:    8888,
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {Role: "prefill", RequiredCapacity: 100, SpareCapacity: 10},
+					"decode":  {Role: "decode", RequiredCapacity: 200, SpareCapacity: 20},
+				},
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "p", Role: "prefill", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.3},
+					{VariantName: "d", Role: "decode", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.6},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
+					ModelID:   "model-1",
+					Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "p", Role: "prefill", CurrentReplicas: 1},
+						{VariantName: "d", Role: "decode", CurrentReplicas: 1},
+					},
+				}),
+			}
+
+			dm := decisionMap(optimizer.Optimize(ctx, requests, nil))
+			Expect(dm["p"].RequiredCapacity).To(Equal(100.0))
+			Expect(dm["p"].SpareCapacity).To(Equal(10.0))
+			Expect(dm["d"].RequiredCapacity).To(Equal(200.0))
+			Expect(dm["d"].SpareCapacity).To(Equal(20.0))
+		})
+
 		It("should not skip variants with pending replicas", func() {
 			r := &interfaces.AnalyzerResult{
 				RequiredCapacity: 5000,

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -66,6 +66,39 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			Expect(dm["expensive"].TargetReplicas).To(Equal(1)) // unchanged
 		})
 
+		It("propagates observability fields (utilization/required/spare) from the analyzer result", func() {
+			// Regression guard for the greedy-by-score path, which shares
+			// buildDecisionsWithOptimizer with cost-aware. Without the copy the V2 gauges
+			// (wva_saturation_utilization / wva_required_capacity / wva_spare_capacity) read 0.
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				AnalyzedAt:       time.Now(),
+				RequiredCapacity: 5000,
+				SpareCapacity:    1200,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.42},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
+					ModelID:   "model-1",
+					Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
+					},
+				}),
+			}
+			constraints := []*ResourceConstraints{
+				{Pools: map[string]ResourcePool{"A100": {Limit: 10}}},
+			}
+
+			dm := decisionMap(optimizer.Optimize(ctx, requests, constraints))
+			Expect(dm["v1"].Utilization).To(Equal(0.42))
+			Expect(dm["v1"].RequiredCapacity).To(Equal(5000.0))
+			Expect(dm["v1"].SpareCapacity).To(Equal(1200.0))
+		})
+
 		It("should handle GPU exhaustion with partial allocation", func() {
 			r := &interfaces.AnalyzerResult{
 				RequiredCapacity: 50000,

--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -236,10 +236,11 @@ type VariantDecision struct {
 	// --- Resource requirements (for resource limiting) ---
 	GPUsPerReplica int // GPUs required per replica
 	// SpareCapacity indicates how much spare capacity this variant has.
-	// 0.0 = fully saturated, 1.0 = completely idle.
-	// Used by allocation algorithms to prioritize saturated variants.
-	// V1: threshold-relative spare KV capacity (AvgSpareKvCapacity).
-	// V2: 1.0 - Utilization (absolute spare).
+	// V1: threshold-relative spare KV capacity (AvgSpareKvCapacity), a 0.0-1.0
+	//     fraction (0.0 = fully saturated, 1.0 = completely idle).
+	// V2: absolute spare in KV-cache tokens, max(0, TotalSupply - TotalDemand/scaleDownBoundary)
+	//     from AnalyzerResult — the scale-down companion to RequiredCapacity, in the same
+	//     token units (unit is "continuous", matching RequiredCapacityUnit).
 	SpareCapacity float64
 	// Utilization is the variant-level utilization ratio (0.0-1.0) reported for
 	// observability. The exact formula differs by analyzer because V1 and V2
@@ -254,10 +255,10 @@ type VariantDecision struct {
 	KvCacheTokensUsed int64
 	// KvCacheTokensCapacity is the sum of TotalKvCapacityTokens across this variant's replicas.
 	KvCacheTokensCapacity int64
-	// RequiredCapacity is the model-level required capacity (>0 means scale-up needed).
-	// Same value for all variants of a model.
-	// V1: binary (1.0 if shouldScaleUp, else 0.0).
-	// V2: continuous token-based demand from AnalyzerResult.
+	// RequiredCapacity indicates whether scale-up is needed (>0 means yes).
+	// V1: binary (1.0 if shouldScaleUp, else 0.0), model-level.
+	// V2: continuous token-based deficit from AnalyzerResult — per-role for P/D
+	//     disaggregated models, model-level otherwise.
 	// Use RequiredCapacityUnit to disambiguate the units when consuming this field
 	// (or its corresponding Prometheus metric).
 	RequiredCapacity float64

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -166,14 +166,14 @@ func InitMetrics(registry prometheus.Registerer) error {
 	spareCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVASpareCapacity,
-			Help: "Per-variant spare KV-cache capacity (0.0-1.0) from saturation analysis. V1 path: threshold-relative spare (kvCacheThreshold - avg KV usage). V2 path: 1.0 - utilization.",
+			Help: fmt.Sprintf("Spare capacity from saturation analysis; >0 indicates safe scale-down headroom. The %q label (shared with wva_required_capacity) interprets the value: %q → absolute spare in KV-cache tokens, max(0, TotalSupply - TotalDemand/scaleDownBoundary) (V2 path); otherwise a 0.0-1.0 threshold-relative fraction (V1 path).", constants.LabelUnit, constants.UnitContinuous),
 		},
-		satAccelLabels,
+		requiredCapacityLabels,
 	)
 	requiredCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVARequiredCapacity,
-			Help: fmt.Sprintf("Model-level required capacity; >0 indicates scale-up needed. Use the %q label to interpret the value: %q → 0/1 scale-up signal (V1), %q → token demand (V2).", constants.LabelUnit, constants.UnitBinary, constants.UnitContinuous),
+			Help: fmt.Sprintf("Required capacity; >0 indicates scale-up needed (V2: per-role for P/D-disaggregated models, model-level otherwise). Use the %q label to interpret the value: %q → 0/1 scale-up signal (V1), %q → token demand (V2).", constants.LabelUnit, constants.UnitBinary, constants.UnitContinuous),
 		},
 		requiredCapacityLabels,
 	)
@@ -814,8 +814,8 @@ func SetMetricsFreshnessStatus(variantName, status string, count int) {
 //
 // modelID is exposed as the model_name label so dashboards can group/filter by
 // the model a variant serves. requiredCapacityUnit ("binary" or "continuous")
-// is used as the "unit" label on wva_required_capacity to describe how the
-// value should be interpreted.
+// is used as the "unit" label on both wva_required_capacity and wva_spare_capacity
+// (they share the same label set) to describe how the value should be interpreted.
 //
 // Callers MUST invoke InitMetrics before this method (the package-level
 // metric vars are nil otherwise, and the Set calls below would panic).
@@ -838,7 +838,9 @@ func (m *MetricsEmitter) RecordSaturationMetrics(
 		constants.LabelNamespace:   namespace,
 		constants.LabelModelName:   modelID,
 	}
-	requiredLabels := prometheus.Labels{
+	// capacityLabels are shared by wva_required_capacity and wva_spare_capacity: both
+	// are model/role-level signals carrying the unit label (no accelerator_type).
+	capacityLabels := prometheus.Labels{
 		constants.LabelVariantName: variantName,
 		constants.LabelNamespace:   namespace,
 		constants.LabelModelName:   modelID,
@@ -848,12 +850,12 @@ func (m *MetricsEmitter) RecordSaturationMetrics(
 	if controllerInstance != "" {
 		accelLabels[constants.LabelControllerInstance] = controllerInstance
 		modelLabels[constants.LabelControllerInstance] = controllerInstance
-		requiredLabels[constants.LabelControllerInstance] = controllerInstance
+		capacityLabels[constants.LabelControllerInstance] = controllerInstance
 	}
 
 	saturationUtilization.With(accelLabels).Set(utilization)
-	spareCapacity.With(accelLabels).Set(spare)
-	requiredCapacity.With(requiredLabels).Set(required)
+	spareCapacity.With(capacityLabels).Set(spare)
+	requiredCapacity.With(capacityLabels).Set(required)
 	kvCacheTokensUsed.With(modelLabels).Set(float64(kvTokensUsed))
 	kvCacheTokensCapacity.With(modelLabels).Set(float64(kvTokensCapacity))
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -166,14 +166,14 @@ func InitMetrics(registry prometheus.Registerer) error {
 	spareCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVASpareCapacity,
-			Help: fmt.Sprintf("Spare capacity from saturation analysis; >0 indicates safe scale-down headroom. The %q label (shared with wva_required_capacity) interprets the value: %q → absolute spare in KV-cache tokens, max(0, TotalSupply - TotalDemand/scaleDownBoundary) (V2 path); otherwise a 0.0-1.0 threshold-relative fraction (V1 path).", constants.LabelUnit, constants.UnitContinuous),
+			Help: fmt.Sprintf("Spare capacity; >0 indicates safe scale-down headroom (per-role for P/D-disaggregated models, model-level otherwise). The %q label (shared with wva_required_capacity) interprets the value: %q → token surplus from the Token-based analyzer, max(0, TotalSupply - TotalDemand/scaleDownBoundary); empty → a 0.0-1.0 threshold-relative fraction from the Percentage-based analyzer.", constants.LabelUnit, constants.UnitContinuous),
 		},
 		requiredCapacityLabels,
 	)
 	requiredCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVARequiredCapacity,
-			Help: fmt.Sprintf("Required capacity; >0 indicates scale-up needed (V2: per-role for P/D-disaggregated models, model-level otherwise). Use the %q label to interpret the value: %q → 0/1 scale-up signal (V1), %q → token demand (V2).", constants.LabelUnit, constants.UnitBinary, constants.UnitContinuous),
+			Help: fmt.Sprintf("Required capacity; >0 indicates scale-up needed (per-role for P/D-disaggregated models, model-level otherwise). Use the %q label to interpret the value: %q → token demand from the Token-based analyzer, %q → 0/1 scale-up signal from the Percentage-based analyzer.", constants.LabelUnit, constants.UnitContinuous, constants.UnitBinary),
 		},
 		requiredCapacityLabels,
 	)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -249,10 +249,10 @@ var _ = Describe("RecordSaturationMetrics", func() {
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(0.75))
 
-		// spare_capacity
+		// spare_capacity (carries unit label, same label set as required_capacity)
 		mf = gatherMetric(registry, constants.WVASpareCapacity)
 		Expect(mf).NotTo(BeNil())
-		val, ok = gaugeValue(mf, accelLabels)
+		val, ok = gaugeValue(mf, requiredLabels)
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(0.25))
 
@@ -382,20 +382,23 @@ var _ = Describe("RecordSaturationMetrics", func() {
 			constants.LabelUnit:        constants.UnitBinary,
 		}
 
-		for _, metricName := range []string{
-			constants.WVASaturationUtilization,
-			constants.WVASpareCapacity,
-		} {
-			mf := gatherMetric(registry, metricName)
-			Expect(mf).NotTo(BeNil(), "metric %s not found", metricName)
-			val, ok := gaugeValue(mf, accelLabels)
-			Expect(ok).To(BeTrue(), "gauge not found for %s", metricName)
-			Expect(val).To(Equal(0.0), "expected 0 for %s", metricName)
-		}
+		// saturation_utilization is per-variant (accelerator-labeled).
+		mf := gatherMetric(registry, constants.WVASaturationUtilization)
+		Expect(mf).NotTo(BeNil(), "metric %s not found", constants.WVASaturationUtilization)
+		val, ok := gaugeValue(mf, accelLabels)
+		Expect(ok).To(BeTrue(), "gauge not found for %s", constants.WVASaturationUtilization)
+		Expect(val).To(Equal(0.0))
 
-		mf := gatherMetric(registry, constants.WVARequiredCapacity)
+		// spare_capacity is model/role-level (unit-labeled, same set as required_capacity).
+		mf = gatherMetric(registry, constants.WVASpareCapacity)
+		Expect(mf).NotTo(BeNil(), "metric %s not found", constants.WVASpareCapacity)
+		val, ok = gaugeValue(mf, requiredLabels)
+		Expect(ok).To(BeTrue(), "gauge not found for %s", constants.WVASpareCapacity)
+		Expect(val).To(Equal(0.0))
+
+		mf = gatherMetric(registry, constants.WVARequiredCapacity)
 		Expect(mf).NotTo(BeNil())
-		val, ok := gaugeValue(mf, requiredLabels)
+		val, ok = gaugeValue(mf, requiredLabels)
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(0.0))
 


### PR DESCRIPTION
## Fixes

`wva_saturation_utilization`, `wva_required_capacity`, and `wva_spare_capacity` always read **0** on the V2 saturation path.

## Proposed Changes

- On the V2 path, `buildDecisionsWithOptimizer` (shared by the cost-aware and greedy-by-score optimizers) never copied `Utilization` / `RequiredCapacity` / `SpareCapacity` onto the `VariantDecision` the actuator records — the values were computed on the `AnalyzerResult` but dropped, so the three gauges emitted 0 (despite the Stage-4 comment claiming they were "already set").
- Copy them onto each decision:
  - `Utilization` ← per-variant `VariantCapacity` (demand/capacity ratio).
  - `RequiredCapacity` / `SpareCapacity` ← saturation `AnalyzerResult` — **per-role** for P/D-disaggregated models (`RoleCapacities`), model-level otherwise. `SpareCapacity` is now absolute KV-cache **tokens** (the scale-down companion to `RequiredCapacity`), not the `1 − utilization` ratio previously documented (redundant with the utilization gauge, and never emitted).
- Give `wva_spare_capacity` the same `unit` label as `wva_required_capacity` (shared analyzer-path unit: `continuous` for V2 tokens; fraction for V1) and switch it to the model/role-level label set — the two matched gauges are now symmetric and self-describing.
- Sourced from the saturation analyzer entry (always present on the V2 path); the throughput analyzer also leaves these zero and is not reflected in the `saturation_*` gauges by design.

Updated `VariantDecision` + `WVASpareCapacity` doc comments, the spare/required metric help, and `docs/developer-guide/prometheus.md` (labels, V2 token semantics, and the now-invalid `wva_spare_capacity < 0.2` alert). Added optimizer propagation tests for **both** the cost-aware and greedy-by-score paths (model-level + per-role); updated metrics tests for the spare `unit` label.

## Pre-review Checklist

- [x] **E2E tests** — unit tests added (`cost_aware_optimizer_test.go`, `metrics_test.go`); envtest/E2E via CI
- [ ] **Docs PR** — companion docs PR (`docs/v2-saturation-engine`) documents the now-working metrics

## Release Note

```release-note
Fix wva_saturation_utilization, wva_required_capacity, and wva_spare_capacity reading 0 on the V2 saturation path; wva_spare_capacity is now KV-cache tokens with a `unit` label matching wva_required_capacity.
```

## Notes for reviewers

- **Semantics change:** `wva_spare_capacity` on V2 is now KV-cache tokens (was documented as `1 − utilization`, but always emitted 0). Not plotted in the shipped Grafana dashboard, so no panel breaks.
- **Label change:** `wva_spare_capacity` drops `accelerator_type` and gains `unit` (now matches `wva_required_capacity`, a model/role-level signal). Safe because the metric was always 0.
