### PR TITLE
ci: merge main into PR branch before running /ok-to-test

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -354,6 +354,16 @@ jobs:
         with:
           # Use PR head SHA from gate (works for both pull_request and issue_comment)
           ref: ${{ needs.gate.outputs.pr_head_sha }}
+          fetch-depth: 0
+
+      - name: Merge main into PR branch
+        if: github.event_name == 'issue_comment'
+        run: |
+          git config user.email "ci@github.com"
+          git config user.name "CI"
+          git remote add upstream ${{ github.server_url }}/${{ github.repository }}.git
+          git fetch upstream main
+          git merge upstream/main --no-edit
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -402,6 +412,16 @@ jobs:
         with:
           # Use PR head SHA from gate (works for both pull_request and issue_comment)
           ref: ${{ needs.gate.outputs.pr_head_sha }}
+          fetch-depth: 0
+
+      - name: Merge main into PR branch
+        if: github.event_name == 'issue_comment'
+        run: |
+          git config user.email "ci@github.com"
+          git config user.name "CI"
+          git remote add upstream ${{ github.server_url }}/${{ github.repository }}.git
+          git fetch upstream main
+          git merge upstream/main --no-edit
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -391,6 +391,16 @@ jobs:
           repository: ${{ needs.check-code-changes.outputs.pr_head_repo || github.repository }}
           ref: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Merge main into PR branch
+        if: github.event_name == 'issue_comment'
+        run: |
+          git config user.email "ci@github.com"
+          git config user.name "CI"
+          git remote add upstream ${{ github.server_url }}/${{ github.repository }}.git
+          git fetch upstream main
+          git merge upstream/main --no-edit
 
       - name: Extract Go version from go.mod
         run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :bug: Merge `main` into the PR branch before running tests on `/ok-to-test` triggers

Previously, `issue_comment` triggered runs (fork PRs via `/ok-to-test`) checked out only the fork's head SHA in isolation. Native `pull_request` events automatically test GitHub's synthetic merge commit, but the comment path bypassed that. Tests could pass on the fork tip while failing after merge if `main` had advanced. Both Kind and OpenShift E2E workflows now fetch `main` from the base repo and merge it into the PR branch before building or running tests, matching the
behaviour of the native `pull_request` event.

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **E2E tests** for any new behavior — CI change only, no new code paths
- [ ] **Docs PR** for any user-facing impact — not user-facing
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — not applicable

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
NONE
```


**Docs**
NONE
<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
