### PR TITLE
docs: remove orphaned VLLM_MAX_NUM_SEQS from deploy READMEs

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -756,7 +756,6 @@ For rapid testing of autoscaling behavior, configure vLLM with a low `max-num-se
 
 ```bash
 # Deploy WVA infra, then tune vLLM max-num-seqs in the llm-d ModelService manifest
-export VLLM_MAX_NUM_SEQS=8
 make deploy-wva-on-k8s   # runs install.sh (WVA + monitoring + scaler + LWS)
 # Apply llm-d model serving manifests separately via kubectl apply or the llm-d guides
 ```

--- a/deploy/kind-emulator/README.md
+++ b/deploy/kind-emulator/README.md
@@ -65,7 +65,6 @@ export ITL_AVERAGE_LATENCY_MS=20            # Average inter-token latency for th
 export TTFT_AVERAGE_LATENCY_MS=200          # Average time-to-first-token for the llm-d-inference-sim
 
 # Performance tuning (optional)
-export VLLM_MAX_NUM_SEQS=64                 # vLLM max concurrent sequences (batch size)
 export HPA_STABILIZATION_SECONDS=240        # HPA stabilization window
 
 # Image load (optional; auto-detected if unset)

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -103,7 +103,6 @@ export WVA_IMAGE_TAG="latest"               # WVA version
 # HPA stabilization: configure on the HPA resource directly, not install.sh
 
 # Performance tuning (optional; set in llm-d ModelService manifest)
-export VLLM_MAX_NUM_SEQS=64                 # vLLM max concurrent sequences (batch size)
 export ACCELERATOR_TYPE="A100"              # GPU type (auto-detected)
 ```
 
@@ -169,7 +168,6 @@ make deploy-wva-on-k8s
 ```bash
 export HF_TOKEN="hf_xxxxx"
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B"
-export VLLM_MAX_NUM_SEQS=64         # Match desired max batch size
 make deploy-wva-on-k8s
 ```
 

--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -99,7 +99,6 @@ export ACCELERATOR_TYPE="H100"              # GPU type (auto-detected)
 export GATEWAY_PROVIDER="istio"             # Gateway: istio or kgateway
 
 # Performance tuning (optional)
-export VLLM_MAX_NUM_SEQS=64                 # vLLM max concurrent sequences (batch size)
 export HPA_STABILIZATION_SECONDS=240        # HPA stabilization window
 ```
 
@@ -150,7 +149,6 @@ make deploy-wva-on-openshift
 ```bash
 export HF_TOKEN="hf_xxxxx"
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B"
-export VLLM_MAX_NUM_SEQS=64         # Match desired max batch size
 make deploy-wva-on-openshift
 ```
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :wastebasket: Remove the six orphaned `export VLLM_MAX_NUM_SEQS=...` lines from `deploy/README.md`, `deploy/kind-emulator/README.md`, `deploy/kubernetes/README.md`, and `deploy/openshift/README.md`
- :broom: `VLLM_MAX_NUM_SEQS` is no longer read by any deploy script or CI workflow — the pre-deployed vLLM model server that consumed it was removed in #1370, so these docs told users to export a variable nothing reads
- :broom: Kept the surrounding guidance to tune `max-num-seqs` in the llm-d ModelService manifest, which remains the correct way to set it

### Pre-review Checklist

- [x] **E2E tests** for any new behavior — N/A; docs-only, no behavior change
- [x] **Docs PR** for any user-facing impact — this *is* the docs change
- [x] **Proposal PR** for any new enhancement or change to existing behavior — N/A

**Release Note**

```release-note
NONE
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
