### PR TITLE
epp-saturation analyzer

### DIFF
--- a/deploy/configmap-saturation-scaling.yaml
+++ b/deploy/configmap-saturation-scaling.yaml
@@ -32,11 +32,9 @@ data:
     enableLimiter: false
 
   # EPP-saturation analyzer example: derives saturation from the EPP's P90
-  # predicted latency vs the SLOs below (see
-  # docs/developer-guide/epp-saturation-benchmark.md and
-  # config/samples/epp-saturation-benchmark/). The threshold band, smoothing,
-  # and clamp default to the benchmarked values (0.55 / 0.40 / 0.6 / 2.0) —
-  # only set them here to override.
+  # predicted latency vs the SLOs below. The threshold band and smoothing
+  # default to the benchmarked values (0.55 / 0.40 / 0.6) — only set them here
+  # to override.
   # default: |
   #   analyzerName: epp-saturation
   #   ttftSLOMs: 3000
@@ -44,8 +42,6 @@ data:
   #   # scaleUpThreshold: 0.55
   #   # scaleDownBoundary: 0.40
   #   # smoothingAlpha: 0.6
-  #   # saturationCap: 2.0
-  #   # holdScaleUpWhileWarming: false
 
   # Example per-model override for granite model in lab namespace
   # Uncomment and customize as needed

--- a/deploy/configmap-saturation-scaling.yaml
+++ b/deploy/configmap-saturation-scaling.yaml
@@ -31,6 +31,22 @@ data:
     # When true, scale-up decisions are limited by available GPU capacity
     enableLimiter: false
 
+  # EPP-saturation analyzer example: derives saturation from the EPP's P90
+  # predicted latency vs the SLOs below (see
+  # docs/developer-guide/epp-saturation-benchmark.md and
+  # config/samples/epp-saturation-benchmark/). The threshold band, smoothing,
+  # and clamp default to the benchmarked values (0.55 / 0.40 / 0.6 / 2.0) —
+  # only set them here to override.
+  # default: |
+  #   analyzerName: epp-saturation
+  #   ttftSLOMs: 3000
+  #   tpotSLOMs: 100
+  #   # scaleUpThreshold: 0.55
+  #   # scaleDownBoundary: 0.40
+  #   # smoothingAlpha: 0.6
+  #   # saturationCap: 2.0
+  #   # holdScaleUpWhileWarming: false
+
   # Example per-model override for granite model in lab namespace
   # Uncomment and customize as needed
   # granite-override: |

--- a/internal/collector/registration/epp_saturation.go
+++ b/internal/collector/registration/epp_saturation.go
@@ -1,0 +1,127 @@
+package registration
+
+import (
+	"os"
+	"regexp"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// Environment variables overriding the EPP latency metric names the saturation
+// queries are built from. The defaults are the llm-d EPP's metric contract;
+// override them when the EPP build exposes the histograms under different
+// names (e.g. the upstream gateway-api-inference-extension
+// `inference_objective_*` family, or a renamed fork).
+const (
+	EnvEPPPredictedTTFTMetric = "WVA_EPP_PREDICTED_TTFT_METRIC"
+	EnvEPPActualTTFTMetric    = "WVA_EPP_ACTUAL_TTFT_METRIC"
+	EnvEPPPredictedTPOTMetric = "WVA_EPP_PREDICTED_TPOT_METRIC"
+	EnvEPPActualTPOTMetric    = "WVA_EPP_ACTUAL_TPOT_METRIC"
+)
+
+// Default EPP latency metric names (histogram base names, without the
+// `_bucket` suffix).
+const (
+	DefaultEPPPredictedTTFTMetric = "llm_d_epp_request_predicted_ttft_seconds"
+	DefaultEPPActualTTFTMetric    = "llm_d_epp_request_ttft_seconds"
+	DefaultEPPPredictedTPOTMetric = "llm_d_epp_request_predicted_tpot_seconds"
+	DefaultEPPActualTPOTMetric    = "llm_d_epp_request_streaming_tpot_seconds"
+)
+
+// Query name constants for EPP saturation metrics.
+const (
+	// QueryEPPPredictedTTFT is the pool's recent P90 time-to-first-token in
+	// seconds. It prefers the EPP's *predicted* TTFT and falls back to *actual*
+	// TTFT when the predicted series is unavailable (PromQL `or`). The analyzer
+	// divides this by the configured TTFT SLO to derive saturation. Returns no
+	// value (NaN) when there is no recent traffic — the analyzer treats that as 0.
+	QueryEPPPredictedTTFT = "epp_predicted_ttft_seconds"
+
+	// QueryEPPPredictedTPOT is the pool's recent P90 time-per-output-token in
+	// seconds, predicted-preferred with actual fallback, analogous to
+	// QueryEPPPredictedTTFT. The fallback is the actual streaming TPOT
+	// histogram, covering EPP builds that don't emit predicted TPOT.
+	QueryEPPPredictedTPOT = "epp_predicted_tpot_seconds"
+)
+
+// p90Rate builds a PromQL expression for the time-windowed P90 of a histogram
+// (histogram_quantile over 1m bucket rates).
+//
+// The tail quantile — not the mean — is the control signal on purpose. The SLO
+// objective is per-request (tail) attainment, and the mean of predicted latency
+// stays flat under moderate load (continuous batching absorbs load with little
+// mean-latency movement) and only rises after the queue already exists — a
+// trailing indicator. The P90 rises as soon as queueing variance appears, giving
+// the scale-up signal an early-warning property that the mean lacks. (Observed
+// live: a mean-based signal read 0.19–0.28 saturation at a load level where P90
+// pressure was already building, firing scale-up ~2–4 min after the knee instead
+// of at its onset.)
+func p90Rate(metric string) string {
+	return "histogram_quantile(0.9, sum(rate(" + metric + "_bucket[1m])) by (le))"
+}
+
+// predictedOrActual builds the predicted-preferred / actual-fallback expression.
+// The predicted side is filtered with `>= 0` before the `or`: a predicted
+// histogram that exists but is not incrementing (stalled predictor sidecar, or a
+// build that registers the histogram without ever observing into it) yields a
+// present-but-NaN sample (histogram_quantile over all-zero rates), and PromQL
+// `or` would return that NaN instead of falling back — the analyzer would then
+// read NaN as 0 latency and scale down under real load. NaN fails every
+// comparison, so `>= 0` drops the dead predicted sample and lets `or` consult
+// the actual-latency signal.
+func predictedOrActual(predicted, actual string) string {
+	return "((" + p90Rate(predicted) + ") >= 0) or (" + p90Rate(actual) + ")"
+}
+
+// validMetricName matches legal Prometheus metric names. Overrides that fail
+// it are rejected (falling back to the default) so a typo'd or malformed env
+// var cannot produce a broken — or injected — PromQL expression.
+var validMetricName = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+
+// metricFromEnv returns the metric name from the given environment variable,
+// or def when the variable is unset or not a valid Prometheus metric name.
+func metricFromEnv(envVar, def string) string {
+	name := os.Getenv(envVar)
+	if name == "" {
+		return def
+	}
+	if !validMetricName.MatchString(name) {
+		ctrl.Log.Info("Ignoring invalid EPP metric name override",
+			"envVar", envVar, "value", name, "default", def)
+		return def
+	}
+	return name
+}
+
+// RegisterEPPSaturationQueries registers queries used by the EPP saturation analyzer.
+//
+// The analyzer derives saturation itself (saturation = max(TTFT/SLO, TPOT/SLO))
+// from these latency signals rather than reading a pre-computed saturation gauge
+// from the EPP, so the SLO policy lives in WVA config. Each query prefers the
+// predicted latency and falls back to the actual latency via PromQL `or`. The
+// metric names default to the llm-d EPP contract and can be overridden with the
+// WVA_EPP_*_METRIC environment variables.
+func RegisterEPPSaturationQueries(sourceRegistry *source.SourceRegistry) {
+	registry := sourceRegistry.Get("prometheus").QueryList()
+
+	registry.MustRegister(source.QueryTemplate{
+		Name: QueryEPPPredictedTTFT,
+		Type: source.QueryTypePromQL,
+		Template: predictedOrActual(
+			metricFromEnv(EnvEPPPredictedTTFTMetric, DefaultEPPPredictedTTFTMetric),
+			metricFromEnv(EnvEPPActualTTFTMetric, DefaultEPPActualTTFTMetric)),
+		Params:      []string{},
+		Description: "Pool P90 TTFT (seconds), predicted-preferred with actual fallback; analyzer divides by the TTFT SLO",
+	})
+
+	registry.MustRegister(source.QueryTemplate{
+		Name: QueryEPPPredictedTPOT,
+		Type: source.QueryTypePromQL,
+		Template: predictedOrActual(
+			metricFromEnv(EnvEPPPredictedTPOTMetric, DefaultEPPPredictedTPOTMetric),
+			metricFromEnv(EnvEPPActualTPOTMetric, DefaultEPPActualTPOTMetric)),
+		Params:      []string{},
+		Description: "Pool P90 TPOT (seconds), predicted-preferred with actual streaming-TPOT fallback; analyzer divides by the TPOT SLO",
+	})
+}

--- a/internal/collector/registration/epp_saturation_test.go
+++ b/internal/collector/registration/epp_saturation_test.go
@@ -1,0 +1,84 @@
+package registration
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
+)
+
+var _ = Describe("RegisterEPPSaturationQueries", func() {
+	var registry *source.SourceRegistry
+
+	// register builds a fresh registry and runs query registration, picking up
+	// whatever WVA_EPP_*_METRIC environment is in effect.
+	register := func() {
+		registry = source.NewSourceRegistry()
+		metricsSource := prometheus.NewPrometheusSource(context.Background(), &mockPrometheusAPI{}, prometheus.DefaultPrometheusSourceConfig())
+		Expect(registry.Register("prometheus", metricsSource)).To(Succeed())
+		RegisterEPPSaturationQueries(registry)
+	}
+
+	template := func(queryName string) string {
+		q := registry.Get("prometheus").QueryList().Get(queryName)
+		Expect(q).NotTo(BeNil())
+		return q.Template
+	}
+
+	unsetOverrides := func() {
+		for _, envVar := range []string{
+			EnvEPPPredictedTTFTMetric, EnvEPPActualTTFTMetric,
+			EnvEPPPredictedTPOTMetric, EnvEPPActualTPOTMetric,
+		} {
+			Expect(os.Unsetenv(envVar)).To(Succeed())
+		}
+	}
+
+	BeforeEach(unsetOverrides)
+	AfterEach(unsetOverrides)
+
+	It("defaults to the llm-d EPP metric names, predicted-preferred with actual fallback", func() {
+		register()
+
+		ttft := template(QueryEPPPredictedTTFT)
+		Expect(ttft).To(ContainSubstring("llm_d_epp_request_predicted_ttft_seconds_bucket"))
+		Expect(ttft).To(ContainSubstring("llm_d_epp_request_ttft_seconds_bucket"))
+		// The dead-predictor guard: filter the predicted side before `or`.
+		Expect(ttft).To(ContainSubstring(">= 0) or"))
+
+		tpot := template(QueryEPPPredictedTPOT)
+		Expect(tpot).To(ContainSubstring("llm_d_epp_request_predicted_tpot_seconds_bucket"))
+		Expect(tpot).To(ContainSubstring("llm_d_epp_request_streaming_tpot_seconds_bucket"))
+	})
+
+	It("honors WVA_EPP_*_METRIC overrides", func() {
+		Expect(os.Setenv(EnvEPPPredictedTTFTMetric, "inference_objective_request_predicted_ttft_seconds")).To(Succeed())
+		Expect(os.Setenv(EnvEPPActualTTFTMetric, "inference_objective_request_ttft_seconds")).To(Succeed())
+		Expect(os.Setenv(EnvEPPPredictedTPOTMetric, "inference_objective_request_predicted_tpot_seconds")).To(Succeed())
+		Expect(os.Setenv(EnvEPPActualTPOTMetric, "inference_objective_request_tpot_seconds")).To(Succeed())
+		register()
+
+		ttft := template(QueryEPPPredictedTTFT)
+		Expect(ttft).To(ContainSubstring("inference_objective_request_predicted_ttft_seconds_bucket"))
+		Expect(ttft).To(ContainSubstring("inference_objective_request_ttft_seconds_bucket"))
+		Expect(ttft).NotTo(ContainSubstring("llm_d_epp"))
+
+		tpot := template(QueryEPPPredictedTPOT)
+		Expect(tpot).To(ContainSubstring("inference_objective_request_predicted_tpot_seconds_bucket"))
+		Expect(tpot).To(ContainSubstring("inference_objective_request_tpot_seconds_bucket"))
+		Expect(tpot).NotTo(ContainSubstring("llm_d_epp"))
+	})
+
+	It("rejects an override that is not a valid Prometheus metric name", func() {
+		Expect(os.Setenv(EnvEPPActualTPOTMetric, `foo{namespace="x"}) or vector(0`)).To(Succeed())
+		register()
+
+		tpot := template(QueryEPPPredictedTPOT)
+		Expect(tpot).NotTo(ContainSubstring("vector(0"))
+		Expect(tpot).To(ContainSubstring("llm_d_epp_request_streaming_tpot_seconds_bucket"))
+	})
+})

--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -71,25 +71,6 @@ type SaturationScalingConfig struct {
 	TTFTSLOMs float64 `yaml:"ttftSLOMs,omitempty"`
 	TPOTSLOMs float64 `yaml:"tpotSLOMs,omitempty"`
 
-	// SaturationCap bounds the raw saturation signal the epp-saturation analyzer
-	// feeds into its EMA. Near the queueing knee the signal can spike to many × SLO;
-	// clamping it keeps the smoothed signal from staying inflated for many cycles
-	// after the pool recovers (which otherwise causes scale-up overshoot). Default:
-	// 2.0. Ignored by other analyzers.
-	SaturationCap float64 `yaml:"saturationCap,omitempty"`
-
-	// HoldScaleUpWhileWarming enables warmup-aware scale-up damping for the
-	// epp-saturation path: while replicas already requested are still warming
-	// (pending > 0), the target is held at the current replica count so the pool
-	// does not stack a new scale-up request every cycle before the in-flight pods
-	// come online. Scale-down is unaffected.
-	//
-	// Nil defaults to FALSE. The hold lowers the replica peak for step-and-hold
-	// workloads, but its one-pod-per-warmup climb falls behind a rising (ramping)
-	// load and causes sustained SLO violations, so it is opt-in for steady,
-	// cost-sensitive workloads only. Ignored by other analyzers.
-	HoldScaleUpWhileWarming *bool `yaml:"holdScaleUpWhileWarming,omitempty"`
-
 	// Analyzers configures the set of analyzers and their weights.
 	// When empty and AnalyzerName is "saturation", defaults to
 	// [{Name: "saturation", Score: 1.0, Enabled: true}].
@@ -235,12 +216,6 @@ func (c *SaturationScalingConfig) Merge(override SaturationScalingConfig) {
 	if override.Priority != 0 {
 		c.Priority = override.Priority
 	}
-	if override.SaturationCap != 0 {
-		c.SaturationCap = override.SaturationCap
-	}
-	if override.HoldScaleUpWhileWarming != nil {
-		c.HoldScaleUpWhileWarming = override.HoldScaleUpWhileWarming
-	}
 	if override.TTFTSLOMs != 0 {
 		c.TTFTSLOMs = override.TTFTSLOMs
 	}
@@ -298,22 +273,6 @@ func (c *SaturationScalingConfig) Validate() error {
 		}
 		if c.SmoothingAlpha < 0 || c.SmoothingAlpha > 1.0 {
 			return fmt.Errorf("smoothingAlpha must be in [0, 1], got %.2f", c.SmoothingAlpha)
-		}
-		// The cap must leave room to cross the scale-up threshold, otherwise
-		// clamping makes scale-up permanently impossible. Compare against the
-		// effective (defaulted) threshold when unset — the epp-saturation
-		// analyzer's own default (epp_saturation.DefaultEPPScaleUpThreshold =
-		// 0.55), not the V2 DefaultScaleUpThreshold, which does not apply on
-		// this path. Kept as a literal to avoid importing the analyzer package
-		// from config.
-		if c.SaturationCap > 0 {
-			up := c.ScaleUpThreshold
-			if up == 0 {
-				up = 0.55
-			}
-			if c.SaturationCap < up {
-				return fmt.Errorf("saturationCap (%.2f) must be >= scaleUpThreshold (%.2f)", c.SaturationCap, up)
-			}
 		}
 	}
 

--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -42,7 +42,8 @@ type SaturationScalingConfig struct {
 	// ScaleUpThreshold is the utilization threshold above which scale-up is triggered.
 	// Applied by the engine post-step universally to every analyzer's result:
 	//   requiredCapacity = max(0, totalDemand / ScaleUpThreshold − anticipatedSupply)
-	// Default: 0.85 (85% utilization triggers scale-up)
+	// Default: 0.85 for the V2 path; when unset on the epp-saturation path,
+	// the analyzer's own default (0.55, below the queueing knee) applies.
 	ScaleUpThreshold float64 `yaml:"scaleUpThreshold,omitempty"`
 
 	// ScaleDownBoundary is the utilization boundary below which scale-down is safe.
@@ -55,6 +56,39 @@ type SaturationScalingConfig struct {
 	// Higher priority → preferential GPU allocation in fair-share.
 	// Default: 1.0 (neutral).
 	Priority float64 `yaml:"priority,omitempty"`
+
+	// SmoothingAlpha is the EMA smoothing factor applied to the raw saturation
+	// signal by the epp-saturation analyzer. Range (0.0, 1.0]: 1.0 = no smoothing,
+	// 0.6 = light (analyzer default; spike suppression is saturationCap's job), 0.1 = heavy.
+	// Ignored by other analyzers.
+	SmoothingAlpha float64 `yaml:"smoothingAlpha,omitempty"`
+
+	// TTFTSLOMs and TPOTSLOMs are the latency SLO targets (milliseconds) the
+	// epp-saturation analyzer divides the EPP's predicted latencies by to derive
+	// the saturation signal: saturation = max(predTTFT/TTFTSLO, predTPOT/TPOTSLO).
+	// The SLO policy lives here (in WVA) rather than in the EPP. Defaults: 3000 / 100.
+	// Ignored by other analyzers.
+	TTFTSLOMs float64 `yaml:"ttftSLOMs,omitempty"`
+	TPOTSLOMs float64 `yaml:"tpotSLOMs,omitempty"`
+
+	// SaturationCap bounds the raw saturation signal the epp-saturation analyzer
+	// feeds into its EMA. Near the queueing knee the signal can spike to many × SLO;
+	// clamping it keeps the smoothed signal from staying inflated for many cycles
+	// after the pool recovers (which otherwise causes scale-up overshoot). Default:
+	// 2.0. Ignored by other analyzers.
+	SaturationCap float64 `yaml:"saturationCap,omitempty"`
+
+	// HoldScaleUpWhileWarming enables warmup-aware scale-up damping for the
+	// epp-saturation path: while replicas already requested are still warming
+	// (pending > 0), the target is held at the current replica count so the pool
+	// does not stack a new scale-up request every cycle before the in-flight pods
+	// come online. Scale-down is unaffected.
+	//
+	// Nil defaults to FALSE. The hold lowers the replica peak for step-and-hold
+	// workloads, but its one-pod-per-warmup climb falls behind a rising (ramping)
+	// load and causes sustained SLO violations, so it is opt-in for steady,
+	// cost-sensitive workloads only. Ignored by other analyzers.
+	HoldScaleUpWhileWarming *bool `yaml:"holdScaleUpWhileWarming,omitempty"`
 
 	// Analyzers configures the set of analyzers and their weights.
 	// When empty and AnalyzerName is "saturation", defaults to
@@ -201,6 +235,21 @@ func (c *SaturationScalingConfig) Merge(override SaturationScalingConfig) {
 	if override.Priority != 0 {
 		c.Priority = override.Priority
 	}
+	if override.SaturationCap != 0 {
+		c.SaturationCap = override.SaturationCap
+	}
+	if override.HoldScaleUpWhileWarming != nil {
+		c.HoldScaleUpWhileWarming = override.HoldScaleUpWhileWarming
+	}
+	if override.TTFTSLOMs != 0 {
+		c.TTFTSLOMs = override.TTFTSLOMs
+	}
+	if override.TPOTSLOMs != 0 {
+		c.TPOTSLOMs = override.TPOTSLOMs
+	}
+	if override.SmoothingAlpha != 0 {
+		c.SmoothingAlpha = override.SmoothingAlpha
+	}
 	if len(override.Analyzers) > 0 {
 		c.Analyzers = override.Analyzers
 	}
@@ -236,6 +285,36 @@ func (c *SaturationScalingConfig) Validate() error {
 	if c.KvCacheThreshold < c.KvSpareTrigger {
 		return fmt.Errorf("kvCacheThreshold (%.2f) should be >= kvSpareTrigger (%.2f)",
 			c.KvCacheThreshold, c.KvSpareTrigger)
+	}
+
+	// EPP-saturation analyzer fields. These are load-time checks on the fields the
+	// epp-saturation analyzer consumes; zero values are allowed (defaults apply).
+	if c.AnalyzerName == "epp-saturation" {
+		if c.TTFTSLOMs < 0 {
+			return fmt.Errorf("ttftSLOMs must be >= 0, got %.2f", c.TTFTSLOMs)
+		}
+		if c.TPOTSLOMs < 0 {
+			return fmt.Errorf("tpotSLOMs must be >= 0, got %.2f", c.TPOTSLOMs)
+		}
+		if c.SmoothingAlpha < 0 || c.SmoothingAlpha > 1.0 {
+			return fmt.Errorf("smoothingAlpha must be in [0, 1], got %.2f", c.SmoothingAlpha)
+		}
+		// The cap must leave room to cross the scale-up threshold, otherwise
+		// clamping makes scale-up permanently impossible. Compare against the
+		// effective (defaulted) threshold when unset — the epp-saturation
+		// analyzer's own default (epp_saturation.DefaultEPPScaleUpThreshold =
+		// 0.55), not the V2 DefaultScaleUpThreshold, which does not apply on
+		// this path. Kept as a literal to avoid importing the analyzer package
+		// from config.
+		if c.SaturationCap > 0 {
+			up := c.ScaleUpThreshold
+			if up == 0 {
+				up = 0.55
+			}
+			if c.SaturationCap < up {
+				return fmt.Errorf("saturationCap (%.2f) must be >= scaleUpThreshold (%.2f)", c.SaturationCap, up)
+			}
+		}
 	}
 
 	// V2 analyzer threshold validation (global defaults)

--- a/internal/engines/analyzers/epp_saturation/analyzer.go
+++ b/internal/engines/analyzers/epp_saturation/analyzer.go
@@ -95,24 +95,11 @@ func (a *EPPSaturationAnalyzer) Analyze(ctx context.Context, input interfaces.An
 	tpotSaturation := tpotSeconds / (cfg.TPOTSLOMs / 1000.0)
 	rawSaturation := math.Max(ttftSaturation, tpotSaturation)
 
-	// Clamp the raw signal before smoothing. Near the queueing knee the predicted
-	// latency (and thus saturation) can spike to tens or hundreds × SLO; anything
-	// above the cap already means "scale up at the max per-cycle rate", so the extra
-	// magnitude carries no additional actionable information and only poisons the
-	// EMA — a single spike then decays slowly, holding replicas high long after the
-	// pool has recovered. Clamping keeps the EMA peak bounded so it recovers in a
-	// few cycles regardless of spike size. The true uncapped signal is preserved in
-	// RawSignal for observability.
-	cappedSaturation := rawSaturation
-	if cfg.SaturationCap > 0 && cappedSaturation > cfg.SaturationCap {
-		cappedSaturation = cfg.SaturationCap
-	}
-
 	// Apply EMA smoothing to absorb single-cycle spikes/dips before the signal
 	// drives scaling decisions. First observation per (namespace, modelID) is
 	// used as-is (no warmup).
 	smoothingKey := input.Namespace + "/" + input.ModelID
-	saturationScore := a.smooth(smoothingKey, cappedSaturation, cfg.SmoothingAlpha)
+	saturationScore := a.smooth(smoothingKey, rawSaturation, cfg.SmoothingAlpha)
 
 	logger.Info("EPP pool saturation score",
 		"modelID", input.ModelID,
@@ -123,43 +110,18 @@ func (a *EPPSaturationAnalyzer) Analyze(ctx context.Context, input interfaces.An
 		"ttftSaturation", ttftSaturation,
 		"tpotSaturation", tpotSaturation,
 		"rawSaturation", rawSaturation,
-		"cappedSaturation", cappedSaturation,
-		"saturationCap", cfg.SaturationCap,
 		"smoothedSaturation", saturationScore,
 		"smoothingAlpha", cfg.SmoothingAlpha,
 		"scaleUpThreshold", cfg.ScaleUpThreshold,
 		"scaleDownBoundary", cfg.ScaleDownBoundary)
 
-	// Compute current + ready replica counts from variant states.
-	var totalReplicas, readyReplicas int
+	// Compute the current replica count from variant states.
+	var totalReplicas int
 	for _, vs := range input.VariantStates {
 		totalReplicas += vs.CurrentReplicas
-		if r := vs.CurrentReplicas - vs.PendingReplicas; r > 0 {
-			readyReplicas += r
-		}
 	}
 	if totalReplicas == 0 {
 		totalReplicas = 1
-	}
-
-	// Credit in-flight (warming) replicas. The saturation signal is measured from
-	// the Ready pods; while a scale-up is in flight those Ready pods absorb more
-	// than their eventual share, so the raw signal over-states the post-warmup
-	// load. Once the pending pods become Ready the load spreads across all
-	// totalReplicas, so the demand that should drive scaling is the *anticipated*
-	// saturation: signal × ready/total. This makes scale-up ask only for the
-	// deficit beyond the pods already coming online (instead of racing to
-	// maxReplicas while pods warm), and re-converge as pending pods become Ready.
-	// readyFraction = 1.0 in steady state (no pending), so behavior is unchanged.
-	readyFraction := 1.0
-	if readyReplicas > 0 && readyReplicas < totalReplicas {
-		readyFraction = float64(readyReplicas) / float64(totalReplicas)
-	}
-	effectiveDemand := saturationScore * readyFraction
-	if readyFraction < 1.0 {
-		logger.Info("EPP saturation crediting in-flight replicas",
-			"modelID", input.ModelID, "readyReplicas", readyReplicas, "totalReplicas", totalReplicas,
-			"readyFraction", readyFraction, "smoothedSaturation", saturationScore, "effectiveDemand", effectiveDemand)
 	}
 
 	// Normalized capacity model for proportional scaling.
@@ -188,7 +150,7 @@ func (a *EPPSaturationAnalyzer) Analyze(ctx context.Context, input interfaces.An
 	//
 	perReplicaCapacity := 1.0 / float64(totalReplicas)
 	totalSupply := 1.0             // normalized pool capacity
-	totalDemand := effectiveDemand // in-flight-credited saturation drives scaling
+	totalDemand := saturationScore // smoothed saturation drives scaling
 
 	utilization := saturationScore
 	if utilization > 1.0 {
@@ -198,14 +160,6 @@ func (a *EPPSaturationAnalyzer) Analyze(ctx context.Context, input interfaces.An
 	// Scaling signals using the same threshold logic as V2:
 	// requiredCapacity > 0 → scale-up needed
 	// spareCapacity > 0 → scale-down possible
-	//
-	// Scale-up uses the credited demand (effectiveDemand) so in-flight replicas
-	// are not double-provisioned. Scale-down deliberately uses the UNCREDITED
-	// smoothed signal: the credit discounts demand by ready/total, so during a
-	// warmup it could push a signal that is above the scale-up threshold below the
-	// scale-down boundary and shed replicas mid-scale-up (worse with pods stuck
-	// Pending, where the discount persists indefinitely). A pool may only scale
-	// down when the measured signal itself has real headroom.
 	requiredCapacity := math.Max(0, totalDemand/cfg.ScaleUpThreshold-totalSupply)
 	spareCapacity := math.Max(0, totalSupply-saturationScore/cfg.ScaleDownBoundary)
 
@@ -245,10 +199,6 @@ func (a *EPPSaturationAnalyzer) Analyze(ctx context.Context, input interfaces.An
 		Utilization:       utilization,
 		RequiredCapacity:  requiredCapacity,
 		SpareCapacity:     spareCapacity,
-		// Observability: preserve the uncapped raw vs smoothed signal so the
-		// engine can emit them as metrics (Utilization above is capped at 1.0).
-		RawSignal:      rawSaturation,
-		SmoothedSignal: saturationScore,
 	}, nil
 }
 

--- a/internal/engines/analyzers/epp_saturation/analyzer.go
+++ b/internal/engines/analyzers/epp_saturation/analyzer.go
@@ -1,0 +1,306 @@
+// Package epp_saturation implements an analyzer that derives a pool-level
+// saturation signal from the EPP's predicted-latency histograms. Unlike the
+// V1/V2 saturation analyzers that scrape per-pod vLLM metrics and compute
+// capacity internally, this analyzer queries the recent P90 of the EPP's
+// predicted TTFT/TPOT (falling back to actual latency) and divides by the
+// configured SLOs:
+//
+//	saturation = max(P90 predTTFT / ttftSLOMs, P90 predTPOT / tpotSLOMs)
+//
+// A value < 1.0 means the pool's tail latency is within SLO (headroom);
+// >= 1.0 means the P90 is at or over SLO.
+package epp_saturation
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// AnalyzerName is the canonical name used in config and result metadata.
+const AnalyzerName = "epp-saturation"
+
+// EPPSaturationAnalyzer implements interfaces.Analyzer using the EPP's
+// pool-level saturation signal. It assumes a single model per pool.
+type EPPSaturationAnalyzer struct {
+	metricsRegistry *source.SourceRegistry
+
+	// mu protects smoothedByKey.
+	mu sync.Mutex
+	// smoothedByKey holds the per-model EMA state, keyed by "namespace/modelID".
+	// A missing key means no prior observation (first sample is used as-is).
+	smoothedByKey map[string]float64
+}
+
+// NewEPPSaturationAnalyzer creates a new EPP saturation analyzer.
+func NewEPPSaturationAnalyzer(registry *source.SourceRegistry) *EPPSaturationAnalyzer {
+	return &EPPSaturationAnalyzer{
+		metricsRegistry: registry,
+		smoothedByKey:   make(map[string]float64),
+	}
+}
+
+// smooth applies an EMA update to the per-model saturation state and returns
+// the new smoothed value. The first sample for a key is used as-is (no warmup
+// required). Safe for concurrent use.
+func (a *EPPSaturationAnalyzer) smooth(key string, raw, alpha float64) float64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	prev, ok := a.smoothedByKey[key]
+	if !ok {
+		a.smoothedByKey[key] = raw
+		return raw
+	}
+	next := alpha*raw + (1.0-alpha)*prev
+	a.smoothedByKey[key] = next
+	return next
+}
+
+// Name implements interfaces.Analyzer.
+func (a *EPPSaturationAnalyzer) Name() string {
+	return AnalyzerName
+}
+
+// Analyze implements interfaces.Analyzer.
+// It queries the EPP pool saturation metric from Prometheus and translates
+// it into capacity signals for the optimizer pipeline.
+func (a *EPPSaturationAnalyzer) Analyze(ctx context.Context, input interfaces.AnalyzerInput) (*interfaces.AnalyzerResult, error) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	cfg, ok := input.Config.(*EPPSaturationConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected *EPPSaturationConfig, got %T", input.Config)
+	}
+
+	// Derive saturation from the EPP's predicted latencies and the configured SLOs:
+	//   saturation = max(predictedTTFT / TTFTSLO, predictedTPOT / TPOTSLO)
+	// Each query prefers predicted latency and falls back to actual latency. A
+	// missing value (no recent traffic → NaN) is treated as 0 latency, so an idle
+	// pool reports low saturation and scales toward minReplicas. A genuine query
+	// error is propagated and handled by the engine's safety-net path.
+	ttftSeconds, tpotSeconds, err := a.queryLatenciesSeconds(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query EPP latencies: %w", err)
+	}
+
+	ttftSaturation := ttftSeconds / (cfg.TTFTSLOMs / 1000.0)
+	tpotSaturation := tpotSeconds / (cfg.TPOTSLOMs / 1000.0)
+	rawSaturation := math.Max(ttftSaturation, tpotSaturation)
+
+	// Clamp the raw signal before smoothing. Near the queueing knee the predicted
+	// latency (and thus saturation) can spike to tens or hundreds × SLO; anything
+	// above the cap already means "scale up at the max per-cycle rate", so the extra
+	// magnitude carries no additional actionable information and only poisons the
+	// EMA — a single spike then decays slowly, holding replicas high long after the
+	// pool has recovered. Clamping keeps the EMA peak bounded so it recovers in a
+	// few cycles regardless of spike size. The true uncapped signal is preserved in
+	// RawSignal for observability.
+	cappedSaturation := rawSaturation
+	if cfg.SaturationCap > 0 && cappedSaturation > cfg.SaturationCap {
+		cappedSaturation = cfg.SaturationCap
+	}
+
+	// Apply EMA smoothing to absorb single-cycle spikes/dips before the signal
+	// drives scaling decisions. First observation per (namespace, modelID) is
+	// used as-is (no warmup).
+	smoothingKey := input.Namespace + "/" + input.ModelID
+	saturationScore := a.smooth(smoothingKey, cappedSaturation, cfg.SmoothingAlpha)
+
+	logger.Info("EPP pool saturation score",
+		"modelID", input.ModelID,
+		"ttftSeconds", ttftSeconds,
+		"tpotSeconds", tpotSeconds,
+		"ttftSLOMs", cfg.TTFTSLOMs,
+		"tpotSLOMs", cfg.TPOTSLOMs,
+		"ttftSaturation", ttftSaturation,
+		"tpotSaturation", tpotSaturation,
+		"rawSaturation", rawSaturation,
+		"cappedSaturation", cappedSaturation,
+		"saturationCap", cfg.SaturationCap,
+		"smoothedSaturation", saturationScore,
+		"smoothingAlpha", cfg.SmoothingAlpha,
+		"scaleUpThreshold", cfg.ScaleUpThreshold,
+		"scaleDownBoundary", cfg.ScaleDownBoundary)
+
+	// Compute current + ready replica counts from variant states.
+	var totalReplicas, readyReplicas int
+	for _, vs := range input.VariantStates {
+		totalReplicas += vs.CurrentReplicas
+		if r := vs.CurrentReplicas - vs.PendingReplicas; r > 0 {
+			readyReplicas += r
+		}
+	}
+	if totalReplicas == 0 {
+		totalReplicas = 1
+	}
+
+	// Credit in-flight (warming) replicas. The saturation signal is measured from
+	// the Ready pods; while a scale-up is in flight those Ready pods absorb more
+	// than their eventual share, so the raw signal over-states the post-warmup
+	// load. Once the pending pods become Ready the load spreads across all
+	// totalReplicas, so the demand that should drive scaling is the *anticipated*
+	// saturation: signal × ready/total. This makes scale-up ask only for the
+	// deficit beyond the pods already coming online (instead of racing to
+	// maxReplicas while pods warm), and re-converge as pending pods become Ready.
+	// readyFraction = 1.0 in steady state (no pending), so behavior is unchanged.
+	readyFraction := 1.0
+	if readyReplicas > 0 && readyReplicas < totalReplicas {
+		readyFraction = float64(readyReplicas) / float64(totalReplicas)
+	}
+	effectiveDemand := saturationScore * readyFraction
+	if readyFraction < 1.0 {
+		logger.Info("EPP saturation crediting in-flight replicas",
+			"modelID", input.ModelID, "readyReplicas", readyReplicas, "totalReplicas", totalReplicas,
+			"readyFraction", readyFraction, "smoothedSaturation", saturationScore, "effectiveDemand", effectiveDemand)
+	}
+
+	// Normalized capacity model for proportional scaling.
+	//
+	// We normalize the pool's capacity to 1.0 (its full SLO budget) so that
+	// each replica contributes perReplicaCapacity = 1/N of the total. The
+	// saturation score IS the demand in normalized units (demand/capacity ratio).
+	//
+	// This makes the optimizer compute proportional replica deltas:
+	//   replicasNeeded = ceil(requiredCapacity / perReplicaCapacity)
+	//                  = ceil(requiredCapacity * N)
+	//
+	// Examples (scaleUpThreshold=0.85, scaleDownBoundary=0.50):
+	//
+	//   saturation=0.95, N=4:
+	//     required = 0.95/0.85 - 1.0 = 0.118
+	//     replicas = ceil(0.118 * 4) = ceil(0.47) = 1  (add 1 of 4)
+	//
+	//   saturation=0.95, N=40:
+	//     required = 0.118
+	//     replicas = ceil(0.118 * 40) = ceil(4.7) = 5  (add 5 of 40)
+	//
+	//   saturation=0.30, N=40:
+	//     spare = 1.0 - 0.30/0.50 = 0.40
+	//     replicas = floor(0.40 * 40) = 16  (remove 16 of 40 → 24 left, sat→0.50)
+	//
+	perReplicaCapacity := 1.0 / float64(totalReplicas)
+	totalSupply := 1.0             // normalized pool capacity
+	totalDemand := effectiveDemand // in-flight-credited saturation drives scaling
+
+	utilization := saturationScore
+	if utilization > 1.0 {
+		utilization = 1.0 // cap for the 0-1 field; raw score preserved in demand
+	}
+
+	// Scaling signals using the same threshold logic as V2:
+	// requiredCapacity > 0 → scale-up needed
+	// spareCapacity > 0 → scale-down possible
+	//
+	// Scale-up uses the credited demand (effectiveDemand) so in-flight replicas
+	// are not double-provisioned. Scale-down deliberately uses the UNCREDITED
+	// smoothed signal: the credit discounts demand by ready/total, so during a
+	// warmup it could push a signal that is above the scale-up threshold below the
+	// scale-down boundary and shed replicas mid-scale-up (worse with pods stuck
+	// Pending, where the discount persists indefinitely). A pool may only scale
+	// down when the measured signal itself has real headroom.
+	requiredCapacity := math.Max(0, totalDemand/cfg.ScaleUpThreshold-totalSupply)
+	spareCapacity := math.Max(0, totalSupply-saturationScore/cfg.ScaleDownBoundary)
+
+	// Build per-variant capacity breakdown.
+	// Single model per pool: distribute proportionally across variants.
+	variantCapacities := make([]interfaces.VariantCapacity, 0, len(input.VariantStates))
+	for _, vs := range input.VariantStates {
+		readyCount := vs.CurrentReplicas - vs.PendingReplicas
+		if readyCount < 0 {
+			readyCount = 0
+		}
+
+		variantSupply := float64(readyCount) * perReplicaCapacity
+		variantDemand := saturationScore * variantSupply
+		vc := interfaces.VariantCapacity{
+			VariantName:        vs.VariantName,
+			AcceleratorName:    "", // not needed for EPP-based signal
+			Cost:               saturation.DefaultVariantCost,
+			ReplicaCount:       readyCount,
+			PendingReplicas:    vs.PendingReplicas,
+			PerReplicaCapacity: perReplicaCapacity,
+			TotalCapacity:      variantSupply,
+			TotalDemand:        variantDemand,
+			Utilization:        saturationScore,
+		}
+		variantCapacities = append(variantCapacities, vc)
+	}
+
+	return &interfaces.AnalyzerResult{
+		AnalyzerName:      a.Name(),
+		ModelID:           input.ModelID,
+		Namespace:         input.Namespace,
+		AnalyzedAt:        time.Now(),
+		VariantCapacities: variantCapacities,
+		TotalSupply:       totalSupply,
+		TotalDemand:       totalDemand,
+		Utilization:       utilization,
+		RequiredCapacity:  requiredCapacity,
+		SpareCapacity:     spareCapacity,
+		// Observability: preserve the uncapped raw vs smoothed signal so the
+		// engine can emit them as metrics (Utilization above is capped at 1.0).
+		RawSignal:      rawSaturation,
+		SmoothedSignal: saturationScore,
+	}, nil
+}
+
+// queryLatenciesSeconds fetches the pool TTFT and TPOT (seconds) from Prometheus
+// in a single Refresh (one round trip; the source executes the queries
+// concurrently). A query that returns no series, or a NaN value (no recent
+// traffic → 0/0 rate), is reported as 0 latency rather than an error, so an idle
+// pool yields low saturation. Only a transport/query error is returned as an
+// error (handled by the engine's safety-net path).
+func (a *EPPSaturationAnalyzer) queryLatenciesSeconds(ctx context.Context) (ttft, tpot float64, err error) {
+	promSource := a.metricsRegistry.Get("prometheus")
+	if promSource == nil {
+		return 0, 0, fmt.Errorf("prometheus source not registered")
+	}
+
+	results, err := promSource.Refresh(ctx, source.RefreshSpec{
+		Queries: []string{registration.QueryEPPPredictedTTFT, registration.QueryEPPPredictedTPOT},
+		Params:  map[string]string{},
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("prometheus refresh failed: %w", err)
+	}
+
+	ttft, err = latencyFromResult(results, registration.QueryEPPPredictedTTFT)
+	if err != nil {
+		return 0, 0, err
+	}
+	tpot, err = latencyFromResult(results, registration.QueryEPPPredictedTPOT)
+	if err != nil {
+		return 0, 0, err
+	}
+	return ttft, tpot, nil
+}
+
+// latencyFromResult extracts one latency value from a Refresh result map,
+// applying the empty/NaN/negative → 0 mapping described on queryLatenciesSeconds.
+func latencyFromResult(results map[string]*source.MetricResult, queryName string) (float64, error) {
+	result, ok := results[queryName]
+	if !ok || result == nil {
+		return 0, fmt.Errorf("no result for query %s", queryName)
+	}
+	if result.Error != nil {
+		return 0, fmt.Errorf("query %s failed: %w", queryName, result.Error)
+	}
+	// No series (no recent traffic) → treat as 0 latency.
+	if len(result.Values) == 0 {
+		return 0, nil
+	}
+	v := result.Values[0].Value
+	// NaN (0/0 rate when idle) or negative → 0 latency.
+	if math.IsNaN(v) || v < 0 {
+		return 0, nil
+	}
+	return v, nil
+}

--- a/internal/engines/analyzers/epp_saturation/analyzer_test.go
+++ b/internal/engines/analyzers/epp_saturation/analyzer_test.go
@@ -227,57 +227,6 @@ func TestAnalyze_Overloaded(t *testing.T) {
 	// Optimizer: ceil(0.765 / 0.5) = 2 replicas added (N=2, perReplica=0.5)
 }
 
-func TestAnalyze_SaturationCap_ClampsRawBeforeEMA(t *testing.T) {
-	// Raw saturation of 5.0 (TTFT 5s / 1s SLO) is deep in the knee. With a cap of
-	// 2.0 the value feeding the EMA/decision is clamped to 2.0, but the true
-	// uncapped signal is still surfaced in RawSignal for observability.
-	input := func() interfaces.AnalyzerInput {
-		return interfaces.AnalyzerInput{
-			ModelID:   "test-model",
-			Namespace: "default",
-			VariantStates: []interfaces.VariantReplicaState{
-				{VariantName: "variant-a", CurrentReplicas: 4, PendingReplicas: 0},
-			},
-		}
-	}
-
-	// With cap: demand is clamped to 2.0, raw signal preserved at 5.0.
-	analyzer := setupAnalyzer(5.0)
-	in := input()
-	in.Config = &EPPSaturationConfig{
-		ScaleUpThreshold:  0.85,
-		ScaleDownBoundary: 0.50,
-		SmoothingAlpha:    1.0, // no smoothing — isolate the clamp
-		TTFTSLOMs:         1000,
-		TPOTSLOMs:         10000,
-		SaturationCap:     2.0,
-	}
-	result, err := analyzer.Analyze(context.Background(), in)
-	require.NoError(t, err)
-	assert.InDelta(t, 5.0, result.RawSignal, 0.01, "uncapped raw preserved for observability")
-	assert.InDelta(t, 2.0, result.SmoothedSignal, 0.01, "EMA fed the clamped value")
-	assert.InDelta(t, 2.0, result.TotalDemand, 0.01, "demand clamped to the cap")
-	// required = 2.0/0.85 - 1.0 ≈ 1.353 (vs 4.88 uncapped)
-	assert.InDelta(t, 1.353, result.RequiredCapacity, 0.01)
-
-	// With a very large cap (the documented way to effectively disable clamping —
-	// a zero value is replaced by the default via ApplyDefaults, it does not
-	// disable): demand is the full raw 5.0.
-	analyzerNoCap := setupAnalyzer(5.0)
-	inNoCap := input()
-	inNoCap.Config = &EPPSaturationConfig{
-		ScaleUpThreshold:  0.85,
-		ScaleDownBoundary: 0.50,
-		SmoothingAlpha:    1.0,
-		TTFTSLOMs:         1000,
-		TPOTSLOMs:         10000,
-		SaturationCap:     1e9, // effectively disabled
-	}
-	resultNoCap, err := analyzerNoCap.Analyze(context.Background(), inNoCap)
-	require.NoError(t, err)
-	assert.InDelta(t, 5.0, resultNoCap.TotalDemand, 0.01, "no clamp when cap is effectively disabled")
-}
-
 func TestAnalyze_InHysteresisZone_NoAction(t *testing.T) {
 	analyzer := setupAnalyzer(0.65) // between 0.50 (down) and 0.85 (up)
 	cfg := &EPPSaturationConfig{
@@ -330,18 +279,10 @@ func TestAnalyze_PendingReplicas(t *testing.T) {
 
 	// totalReplicas = 4 (current, including pending), normalized supply = 1.0
 	assert.InDelta(t, 1.0, result.TotalSupply, 0.01)
-	// In-flight credit: readyReplicas = 4 - 2 = 2, readyFraction = 2/4 = 0.5, so
-	// the demand driving scaling is the anticipated post-warmup saturation:
-	// 0.95 * 0.5 = 0.475 (the 2 warming pods are credited, so scale-up only asks
-	// for the deficit beyond what is already coming online).
-	assert.InDelta(t, 0.475, result.TotalDemand, 0.01)
-	// Direction guards: the credited demand (0.475/0.85 < 1) means no further
-	// scale-up is needed, and — critically — the credit must NOT flip the pool
-	// into scale-down: spare capacity is derived from the UNCREDITED smoothed
-	// signal (0.95 > 0.50 boundary), so no replicas may be shed mid-warmup even
-	// though the credited demand (0.475) dipped below the boundary.
-	assert.Equal(t, 0.0, result.RequiredCapacity, "credited demand below threshold → no scale-up")
-	assert.Equal(t, 0.0, result.SpareCapacity, "uncredited signal above boundary → scale-down must not fire during warmup")
+	assert.InDelta(t, 0.95, result.TotalDemand, 0.01)
+	// required = 0.95/0.85 - 1.0 ≈ 0.118
+	assert.InDelta(t, 0.118, result.RequiredCapacity, 0.01)
+	assert.Equal(t, 0.0, result.SpareCapacity)
 
 	// Per-variant: readyCount = 4 - 2 = 2, perReplicaCapacity = 1/4 = 0.25
 	// variant capacity = 2 * 0.25 = 0.5
@@ -370,7 +311,6 @@ func TestConfig_Defaults(t *testing.T) {
 	assert.Equal(t, DefaultEPPScaleUpThreshold, cfg.ScaleUpThreshold)
 	assert.Equal(t, DefaultEPPScaleDownBoundary, cfg.ScaleDownBoundary)
 	assert.Equal(t, DefaultEPPSmoothingAlpha, cfg.SmoothingAlpha)
-	assert.Equal(t, DefaultEPPSaturationCap, cfg.SaturationCap)
 }
 
 func TestConfig_Validate(t *testing.T) {
@@ -386,8 +326,6 @@ func TestConfig_Validate(t *testing.T) {
 		{"alpha zero", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 0}, true},
 		{"alpha too high", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 1.5}, true},
 		{"alpha one ok", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 1.0, TTFTSLOMs: 3000, TPOTSLOMs: 100}, false},
-		{"cap ok", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 0.3, TTFTSLOMs: 3000, TPOTSLOMs: 100, SaturationCap: 2.0}, false},
-		{"cap below scaleUpThreshold", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 0.3, TTFTSLOMs: 3000, TPOTSLOMs: 100, SaturationCap: 0.5}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/engines/analyzers/epp_saturation/analyzer_test.go
+++ b/internal/engines/analyzers/epp_saturation/analyzer_test.go
@@ -1,0 +1,545 @@
+package epp_saturation
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// fakePrometheusSource is a test double for source.MetricsSource that returns
+// a pre-configured saturation value.
+type fakePrometheusSource struct {
+	queryList  *source.QueryList
+	saturation float64 // returned for every query unless ttftVal/tpotVal are set
+	ttftVal    *float64
+	tpotVal    *float64
+	nan        bool // when true, every query returns NaN (simulates no recent traffic)
+	err        error
+}
+
+func newFakePrometheusSource(saturation float64, err error) *fakePrometheusSource {
+	return &fakePrometheusSource{
+		queryList:  source.NewQueryList(),
+		saturation: saturation,
+		err:        err,
+	}
+}
+
+func (f *fakePrometheusSource) QueryList() *source.QueryList {
+	return f.queryList
+}
+
+func (f *fakePrometheusSource) Refresh(_ context.Context, spec source.RefreshSpec) (map[string]*source.MetricResult, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	results := make(map[string]*source.MetricResult)
+	for _, q := range spec.Queries {
+		val := f.saturation
+		switch {
+		case f.nan:
+			val = math.NaN()
+		case q == registration.QueryEPPPredictedTTFT && f.ttftVal != nil:
+			val = *f.ttftVal
+		case q == registration.QueryEPPPredictedTPOT && f.tpotVal != nil:
+			val = *f.tpotVal
+		}
+		results[q] = &source.MetricResult{
+			QueryName:   q,
+			CollectedAt: time.Now(),
+			Values: []source.MetricValue{
+				{Value: val, Timestamp: time.Now()},
+			},
+		}
+	}
+	return results, nil
+}
+
+func (f *fakePrometheusSource) Get(queryName string, params map[string]string) *source.CachedValue {
+	return nil
+}
+
+func setupAnalyzer(saturation float64) *EPPSaturationAnalyzer {
+	registry := source.NewSourceRegistry()
+	fakeProm := newFakePrometheusSource(saturation, nil)
+	registry.MustRegister("prometheus", fakeProm)
+	registration.RegisterEPPSaturationQueries(registry)
+	return NewEPPSaturationAnalyzer(registry)
+}
+
+func TestAnalyze_LowSaturation_ScaleDown(t *testing.T) {
+	analyzer := setupAnalyzer(0.3)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing — use raw signal directly
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 4, PendingReplicas: 0},
+		},
+	}
+
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+
+	assert.Equal(t, AnalyzerName, result.AnalyzerName)
+	assert.Equal(t, "test-model", result.ModelID)
+	// Normalized model: supply=1.0, demand=saturation
+	assert.InDelta(t, 1.0, result.TotalSupply, 0.01)
+	assert.InDelta(t, 0.3, result.TotalDemand, 0.01)
+	assert.InDelta(t, 0.3, result.Utilization, 0.01)
+	assert.Equal(t, 0.0, result.RequiredCapacity, "should not need scale-up")
+	// spare = 1.0 - 0.3/0.50 = 0.4
+	assert.InDelta(t, 0.4, result.SpareCapacity, 0.01, "should have spare capacity for scale-down")
+	// Optimizer: floor(0.4 / 0.25) = 1 replica removed (proportional to pool size)
+}
+
+func TestAnalyze_HighSaturation_ScaleUp(t *testing.T) {
+	analyzer := setupAnalyzer(0.95)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing — use raw signal directly
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 4, PendingReplicas: 0},
+		},
+	}
+
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+
+	assert.InDelta(t, 1.0, result.TotalSupply, 0.01)
+	assert.InDelta(t, 0.95, result.TotalDemand, 0.01)
+	// required = 0.95/0.85 - 1.0 ≈ 0.118
+	assert.InDelta(t, 0.118, result.RequiredCapacity, 0.01, "should need scale-up")
+	assert.Equal(t, 0.0, result.SpareCapacity, "should not have spare capacity")
+	// Optimizer: ceil(0.118 / 0.25) = 1 replica added
+}
+
+func TestAnalyze_HighSaturation_LargePool(t *testing.T) {
+	// Verify proportional scaling: same saturation, more replicas → more added
+	analyzer := setupAnalyzer(0.95)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing — use raw signal directly
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 40, PendingReplicas: 0},
+		},
+	}
+
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+
+	// required = 0.95/0.85 - 1.0 ≈ 0.118
+	assert.InDelta(t, 0.118, result.RequiredCapacity, 0.01)
+	// perReplicaCapacity = 1/40 = 0.025
+	assert.InDelta(t, 0.025, result.VariantCapacities[0].PerReplicaCapacity, 0.001)
+	// Optimizer: ceil(0.118 / 0.025) = 5 replicas added (vs 1 for N=4)
+}
+
+func TestAnalyze_LowSaturation_LargePool(t *testing.T) {
+	analyzer := setupAnalyzer(0.3)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing — use raw signal directly
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 40, PendingReplicas: 0},
+		},
+	}
+
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+
+	// spare = 1.0 - 0.3/0.50 = 0.4
+	assert.InDelta(t, 0.4, result.SpareCapacity, 0.01)
+	// perReplicaCapacity = 1/40 = 0.025
+	// Optimizer: floor(0.4 / 0.025) = 16 replicas removed → 24 left → saturation 0.50
+}
+
+func TestAnalyze_Overloaded(t *testing.T) {
+	analyzer := setupAnalyzer(1.5)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing — use raw signal directly
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 2, PendingReplicas: 0},
+		},
+	}
+
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+
+	assert.InDelta(t, 1.0, result.TotalSupply, 0.01)
+	assert.InDelta(t, 1.5, result.TotalDemand, 0.01)
+	assert.InDelta(t, 1.0, result.Utilization, 0.01) // capped at 1.0
+	// required = 1.5/0.85 - 1.0 ≈ 0.765
+	assert.InDelta(t, 0.765, result.RequiredCapacity, 0.01, "should need scale-up when overloaded")
+	// Optimizer: ceil(0.765 / 0.5) = 2 replicas added (N=2, perReplica=0.5)
+}
+
+func TestAnalyze_SaturationCap_ClampsRawBeforeEMA(t *testing.T) {
+	// Raw saturation of 5.0 (TTFT 5s / 1s SLO) is deep in the knee. With a cap of
+	// 2.0 the value feeding the EMA/decision is clamped to 2.0, but the true
+	// uncapped signal is still surfaced in RawSignal for observability.
+	input := func() interfaces.AnalyzerInput {
+		return interfaces.AnalyzerInput{
+			ModelID:   "test-model",
+			Namespace: "default",
+			VariantStates: []interfaces.VariantReplicaState{
+				{VariantName: "variant-a", CurrentReplicas: 4, PendingReplicas: 0},
+			},
+		}
+	}
+
+	// With cap: demand is clamped to 2.0, raw signal preserved at 5.0.
+	analyzer := setupAnalyzer(5.0)
+	in := input()
+	in.Config = &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing — isolate the clamp
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+		SaturationCap:     2.0,
+	}
+	result, err := analyzer.Analyze(context.Background(), in)
+	require.NoError(t, err)
+	assert.InDelta(t, 5.0, result.RawSignal, 0.01, "uncapped raw preserved for observability")
+	assert.InDelta(t, 2.0, result.SmoothedSignal, 0.01, "EMA fed the clamped value")
+	assert.InDelta(t, 2.0, result.TotalDemand, 0.01, "demand clamped to the cap")
+	// required = 2.0/0.85 - 1.0 ≈ 1.353 (vs 4.88 uncapped)
+	assert.InDelta(t, 1.353, result.RequiredCapacity, 0.01)
+
+	// With a very large cap (the documented way to effectively disable clamping —
+	// a zero value is replaced by the default via ApplyDefaults, it does not
+	// disable): demand is the full raw 5.0.
+	analyzerNoCap := setupAnalyzer(5.0)
+	inNoCap := input()
+	inNoCap.Config = &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0,
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+		SaturationCap:     1e9, // effectively disabled
+	}
+	resultNoCap, err := analyzerNoCap.Analyze(context.Background(), inNoCap)
+	require.NoError(t, err)
+	assert.InDelta(t, 5.0, resultNoCap.TotalDemand, 0.01, "no clamp when cap is effectively disabled")
+}
+
+func TestAnalyze_InHysteresisZone_NoAction(t *testing.T) {
+	analyzer := setupAnalyzer(0.65) // between 0.50 (down) and 0.85 (up)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing — use raw signal directly
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 4, PendingReplicas: 0},
+		},
+	}
+
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+
+	// 0.65/0.85 = 0.765 < 1.0 → no scale-up
+	assert.Equal(t, 0.0, result.RequiredCapacity, "should not need scale-up in hysteresis zone")
+	// 1.0 - 0.65/0.50 = 1.0 - 1.3 < 0 → no scale-down
+	assert.Equal(t, 0.0, result.SpareCapacity, "should not have spare capacity in hysteresis zone")
+}
+
+func TestAnalyze_PendingReplicas(t *testing.T) {
+	analyzer := setupAnalyzer(0.95)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing — use raw signal directly
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 4, PendingReplicas: 2},
+		},
+	}
+
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+
+	// totalReplicas = 4 (current, including pending), normalized supply = 1.0
+	assert.InDelta(t, 1.0, result.TotalSupply, 0.01)
+	// In-flight credit: readyReplicas = 4 - 2 = 2, readyFraction = 2/4 = 0.5, so
+	// the demand driving scaling is the anticipated post-warmup saturation:
+	// 0.95 * 0.5 = 0.475 (the 2 warming pods are credited, so scale-up only asks
+	// for the deficit beyond what is already coming online).
+	assert.InDelta(t, 0.475, result.TotalDemand, 0.01)
+	// Direction guards: the credited demand (0.475/0.85 < 1) means no further
+	// scale-up is needed, and — critically — the credit must NOT flip the pool
+	// into scale-down: spare capacity is derived from the UNCREDITED smoothed
+	// signal (0.95 > 0.50 boundary), so no replicas may be shed mid-warmup even
+	// though the credited demand (0.475) dipped below the boundary.
+	assert.Equal(t, 0.0, result.RequiredCapacity, "credited demand below threshold → no scale-up")
+	assert.Equal(t, 0.0, result.SpareCapacity, "uncredited signal above boundary → scale-down must not fire during warmup")
+
+	// Per-variant: readyCount = 4 - 2 = 2, perReplicaCapacity = 1/4 = 0.25
+	// variant capacity = 2 * 0.25 = 0.5
+	require.Len(t, result.VariantCapacities, 1)
+	assert.Equal(t, 2, result.VariantCapacities[0].ReplicaCount)
+	assert.InDelta(t, 0.5, result.VariantCapacities[0].TotalCapacity, 0.01)
+	assert.InDelta(t, 0.25, result.VariantCapacities[0].PerReplicaCapacity, 0.01)
+}
+
+func TestAnalyze_WrongConfigType(t *testing.T) {
+	analyzer := setupAnalyzer(0.5)
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    nil, // wrong type
+	}
+
+	_, err := analyzer.Analyze(context.Background(), input)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected *EPPSaturationConfig")
+}
+
+func TestConfig_Defaults(t *testing.T) {
+	cfg := &EPPSaturationConfig{}
+	cfg.ApplyDefaults()
+	assert.Equal(t, DefaultEPPScaleUpThreshold, cfg.ScaleUpThreshold)
+	assert.Equal(t, DefaultEPPScaleDownBoundary, cfg.ScaleDownBoundary)
+	assert.Equal(t, DefaultEPPSmoothingAlpha, cfg.SmoothingAlpha)
+	assert.Equal(t, DefaultEPPSaturationCap, cfg.SaturationCap)
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     EPPSaturationConfig
+		wantErr bool
+	}{
+		{"valid", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 0.3, TTFTSLOMs: 3000, TPOTSLOMs: 100}, false},
+		{"up <= down", EPPSaturationConfig{ScaleUpThreshold: 0.50, ScaleDownBoundary: 0.85, SmoothingAlpha: 0.3}, true},
+		{"up zero", EPPSaturationConfig{ScaleUpThreshold: 0, ScaleDownBoundary: 0.50, SmoothingAlpha: 0.3}, true},
+		{"down zero", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0, SmoothingAlpha: 0.3}, true},
+		{"alpha zero", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 0}, true},
+		{"alpha too high", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 1.5}, true},
+		{"alpha one ok", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 1.0, TTFTSLOMs: 3000, TPOTSLOMs: 100}, false},
+		{"cap ok", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 0.3, TTFTSLOMs: 3000, TPOTSLOMs: 100, SaturationCap: 2.0}, false},
+		{"cap below scaleUpThreshold", EPPSaturationConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.50, SmoothingAlpha: 0.3, TTFTSLOMs: 3000, TPOTSLOMs: 100, SaturationCap: 0.5}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// setupAnalyzerMutable returns the analyzer plus a pointer to the fake
+// source's saturation value so tests can change it between calls.
+func setupAnalyzerMutable(initial float64) (*EPPSaturationAnalyzer, *fakePrometheusSource) {
+	registry := source.NewSourceRegistry()
+	fakeProm := newFakePrometheusSource(initial, nil)
+	registry.MustRegister("prometheus", fakeProm)
+	registration.RegisterEPPSaturationQueries(registry)
+	return NewEPPSaturationAnalyzer(registry), fakeProm
+}
+
+func TestAnalyze_EMASmoothing(t *testing.T) {
+	analyzer, src := setupAnalyzerMutable(0.5)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    0.3,
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 10, PendingReplicas: 0},
+		},
+	}
+
+	// First sample: no smoothing — use raw value as-is.
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.5, result.Utilization, 0.001, "first sample should be raw")
+
+	// Second sample: spike to 1.0. EMA(0.3): 0.3*1.0 + 0.7*0.5 = 0.65
+	src.saturation = 1.0
+	result, err = analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.65, result.Utilization, 0.001, "after one spike, smoothed should be 0.65")
+
+	// Third sample: still 1.0. EMA: 0.3*1.0 + 0.7*0.65 = 0.755
+	result, err = analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.755, result.Utilization, 0.001)
+
+	// Fourth sample: dip to 0.1. EMA: 0.3*0.1 + 0.7*0.755 = 0.5585
+	src.saturation = 0.1
+	result, err = analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.5585, result.Utilization, 0.001, "single dip should not push smoothed below scaleDownBoundary")
+	assert.Equal(t, 0.0, result.SpareCapacity, "single dip should not trigger scale-down")
+}
+
+func TestAnalyze_NoSmoothing_AlphaOne(t *testing.T) {
+	analyzer, src := setupAnalyzerMutable(0.5)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing
+		TTFTSLOMs:         1000,
+		TPOTSLOMs:         10000,
+	}
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 10, PendingReplicas: 0},
+		},
+	}
+
+	// Each sample should be used raw.
+	for _, raw := range []float64{0.2, 0.9, 0.1, 1.5} {
+		src.saturation = raw
+		result, err := analyzer.Analyze(context.Background(), input)
+		require.NoError(t, err)
+		// Utilization is capped at 1.0 internally, so compare the total demand instead.
+		assert.InDelta(t, raw, result.TotalDemand, 0.001, "alpha=1.0 should not smooth (raw=%v)", raw)
+	}
+}
+
+func float64Ptr(v float64) *float64 { return &v }
+
+// TestAnalyze_DerivesSaturationFromLatency verifies saturation is the max of the
+// per-target terms (predictedTTFT/TTFTSLO, predictedTPOT/TPOTSLO).
+func TestAnalyze_DerivesSaturationFromLatency(t *testing.T) {
+	analyzer, src := setupAnalyzerMutable(0)
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0, // no smoothing
+		TTFTSLOMs:         3000,
+		TPOTSLOMs:         100,
+	}
+	input := interfaces.AnalyzerInput{
+		ModelID:   "test-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 10},
+		},
+	}
+
+	// TTFT binds: ttft=4.5s/3s = 1.5 ; tpot=0.05s/0.1s = 0.5 ; max = 1.5
+	src.ttftVal = float64Ptr(4.5)
+	src.tpotVal = float64Ptr(0.05)
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+	assert.InDelta(t, 1.5, result.TotalDemand, 0.001, "TTFT term should bind (1.5)")
+
+	// TPOT binds: ttft=1.5s/3s = 0.5 ; tpot=0.08s/0.1s = 0.8 ; max = 0.8
+	src.ttftVal = float64Ptr(1.5)
+	src.tpotVal = float64Ptr(0.08)
+	result, err = analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.8, result.TotalDemand, 0.001, "TPOT term should bind (0.8)")
+}
+
+// TestAnalyze_NoTrafficIsZeroSaturation verifies a NaN latency (no recent
+// traffic) is treated as zero saturation, so an idle pool reports spare capacity.
+func TestAnalyze_NoTrafficIsZeroSaturation(t *testing.T) {
+	analyzer, src := setupAnalyzerMutable(0)
+	src.nan = true
+	cfg := &EPPSaturationConfig{
+		ScaleUpThreshold:  0.85,
+		ScaleDownBoundary: 0.50,
+		SmoothingAlpha:    1.0,
+		TTFTSLOMs:         3000,
+		TPOTSLOMs:         100,
+	}
+	input := interfaces.AnalyzerInput{
+		ModelID:   "idle-model",
+		Namespace: "default",
+		Config:    cfg,
+		VariantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", CurrentReplicas: 10},
+		},
+	}
+	result, err := analyzer.Analyze(context.Background(), input)
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, result.TotalDemand, "no traffic => zero saturation")
+	assert.Greater(t, result.SpareCapacity, 0.0, "idle pool should report spare capacity (scale down)")
+}

--- a/internal/engines/analyzers/epp_saturation/config.go
+++ b/internal/engines/analyzers/epp_saturation/config.go
@@ -22,9 +22,8 @@ const (
 
 	// DefaultEPPSmoothingAlpha is the EMA smoothing factor applied to the raw
 	// saturation signal. Range (0.0, 1.0]: 1.0 = no smoothing, lower = heavier
-	// smoothing. 0.6 lets the smoothed signal reach the (clamped) raw level in
-	// 1–2 cycles so the scale-up ask is sized promptly; spike protection is the
-	// clamp's job (SaturationCap), not the EMA's.
+	// smoothing. 0.6 lets the smoothed signal reach the raw level in 1–2 cycles
+	// so the scale-up ask is sized promptly.
 	DefaultEPPSmoothingAlpha = 0.6
 
 	// DefaultEPPTTFTSLOMs is the default time-to-first-token SLO (milliseconds)
@@ -34,16 +33,6 @@ const (
 	// DefaultEPPTPOTSLOMs is the default time-per-output-token SLO (milliseconds)
 	// the analyzer divides predicted TPOT by to derive saturation.
 	DefaultEPPTPOTSLOMs = 100.0
-
-	// DefaultEPPSaturationCap bounds the raw saturation signal before it feeds the
-	// EMA. Near the queueing knee, predicted latency (and thus saturation) can spike
-	// to tens or hundreds × SLO; any value above the cap already means "scale up at
-	// the max per-cycle rate", so the extra magnitude carries no additional
-	// actionable information and only poisons the EMA (a single spike then decays
-	// slowly, holding replicas high long after the pool recovers). Clamping the raw
-	// signal keeps the EMA peak bounded so it recovers in a few cycles regardless of
-	// spike size. 2.0 = "at most 2× SLO worth of demand pressure per cycle".
-	DefaultEPPSaturationCap = 2.0
 )
 
 // EPPSaturationConfig holds configuration for the EPP saturation analyzer.
@@ -63,14 +52,12 @@ type EPPSaturationConfig struct {
 	// lulls while idle pools shed. Default 0.40.
 	ScaleDownBoundary float64 `yaml:"scaleDownBoundary,omitempty"`
 
-	// SmoothingAlpha is the EMA smoothing factor applied to the (clamped) raw
-	// saturation signal before it drives scaling decisions. Range (0.0, 1.0]:
+	// SmoothingAlpha is the EMA smoothing factor applied to the raw saturation
+	// signal before it drives scaling decisions. Range (0.0, 1.0]:
 	//   1.0  = no smoothing (use raw signal)
-	//   0.6  = light smoothing (default) — reaches the clamped level in 1–2 cycles
+	//   0.6  = light smoothing (default) — reaches the raw level in 1–2 cycles
 	//   0.1  = heavy smoothing
 	// The smoothed value evolves as: smoothed = alpha*raw + (1-alpha)*smoothed_prev.
-	// Spike suppression is primarily SaturationCap's job; alpha mainly sets how
-	// fast the scale-up ask is sized after a load change.
 	SmoothingAlpha float64 `yaml:"smoothingAlpha,omitempty"`
 
 	// TTFTSLOMs and TPOTSLOMs are the latency SLO targets (milliseconds) used to
@@ -82,14 +69,6 @@ type EPPSaturationConfig struct {
 	// saturation gauge.
 	TTFTSLOMs float64 `yaml:"ttftSLOMs,omitempty"`
 	TPOTSLOMs float64 `yaml:"tpotSLOMs,omitempty"`
-
-	// SaturationCap bounds the raw saturation signal before EMA smoothing. Values
-	// above the cap are clamped to it, so a single knee-region spike (which can be
-	// tens or hundreds × SLO) cannot dominate the smoothed signal for many cycles.
-	// The true uncapped signal is still surfaced for observability (RawSignal).
-	// A zero value is replaced by the default (2.0) via ApplyDefaults — it does
-	// NOT disable clamping; to effectively disable, set a very large value.
-	SaturationCap float64 `yaml:"saturationCap,omitempty"`
 }
 
 // GetAnalyzerName implements interfaces.AnalyzerConfig.
@@ -114,9 +93,6 @@ func (c *EPPSaturationConfig) ApplyDefaults() {
 	if c.TPOTSLOMs == 0 {
 		c.TPOTSLOMs = DefaultEPPTPOTSLOMs
 	}
-	if c.SaturationCap == 0 {
-		c.SaturationCap = DefaultEPPSaturationCap
-	}
 }
 
 // Validate checks for invalid threshold values.
@@ -139,12 +115,6 @@ func (c *EPPSaturationConfig) Validate() error {
 	}
 	if c.TPOTSLOMs <= 0 {
 		return fmt.Errorf("tpotSLOMs must be > 0, got %.2f", c.TPOTSLOMs)
-	}
-	// The cap must leave room to cross the scale-up threshold, otherwise clamping
-	// would make scale-up impossible.
-	if c.SaturationCap > 0 && c.SaturationCap < c.ScaleUpThreshold {
-		return fmt.Errorf("saturationCap (%.2f) must be >= scaleUpThreshold (%.2f)",
-			c.SaturationCap, c.ScaleUpThreshold)
 	}
 	return nil
 }

--- a/internal/engines/analyzers/epp_saturation/config.go
+++ b/internal/engines/analyzers/epp_saturation/config.go
@@ -1,0 +1,150 @@
+package epp_saturation
+
+import "fmt"
+
+const (
+	// DefaultEPPScaleUpThreshold is the saturation level above which scale-up
+	// is triggered. Set below the queueing knee on purpose: the P90 signal's
+	// healthy band sits around 0.2–0.45 of the SLO (latency barely moves with
+	// load under continuous batching, then goes vertical), so a threshold near
+	// 1.0 only fires after the SLO budget is nearly burned. 0.55 fires on the
+	// P90 pre-rise at the knee's base — benchmarked at 95.8% SLO attainment vs
+	// 84.7% for a 0.85 threshold (docs/developer-guide/epp-saturation-benchmark.md).
+	// Workloads whose SLO is close to their base latency (healthy band shifted
+	// upward) should raise this.
+	DefaultEPPScaleUpThreshold = 0.55
+
+	// DefaultEPPScaleDownBoundary is the saturation level below which scale-down
+	// is safe. 0.40 sits just below the P90 signal's healthy-load band
+	// (~0.35–0.45), so pools serving real traffic retain their replicas through
+	// short lulls while idle pools (signal ≈ 0.1) still scale down.
+	DefaultEPPScaleDownBoundary = 0.40
+
+	// DefaultEPPSmoothingAlpha is the EMA smoothing factor applied to the raw
+	// saturation signal. Range (0.0, 1.0]: 1.0 = no smoothing, lower = heavier
+	// smoothing. 0.6 lets the smoothed signal reach the (clamped) raw level in
+	// 1–2 cycles so the scale-up ask is sized promptly; spike protection is the
+	// clamp's job (SaturationCap), not the EMA's.
+	DefaultEPPSmoothingAlpha = 0.6
+
+	// DefaultEPPTTFTSLOMs is the default time-to-first-token SLO (milliseconds)
+	// the analyzer divides predicted TTFT by to derive saturation.
+	DefaultEPPTTFTSLOMs = 3000.0
+
+	// DefaultEPPTPOTSLOMs is the default time-per-output-token SLO (milliseconds)
+	// the analyzer divides predicted TPOT by to derive saturation.
+	DefaultEPPTPOTSLOMs = 100.0
+
+	// DefaultEPPSaturationCap bounds the raw saturation signal before it feeds the
+	// EMA. Near the queueing knee, predicted latency (and thus saturation) can spike
+	// to tens or hundreds × SLO; any value above the cap already means "scale up at
+	// the max per-cycle rate", so the extra magnitude carries no additional
+	// actionable information and only poisons the EMA (a single spike then decays
+	// slowly, holding replicas high long after the pool recovers). Clamping the raw
+	// signal keeps the EMA peak bounded so it recovers in a few cycles regardless of
+	// spike size. 2.0 = "at most 2× SLO worth of demand pressure per cycle".
+	DefaultEPPSaturationCap = 2.0
+)
+
+// EPPSaturationConfig holds configuration for the EPP saturation analyzer.
+// It implements interfaces.AnalyzerConfig.
+type EPPSaturationConfig struct {
+	// ScaleUpThreshold is the saturation score above which scale-up is triggered.
+	// Value range: (0.0, 2.0+]. Since saturation = P90 predictedLatency/SLO, the
+	// threshold should sit at the top of the signal's healthy band (measured
+	// ~0.2–0.45 when the SLO is generously above base latency) so it fires on
+	// the pre-knee rise; values near 1.0 fire only after the SLO budget is
+	// nearly consumed. Default 0.55.
+	ScaleUpThreshold float64 `yaml:"scaleUpThreshold,omitempty"`
+
+	// ScaleDownBoundary is the saturation score below which scale-down is safe.
+	// Must be less than ScaleUpThreshold to create a hysteresis band. Placed
+	// just below the healthy-load band so serving pools hold replicas through
+	// lulls while idle pools shed. Default 0.40.
+	ScaleDownBoundary float64 `yaml:"scaleDownBoundary,omitempty"`
+
+	// SmoothingAlpha is the EMA smoothing factor applied to the (clamped) raw
+	// saturation signal before it drives scaling decisions. Range (0.0, 1.0]:
+	//   1.0  = no smoothing (use raw signal)
+	//   0.6  = light smoothing (default) — reaches the clamped level in 1–2 cycles
+	//   0.1  = heavy smoothing
+	// The smoothed value evolves as: smoothed = alpha*raw + (1-alpha)*smoothed_prev.
+	// Spike suppression is primarily SaturationCap's job; alpha mainly sets how
+	// fast the scale-up ask is sized after a load change.
+	SmoothingAlpha float64 `yaml:"smoothingAlpha,omitempty"`
+
+	// TTFTSLOMs and TPOTSLOMs are the latency SLO targets (milliseconds) used to
+	// derive saturation from the EPP's predicted latencies:
+	//   saturation = max(predictedTTFT / TTFTSLOMs, predictedTPOT / TPOTSLOMs)
+	// The analyzer queries predicted latency (falling back to actual latency when
+	// the predicted series is unavailable) and divides by these targets, so the
+	// SLO policy lives in WVA rather than depending on the EPP to pre-compute a
+	// saturation gauge.
+	TTFTSLOMs float64 `yaml:"ttftSLOMs,omitempty"`
+	TPOTSLOMs float64 `yaml:"tpotSLOMs,omitempty"`
+
+	// SaturationCap bounds the raw saturation signal before EMA smoothing. Values
+	// above the cap are clamped to it, so a single knee-region spike (which can be
+	// tens or hundreds × SLO) cannot dominate the smoothed signal for many cycles.
+	// The true uncapped signal is still surfaced for observability (RawSignal).
+	// A zero value is replaced by the default (2.0) via ApplyDefaults — it does
+	// NOT disable clamping; to effectively disable, set a very large value.
+	SaturationCap float64 `yaml:"saturationCap,omitempty"`
+}
+
+// GetAnalyzerName implements interfaces.AnalyzerConfig.
+func (c *EPPSaturationConfig) GetAnalyzerName() string {
+	return AnalyzerName
+}
+
+// ApplyDefaults fills in zero-valued fields with defaults.
+func (c *EPPSaturationConfig) ApplyDefaults() {
+	if c.ScaleUpThreshold == 0 {
+		c.ScaleUpThreshold = DefaultEPPScaleUpThreshold
+	}
+	if c.ScaleDownBoundary == 0 {
+		c.ScaleDownBoundary = DefaultEPPScaleDownBoundary
+	}
+	if c.SmoothingAlpha == 0 {
+		c.SmoothingAlpha = DefaultEPPSmoothingAlpha
+	}
+	if c.TTFTSLOMs == 0 {
+		c.TTFTSLOMs = DefaultEPPTTFTSLOMs
+	}
+	if c.TPOTSLOMs == 0 {
+		c.TPOTSLOMs = DefaultEPPTPOTSLOMs
+	}
+	if c.SaturationCap == 0 {
+		c.SaturationCap = DefaultEPPSaturationCap
+	}
+}
+
+// Validate checks for invalid threshold values.
+func (c *EPPSaturationConfig) Validate() error {
+	if c.ScaleUpThreshold <= 0 {
+		return fmt.Errorf("scaleUpThreshold must be > 0, got %.2f", c.ScaleUpThreshold)
+	}
+	if c.ScaleDownBoundary <= 0 {
+		return fmt.Errorf("scaleDownBoundary must be > 0, got %.2f", c.ScaleDownBoundary)
+	}
+	if c.ScaleUpThreshold <= c.ScaleDownBoundary {
+		return fmt.Errorf("scaleUpThreshold (%.2f) must be > scaleDownBoundary (%.2f)",
+			c.ScaleUpThreshold, c.ScaleDownBoundary)
+	}
+	if c.SmoothingAlpha <= 0 || c.SmoothingAlpha > 1.0 {
+		return fmt.Errorf("smoothingAlpha must be in (0, 1], got %.2f", c.SmoothingAlpha)
+	}
+	if c.TTFTSLOMs <= 0 {
+		return fmt.Errorf("ttftSLOMs must be > 0, got %.2f", c.TTFTSLOMs)
+	}
+	if c.TPOTSLOMs <= 0 {
+		return fmt.Errorf("tpotSLOMs must be > 0, got %.2f", c.TPOTSLOMs)
+	}
+	// The cap must leave room to cross the scale-up threshold, otherwise clamping
+	// would make scale-up impossible.
+	if c.SaturationCap > 0 && c.SaturationCap < c.ScaleUpThreshold {
+		return fmt.Errorf("saturationCap (%.2f) must be >= scaleUpThreshold (%.2f)",
+			c.SaturationCap, c.ScaleUpThreshold)
+	}
+	return nil
+}

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1694,8 +1694,6 @@ func (e *Engine) applySaturationDecisions(
 				MetricsAvailable:  metricsAvailable,
 				MetricsReason:     metricsReason,
 				MetricsMessage:    metricsMessage,
-				ScalingCapped:     decision.ScalingCapped,
-				UncappedReplicas:  decision.UncappedReplicas,
 			})
 
 			// 2. Trigger Reconciler

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -41,6 +41,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/discovery"
+	epp_saturation "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/epp_saturation"
 	queueingmodel "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel"
 	saturation_v2 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/saturation_v2"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/common"
@@ -153,6 +154,10 @@ type Engine struct {
 	// Selected via analyzerName: "queueing-model" in SaturationScalingConfig.
 	queueingModelAnalyzer *queueingmodel.QueueingModelAnalyzer
 
+	// eppSaturationAnalyzer derives pool saturation from the EPP's predicted-latency histograms.
+	// Selected via analyzerName: "epp-saturation" in SaturationScalingConfig.
+	eppSaturationAnalyzer *epp_saturation.EPPSaturationAnalyzer
+
 	// capacityStore is shared with the V2 analyzer for caching capacity knowledge.
 	capacityStore *saturation_v2.CapacityKnowledgeStore
 
@@ -234,6 +239,7 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 		metricsRegistry:         metricsRegistry,
 		saturationV2Analyzer:    satV2,
 		queueingModelAnalyzer:   queueingmodel.NewQueueingModelAnalyzer(),
+		eppSaturationAnalyzer:   epp_saturation.NewEPPSaturationAnalyzer(metricsRegistry),
 		capacityStore:           capacityStore,
 		optimizer:               scalingOptimizer,
 		metricsEmitter:          metrics.NewMetricsEmitter(),
@@ -243,11 +249,15 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 		},
 	}
 
+	pollInterval := cfg.OptimizationInterval()
+	if pollInterval <= 0 {
+		pollInterval = 30 * time.Second
+	}
 	engine.executor = executor.NewPollingExecutor(executor.PollingConfig{
 		Config: executor.Config{
 			OptimizeFunc: engine.optimize,
 		},
-		Interval:     30 * time.Second,
+		Interval:     pollInterval,
 		RetryBackoff: 100 * time.Millisecond,
 	})
 
@@ -266,6 +276,9 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 	// ReplicaMetrics struct and used by the queueing model analyzer to
 	// estimate per-replica arrival rate and model queue behavior.
 	registration.RegisterQueueingModelQueries(metricsRegistry)
+
+	// Register EPP saturation queries (P90 predicted/actual latency histograms).
+	registration.RegisterEPPSaturationQueries(metricsRegistry)
 
 	return &engine
 }
@@ -430,7 +443,7 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 
 	// Select optimizer based on enableLimiter flag (both are stateless, safe to swap)
 	// Applies to V2 and queueing-model paths which both use the optimizer pipeline.
-	if analyzerName == interfaces.SaturationAnalyzerName || analyzerName == interfaces.QueueingModelAnalyzerName {
+	if analyzerName == interfaces.SaturationAnalyzerName || analyzerName == interfaces.QueueingModelAnalyzerName || analyzerName == epp_saturation.AnalyzerName {
 		savedOptimizer := e.optimizer
 		if enableLimiter {
 			e.optimizer = pipeline.NewGreedyByScoreOptimizer()
@@ -457,6 +470,8 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 		allDecisions = e.optimizeQueueingModel(ctx, modelGroups, currentAllocations)
 	case interfaces.SaturationAnalyzerName:
 		allDecisions = e.optimizeV2(ctx, modelGroups, currentAllocations)
+	case epp_saturation.AnalyzerName:
+		allDecisions = e.optimizeEPPSaturation(ctx, modelGroups, currentAllocations)
 	default:
 		allDecisions = e.optimizeV1(ctx, modelGroups, currentAllocations)
 	}
@@ -1679,6 +1694,8 @@ func (e *Engine) applySaturationDecisions(
 				MetricsAvailable:  metricsAvailable,
 				MetricsReason:     metricsReason,
 				MetricsMessage:    metricsMessage,
+				ScalingCapped:     decision.ScalingCapped,
+				UncappedReplicas:  decision.UncappedReplicas,
 			})
 
 			// 2. Trigger Reconciler

--- a/internal/engines/saturation/engine_epp_saturation.go
+++ b/internal/engines/saturation/engine_epp_saturation.go
@@ -2,37 +2,17 @@ package saturation
 
 import (
 	"context"
-	"fmt"
-	"math"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	epp_saturation "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/epp_saturation"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/common"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
-
-// eppSignalUnavailableMessage is the MetricsAvailable=False message used when the
-// EPP predicted-latency signal cannot be queried.
-const eppSignalUnavailableMessage = "EPP saturation signal unavailable (EPP metrics or predictor sidecar may be down)"
-
-// applyWarmupHold implements warmup-aware scale-up damping: while replicas already
-// requested are still warming (pending > 0), a scale-up target (target > current) is
-// held at the current replica count so the pool does not stack a new scale-up before
-// the in-flight pods come online. Scale-down and no-op targets (target <= current)
-// are returned unchanged.
-func applyWarmupHold(target, current, pending int) int {
-	if pending > 0 && target > current {
-		return current
-	}
-	return target
-}
 
 // optimizeEPPSaturation runs the EPP saturation analyzer path.
 // Unlike V1/V2, this does not collect per-replica metrics from vLLM pods.
@@ -46,13 +26,6 @@ func (e *Engine) optimizeEPPSaturation(
 	logger := ctrl.LoggerFrom(ctx)
 
 	var requests []pipeline.ModelScalingRequest
-	// uncappedByModel holds the recommendation the EPP formula would make absent
-	// the maxReplicas clamp, keyed by "namespace/modelID". Used post-optimize to
-	// flag decisions that were capped (see RFC #1018 proposal #2).
-	uncappedByModel := make(map[string]int)
-	// holdWarmByModel records the resolved warmup-hold setting per "namespace/modelID"
-	// so the post-optimizer damping can honor per-model config overrides.
-	holdWarmByModel := make(map[string]bool)
 
 	for groupKey, modelVAs := range modelGroups {
 		modelID := modelVAs[0].Spec.ModelID
@@ -71,15 +44,6 @@ func (e *Engine) optimizeEPPSaturation(
 			continue
 		}
 		saturationConfig := resolveSaturationConfig(saturationConfigMap, modelID, namespace)
-		// Warmup hold defaults OFF: it lowers the replica peak for step-and-hold
-		// workloads but its deliberate one-pod-per-warmup climb falls behind a rising
-		// (ramping) load, causing sustained SLO violations. It is opt-in for steady,
-		// cost-sensitive workloads. See docs/developer-guide/epp-saturation-benchmark.md.
-		holdWarm := false
-		if saturationConfig.HoldScaleUpWhileWarming != nil {
-			holdWarm = *saturationConfig.HoldScaleUpWhileWarming
-		}
-		holdWarmByModel[utils.GetNamespacedKey(namespace, modelID)] = holdWarm
 
 		// Fetch scale targets and build variant states directly — skip per-replica
 		// vLLM metrics collection since EPP saturation is a pool-level signal.
@@ -115,16 +79,13 @@ func (e *Engine) optimizeEPPSaturation(
 			SmoothingAlpha:    saturationConfig.SmoothingAlpha,
 			TTFTSLOMs:         saturationConfig.TTFTSLOMs,
 			TPOTSLOMs:         saturationConfig.TPOTSLOMs,
-			SaturationCap:     saturationConfig.SaturationCap,
 		}
 		eppCfg.ApplyDefaults()
 		if err := eppCfg.Validate(); err != nil {
-			// An invalid config (e.g. saturationCap below scaleUpThreshold, which
-			// would permanently disable scale-up) must not silently drive scaling.
-			// Hold the last desired replicas and surface MetricsAvailable=False.
+			// An invalid config must not silently drive scaling. Hold the last
+			// desired replicas via the safety net.
 			logger.Error(err, "Invalid EPP saturation config; holding last decision", "modelID", modelID)
 			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, scaleTargets)
-			e.markEPPSignalUnavailable(modelVAs)
 			continue
 		}
 
@@ -139,12 +100,8 @@ func (e *Engine) optimizeEPPSaturation(
 		result, err := e.eppSaturationAnalyzer.Analyze(ctx, input)
 		if err != nil {
 			logger.Error(err, "EPP saturation analysis failed", "modelID", modelID)
-			// Preserve the last desired replica count via the safety net, and
-			// explicitly mark metrics unavailable so the VA surfaces an
-			// EPP-specific MetricsAvailable=False condition rather than relying
-			// on the implicit (no-decision) fallthrough (RFC #1018 proposal #4).
+			// Preserve the last desired replica count via the safety net.
 			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, scaleTargets)
-			e.markEPPSignalUnavailable(modelVAs)
 			continue
 		}
 
@@ -162,41 +119,6 @@ func (e *Engine) optimizeEPPSaturation(
 			"totalDemand", result.TotalDemand,
 			"requiredCapacity", result.RequiredCapacity,
 			"spareCapacity", result.SpareCapacity)
-
-		// Emit raw vs smoothed saturation per variant so operators can observe the
-		// EMA and tune smoothingAlpha. The pool-level signal applies to every
-		// variant in the model.
-		for i := range modelVAs {
-			va := &modelVAs[i]
-			e.metricsEmitter.RecordEPPSaturationMetrics(ctx, va.Name, va.Namespace, modelID,
-				result.RawSignal, result.SmoothedSignal)
-		}
-
-		// Record what the EPP formula would recommend absent the maxReplicas clamp,
-		// so we can flag capped decisions after the optimizer runs. The analyzer
-		// already returns the credited requiredCapacity (max(0, S_effective/T_up − 1)
-		// with normalized supply 1.0), so reuse it rather than mirroring the formula:
-		//   uncappedTarget = N + ceil(result.RequiredCapacity * N)
-		//
-		// This is a pool-level total. We only attribute it for single-variant model
-		// groups, where the variant target equals the pool total; with multiple
-		// variants the optimizer splits the total across them and a per-variant
-		// maxReplicas comparison would misfire, so cap detection is skipped (the
-		// gauge is still emitted as 0 below).
-		if len(modelVAs) == 1 {
-			totalReplicas := 0
-			for _, vs := range variantStates {
-				totalReplicas += vs.CurrentReplicas
-			}
-			if totalReplicas == 0 {
-				totalReplicas = 1 // match the analyzer's floor so scale-up-from-zero is still flaggable
-			}
-			uncapped := totalReplicas + int(math.Ceil(result.RequiredCapacity*float64(totalReplicas)))
-			uncappedByModel[utils.GetNamespacedKey(namespace, modelID)] = uncapped
-		} else {
-			logger.Info("Skipping cap detection for multi-variant model group (pool total not attributable per variant); ScalingCapped will read False rather than Unknown",
-				"modelID", modelID, "variantCount", len(modelVAs))
-		}
 
 		requests = append(requests, pipeline.ModelScalingRequest{
 			ModelID:   modelID,
@@ -258,97 +180,5 @@ func (e *Engine) optimizeEPPSaturation(
 		}
 	}
 
-	// Warmup-aware scale-up damping (RFC #1018): the EPP saturation signal is
-	// measured only on Ready pods, so while replicas already requested are still
-	// warming (pending > 0) the pool keeps reporting high saturation and the
-	// optimizer would stack a new scale-up every cycle before the in-flight pods
-	// come online — racing to maxReplicas (observed live: overshoot to 11 when ~6
-	// sufficed). Hold the target at the current replica count until the requested
-	// pods become Ready. This replaces unreliable extrapolation near the queueing
-	// knee with empirical probing: add capacity, wait for it to take effect,
-	// re-measure. Scale-down (target < current) is never suppressed. Applied
-	// post-optimizer so it is independent of optimizer internals.
-	// Variant names are only unique per-namespace, so key by namespace+name
-	// (requests can span namespaces within one optimize pass).
-	stateByVariant := make(map[string]interfaces.VariantReplicaState)
-	for _, req := range requests {
-		for _, vs := range req.VariantStates {
-			stateByVariant[utils.GetNamespacedKey(req.Namespace, vs.VariantName)] = vs
-		}
-	}
-	for i := range allDecisions {
-		d := &allDecisions[i]
-		if !holdWarmByModel[utils.GetNamespacedKey(d.Namespace, d.ModelID)] {
-			continue
-		}
-		st, ok := stateByVariant[utils.GetNamespacedKey(d.Namespace, d.VariantName)]
-		if !ok {
-			continue
-		}
-		if held := applyWarmupHold(d.TargetReplicas, st.CurrentReplicas, st.PendingReplicas); held != d.TargetReplicas {
-			logger.Info("EPP saturation holding scale-up while replicas warm up",
-				"variant", d.VariantName, "modelID", d.ModelID,
-				"currentReplicas", st.CurrentReplicas, "pendingReplicas", st.PendingReplicas,
-				"requestedTarget", d.TargetReplicas)
-			d.TargetReplicas = held
-			// Keep Action/reason consistent with the held target so scaling-event
-			// records, metrics, and logs don't report ScaleUp on a held no-op cycle
-			// (SetDecisionReason is the single writer of d.Action).
-			category := d.ReasonCategory()
-			if category == "" {
-				category = interfaces.DecisionReasonV2
-			}
-			d.SetDecisionReason(interfaces.ActionNoChange, category,
-				fmt.Sprintf("%s no-change (scale-up held while %d replica(s) warm up)", category, st.PendingReplicas))
-		}
-	}
-
-	// Flag decisions whose recommendation was clamped to maxReplicas and emit the
-	// wva_scale_capped gauge so operators can distinguish "fine at the cap" from
-	// "wanted more but was blocked" (RFC #1018 proposal #2). A decision is capped
-	// when the uncapped formula recommendation exceeds maxReplicas and the final
-	// target is pinned at the cap.
-	for i := range allDecisions {
-		d := &allDecisions[i]
-		uncapped, ok := uncappedByModel[utils.GetNamespacedKey(d.Namespace, d.ModelID)]
-		capped := ok && d.MaxReplicas != nil && *d.MaxReplicas > 0 &&
-			uncapped > *d.MaxReplicas && d.TargetReplicas >= *d.MaxReplicas
-		if capped {
-			d.ScalingCapped = true
-			d.UncappedReplicas = uncapped
-			logger.Info("Scaling recommendation capped by maxReplicas (EPP saturation)",
-				"variant", d.VariantName, "modelID", d.ModelID,
-				"uncappedReplicas", uncapped, "maxReplicas", *d.MaxReplicas)
-		}
-		e.metricsEmitter.RecordScaleCappedMetric(ctx, d.VariantName, d.Namespace, d.ModelID, capped)
-	}
-
 	return allDecisions
-}
-
-// markEPPSignalUnavailable pushes a MetricsAvailable=False decision into the
-// shared cache for each non-synthetic VA in the model and triggers a reconcile,
-// so the EPP signal-unavailable state is surfaced as a status condition with an
-// EPP-specific reason. Mirrors the no-accelerator safety path in applySaturationDecisions.
-//
-// The existing cache entry (last good target, ScalingCapped state, accelerator)
-// is preserved and only the metrics-availability fields are rewritten — a
-// transient Prometheus blip must not flip the ScalingCapped condition to False
-// while the pool is still pinned at the cap, nor discard the last good decision.
-func (e *Engine) markEPPSignalUnavailable(modelVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling) {
-	for i := range modelVAs {
-		va := &modelVAs[i]
-		if utils.IsSynthetic(va) {
-			continue
-		}
-		decision, ok := common.DecisionCache.Get(va.Name, va.Namespace)
-		if !ok {
-			decision = interfaces.VariantDecision{VariantName: va.Name, Namespace: va.Namespace}
-		}
-		decision.MetricsAvailable = false
-		decision.MetricsReason = llmdVariantAutoscalingV1alpha1.ReasonPrometheusError
-		decision.MetricsMessage = eppSignalUnavailableMessage
-		common.DecisionCache.Set(va.Name, va.Namespace, decision)
-		common.DecisionTrigger <- event.GenericEvent{Object: va}
-	}
 }

--- a/internal/engines/saturation/engine_epp_saturation.go
+++ b/internal/engines/saturation/engine_epp_saturation.go
@@ -1,0 +1,354 @@
+package saturation
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	epp_saturation "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/epp_saturation"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/common"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+// eppSignalUnavailableMessage is the MetricsAvailable=False message used when the
+// EPP predicted-latency signal cannot be queried.
+const eppSignalUnavailableMessage = "EPP saturation signal unavailable (EPP metrics or predictor sidecar may be down)"
+
+// applyWarmupHold implements warmup-aware scale-up damping: while replicas already
+// requested are still warming (pending > 0), a scale-up target (target > current) is
+// held at the current replica count so the pool does not stack a new scale-up before
+// the in-flight pods come online. Scale-down and no-op targets (target <= current)
+// are returned unchanged.
+func applyWarmupHold(target, current, pending int) int {
+	if pending > 0 && target > current {
+		return current
+	}
+	return target
+}
+
+// optimizeEPPSaturation runs the EPP saturation analyzer path.
+// Unlike V1/V2, this does not collect per-replica metrics from vLLM pods.
+// Instead, it queries the P90 of the EPP's predicted-latency histograms and
+// translates the derived saturation into scaling decisions via the optimizer pipeline.
+func (e *Engine) optimizeEPPSaturation(
+	ctx context.Context,
+	modelGroups map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	currentAllocations map[string]*interfaces.Allocation,
+) []interfaces.VariantDecision {
+	logger := ctrl.LoggerFrom(ctx)
+
+	var requests []pipeline.ModelScalingRequest
+	// uncappedByModel holds the recommendation the EPP formula would make absent
+	// the maxReplicas clamp, keyed by "namespace/modelID". Used post-optimize to
+	// flag decisions that were capped (see RFC #1018 proposal #2).
+	uncappedByModel := make(map[string]int)
+	// holdWarmByModel records the resolved warmup-hold setting per "namespace/modelID"
+	// so the post-optimizer damping can honor per-model config overrides.
+	holdWarmByModel := make(map[string]bool)
+
+	for groupKey, modelVAs := range modelGroups {
+		modelID := modelVAs[0].Spec.ModelID
+		namespace := modelVAs[0].Namespace
+		logger.Info("Processing model (EPP saturation)",
+			"modelID", modelID,
+			"namespace", namespace,
+			"variantCount", len(modelVAs),
+			"groupKey", groupKey)
+
+		// Get saturation config for threshold values
+		saturationConfigMap := e.Config.SaturationConfigForNamespace(namespace)
+		if len(saturationConfigMap) == 0 {
+			logger.Info("Saturation scaling config not loaded yet for namespace, skipping model",
+				"namespace", namespace, "modelID", modelID)
+			continue
+		}
+		saturationConfig := resolveSaturationConfig(saturationConfigMap, modelID, namespace)
+		// Warmup hold defaults OFF: it lowers the replica peak for step-and-hold
+		// workloads but its deliberate one-pod-per-warmup climb falls behind a rising
+		// (ramping) load, causing sustained SLO violations. It is opt-in for steady,
+		// cost-sensitive workloads. See docs/developer-guide/epp-saturation-benchmark.md.
+		holdWarm := false
+		if saturationConfig.HoldScaleUpWhileWarming != nil {
+			holdWarm = *saturationConfig.HoldScaleUpWhileWarming
+		}
+		holdWarmByModel[utils.GetNamespacedKey(namespace, modelID)] = holdWarm
+
+		// Fetch scale targets and build variant states directly — skip per-replica
+		// vLLM metrics collection since EPP saturation is a pool-level signal.
+		scaleTargets := make(map[string]scaletarget.ScaleTargetAccessor)
+		variantAccel := make(map[string]string, len(modelVAs))
+		for i := range modelVAs {
+			va := &modelVAs[i]
+			scaleTarget, err := scaletarget.FetchScaleTarget(ctx, e.client, va.Name, va.Spec.ScaleTargetRef.Kind, va.GetScaleTargetName(), va.Namespace)
+			if err != nil {
+				logger.V(logging.DEBUG).Info("Could not get scale target for VA",
+					"variant", va.Name, "error", err)
+				continue
+			}
+			scaleTargets[utils.GetNamespacedKey(va.Namespace, va.GetScaleTargetName())] = scaleTarget
+			variantAccel[va.Name] = utils.GetAcceleratorNameFromScaleTarget(va, scaleTarget)
+		}
+		if len(scaleTargets) == 0 {
+			logger.Info("Skipping model: no scale targets resolved", "modelID", modelID)
+			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, nil)
+			continue
+		}
+		variantStates := e.BuildVariantStates(ctx, modelVAs, scaleTargets, e.client)
+		if len(variantStates) == 0 {
+			logger.Info("Skipping model: no variant states built", "modelID", modelID)
+			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, scaleTargets)
+			continue
+		}
+
+		// Build EPP saturation config from the saturation config thresholds
+		eppCfg := &epp_saturation.EPPSaturationConfig{
+			ScaleUpThreshold:  saturationConfig.ScaleUpThreshold,
+			ScaleDownBoundary: saturationConfig.ScaleDownBoundary,
+			SmoothingAlpha:    saturationConfig.SmoothingAlpha,
+			TTFTSLOMs:         saturationConfig.TTFTSLOMs,
+			TPOTSLOMs:         saturationConfig.TPOTSLOMs,
+			SaturationCap:     saturationConfig.SaturationCap,
+		}
+		eppCfg.ApplyDefaults()
+		if err := eppCfg.Validate(); err != nil {
+			// An invalid config (e.g. saturationCap below scaleUpThreshold, which
+			// would permanently disable scale-up) must not silently drive scaling.
+			// Hold the last desired replicas and surface MetricsAvailable=False.
+			logger.Error(err, "Invalid EPP saturation config; holding last decision", "modelID", modelID)
+			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, scaleTargets)
+			e.markEPPSignalUnavailable(modelVAs)
+			continue
+		}
+
+		// Run the EPP saturation analyzer (queries Prometheus for pool saturation)
+		input := interfaces.AnalyzerInput{
+			ModelID:       modelID,
+			Namespace:     namespace,
+			Config:        eppCfg,
+			VariantStates: variantStates,
+		}
+
+		result, err := e.eppSaturationAnalyzer.Analyze(ctx, input)
+		if err != nil {
+			logger.Error(err, "EPP saturation analysis failed", "modelID", modelID)
+			// Preserve the last desired replica count via the safety net, and
+			// explicitly mark metrics unavailable so the VA surfaces an
+			// EPP-specific MetricsAvailable=False condition rather than relying
+			// on the implicit (no-decision) fallthrough (RFC #1018 proposal #4).
+			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, scaleTargets)
+			e.markEPPSignalUnavailable(modelVAs)
+			continue
+		}
+
+		// Fill in accelerator names on variant capacities (analyzer doesn't know them).
+		for i := range result.VariantCapacities {
+			if name, ok := variantAccel[result.VariantCapacities[i].VariantName]; ok {
+				result.VariantCapacities[i].AcceleratorName = name
+			}
+		}
+
+		logger.Info("EPP saturation analysis result",
+			"modelID", modelID,
+			"saturation", result.Utilization,
+			"totalSupply", result.TotalSupply,
+			"totalDemand", result.TotalDemand,
+			"requiredCapacity", result.RequiredCapacity,
+			"spareCapacity", result.SpareCapacity)
+
+		// Emit raw vs smoothed saturation per variant so operators can observe the
+		// EMA and tune smoothingAlpha. The pool-level signal applies to every
+		// variant in the model.
+		for i := range modelVAs {
+			va := &modelVAs[i]
+			e.metricsEmitter.RecordEPPSaturationMetrics(ctx, va.Name, va.Namespace, modelID,
+				result.RawSignal, result.SmoothedSignal)
+		}
+
+		// Record what the EPP formula would recommend absent the maxReplicas clamp,
+		// so we can flag capped decisions after the optimizer runs. The analyzer
+		// already returns the credited requiredCapacity (max(0, S_effective/T_up − 1)
+		// with normalized supply 1.0), so reuse it rather than mirroring the formula:
+		//   uncappedTarget = N + ceil(result.RequiredCapacity * N)
+		//
+		// This is a pool-level total. We only attribute it for single-variant model
+		// groups, where the variant target equals the pool total; with multiple
+		// variants the optimizer splits the total across them and a per-variant
+		// maxReplicas comparison would misfire, so cap detection is skipped (the
+		// gauge is still emitted as 0 below).
+		if len(modelVAs) == 1 {
+			totalReplicas := 0
+			for _, vs := range variantStates {
+				totalReplicas += vs.CurrentReplicas
+			}
+			if totalReplicas == 0 {
+				totalReplicas = 1 // match the analyzer's floor so scale-up-from-zero is still flaggable
+			}
+			uncapped := totalReplicas + int(math.Ceil(result.RequiredCapacity*float64(totalReplicas)))
+			uncappedByModel[utils.GetNamespacedKey(namespace, modelID)] = uncapped
+		} else {
+			logger.Info("Skipping cap detection for multi-variant model group (pool total not attributable per variant); ScalingCapped will read False rather than Unknown",
+				"modelID", modelID, "variantCount", len(modelVAs))
+		}
+
+		requests = append(requests, pipeline.ModelScalingRequest{
+			ModelID:   modelID,
+			Namespace: namespace,
+			AnalyzerResults: []pipeline.NamedAnalyzerResult{{
+				// Optimizer's saturationEntry keys on SaturationAnalyzerName,
+				// so the EPP saturation result occupies the saturation slot.
+				Name:      interfaces.SaturationAnalyzerName,
+				Result:    result,
+				Score:     1.0, // EPP path: single analyzer, no per-entry score config
+				Remaining: result.RequiredCapacity,
+				Spare:     result.SpareCapacity,
+			}},
+			VariantStates: variantStates,
+			Priority:      saturationConfig.Priority,
+		})
+	}
+
+	if len(requests) == 0 {
+		return nil
+	}
+
+	// Run optimizer (same pipeline as V2)
+	var constraints []*pipeline.ResourceConstraints
+	if _, ok := e.optimizer.(*pipeline.GreedyByScoreOptimizer); ok {
+		currentUsage := computeCurrentGPUUsage(requests)
+		if limiter, ok := e.GPULimiter.(*pipeline.DefaultLimiter); ok {
+			constraint, err := limiter.ComputeConstraints(ctx, currentUsage)
+			if err != nil {
+				logger.Error(err, "Failed to compute GPU constraints, falling back to unlimited")
+			} else {
+				constraints = append(constraints, constraint)
+			}
+		}
+	}
+	allDecisions := e.optimizer.Optimize(ctx, requests, constraints)
+
+	logger.Info("EPP saturation optimizer produced decisions",
+		"optimizer", e.optimizer.Name(),
+		"decisionCount", len(allDecisions),
+		"modelCount", len(requests))
+
+	// Apply enforcer per-model (scale-to-zero, min replicas)
+	for _, req := range requests {
+		if hasMinReplicasAboveZero(req.VariantStates) {
+			logger.V(logging.DEBUG).Info("Skipping scale-to-zero enforcement (EPP saturation): variant has minReplicas > 0",
+				"modelID", req.ModelID)
+			continue
+		}
+
+		scaleToZeroConfig := e.Config.ScaleToZeroConfigForNamespace(req.Namespace)
+		scaledToZero := e.ScaleToZeroEnforcer.EnforcePolicyOnDecisions(
+			ctx, req.ModelID, req.Namespace,
+			allDecisions, scaleToZeroConfig, e.optimizer.Name(),
+		)
+		if scaledToZero {
+			logger.Info("Scale-to-zero enforcement applied (EPP saturation)",
+				"modelID", req.ModelID)
+		}
+	}
+
+	// Warmup-aware scale-up damping (RFC #1018): the EPP saturation signal is
+	// measured only on Ready pods, so while replicas already requested are still
+	// warming (pending > 0) the pool keeps reporting high saturation and the
+	// optimizer would stack a new scale-up every cycle before the in-flight pods
+	// come online — racing to maxReplicas (observed live: overshoot to 11 when ~6
+	// sufficed). Hold the target at the current replica count until the requested
+	// pods become Ready. This replaces unreliable extrapolation near the queueing
+	// knee with empirical probing: add capacity, wait for it to take effect,
+	// re-measure. Scale-down (target < current) is never suppressed. Applied
+	// post-optimizer so it is independent of optimizer internals.
+	// Variant names are only unique per-namespace, so key by namespace+name
+	// (requests can span namespaces within one optimize pass).
+	stateByVariant := make(map[string]interfaces.VariantReplicaState)
+	for _, req := range requests {
+		for _, vs := range req.VariantStates {
+			stateByVariant[utils.GetNamespacedKey(req.Namespace, vs.VariantName)] = vs
+		}
+	}
+	for i := range allDecisions {
+		d := &allDecisions[i]
+		if !holdWarmByModel[utils.GetNamespacedKey(d.Namespace, d.ModelID)] {
+			continue
+		}
+		st, ok := stateByVariant[utils.GetNamespacedKey(d.Namespace, d.VariantName)]
+		if !ok {
+			continue
+		}
+		if held := applyWarmupHold(d.TargetReplicas, st.CurrentReplicas, st.PendingReplicas); held != d.TargetReplicas {
+			logger.Info("EPP saturation holding scale-up while replicas warm up",
+				"variant", d.VariantName, "modelID", d.ModelID,
+				"currentReplicas", st.CurrentReplicas, "pendingReplicas", st.PendingReplicas,
+				"requestedTarget", d.TargetReplicas)
+			d.TargetReplicas = held
+			// Keep Action/reason consistent with the held target so scaling-event
+			// records, metrics, and logs don't report ScaleUp on a held no-op cycle
+			// (SetDecisionReason is the single writer of d.Action).
+			category := d.ReasonCategory()
+			if category == "" {
+				category = interfaces.DecisionReasonV2
+			}
+			d.SetDecisionReason(interfaces.ActionNoChange, category,
+				fmt.Sprintf("%s no-change (scale-up held while %d replica(s) warm up)", category, st.PendingReplicas))
+		}
+	}
+
+	// Flag decisions whose recommendation was clamped to maxReplicas and emit the
+	// wva_scale_capped gauge so operators can distinguish "fine at the cap" from
+	// "wanted more but was blocked" (RFC #1018 proposal #2). A decision is capped
+	// when the uncapped formula recommendation exceeds maxReplicas and the final
+	// target is pinned at the cap.
+	for i := range allDecisions {
+		d := &allDecisions[i]
+		uncapped, ok := uncappedByModel[utils.GetNamespacedKey(d.Namespace, d.ModelID)]
+		capped := ok && d.MaxReplicas != nil && *d.MaxReplicas > 0 &&
+			uncapped > *d.MaxReplicas && d.TargetReplicas >= *d.MaxReplicas
+		if capped {
+			d.ScalingCapped = true
+			d.UncappedReplicas = uncapped
+			logger.Info("Scaling recommendation capped by maxReplicas (EPP saturation)",
+				"variant", d.VariantName, "modelID", d.ModelID,
+				"uncappedReplicas", uncapped, "maxReplicas", *d.MaxReplicas)
+		}
+		e.metricsEmitter.RecordScaleCappedMetric(ctx, d.VariantName, d.Namespace, d.ModelID, capped)
+	}
+
+	return allDecisions
+}
+
+// markEPPSignalUnavailable pushes a MetricsAvailable=False decision into the
+// shared cache for each non-synthetic VA in the model and triggers a reconcile,
+// so the EPP signal-unavailable state is surfaced as a status condition with an
+// EPP-specific reason. Mirrors the no-accelerator safety path in applySaturationDecisions.
+//
+// The existing cache entry (last good target, ScalingCapped state, accelerator)
+// is preserved and only the metrics-availability fields are rewritten — a
+// transient Prometheus blip must not flip the ScalingCapped condition to False
+// while the pool is still pinned at the cap, nor discard the last good decision.
+func (e *Engine) markEPPSignalUnavailable(modelVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling) {
+	for i := range modelVAs {
+		va := &modelVAs[i]
+		if utils.IsSynthetic(va) {
+			continue
+		}
+		decision, ok := common.DecisionCache.Get(va.Name, va.Namespace)
+		if !ok {
+			decision = interfaces.VariantDecision{VariantName: va.Name, Namespace: va.Namespace}
+		}
+		decision.MetricsAvailable = false
+		decision.MetricsReason = llmdVariantAutoscalingV1alpha1.ReasonPrometheusError
+		decision.MetricsMessage = eppSignalUnavailableMessage
+		common.DecisionCache.Set(va.Name, va.Namespace, decision)
+		common.DecisionTrigger <- event.GenericEvent{Object: va}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new "epp-saturation" analyzer for pool-level scaling based on predicted latency signals from the EPP (External Prediction Provider). It adds configuration options, Prometheus query registration, and a full analyzer implementation, allowing scaling decisions to be driven by the P90 of predicted TTFT/TPOT versus configurable SLOs. The implementation includes robust configuration, environment variable overrides, and comprehensive tests.

**Key changes:**

### EPP-Saturation Analyzer Implementation

* Added a new analyzer `epp-saturation` in `internal/engines/analyzers/epp_saturation/analyzer.go`, which derives pool saturation from EPP's predicted TTFT/TPOT histograms, applies exponential smoothing, and computes scaling signals based on configurable SLOs.

### Prometheus Query Registration

* Introduced `internal/collector/registration/epp_saturation.go` to register Prometheus queries for EPP-predicted TTFT and TPOT, supporting environment variable overrides for metric names and validating input to prevent malformed queries.
* Added tests in `internal/collector/registration/epp_saturation_test.go` to verify correct query generation, environment variable overrides, and input validation.

### Configuration Enhancements

* Extended `SaturationScalingConfig` with new fields: `TTFTSLOMs`, `TPOTSLOMs`, and `SmoothingAlpha` for the epp-saturation analyzer, with support for merging and validation. [[1]](diffhunk://#diff-ab1056e3f6f6c2232940d5a2335cdb6c30b98c8fa017d2aa4be45ca1586c8360R60-R73) [[2]](diffhunk://#diff-ab1056e3f6f6c2232940d5a2335cdb6c30b98c8fa017d2aa4be45ca1586c8360R219-R227) [[3]](diffhunk://#diff-ab1056e3f6f6c2232940d5a2335cdb6c30b98c8fa017d2aa4be45ca1586c8360R265-R278)
* Clarified the defaulting and application of `ScaleUpThreshold` for the epp-saturation path.

### Documentation and Example Configuration

* Added an example configuration block for the epp-saturation analyzer in `deploy/configmap-saturation-scaling.yaml` to guide users in setting SLOs and thresholds.

---

These changes together enable a new, SLO-driven scaling path based on EPP-predicted latency, improving responsiveness and configurability for advanced scaling scenarios.