### PR TITLE
bug: Observability - Dashboard: Limiter Impact Panel fix

### DIFF
--- a/deploy/grafana/operational-dashboard.json
+++ b/deploy/grafana/operational-dashboard.json
@@ -1428,7 +1428,7 @@
         "type": "prometheus",
         "uid": "$datasource_uid"
       },
-      "description": "Average number of scaling decisions limited by constraints per optimization cycle (averaged over 1 hour). Shows how often limiters prevent scaling due to insufficient capacity. For example, there were 36 limited decisions total in the last hour for 30 seconds optimization interval, and there are 120 optimization cycles per hour (3600 seconds ÷ 30 seconds), then the average is 36 ÷ 120 = 0.3 decisions per cycle. The metric is wva_decisions_limited_total.",
+      "description": "Number of scaling decisions limited by constraints in the last 15 minutes. Shows how often limiters prevent scaling due to insufficient capacity. The metric is wva_decisions_limited_total.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1511,7 +1511,7 @@
             "uid": "$datasource_uid"
           },
           "editorMode": "code",
-          "expr": "sum(rate(wva_decisions_limited_total{$namespace_label=~\"$namespace\", variant_name=~\"$variant\"}[1h])) by ($namespace_label, variant_name, limiter_name) * max(wva_config_optimization_interval_seconds)",
+          "expr": "sum(increase(wva_decisions_limited_total{$namespace_label=~\"$namespace\", variant_name=~\"$variant\"}[15m])) by ($namespace_label, variant_name, limiter_name)",
           "instant": false,
           "legendFormat": "{{variant_name}} - {{limiter_name}}",
           "range": true,

--- a/deploy/grafana/operational-dashboard.json
+++ b/deploy/grafana/operational-dashboard.json
@@ -1428,7 +1428,7 @@
         "type": "prometheus",
         "uid": "$datasource_uid"
       },
-      "description": "Number of scaling decisions limited by constraints in the last 15 minutes. Shows how often limiters prevent scaling due to insufficient capacity. The metric is wva_decisions_limited_total.",
+      "description": "Average number of scaling decisions limited by constraints per optimization cycle (averaged over 1 hour). Shows how often limiters prevent scaling due to insufficient capacity. For example, there were 36 limited decisions total in the last hour for 30 seconds optimization interval, and there are 120 optimization cycles per hour (3600 seconds ÷ 30 seconds), then the average is 36 ÷ 120 = 0.3 decisions per cycle. The metric is wva_decisions_limited_total.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1511,7 +1511,7 @@
             "uid": "$datasource_uid"
           },
           "editorMode": "code",
-          "expr": "sum(increase(wva_decisions_limited_total{$namespace_label=~\"$namespace\", variant_name=~\"$variant\"}[15m])) by ($namespace_label, variant_name, limiter_name)",
+          "expr": "sum(rate(wva_decisions_limited_total{$namespace_label=~\"$namespace\", variant_name=~\"$variant\"}[1h])) by ($namespace_label, variant_name, limiter_name) * scalar(max(wva_config_optimization_interval_seconds))",
           "instant": false,
           "legendFormat": "{{variant_name}} - {{limiter_name}}",
           "range": true,


### PR DESCRIPTION
The problem:

<!-- Please include the 'why' behind your changes if no issue exists -->
With the current dashboard, although there's metric provided by limiter, e.g.:
```
{                              
    "metric": {                                                                                  
      "__name__": "wva_decisions_limited_total",                                                 
      "container": "manager",                                                                    
      "endpoint": "https",                                                                       
      "exported_namespace": "llm-d-sim",                                                         
      "instance": "10.244.1.4:8443",                                                             
      "job": "wva-controller-manager-metrics-service",                                           
      "limiter_name": "gpu-limiter",                                                             
      "namespace": "workload-variant-autoscaler-system",                                         
      "pod": "wva-controller-manager-7864fc96f6-8plxq",                                          
      "service": "wva-controller-manager-metrics-service",                                       
      "variant_name": "dev-model-hpa"                                                            
    },                                                                                           
    "value": [                                                                                   
      1783354162.165,                                                                            
      "10"                                                                                       
    ]                                                                                            
  }                                                               

```
the dashboard shows "No Data". This is incorrect or at least very misleading. The problem is the PrompQL expression (see the diff). I've updated the expression. Now the panel shows the limiter in action.

<img width="1506" height="590" alt="image" src="https://github.com/user-attachments/assets/6d550569-952f-4ef0-bd05-eb9ac91d8621" />



## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
- :bug: Fix bug

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [N/A ] **E2E tests** for any new behavior
- [N/A] **Docs PR** for any user-facing impact
- [N/A] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
N/A
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
N/A
