### PR TITLE
fix(variants): scope HPA/ScaledObject list calls to tracked namespaces

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -501,6 +501,7 @@ func main() {
 		engine.SetLimiterBuilder(func() (pipeline.Limiter, error) {
 			return pipeline.NewLimiterFromConfig(cfg, mgr.GetClient())
 		})
+		engine.Datastore = ds
 		if taRegistered {
 			registration.RegisterThroughputAnalyzerQueries(sourceRegistry)
 			if err := engine.RegisterAnalyzer(throughput.AnalyzerName, throughput.NewThroughputAnalyzer()); err != nil {

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -41,6 +41,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	queueingmodel "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel"
 	saturation_v2 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/saturation_v2"
@@ -145,6 +146,10 @@ type Engine struct {
 	vaEventTracker map[string]bool
 
 	Config *config.Config // Unified configuration (injected from main.go)
+
+	// Datastore is used to scope HPA/ScaledObject list calls to tracked namespaces.
+	// When nil, list calls fall back to cluster-wide.
+	Datastore datastore.Datastore
 
 	// ReplicaMetricsCollector is the collector for replica metrics using the source infrastructure
 	ReplicaMetricsCollector *collector.ReplicaMetricsCollector
@@ -450,7 +455,11 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 		logger.Info("Scaling to zero is enabled")
 	}
 
-	activeVAs, _, err := utils.ActiveVariantAutoscaling(ctx, e.client)
+	var trackedNamespaces []string
+	if e.Datastore != nil {
+		trackedNamespaces = e.Datastore.ListTrackedNamespaces()
+	}
+	activeVAs, _, err := utils.ActiveVariantAutoscaling(ctx, e.client, trackedNamespaces)
 	if err != nil {
 		logger.Error(err, "Unable to get active variant autoscalings")
 		return err

--- a/internal/engines/scalefromzero/engine.go
+++ b/internal/engines/scalefromzero/engine.go
@@ -129,7 +129,7 @@ func (e *Engine) optimize(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 
 	// Get all inactive (replicas == 0) VAs
-	inactiveVAs, scaleTargets, err := utils.InactiveVariantAutoscaling(ctx, e.client)
+	inactiveVAs, scaleTargets, err := utils.InactiveVariantAutoscaling(ctx, e.client, e.Datastore.ListTrackedNamespaces())
 	if err != nil {
 		return err
 	}

--- a/internal/engines/scalefromzero/engine_test.go
+++ b/internal/engines/scalefromzero/engine_test.go
@@ -283,7 +283,7 @@ func TestMultipleInactiveVariants(t *testing.T) {
 	}
 
 	// Get all inactive VAs
-	inactiveVAs, scaleTargets, err := utils.InactiveVariantAutoscaling(ctx, fakeClient)
+	inactiveVAs, scaleTargets, err := utils.InactiveVariantAutoscaling(ctx, fakeClient, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(inactiveVAs), "Should have 3 inactive VAs")
 

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -41,8 +41,9 @@ type VariantFilter func(scaletarget.ScaleTargetAccessor) bool
 // ActiveVariantAutoscalingByModel retrieves all VariantAutoscaling resources that are ready for optimization
 // and have at least one target replica.
 // Returns the shallow-copied VAs (not safe for mutation) grouped by ModelID.
-func ActiveVariantAutoscalingByModel(ctx context.Context, client client.Client) (map[string][]wvav1alpha1.VariantAutoscaling, error) {
-	vas, _, err := ActiveVariantAutoscaling(ctx, client)
+// trackedNamespaces scopes HPA/ScaledObject discovery to specific namespaces; nil means cluster-wide.
+func ActiveVariantAutoscalingByModel(ctx context.Context, client client.Client, trackedNamespaces []string) (map[string][]wvav1alpha1.VariantAutoscaling, error) {
+	vas, _, err := ActiveVariantAutoscaling(ctx, client, trackedNamespaces)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +53,9 @@ func ActiveVariantAutoscalingByModel(ctx context.Context, client client.Client) 
 // InactiveVariantAutoscalingByModel retrieves all VariantAutoscaling resources that are ready for optimization
 // and have no target replicas.
 // Returns the shallow-copied VAs (not safe for mutation) grouped by ModelID.
-func InactiveVariantAutoscalingByModel(ctx context.Context, client client.Client) (map[string][]wvav1alpha1.VariantAutoscaling, error) {
-	vas, _, err := InactiveVariantAutoscaling(ctx, client)
+// trackedNamespaces scopes HPA/ScaledObject discovery to specific namespaces; nil means cluster-wide.
+func InactiveVariantAutoscalingByModel(ctx context.Context, client client.Client, trackedNamespaces []string) (map[string][]wvav1alpha1.VariantAutoscaling, error) {
+	vas, _, err := InactiveVariantAutoscaling(ctx, client, trackedNamespaces)
 	if err != nil {
 		return nil, err
 	}
@@ -80,22 +82,24 @@ func GroupVariantAutoscalingByModel(
 // and have at least one target replica.
 // Returns a slice of deep-copied VariantAutoscaling objects.
 // It also returns a map of scaleTargetAccessors keyed by "namespace/scaleTargetName".
-func ActiveVariantAutoscaling(ctx context.Context, client client.Client) ([]wvav1alpha1.VariantAutoscaling, map[string]scaletarget.ScaleTargetAccessor, error) {
-	return filterVariantsByScaleTargetAccessor(ctx, client, isActive, "active")
+// trackedNamespaces scopes HPA/ScaledObject discovery to specific namespaces; nil means cluster-wide.
+func ActiveVariantAutoscaling(ctx context.Context, client client.Client, trackedNamespaces []string) ([]wvav1alpha1.VariantAutoscaling, map[string]scaletarget.ScaleTargetAccessor, error) {
+	return filterVariantsByScaleTargetAccessor(ctx, client, isActive, "active", trackedNamespaces)
 }
 
 // InactiveVariantAutoscaling retrieves all VariantAutoscaling resources that are ready for optimization
 // and have no target replicas.
 // Returns a slice of deep-copied VariantAutoscaling objects.
 // It also returns a map of scaleTargetAccessors keyed by "namespace/scaleTargetName".
-func InactiveVariantAutoscaling(ctx context.Context, client client.Client) ([]wvav1alpha1.VariantAutoscaling, map[string]scaletarget.ScaleTargetAccessor, error) {
-	return filterVariantsByScaleTargetAccessor(ctx, client, isInactive, "inactive")
+// trackedNamespaces scopes HPA/ScaledObject discovery to specific namespaces; nil means cluster-wide.
+func InactiveVariantAutoscaling(ctx context.Context, client client.Client, trackedNamespaces []string) ([]wvav1alpha1.VariantAutoscaling, map[string]scaletarget.ScaleTargetAccessor, error) {
+	return filterVariantsByScaleTargetAccessor(ctx, client, isInactive, "inactive", trackedNamespaces)
 }
 
 // filterVariantsByScaleTargetAccessors is a generic function to filter VAs based on scaleTarget state.
 // Returns filtered VAs and a map of scaleTargetAccessors keyed by "namespace/scaleTargetName".
-func filterVariantsByScaleTargetAccessor(ctx context.Context, client client.Client, filter VariantFilter, filterName string) ([]wvav1alpha1.VariantAutoscaling, map[string]scaletarget.ScaleTargetAccessor, error) {
-	readyVAs := readyVariantAutoscalings(ctx, client)
+func filterVariantsByScaleTargetAccessor(ctx context.Context, client client.Client, filter VariantFilter, filterName string, trackedNamespaces []string) ([]wvav1alpha1.VariantAutoscaling, map[string]scaletarget.ScaleTargetAccessor, error) {
+	readyVAs := readyVariantAutoscalings(ctx, client, trackedNamespaces)
 
 	filteredVAs := make([]wvav1alpha1.VariantAutoscaling, 0, len(readyVAs))
 	scaleTargetAccessors := make(map[string]scaletarget.ScaleTargetAccessor)
@@ -161,14 +165,15 @@ func filterVariantsByScaleTargetAccessor(ctx context.Context, client client.Clie
 // synthesizing in-memory VariantAutoscaling objects from annotated ScaledObjects
 // and HPAs (annotation-based discovery). When CONTROLLER_INSTANCE is configured,
 // only variants whose source object carries a matching controller-instance label
-// are returned, enabling multi-controller isolation.
+// are returned, enabling multi-controller isolation. trackedNamespaces scopes
+// HPA/ScaledObject discovery; nil or empty means cluster-wide.
 //
 // Errors from annotation discovery are non-fatal (logged), so this always returns
 // whatever was discovered and never an error.
-func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) []wvav1alpha1.VariantAutoscaling {
+func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client, trackedNamespaces []string) []wvav1alpha1.VariantAutoscaling {
 	logger := ctrl.LoggerFrom(ctx)
 
-	annotated, err := annotationSourcedVariants(ctx, k8sClient)
+	annotated, err := annotationSourcedVariants(ctx, k8sClient, trackedNamespaces)
 	if err != nil {
 		// Non-fatal: log and continue with whatever was discovered.
 		logger.Error(err, "Error while listing annotation-sourced variants (non-fatal)")
@@ -191,53 +196,64 @@ func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) []wv
 	return readyVAs
 }
 
+// namespacedListCalls returns one []client.ListOption slice per namespace to query,
+// or a single empty slice for a cluster-wide query when trackedNamespaces is empty.
+func namespacedListCalls(trackedNamespaces []string) [][]client.ListOption {
+	if len(trackedNamespaces) == 0 {
+		return [][]client.ListOption{{}} // one cluster-wide call
+	}
+	calls := make([][]client.ListOption, len(trackedNamespaces))
+	for i, ns := range trackedNamespaces {
+		calls[i] = []client.ListOption{client.InNamespace(ns)}
+	}
+	return calls
+}
+
 // annotationSourcedVariants lists HPAs and KEDA ScaledObjects bearing llm-d.ai/managed: "true"
 // and synthesizes in-memory VariantAutoscaling objects from them. ScaledObject discovery is
 // skipped gracefully when the KEDA CRD is not installed. When both an HPA and a ScaledObject
 // target the same scale target, the ScaledObject entry wins.
-func annotationSourcedVariants(ctx context.Context, k8sClient client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
+// When trackedNamespaces is non-empty, List calls are scoped per namespace to avoid full-cluster
+// cache scans on every engine tick.
+func annotationSourcedVariants(ctx context.Context, k8sClient client.Client, trackedNamespaces []string) ([]wvav1alpha1.VariantAutoscaling, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	// keyed by namespace/kind/name for deduplication; ScaledObject entries overwrite HPA entries.
 	byTarget := make(map[string]wvav1alpha1.VariantAutoscaling)
 
+	// Build per-call list options: one per tracked namespace, or a single cluster-wide call.
+	nsCalls := namespacedListCalls(trackedNamespaces)
+
 	// HPAs are a core Kubernetes type — always available (lower priority for deduplication).
-	// TODO(#1134): scope to tracked namespaces only (client.InNamespace per ds.ListTrackedNamespaces())
-	// to avoid iterating the full cluster cache on every engine tick.
-	var hpaList autoscalingv2.HorizontalPodAutoscalerList
-	if err := k8sClient.List(ctx, &hpaList); err != nil {
-		return nil, fmt.Errorf("listing HPAs: %w", err)
-	}
-	for i := range hpaList.Items {
-		hpa := &hpaList.Items[i]
-		if !annotations.IsManaged(hpa) || !hpa.DeletionTimestamp.IsZero() {
-			continue
+	for _, opts := range nsCalls {
+		var hpaList autoscalingv2.HorizontalPodAutoscalerList
+		if err := k8sClient.List(ctx, &hpaList, opts...); err != nil {
+			return nil, fmt.Errorf("listing HPAs: %w", err)
 		}
-		va, err := annotations.VariantAutoscalingFromHPA(hpa)
-		if err != nil {
-			logger.V(logging.DEBUG).Info("Skipping HPA with invalid WVA annotations",
-				"namespace", hpa.Namespace, "name", hpa.Name, "error", err)
-			continue
+		for i := range hpaList.Items {
+			hpa := &hpaList.Items[i]
+			if !annotations.IsManaged(hpa) || !hpa.DeletionTimestamp.IsZero() {
+				continue
+			}
+			va, err := annotations.VariantAutoscalingFromHPA(hpa)
+			if err != nil {
+				logger.V(logging.DEBUG).Info("Skipping HPA with invalid WVA annotations",
+					"namespace", hpa.Namespace, "name", hpa.Name, "error", err)
+				continue
+			}
+			key := fmt.Sprintf("%s/%s/%s", va.Namespace, va.Spec.ScaleTargetRef.Kind, va.Spec.ScaleTargetRef.Name)
+			byTarget[key] = *va
 		}
-		key := fmt.Sprintf("%s/%s/%s", va.Namespace, va.Spec.ScaleTargetRef.Kind, va.Spec.ScaleTargetRef.Name)
-		byTarget[key] = *va
 	}
 
 	// KEDA ScaledObjects — may not be installed; handle gracefully.
 	// ScaledObject takes precedence over HPA for the same scale target.
-	// TODO(#1134): scope to tracked namespaces only (client.InNamespace per ds.ListTrackedNamespaces())
-	// to avoid iterating the full cluster cache on every engine tick.
-	var soList kedav1alpha1.ScaledObjectList
-	if err := k8sClient.List(ctx, &soList); err != nil {
-		if apimeta.IsNoMatchError(err) {
-			logger.V(logging.DEBUG).Info("KEDA ScaledObject CRD not available, skipping annotation discovery for ScaledObjects")
-		} else {
-			result := make([]wvav1alpha1.VariantAutoscaling, 0, len(byTarget))
-			for _, va := range byTarget {
-				result = append(result, va)
-			}
-			return result, fmt.Errorf("listing ScaledObjects: %w", err)
+	var soListErr error
+	for _, opts := range nsCalls {
+		var soList kedav1alpha1.ScaledObjectList
+		if err := k8sClient.List(ctx, &soList, opts...); err != nil {
+			soListErr = err
+			break
 		}
-	} else {
 		for i := range soList.Items {
 			so := &soList.Items[i]
 			if !annotations.IsManaged(so) || !so.DeletionTimestamp.IsZero() {
@@ -251,6 +267,17 @@ func annotationSourcedVariants(ctx context.Context, k8sClient client.Client) ([]
 			}
 			key := fmt.Sprintf("%s/%s/%s", va.Namespace, va.Spec.ScaleTargetRef.Kind, va.Spec.ScaleTargetRef.Name)
 			byTarget[key] = *va
+		}
+	}
+	if soListErr != nil {
+		if apimeta.IsNoMatchError(soListErr) {
+			logger.V(logging.DEBUG).Info("KEDA ScaledObject CRD not available, skipping annotation discovery for ScaledObjects")
+		} else {
+			result := make([]wvav1alpha1.VariantAutoscaling, 0, len(byTarget))
+			for _, va := range byTarget {
+				result = append(result, va)
+			}
+			return result, fmt.Errorf("listing ScaledObjects: %w", soListErr)
 		}
 	}
 

--- a/internal/utils/variant_test.go
+++ b/internal/utils/variant_test.go
@@ -208,7 +208,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 			},
 		).Build()
 
-		result, err := annotationSourcedVariants(ctx, cl)
+		result, err := annotationSourcedVariants(ctx, cl, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -223,7 +223,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 			managedSO("ns1", "so-a", "deploy-a", "model-x"),
 		).Build()
 
-		result, err := annotationSourcedVariants(ctx, cl)
+		result, err := annotationSourcedVariants(ctx, cl, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -239,7 +239,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 			managedSO("ns1", "so-b", "deploy-b", "model-x"),
 		).Build()
 
-		result, err := annotationSourcedVariants(ctx, cl)
+		result, err := annotationSourcedVariants(ctx, cl, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -262,7 +262,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 			},
 		}).Build()
 
-		result, err := annotationSourcedVariants(ctx, cl)
+		result, err := annotationSourcedVariants(ctx, cl, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -282,7 +282,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 			},
 		}).Build()
 
-		_, err := annotationSourcedVariants(ctx, cl)
+		_, err := annotationSourcedVariants(ctx, cl, nil)
 		if err == nil {
 			t.Fatal("want error for non-NoMatch ScaledObject list failure, got nil")
 		}
@@ -296,7 +296,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 			managedSO("ns1", "so-a", "deploy-a", "model-so"),
 		).Build()
 
-		result, err := annotationSourcedVariants(ctx, cl)
+		result, err := annotationSourcedVariants(ctx, cl, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -305,6 +305,62 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 		}
 		if result[0].Spec.ModelID != "model-so" {
 			t.Errorf("want ScaledObject to win, got modelID %q", result[0].Spec.ModelID)
+		}
+	})
+}
+
+func TestAnnotationSourcedVariantsNamespaceScoping(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("only resources in tracked namespace are returned", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-a", "deploy-a", "model-x"),
+			managedHPA("ns2", "hpa-b", "deploy-b", "model-y"), // different namespace
+		).Build()
+
+		result, err := annotationSourcedVariants(ctx, cl, []string{"ns1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Errorf("want 1 VA from ns1, got %d", len(result))
+		}
+		if result[0].Namespace != "ns1" {
+			t.Errorf("want namespace ns1, got %q", result[0].Namespace)
+		}
+	})
+
+	t.Run("multiple tracked namespaces union results", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-a", "deploy-a", "model-x"),
+			managedHPA("ns2", "hpa-b", "deploy-b", "model-y"),
+			managedHPA("ns3", "hpa-c", "deploy-c", "model-z"), // not tracked
+		).Build()
+
+		result, err := annotationSourcedVariants(ctx, cl, []string{"ns1", "ns2"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("want 2 VAs from ns1+ns2, got %d", len(result))
+		}
+	})
+
+	t.Run("nil trackedNamespaces falls back to cluster-wide", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-a", "deploy-a", "model-x"),
+			managedHPA("ns2", "hpa-b", "deploy-b", "model-y"),
+		).Build()
+
+		result, err := annotationSourcedVariants(ctx, cl, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("want 2 VAs cluster-wide, got %d", len(result))
 		}
 	})
 }
@@ -318,7 +374,7 @@ func TestReadyVariantAutoscalings(t *testing.T) {
 			managedHPA("ns1", "hpa-ann", "deploy-ann", "model-ann"),
 		).Build()
 
-		result := readyVariantAutoscalings(ctx, cl)
+		result := readyVariantAutoscalings(ctx, cl, nil)
 		if len(result) != 1 {
 			t.Fatalf("want 1 annotation-sourced variant, got %d", len(result))
 		}
@@ -337,7 +393,7 @@ func TestReadyVariantAutoscalings(t *testing.T) {
 			managedSO("ns-so", "so-ann", "deploy-so", "model-so"),
 		).Build()
 
-		result := readyVariantAutoscalings(ctx, cl)
+		result := readyVariantAutoscalings(ctx, cl, nil)
 		if len(result) != 2 {
 			t.Errorf("want 2 variants, got %d", len(result))
 		}
@@ -360,7 +416,7 @@ func TestReadyVariantAutoscalings(t *testing.T) {
 			},
 		}).Build()
 
-		result := readyVariantAutoscalings(ctx, cl)
+		result := readyVariantAutoscalings(ctx, cl, nil)
 		if len(result) != 1 {
 			t.Errorf("want 1 variant (HPA-sourced, KEDA error is non-fatal), got %d", len(result))
 		}


### PR DESCRIPTION
## Summary

Fixes #1134.

`annotationSourcedVariants()` issued two unscoped cluster-wide `List` calls (HPAs and ScaledObjects) on every engine tick, reading the entire cluster cache even when only a small number of namespaces were actually tracked.

**Root cause**: `k8sClient.List(ctx, &hpaList)` and `k8sClient.List(ctx, &soList)` had no `client.ListOption` to restrict the query, as noted by the `TODO(#1134)` comments in the code.

**Fix**: Add a `trackedNamespaces []string` parameter through the call chain. When non-empty, perform one `client.InNamespace(ns)` scoped call per tracked namespace and union the results. When empty/nil, fall back to the original cluster-wide behaviour.

The parameter is threaded through:
- `annotationSourcedVariants(ctx, k8sClient, trackedNamespaces)`
- `readyVariantAutoscalings(ctx, k8sClient, trackedNamespaces)`
- `filterVariantsByScaleTargetAccessor(ctx, client, filter, filterName, trackedNamespaces)`
- `ActiveVariantAutoscaling(ctx, client, trackedNamespaces)`
- `InactiveVariantAutoscaling(ctx, client, trackedNamespaces)`
- `ActiveVariantAutoscalingByModel(ctx, client, trackedNamespaces)`
- `InactiveVariantAutoscalingByModel(ctx, client, trackedNamespaces)`

The scalefromzero engine already holds `Datastore` and now passes `e.Datastore.ListTrackedNamespaces()`. The saturation engine gains an exported `Datastore datastore.Datastore` field (zero-value safe — `nil` means cluster-wide) that is wired from `cmd/main.go` via `engine.Datastore = ds`.

## Changes

- `internal/utils/variant.go`: add `namespacedListCalls` helper; thread `trackedNamespaces` through the full call chain; remove TODO(#1134) comments
- `internal/engines/saturation/engine.go`: add `Datastore datastore.Datastore` field; pass `ListTrackedNamespaces()` to `ActiveVariantAutoscaling`
- `internal/engines/scalefromzero/engine.go`: pass `ListTrackedNamespaces()` to `InactiveVariantAutoscaling`
- `cmd/main.go`: wire `ds` into saturation engine via `engine.Datastore = ds`
- `internal/utils/variant_test.go`: add `TestAnnotationSourcedVariantsNamespaceScoping` (3 cases: single namespace, multi-namespace union, nil fallback); update all call sites to pass `nil`
- `internal/engines/scalefromzero/engine_test.go`: update call site to pass `nil`

## Test plan

- [x] New `TestAnnotationSourcedVariantsNamespaceScoping` tests pass
- [x] All existing unit tests pass (`go test ./internal/utils/... ./internal/engines/...`)
- [x] Full unit test suite passes (`go test ./...`, excluding pre-existing e2e/chart failures requiring a live cluster)
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)