### PR TITLE
test(e2e): add KEDA smoke test suite and non-blocking CI job

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -344,6 +344,62 @@ jobs:
         run: |
           make test-e2e-smoke-with-setup
 
+  # KEDA E2E smoke tests - run automatically on every PR with code changes.
+  # Non-blocking: not a required status check. Will be promoted to required once stable.
+  # Each run gets its own Kind cluster with KEDA installed instead of Prometheus Adapter.
+  e2e-tests-smoke-keda:
+    runs-on: ubuntu-latest
+    needs: [lint-and-test, check-code-changes, check-full-tests]
+    if: github.event_name == 'pull_request' && needs.check-code-changes.result == 'success' && needs.check-code-changes.outputs.has_code_changes == 'true'
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Extract Go version from go.mod
+        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+
+      - name: Set up Go with cache
+        uses: actions/setup-go@v6
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: ./go.sum
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Install Kind
+        run: deploy/ci-pr-checks/install-kind.sh
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build WVA image locally
+        id: build-image
+        env:
+          CHECKOUT_SHA: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
+        run: deploy/ci-pr-checks/build-wva-image-local.sh
+
+      - name: Run e2e tests (KEDA smoke)
+        shell: bash
+        env:
+          ENVIRONMENT: kind-emulator
+          USE_SIMULATOR: "true"
+          SCALE_TO_ZERO_ENABLED: "false"
+          CREATE_CLUSTER: "true"
+          SCALER_BACKEND: keda
+          LLM_D_ROUTER_VERSION: "v0.9.0"
+          WVA_E2E_SECONDARY_OVERLAY_PATH: ${{ github.workspace }}/test/e2e/testdata/secondary-controller
+          IMG: ${{ steps.build-image.outputs.image }}
+          SKIP_BUILD: "true"
+          DELETE_CLUSTER: "true"
+          KV_SPARE_TRIGGER: "0.5"
+          QUEUE_SPARE_TRIGGER: "4.5"
+        run: |
+          make test-e2e-smoke-keda-with-setup
+
   # Full Kind E2E - runs on same-repo pull_request events, /ok-to-test comments, or workflow_dispatch.
   # Add "e2e-tests-full" as a required status check in branch protection so it appears on every PR
   # and must run and pass before merge (shows as "Expected" until triggered).

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ test-e2e-full: ## Run full e2e test suite
 	SCALER_BACKEND=$(SCALER_BACKEND) \
 	MODEL_ID=$(MODEL_ID) \
 	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
-		-ginkgo.label-filter="full && !flaky" $(FOCUS_ARGS) $(SKIP_ARGS); \
+		-ginkgo.label-filter="full && !flaky && !keda" $(FOCUS_ARGS) $(SKIP_ARGS); \
 	TEST_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=========================================="; \

--- a/Makefile
+++ b/Makefile
@@ -248,13 +248,42 @@ test-e2e-smoke: ## Run smoke e2e tests
 	SCALER_BACKEND=$(SCALER_BACKEND) \
 	MODEL_ID=$(MODEL_ID) \
 	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
-		-ginkgo.label-filter="smoke" $(FOCUS_ARGS) $(SKIP_ARGS); \
+		-ginkgo.label-filter="smoke && !keda" $(FOCUS_ARGS) $(SKIP_ARGS); \
 	TEST_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=========================================="; \
 	echo "Test execution completed. Exit code: $$TEST_EXIT_CODE"; \
 	echo "=========================================="; \
 	exit $$TEST_EXIT_CODE
+
+.PHONY: test-e2e-smoke-keda
+test-e2e-smoke-keda: ## Run KEDA smoke e2e tests (requires SCALER_BACKEND=keda infra)
+	@echo "Running KEDA smoke e2e tests..."
+	$(eval FOCUS_ARGS := $(if $(FOCUS),-ginkgo.focus="$(FOCUS)",))
+	$(eval SKIP_ARGS := $(if $(SKIP),-ginkgo.skip="$(SKIP)",))
+	KUBECONFIG=$(KUBECONFIG) \
+	ENVIRONMENT=$(ENVIRONMENT) \
+	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
+	LLMD_NAMESPACE=$(E2E_EMULATED_LLMD_NAMESPACE) \
+	MONITORING_NAMESPACE=$(E2E_MONITORING_NAMESPACE) \
+	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
+	USE_SIMULATOR=$(USE_SIMULATOR) \
+	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
+	SCALER_BACKEND=keda \
+	MODEL_ID=$(MODEL_ID) \
+	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
+		-ginkgo.label-filter="smoke && keda" $(FOCUS_ARGS) $(SKIP_ARGS); \
+	TEST_EXIT_CODE=$$?; \
+	echo ""; \
+	echo "=========================================="; \
+	echo "Test execution completed. Exit code: $$TEST_EXIT_CODE"; \
+	echo "=========================================="; \
+	exit $$TEST_EXIT_CODE
+
+.PHONY: test-e2e-smoke-keda-with-setup
+test-e2e-smoke-keda-with-setup: ## Deploy KEDA infra and run KEDA smoke e2e tests
+	$(MAKE) deploy-e2e-infra SCALER_BACKEND=keda
+	$(MAKE) test-e2e-smoke-keda
 
 # Runs the complete e2e test suite (excluding flaky tests).
 .PHONY: test-e2e-full
@@ -281,7 +310,7 @@ test-e2e-full: ## Run full e2e test suite
 
 # Convenience targets for local e2e testing
 
-# Convenience target that deploys infra + runs smoke tests.
+# Convenience target that deploys infra + runs smoke tests (HPA / Prometheus Adapter path).
 # Set DELETE_CLUSTER=true to delete Kind cluster after tests (default: keep cluster for debugging).
 .PHONY: test-e2e-smoke-with-setup
 test-e2e-smoke-with-setup: deploy-e2e-infra test-e2e-smoke

--- a/config/base/monitoring/servicemonitor.yaml
+++ b/config/base/monitoring/servicemonitor.yaml
@@ -20,6 +20,13 @@ spec:
         # WVA metrics endpoint uses self-signed certificates, so Prometheus must skip verification
         # This is separate from WVA->Prometheus TLS verification
         insecureSkipVerify: true
+      # Drop scrape-target labels so WVA controller metrics are stored as a single
+      # series per (variant_name, namespace) regardless of how many controller pods
+      # are running. Without this, rolling updates produce multiple series and break
+      # KEDA's scalar expectation.
+      metricRelabelings:
+        - action: labeldrop
+          regex: "(instance|pod|container|node)"
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/deploy/ci-e2e-openshift/scale-down-on-failure.sh
+++ b/deploy/ci-e2e-openshift/scale-down-on-failure.sh
@@ -13,6 +13,6 @@ for ns in "$LLMD_NAMESPACE"; do
     kubectl get deployment -n "$ns" -o name 2>/dev/null | grep decode | while read -r deploy; do
       echo "  Scaling down: $deploy"
       kubectl scale "$deploy" -n "$ns" --replicas=0 || true
-    done
+    done || true
   fi
 done

--- a/test/e2e/fixtures/scaled_object_builder.go
+++ b/test/e2e/fixtures/scaled_object_builder.go
@@ -124,7 +124,7 @@ func buildScaledObject(namespace, name, scaleTargetName, vaName string, minRepli
 	prometheusURL := "https://kube-prometheus-stack-prometheus." + monitoringNamespace + ".svc.cluster.local:9090"
 	// Use "namespace" not "exported_namespace": WVA controller emits the metric with label namespace;
 	// exported_namespace is only used by Prometheus Adapter for the external metrics API.
-	query := fmt.Sprintf("max(wva_desired_replicas{variant_name=%q,namespace=%q})", vaName, namespace)
+	query := fmt.Sprintf("wva_desired_replicas{variant_name=%q,namespace=%q}", vaName, namespace)
 
 	spec := kedav1alpha1.ScaledObjectSpec{
 		ScaleTargetRef: &kedav1alpha1.ScaleTarget{

--- a/test/e2e/fixtures/scaled_object_builder.go
+++ b/test/e2e/fixtures/scaled_object_builder.go
@@ -124,7 +124,7 @@ func buildScaledObject(namespace, name, scaleTargetName, vaName string, minRepli
 	prometheusURL := "https://kube-prometheus-stack-prometheus." + monitoringNamespace + ".svc.cluster.local:9090"
 	// Use "namespace" not "exported_namespace": WVA controller emits the metric with label namespace;
 	// exported_namespace is only used by Prometheus Adapter for the external metrics API.
-	query := fmt.Sprintf("wva_desired_replicas{variant_name=%q,namespace=%q}", vaName, namespace)
+	query := fmt.Sprintf("max(wva_desired_replicas{variant_name=%q,namespace=%q})", vaName, namespace)
 
 	spec := kedav1alpha1.ScaledObjectSpec{
 		ScaleTargetRef: &kedav1alpha1.ScaleTarget{

--- a/test/e2e/smoke_keda_test.go
+++ b/test/e2e/smoke_keda_test.go
@@ -1,0 +1,394 @@
+package e2e
+
+import (
+	"time"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	variantautoscalingv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
+)
+
+var _ = Describe("KEDA Smoke Tests - Infrastructure Readiness", Label("smoke", "keda", "full"), func() {
+	Context("Basic infrastructure validation", func() {
+		It("should have WVA controller running and ready", func() {
+			Eventually(func(g Gomega) {
+				pods, err := k8sClient.CoreV1().Pods(cfg.WVANamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: "control-plane=controller-manager",
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods.Items).NotTo(BeEmpty(), "WVA controller pod should exist")
+				readyPods := 0
+				for _, pod := range pods.Items {
+					if pod.Status.Phase == corev1.PodRunning {
+						for _, condition := range pod.Status.Conditions {
+							if condition.Type == "Ready" && condition.Status == "True" {
+								readyPods++
+								break
+							}
+						}
+					}
+				}
+				g.Expect(readyPods).To(BeNumerically(">", 0), "At least one WVA controller pod should be ready")
+			}).Should(Succeed())
+		})
+
+		It("should have llm-d CRDs installed", func() {
+			_, err := k8sClient.Discovery().ServerResourcesForGroupVersion("inference.networking.k8s.io/v1")
+			Expect(err).NotTo(HaveOccurred(), "llm-d CRDs should be installed")
+		})
+
+		It("should have Prometheus running", func() {
+			Eventually(func(g Gomega) {
+				pods, err := k8sClient.CoreV1().Pods(cfg.MonitoringNS).List(ctx, metav1.ListOptions{
+					LabelSelector: "app.kubernetes.io/name=prometheus",
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods.Items).NotTo(BeEmpty(), "Prometheus pod should exist")
+			}).Should(Succeed())
+		})
+
+		It("should have KEDA operator ready", func() {
+			By("Checking KEDA operator pods in " + cfg.KEDANamespace)
+			Eventually(func(g Gomega) {
+				pods, err := k8sClient.CoreV1().Pods(cfg.KEDANamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: "app.kubernetes.io/name=keda-operator",
+				})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to list KEDA operator pods")
+				g.Expect(pods.Items).NotTo(BeEmpty(), "At least one KEDA operator pod should exist")
+				ready := 0
+				for _, p := range pods.Items {
+					if p.Status.Phase == corev1.PodRunning {
+						for _, c := range p.Status.Conditions {
+							if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+								ready++
+								break
+							}
+						}
+					}
+				}
+				g.Expect(ready).To(BeNumerically(">", 0), "At least one KEDA operator pod should be ready")
+			}).Should(Succeed())
+		})
+
+		It("should have KEDA metrics server serving the external metrics API", func() {
+			By("Checking external.metrics.k8s.io/v1beta1 is available (owned by KEDA)")
+			Eventually(func(g Gomega) {
+				_, err := k8sClient.Discovery().ServerResourcesForGroupVersion("external.metrics.k8s.io/v1beta1")
+				g.Expect(err).NotTo(HaveOccurred(), "KEDA metrics server should register external.metrics.k8s.io/v1beta1")
+			}).Should(Succeed())
+		})
+	})
+})
+
+var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", "full"), Ordered, func() {
+	var (
+		poolName         = "smoke-test-pool"
+		modelServiceName = "smoke-test-ms"
+		deploymentName   = modelServiceName + "-decode"
+		vaName           = "smoke-test-va"
+		scalerName       = "smoke-test-hpa" // base name; ScaledObject will be scalerName+"-so"
+		minReplicas      = int32(1)
+	)
+
+	BeforeAll(func() {
+		By("Cleaning up any existing smoke test resources")
+		cleanupSmokeTestResources()
+
+		if cfg.ScaleToZeroEnabled {
+			minReplicas = 0
+		}
+
+		By("Creating model service deployment")
+		err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, vaName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
+
+		DeferCleanup(func() {
+			cleanupResource(ctx, "Deployment", cfg.LLMDNamespace, deploymentName,
+				func() error {
+					return k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, deploymentName, metav1.DeleteOptions{})
+				},
+				func() bool {
+					_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				})
+		})
+
+		By("Creating service to expose model server")
+		err = fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceName, deploymentName, 8000)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create service")
+
+		DeferCleanup(func() {
+			serviceName := modelServiceName + "-service"
+			cleanupResource(ctx, "Service", cfg.LLMDNamespace, serviceName,
+				func() error {
+					return k8sClient.CoreV1().Services(cfg.LLMDNamespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
+				},
+				func() bool {
+					_, err := k8sClient.CoreV1().Services(cfg.LLMDNamespace).Get(ctx, serviceName, metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				})
+		})
+
+		By("Creating ServiceMonitor for metrics scraping")
+		err = fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, cfg.LLMDNamespace, modelServiceName, deploymentName)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create ServiceMonitor")
+
+		DeferCleanup(func() {
+			serviceMonitorName := modelServiceName + "-monitor"
+			cleanupResource(ctx, "ServiceMonitor", cfg.MonitoringNS, serviceMonitorName,
+				func() error {
+					return crClient.Delete(ctx, &promoperator.ServiceMonitor{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      serviceMonitorName,
+							Namespace: cfg.MonitoringNS,
+						},
+					})
+				},
+				func() bool {
+					err := crClient.Get(ctx, client.ObjectKey{Name: serviceMonitorName, Namespace: cfg.MonitoringNS}, &promoperator.ServiceMonitor{})
+					return errors.IsNotFound(err)
+				})
+		})
+
+		By("Waiting for model service to be ready")
+		Eventually(func(g Gomega) {
+			deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)), "Model service should have 1 ready replica")
+		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+
+		By("Creating VariantAutoscaling resource")
+		err = fixtures.EnsureVariantAutoscalingWithDefaults(
+			ctx, crClient, cfg.LLMDNamespace, vaName,
+			deploymentName, cfg.ModelID, cfg.AcceleratorType,
+			cfg.ControllerInstance,
+		)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
+
+		By("Creating ScaledObject")
+		err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerName, deploymentName, vaName, minReplicas, 10, cfg.MonitoringNS)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject")
+	})
+
+	AfterAll(func() {
+		By("Cleaning up KEDA smoke test resources")
+		err := fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		va := &variantautoscalingv1alpha1.VariantAutoscaling{
+			ObjectMeta: metav1.ObjectMeta{Name: vaName, Namespace: cfg.LLMDNamespace},
+		}
+		cleanupResource(ctx, "VA", cfg.LLMDNamespace, vaName,
+			func() error { return crClient.Delete(ctx, va) },
+			func() bool {
+				err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+				return errors.IsNotFound(err)
+			})
+	})
+
+	It("should reconcile the VA successfully", func() {
+		Eventually(func(g Gomega) {
+			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+			g.Expect(err).NotTo(HaveOccurred())
+			condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeTargetResolved)
+			g.Expect(condition).NotTo(BeNil(), "VA should have TargetResolved condition")
+			g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "TargetResolved should be True")
+		}).Should(Succeed())
+	})
+
+	It("should have MetricsAvailable condition set", func() {
+		Eventually(func(g Gomega) {
+			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+			g.Expect(err).NotTo(HaveOccurred())
+			condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeMetricsAvailable)
+			g.Expect(condition).NotTo(BeNil(), "MetricsAvailable condition should exist")
+			g.Expect(condition.Status).To(BeElementOf(metav1.ConditionTrue, metav1.ConditionFalse),
+				"MetricsAvailable should have a valid status")
+		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+	})
+
+	It("should have ScaledObject Ready condition set by KEDA", func() {
+		soName := scalerName + "-so"
+		Eventually(func(g Gomega) {
+			so := &kedav1alpha1.ScaledObject{}
+			err := crClient.Get(ctx, client.ObjectKey{Namespace: cfg.LLMDNamespace, Name: soName}, so)
+			g.Expect(err).NotTo(HaveOccurred(), "ScaledObject %s should exist", soName)
+			ready := so.Status.Conditions.GetReadyCondition()
+			g.Expect(ready.Status).To(Equal(metav1.ConditionTrue), "ScaledObject should have Ready=True")
+		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+	})
+
+	It("should have KEDA create an HPA for the deployment", func() {
+		Eventually(func(g Gomega) {
+			hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			var found bool
+			for _, h := range hpaList.Items {
+				if h.Spec.ScaleTargetRef.Name == deploymentName {
+					found = true
+					g.Expect(h.Status.DesiredReplicas).To(BeNumerically(">=", 0), "KEDA HPA should have desired replicas set")
+					break
+				}
+			}
+			g.Expect(found).To(BeTrue(), "KEDA should have created an HPA targeting %s", deploymentName)
+		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+	})
+
+	It("should verify Prometheus is scraping model server pods", func() {
+		Eventually(func(g Gomega) {
+			pods, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=" + deploymentName,
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pods.Items).NotTo(BeEmpty(), "Should have at least one pod")
+			readyCount := 0
+			for _, pod := range pods.Items {
+				for _, condition := range pod.Status.Conditions {
+					if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+						readyCount++
+						break
+					}
+				}
+			}
+			g.Expect(readyCount).To(BeNumerically(">", 0), "At least one pod should be ready for metrics scraping")
+		}).Should(Succeed())
+	})
+})
+
+var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "full"), Serial, Ordered, func() {
+	var (
+		errorTestPoolName         = "error-test-pool"
+		errorTestModelServiceName = "error-test-ms"
+		errorTestDeploymentName   = errorTestModelServiceName + "-decode"
+		errorTestVAName           = "error-test-va"
+	)
+
+	BeforeAll(func() {
+		By("Cleaning up any existing smoke test resources")
+		cleanupSmokeTestResources()
+
+		By("Creating model service deployment for error handling tests")
+		err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVAName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
+
+		DeferCleanup(func() {
+			cleanupResource(ctx, "Deployment", cfg.LLMDNamespace, errorTestDeploymentName,
+				func() error {
+					return k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, errorTestDeploymentName, metav1.DeleteOptions{})
+				},
+				func() bool {
+					_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				})
+		})
+
+		By("Waiting for model service to be ready")
+		Eventually(func(g Gomega) {
+			deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)), "Model service should have 1 ready replica")
+		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+
+		By("Creating VariantAutoscaling resource")
+		err = fixtures.EnsureVariantAutoscalingWithDefaults(
+			ctx, crClient, cfg.LLMDNamespace, errorTestVAName,
+			errorTestDeploymentName, cfg.ModelID, cfg.AcceleratorType,
+			cfg.ControllerInstance,
+		)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
+
+		By("Waiting for VA to reconcile initially")
+		Eventually(func(g Gomega) {
+			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(va.Status.Conditions).NotTo(BeEmpty(), "VA should have status conditions")
+		}).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		va := &variantautoscalingv1alpha1.VariantAutoscaling{
+			ObjectMeta: metav1.ObjectMeta{Name: errorTestVAName, Namespace: cfg.LLMDNamespace},
+		}
+		cleanupResource(ctx, "VA", cfg.LLMDNamespace, errorTestVAName,
+			func() error { return crClient.Delete(ctx, va) },
+			func() bool {
+				err := crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+				return errors.IsNotFound(err)
+			})
+	})
+
+	It("should handle deployment deletion and recreation gracefully", func() {
+		By("Verifying deployment exists before deletion")
+		_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Deployment should exist before deletion")
+
+		By("Deleting the deployment")
+		err = k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, errorTestDeploymentName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Should be able to delete deployment")
+
+		By("Waiting for deployment to be fully deleted")
+		Eventually(func(g Gomega) {
+			_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+			g.Expect(errors.IsNotFound(err)).To(BeTrue(), "Deployment should be deleted")
+		}, time.Duration(cfg.EventuallyShortSec)*time.Second, time.Duration(cfg.PollIntervalQuickSec)*time.Second).Should(Succeed())
+
+		By("Verifying VA continues to exist after deployment deletion")
+		va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+		err = crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+		Expect(err).NotTo(HaveOccurred(), "VA should continue to exist after deployment deletion")
+
+		By("Recreating the deployment")
+		err = fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVAName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		Expect(err).NotTo(HaveOccurred(), "Failed to recreate model service")
+
+		By("Waiting for deployment to be ready after recreation")
+		Eventually(func(g Gomega) {
+			deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)),
+				"Model service should have 1 ready replica after recreation")
+		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSlowSec)*time.Second).Should(Succeed())
+
+		By("Verifying VA automatically resumes operation")
+		Eventually(func(g Gomega) {
+			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+			g.Expect(err).NotTo(HaveOccurred())
+			condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeTargetResolved)
+			g.Expect(condition).NotTo(BeNil(), "TargetResolved condition should exist")
+			g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "TargetResolved should be True when deployment is recreated")
+		}).Should(Succeed())
+	})
+
+	It("should handle metrics unavailability gracefully", func() {
+		Eventually(func(g Gomega) {
+			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+			g.Expect(err).NotTo(HaveOccurred())
+			condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeMetricsAvailable)
+			g.Expect(condition).NotTo(BeNil(), "MetricsAvailable condition should exist")
+			switch condition.Status {
+			case metav1.ConditionFalse:
+				g.Expect(condition.Reason).To(BeElementOf(
+					variantautoscalingv1alpha1.ReasonMetricsMissing,
+					variantautoscalingv1alpha1.ReasonMetricsStale,
+					variantautoscalingv1alpha1.ReasonPrometheusError,
+					variantautoscalingv1alpha1.ReasonMetricsUnavailable,
+				), "When metrics unavailable, reason should indicate the cause")
+			case metav1.ConditionTrue:
+				g.Expect(condition.Reason).To(Equal(variantautoscalingv1alpha1.ReasonMetricsFound))
+			}
+		}).Should(Succeed())
+	})
+})

--- a/test/e2e/smoke_keda_test.go
+++ b/test/e2e/smoke_keda_test.go
@@ -263,6 +263,40 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 			g.Expect(readyCount).To(BeNumerically(">", 0), "At least one pod should be ready for metrics scraping")
 		}).Should(Succeed())
 	})
+
+	It("should collect saturation metrics without triggering scale-up", func() {
+		By("Verifying VA is reconciled and has conditions")
+		Eventually(func(g Gomega) {
+			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(va.Status.Conditions).NotTo(BeEmpty(), "VA should have status conditions")
+		}).Should(Succeed())
+
+		By("Verifying MetricsAvailable condition indicates metrics collection")
+		va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+		err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+		Expect(err).NotTo(HaveOccurred())
+
+		condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeMetricsAvailable)
+		Expect(condition).NotTo(BeNil(), "MetricsAvailable condition should exist")
+		if condition.Status == metav1.ConditionTrue {
+			Expect(condition.Reason).To(Equal(variantautoscalingv1alpha1.ReasonMetricsFound),
+				"When metrics are available, reason should be MetricsFound")
+		}
+
+		By("Checking if DesiredOptimizedAlloc is populated (best-effort)")
+		if va.Status.DesiredOptimizedAlloc.Accelerator != "" {
+			Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).NotTo(BeNil(),
+				"If DesiredOptimizedAlloc is populated, NumReplicas should be set")
+			Expect(*va.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically(">=", 0),
+				"If DesiredOptimizedAlloc is populated, NumReplicas should be >= 0")
+			GinkgoWriter.Printf("DesiredOptimizedAlloc: accelerator=%s, replicas=%d\n",
+				va.Status.DesiredOptimizedAlloc.Accelerator, *va.Status.DesiredOptimizedAlloc.NumReplicas)
+		} else {
+			GinkgoWriter.Printf("DesiredOptimizedAlloc not yet populated (Engine may not have run yet)\n")
+		}
+	})
 })
 
 var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "full"), Serial, Ordered, func() {


### PR DESCRIPTION
Fixes # (part of prometheus-adapter deprecation migration)

## Proposed Changes

- :gift: Add `smoke_keda_test.go` - dedicated KEDA smoke test suite covering infrastructure readiness, basic autoscaling (ScaledObject Ready condition, KEDA-created HPA), and error handling; labeled `smoke && keda` so it runs independently from the HPA smoke suite
- :gift: Add `test-e2e-smoke-keda` and `test-e2e-smoke-keda-with-setup` make targets; update `test-e2e-smoke` filter to `smoke && !keda`
- :gift: Add non-blocking `e2e-tests-smoke-keda` CI job that spins its own Kind cluster with `SCALER_BACKEND=keda`, running in parallel with the existing HPA smoke job

### Pre-review Checklist

- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [x] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

```release-note
NONE
