### PR TITLE
feat(coordinator): rebalance KEDA ScaledObjects

### DIFF
--- a/config/base/rbac/manager-clusterrole.yaml
+++ b/config/base/rbac/manager-clusterrole.yaml
@@ -84,6 +84,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - leaderworkerset.x-k8s.io

--- a/internal/coordinator/plugins/gpurebalance/plugin.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -19,6 +21,8 @@ const (
 	AnnotationInferencePool = "llm-d.ai/epp-inference-pool"
 	gpuQuotaResource        = "requests.nvidia.com/gpu"
 	eppQueueMetric          = `sum(inference_extension_flow_control_queue_size{inference_pool=%q})`
+	displayKindHPA          = "HorizontalPodAutoscaler"
+	displayKindScaledObject = "ScaledObject"
 )
 
 // Plugin implements the Coordinator Plugin interface for GPU rebalancing.
@@ -29,6 +33,7 @@ type Plugin struct {
 
 // +kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch;patch;update
 
 // New constructs the gpu-rebalance Plugin.
 func New(c client.Client, promAPI promv1.API) *Plugin {
@@ -38,33 +43,34 @@ func New(c client.Client, promAPI promv1.API) *Plugin {
 // Name returns the unique plugin identifier.
 func (p *Plugin) Name() string { return "gpu-rebalance" }
 
-// hpaEntry pairs an HPA with its inference-pool name.
-type hpaEntry struct {
-	hpa  *autoscalingv2.HorizontalPodAutoscaler
-	pool string
+// scalerEntry pairs a managed scaling object with its inference-pool name.
+type scalerEntry struct {
+	obj         client.Object
+	pool        string
+	currentMax  int32
+	displayKind string
 }
 
-// Tick splits the GPU quota proportionally across managed HPAs based on each
-// pool's EPP flow-control queue depth. HPAs are grouped by namespace so each
-// namespace is rebalanced independently against its own ResourceQuota. When
-// all queues in a namespace are zero the quota is divided equally. MaxReplicas
-// is patched only when the computed target differs from the current value.
+// Tick splits the GPU quota proportionally across managed HPAs or KEDA
+// ScaledObjects based on each pool's EPP flow-control queue depth. Objects are
+// grouped by namespace so each namespace is rebalanced independently against
+// its own ResourceQuota. When all queues in a namespace are zero the quota is
+// divided equally. MaxReplicas / maxReplicaCount is patched only when the
+// computed target differs from the current value.
 func (p *Plugin) Tick(ctx context.Context, selected []client.Object) error {
 	log := ctrl.LoggerFrom(ctx).WithName("gpu-rebalance")
 
-	// Group annotated HPAs by namespace.
-	byNamespace := make(map[string][]hpaEntry)
+	// Group annotated scaling objects by namespace.
+	byNamespace := make(map[string][]scalerEntry)
 	for _, obj := range selected {
-		hpa, ok := obj.(*autoscalingv2.HorizontalPodAutoscaler)
+		entry, ok := scalerEntryFromObject(obj)
 		if !ok {
 			continue
 		}
-		pool := hpa.Annotations[AnnotationInferencePool]
-		if pool == "" {
+		if entry.pool == "" {
 			continue
 		}
-		ns := hpa.Namespace
-		byNamespace[ns] = append(byNamespace[ns], hpaEntry{hpa: hpa, pool: pool})
+		byNamespace[entry.obj.GetNamespace()] = append(byNamespace[entry.obj.GetNamespace()], entry)
 	}
 	if len(byNamespace) == 0 {
 		return nil
@@ -78,9 +84,30 @@ func (p *Plugin) Tick(ctx context.Context, selected []client.Object) error {
 	return nil
 }
 
+func scalerEntryFromObject(obj client.Object) (scalerEntry, bool) {
+	switch o := obj.(type) {
+	case *autoscalingv2.HorizontalPodAutoscaler:
+		return scalerEntry{
+			obj:         o,
+			pool:        o.Annotations[AnnotationInferencePool],
+			currentMax:  o.Spec.MaxReplicas,
+			displayKind: displayKindHPA,
+		}, true
+	case *kedav1alpha1.ScaledObject:
+		return scalerEntry{
+			obj:         o,
+			pool:        o.Annotations[AnnotationInferencePool],
+			currentMax:  o.GetHPAMaxReplicas(),
+			displayKind: displayKindScaledObject,
+		}, true
+	default:
+		return scalerEntry{}, false
+	}
+}
+
 // rebalanceNamespace applies proportional GPU quota allocation to all managed
-// HPAs in a single namespace.
-func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns string, entries []hpaEntry) error {
+// scaling objects in a single namespace.
+func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns string, entries []scalerEntry) error {
 	quota, err := p.namespaceGPUQuota(ctx, ns)
 	if err != nil {
 		return fmt.Errorf("reading GPU quota in namespace %s: %w", ns, err)
@@ -169,17 +196,17 @@ func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns str
 	// which dampens burst noise without adding a hard cooldown delay.
 
 	for i, e := range entries {
-		if targets[i] == e.hpa.Spec.MaxReplicas {
+		if targets[i] == e.currentMax {
 			continue
 		}
-		log.Info("Setting maxReplicas",
-			"hpa", e.hpa.Name, "namespace", ns,
+		log.Info("Setting max replica ceiling",
+			"kind", e.displayKind, "name", e.obj.GetName(), "namespace", ns,
 			"pool", e.pool,
-			"from", e.hpa.Spec.MaxReplicas, "to", targets[i],
+			"from", e.currentMax, "to", targets[i],
 			"queue", queues[i], "quota", quota,
 		)
-		if err := p.setMaxReplicas(ctx, e.hpa, targets[i]); err != nil {
-			return fmt.Errorf("patching %s: %w", e.hpa.Name, err)
+		if err := p.setMaxReplicas(ctx, e.obj, targets[i]); err != nil {
+			return fmt.Errorf("patching %s %s: %w", e.displayKind, e.obj.GetName(), err)
 		}
 	}
 	return nil
@@ -226,14 +253,23 @@ func (p *Plugin) queryQueue(ctx context.Context, inferencePool string) (float64,
 	return float64(vec[0].Value), nil
 }
 
-func (p *Plugin) setMaxReplicas(ctx context.Context, hpa *autoscalingv2.HorizontalPodAutoscaler, target int32) error {
+func (p *Plugin) setMaxReplicas(ctx context.Context, obj client.Object, target int32) error {
 	// TODO: MergeFrom uses the object captured at List time. If another controller
 	// or user updated maxReplicas between the List and this Patch, the write will
 	// silently overwrite that change. Use MergeFromWithOptimisticLock (which sets
 	// resourceVersion on the patch) so the API server rejects a stale write with
 	// a 409 Conflict, allowing the Coordinator to re-read and retry cleanly.
 
-	original := hpa.DeepCopy()
-	hpa.Spec.MaxReplicas = target
-	return p.client.Patch(ctx, hpa, client.MergeFrom(original))
+	switch o := obj.(type) {
+	case *autoscalingv2.HorizontalPodAutoscaler:
+		original := o.DeepCopy()
+		o.Spec.MaxReplicas = target
+		return p.client.Patch(ctx, o, client.MergeFrom(original))
+	case *kedav1alpha1.ScaledObject:
+		original := o.DeepCopy()
+		o.Spec.MaxReplicaCount = ptr.To(target)
+		return p.client.Patch(ctx, o, client.MergeFrom(original))
+	default:
+		return fmt.Errorf("unsupported scaler type %T", obj)
+	}
 }

--- a/internal/coordinator/plugins/gpurebalance/plugin.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin.go
@@ -45,10 +45,11 @@ func (p *Plugin) Name() string { return "gpu-rebalance" }
 
 // scalerEntry pairs a managed scaling object with its inference-pool name.
 type scalerEntry struct {
-	obj         client.Object
-	pool        string
-	currentMax  int32
-	displayKind string
+	obj          client.Object
+	pool         string
+	currentMax   int32
+	effectiveMin int32
+	displayKind  string
 }
 
 // Tick splits the GPU quota proportionally across managed HPAs or KEDA
@@ -88,21 +89,33 @@ func scalerEntryFromObject(obj client.Object) (scalerEntry, bool) {
 	switch o := obj.(type) {
 	case *autoscalingv2.HorizontalPodAutoscaler:
 		return scalerEntry{
-			obj:         o,
-			pool:        o.Annotations[AnnotationInferencePool],
-			currentMax:  o.Spec.MaxReplicas,
-			displayKind: displayKindHPA,
+			obj:          o,
+			pool:         o.Annotations[AnnotationInferencePool],
+			currentMax:   o.Spec.MaxReplicas,
+			effectiveMin: effectiveHPAMinReplicas(o.Spec.MinReplicas),
+			displayKind:  displayKindHPA,
 		}, true
 	case *kedav1alpha1.ScaledObject:
 		return scalerEntry{
-			obj:         o,
-			pool:        o.Annotations[AnnotationInferencePool],
-			currentMax:  o.GetHPAMaxReplicas(),
-			displayKind: displayKindScaledObject,
+			obj:          o,
+			pool:         o.Annotations[AnnotationInferencePool],
+			currentMax:   o.GetHPAMaxReplicas(),
+			effectiveMin: *o.GetHPAMinReplicas(),
+			displayKind:  displayKindScaledObject,
 		}, true
 	default:
 		return scalerEntry{}, false
 	}
+}
+
+// effectiveHPAMinReplicas preserves the plugin's existing minimum-one policy.
+// HPA defaults minReplicas to 1 when omitted; explicit zero is also normalized
+// to 1 because gpu-rebalance does not yet support scale-to-zero.
+func effectiveHPAMinReplicas(configured *int32) int32 {
+	if configured != nil && *configured > 1 {
+		return *configured
+	}
+	return 1
 }
 
 // rebalanceNamespace applies proportional GPU quota allocation to all managed
@@ -114,6 +127,16 @@ func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns str
 	}
 	if quota <= 0 {
 		log.V(1).Info("No GPU quota set, skipping", "namespace", ns)
+		return nil
+	}
+
+	minimumTotal := int64(0)
+	for _, entry := range entries {
+		minimumTotal += int64(entry.effectiveMin)
+	}
+	if minimumTotal > quota {
+		log.Info("Configured minimum replicas exceed GPU quota, skipping namespace",
+			"namespace", ns, "minimumTotal", minimumTotal, "quota", quota)
 		return nil
 	}
 
@@ -144,18 +167,6 @@ func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns str
 		}
 	}
 
-	// TODO: the minimum target is hardcoded to 1 but an HPA may have spec.minReplicas
-	// set higher (e.g. 2 or 3). Setting maxReplicas below minReplicas produces an
-	// invalid HPA and Kubernetes will reject the patch. The floor should be
-	// max(1, hpa.Spec.MinReplicas) so the computed target is always a valid value.
-
-	// TODO: when len(entries) > quota the minimum-1 clamp causes every HPA to
-	// receive maxReplicas=1 and allocated exceeds quota (e.g. 100 HPAs, quota=10
-	// → allocated=100). The ResourceQuota becomes the only enforcement and the
-	// first 10 pods to be scheduled win while the other 90 are stuck pending.
-	// Fix: rank HPAs by queue depth, assign maxReplicas=1 only to the top-quota
-	// pools, and park the rest at minReplicas so the budget is not over-committed.
-
 	// TODO: scale-to-zero is not supported. When a pool's queue is 0 its weight is
 	// 0% and the ideal target is 0 replicas, but the floor clamp below forces it to 1.
 	// Supporting scale-to-zero requires: (a) the HPA has spec.minReplicas=0 (opt-in),
@@ -164,15 +175,14 @@ func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns str
 	// before zeroing). Until those conditions are met the floor is kept at 1 to prevent
 	// accidental full scale-down.
 
-	// Targets: floor(quota * weight), minimum 1, remainder to highest-weight pool.
+	// Reserve every scaler's effective minimum, then distribute the remaining
+	// quota proportionally. Any rounding remainder goes to the highest-weight pool.
+	remaining := quota - minimumTotal
 	targets := make([]int32, len(entries))
 	allocated := int64(0)
 	maxWeightIdx := 0
 	for i := range entries {
-		t := int32(math.Floor(float64(quota) * weights[i]))
-		if t < 1 {
-			t = 1
-		}
+		t := entries[i].effectiveMin + int32(math.Floor(float64(remaining)*weights[i]))
 		targets[i] = t
 		allocated += int64(t)
 		if weights[i] > weights[maxWeightIdx] {

--- a/internal/coordinator/plugins/gpurebalance/plugin_test.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -15,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -47,6 +49,9 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 	if err := clientgoscheme.AddToScheme(s); err != nil {
 		t.Fatalf("AddToScheme: %v", err)
 	}
+	if err := kedav1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme KEDA: %v", err)
+	}
 	return s
 }
 
@@ -72,6 +77,35 @@ func makeHPA(name, ns, pool string, maxReplicas int32) *autoscalingv2.Horizontal
 	}
 }
 
+func makeScaledObject(name, pool string, maxReplicas int32) *kedav1alpha1.ScaledObject {
+	ann := map[string]string{}
+	if pool != "" {
+		ann[AnnotationInferencePool] = pool
+	}
+	return &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "ns",
+			Annotations: ann,
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       name + "-deploy",
+			},
+			MaxReplicaCount: ptr.To(maxReplicas),
+			Triggers: []kedav1alpha1.ScaleTriggers{{
+				Type: "prometheus",
+				Metadata: map[string]string{
+					"query":     `sum(inference_extension_flow_control_queue_size{inference_pool="` + pool + `"})`,
+					"threshold": "1",
+				},
+			}},
+		},
+	}
+}
+
 func makeGPUQuota(name, ns string, gpus int64) *corev1.ResourceQuota {
 	return &corev1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
@@ -90,13 +124,26 @@ func newPlugin(t *testing.T, queues map[string]float64, errs map[string]error, o
 	return New(c, &stubPromAPI{queues: queues, errs: errs}), c
 }
 
-func getMaxReplicas(t *testing.T, c client.Client, name, ns string) int32 {
+func getMaxReplicas(t *testing.T, c client.Client, hpa *autoscalingv2.HorizontalPodAutoscaler) int32 {
 	t.Helper()
-	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
-	if err := c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: ns}, hpa); err != nil {
+	name := hpa.Name
+	ns := hpa.Namespace
+	got := &autoscalingv2.HorizontalPodAutoscaler{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: ns}, got); err != nil {
 		t.Fatalf("Get HPA %s/%s: %v", ns, name, err)
 	}
-	return hpa.Spec.MaxReplicas
+	return got.Spec.MaxReplicas
+}
+
+func getMaxReplicaCount(t *testing.T, c client.Client, so *kedav1alpha1.ScaledObject) int32 {
+	t.Helper()
+	name := so.Name
+	ns := so.Namespace
+	got := &kedav1alpha1.ScaledObject{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: ns}, got); err != nil {
+		t.Fatalf("Get ScaledObject %s/%s: %v", ns, name, err)
+	}
+	return got.GetHPAMaxReplicas()
 }
 
 // TestTick_EmptySelectionIsNoop verifies that an empty selected slice returns
@@ -108,9 +155,9 @@ func TestTick_EmptySelectionIsNoop(t *testing.T) {
 	}
 }
 
-// TestTick_SkipsNonHPAObjects verifies that objects that are not HPAs are
-// silently skipped.
-func TestTick_SkipsNonHPAObjects(t *testing.T) {
+// TestTick_SkipsUnsupportedObjects verifies that objects that are neither HPAs
+// nor KEDA ScaledObjects are silently skipped.
+func TestTick_SkipsUnsupportedObjects(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"}}
 	p, _ := newPlugin(t, nil, nil)
 	if err := p.Tick(context.Background(), []client.Object{pod}); err != nil {
@@ -127,8 +174,22 @@ func TestTick_SkipsUnannotatedHPA(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpa}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 10 {
+	if got := getMaxReplicas(t, c, hpa); got != 10 {
 		t.Errorf("maxReplicas changed to %d, want 10 (unannotated HPA should be skipped)", got)
+	}
+}
+
+// TestTick_SkipsUnannotatedScaledObject verifies that a ScaledObject without
+// the llm-d.ai/epp-inference-pool annotation is skipped and never patched.
+func TestTick_SkipsUnannotatedScaledObject(t *testing.T) {
+	so := makeScaledObject("model-a", "" /* no pool */, 10)
+	p, c := newPlugin(t, map[string]float64{"model-a": 100}, nil, so, makeGPUQuota("q", "ns", 10))
+
+	if err := p.Tick(context.Background(), []client.Object{so}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicaCount(t, c, so); got != 10 {
+		t.Errorf("maxReplicaCount changed to %d, want 10 (unannotated ScaledObject should be skipped)", got)
 	}
 }
 
@@ -142,7 +203,7 @@ func TestTick_NoQuota_Skips(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpa}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 10 {
+	if got := getMaxReplicas(t, c, hpa); got != 10 {
 		t.Errorf("maxReplicas changed to %d, want 10 (no quota → skip)", got)
 	}
 }
@@ -160,7 +221,7 @@ func TestRebalance_SinglePool(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpa}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 10 {
+	if got := getMaxReplicas(t, c, hpa); got != 10 {
 		t.Errorf("maxReplicas = %d, want 10", got)
 	}
 }
@@ -179,10 +240,10 @@ func TestRebalance_EqualQueues(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 5 {
+	if got := getMaxReplicas(t, c, hpaA); got != 5 {
 		t.Errorf("model-a maxReplicas = %d, want 5", got)
 	}
-	if got := getMaxReplicas(t, c, "model-b", "ns"); got != 5 {
+	if got := getMaxReplicas(t, c, hpaB); got != 5 {
 		t.Errorf("model-b maxReplicas = %d, want 5", got)
 	}
 }
@@ -201,10 +262,10 @@ func TestRebalance_ProportionalQueues(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 7 {
+	if got := getMaxReplicas(t, c, hpaA); got != 7 {
 		t.Errorf("model-a maxReplicas = %d, want 7", got)
 	}
-	if got := getMaxReplicas(t, c, "model-b", "ns"); got != 3 {
+	if got := getMaxReplicas(t, c, hpaB); got != 3 {
 		t.Errorf("model-b maxReplicas = %d, want 3", got)
 	}
 }
@@ -223,10 +284,10 @@ func TestRebalance_AllQueuesZero(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 5 {
+	if got := getMaxReplicas(t, c, hpaA); got != 5 {
 		t.Errorf("model-a maxReplicas = %d, want 5 (equal split when queues are zero)", got)
 	}
-	if got := getMaxReplicas(t, c, "model-b", "ns"); got != 5 {
+	if got := getMaxReplicas(t, c, hpaB); got != 5 {
 		t.Errorf("model-b maxReplicas = %d, want 5 (equal split when queues are zero)", got)
 	}
 }
@@ -248,10 +309,10 @@ func TestRebalance_QueryError_TreatedAsZero(t *testing.T) {
 	}
 	// model-a failed query → weight=0 → clamped to min 1.
 	// model-b has all queue → gets 10; total=11 but quota enforcement is at admission.
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 1 {
+	if got := getMaxReplicas(t, c, hpaA); got != 1 {
 		t.Errorf("model-a maxReplicas = %d, want 1 (query error → treated as 0, clamped to min)", got)
 	}
-	if got := getMaxReplicas(t, c, "model-b", "ns"); got != 10 {
+	if got := getMaxReplicas(t, c, hpaB); got != 10 {
 		t.Errorf("model-b maxReplicas = %d, want 10 (all queue depth)", got)
 	}
 }
@@ -275,10 +336,10 @@ func TestRebalance_RemainderToHighestWeight(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 7 {
+	if got := getMaxReplicas(t, c, hpaA); got != 7 {
 		t.Errorf("model-a maxReplicas = %d, want 7 (gets remainder)", got)
 	}
-	if got := getMaxReplicas(t, c, "model-b", "ns"); got != 3 {
+	if got := getMaxReplicas(t, c, hpaB); got != 3 {
 		t.Errorf("model-b maxReplicas = %d, want 3", got)
 	}
 }
@@ -299,11 +360,55 @@ func TestRebalance_NoChangeWhenAlreadyCorrect(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 5 {
+	if got := getMaxReplicas(t, c, hpaA); got != 5 {
 		t.Errorf("model-a maxReplicas = %d, want 5", got)
 	}
-	if got := getMaxReplicas(t, c, "model-b", "ns"); got != 5 {
+	if got := getMaxReplicas(t, c, hpaB); got != 5 {
 		t.Errorf("model-b maxReplicas = %d, want 5", got)
+	}
+}
+
+// TestRebalance_ScaledObjects verifies that KEDA ScaledObjects receive
+// proportional GPU quota by patching spec.maxReplicaCount.
+func TestRebalance_ScaledObjects(t *testing.T) {
+	soA := makeScaledObject("model-a", "model-a", 1)
+	soB := makeScaledObject("model-b", "model-b", 1)
+	p, c := newPlugin(t,
+		map[string]float64{"model-a": 70, "model-b": 30},
+		nil,
+		soA, soB, makeGPUQuota("q", "ns", 10),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{soA, soB}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicaCount(t, c, soA); got != 7 {
+		t.Errorf("model-a maxReplicaCount = %d, want 7", got)
+	}
+	if got := getMaxReplicaCount(t, c, soB); got != 3 {
+		t.Errorf("model-b maxReplicaCount = %d, want 3", got)
+	}
+}
+
+// TestRebalance_MixedHPAAndScaledObject verifies that direct HPAs and KEDA
+// ScaledObjects in the same namespace share the ResourceQuota calculation.
+func TestRebalance_MixedHPAAndScaledObject(t *testing.T) {
+	hpaA := makeHPA("model-a", "ns", "model-a", 1)
+	soB := makeScaledObject("model-b", "model-b", 1)
+	p, c := newPlugin(t,
+		map[string]float64{"model-a": 20, "model-b": 80},
+		nil,
+		hpaA, soB, makeGPUQuota("q", "ns", 10),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{hpaA, soB}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicas(t, c, hpaA); got != 2 {
+		t.Errorf("model-a maxReplicas = %d, want 2", got)
+	}
+	if got := getMaxReplicaCount(t, c, soB); got != 8 {
+		t.Errorf("model-b maxReplicaCount = %d, want 8", got)
 	}
 }
 
@@ -329,17 +434,17 @@ func TestRebalance_MultiNamespace(t *testing.T) {
 	}
 
 	tests := []struct {
-		name, ns string
-		want     int32
+		hpa  *autoscalingv2.HorizontalPodAutoscaler
+		want int32
 	}{
-		{"model-a", "ns-x", 3},
-		{"model-b", "ns-x", 7},
-		{"model-c", "ns-y", 3},
-		{"model-d", "ns-y", 3},
+		{hpaA, 3},
+		{hpaB, 7},
+		{hpaC, 3},
+		{hpaD, 3},
 	}
 	for _, tc := range tests {
-		if got := getMaxReplicas(t, c, tc.name, tc.ns); got != tc.want {
-			t.Errorf("%s/%s maxReplicas = %d, want %d", tc.ns, tc.name, got, tc.want)
+		if got := getMaxReplicas(t, c, tc.hpa); got != tc.want {
+			t.Errorf("%s/%s maxReplicas = %d, want %d", tc.hpa.Namespace, tc.hpa.Name, got, tc.want)
 		}
 	}
 }

--- a/internal/coordinator/plugins/gpurebalance/plugin_test.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin_test.go
@@ -146,6 +146,45 @@ func getMaxReplicaCount(t *testing.T, c client.Client, so *kedav1alpha1.ScaledOb
 	return got.GetHPAMaxReplicas()
 }
 
+func TestScalerEntryFromObject_EffectiveMinimum(t *testing.T) {
+	hpaNil := makeHPA("hpa-nil", "ns", "hpa-nil", 10)
+	hpaZero := makeHPA("hpa-zero", "ns", "hpa-zero", 10)
+	hpaZero.Spec.MinReplicas = ptr.To[int32](0)
+	hpaThree := makeHPA("hpa-three", "ns", "hpa-three", 10)
+	hpaThree.Spec.MinReplicas = ptr.To[int32](3)
+
+	soNil := makeScaledObject("so-nil", "so-nil", 10)
+	soZero := makeScaledObject("so-zero", "so-zero", 10)
+	soZero.Spec.MinReplicaCount = ptr.To[int32](0)
+	soThree := makeScaledObject("so-three", "so-three", 10)
+	soThree.Spec.MinReplicaCount = ptr.To[int32](3)
+
+	tests := []struct {
+		name string
+		obj  client.Object
+		want int32
+	}{
+		{name: "HPA nil defaults to one", obj: hpaNil, want: 1},
+		{name: "HPA zero uses minimum-one policy", obj: hpaZero, want: 1},
+		{name: "HPA configured minimum", obj: hpaThree, want: 3},
+		{name: "ScaledObject nil defaults to one", obj: soNil, want: 1},
+		{name: "ScaledObject zero defaults to one", obj: soZero, want: 1},
+		{name: "ScaledObject configured minimum", obj: soThree, want: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, ok := scalerEntryFromObject(tt.obj)
+			if !ok {
+				t.Fatal("scalerEntryFromObject returned ok=false")
+			}
+			if entry.effectiveMin != tt.want {
+				t.Errorf("effectiveMin = %d, want %d", entry.effectiveMin, tt.want)
+			}
+		})
+	}
+}
+
 // TestTick_EmptySelectionIsNoop verifies that an empty selected slice returns
 // nil without touching the cluster.
 func TestTick_EmptySelectionIsNoop(t *testing.T) {
@@ -307,13 +346,12 @@ func TestRebalance_QueryError_TreatedAsZero(t *testing.T) {
 	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// model-a failed query → weight=0 → clamped to min 1.
-	// model-b has all queue → gets 10; total=11 but quota enforcement is at admission.
+	// Reserve one replica for each pool, then give the remaining eight to model-b.
 	if got := getMaxReplicas(t, c, hpaA); got != 1 {
 		t.Errorf("model-a maxReplicas = %d, want 1 (query error → treated as 0, clamped to min)", got)
 	}
-	if got := getMaxReplicas(t, c, hpaB); got != 10 {
-		t.Errorf("model-b maxReplicas = %d, want 10 (all queue depth)", got)
+	if got := getMaxReplicas(t, c, hpaB); got != 9 {
+		t.Errorf("model-b maxReplicas = %d, want 9 (all remaining quota)", got)
 	}
 }
 
@@ -409,6 +447,92 @@ func TestRebalance_MixedHPAAndScaledObject(t *testing.T) {
 	}
 	if got := getMaxReplicaCount(t, c, soB); got != 8 {
 		t.Errorf("model-b maxReplicaCount = %d, want 8", got)
+	}
+}
+
+func TestRebalance_ReservesHPAMinimum(t *testing.T) {
+	hpaA := makeHPA("model-a", "ns", "model-a", 10)
+	hpaA.Spec.MinReplicas = ptr.To[int32](5)
+	hpaB := makeHPA("model-b", "ns", "model-b", 10)
+	p, c := newPlugin(t,
+		map[string]float64{"model-a": 50, "model-b": 50},
+		nil,
+		hpaA, hpaB, makeGPUQuota("q", "ns", 10),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicas(t, c, hpaA); got != 7 {
+		t.Errorf("model-a maxReplicas = %d, want 7", got)
+	}
+	if got := getMaxReplicas(t, c, hpaB); got != 3 {
+		t.Errorf("model-b maxReplicas = %d, want 3", got)
+	}
+}
+
+func TestRebalance_ReservesScaledObjectMinimum(t *testing.T) {
+	soA := makeScaledObject("model-a", "model-a", 10)
+	soA.Spec.MinReplicaCount = ptr.To[int32](5)
+	soB := makeScaledObject("model-b", "model-b", 10)
+	p, c := newPlugin(t,
+		map[string]float64{"model-a": 50, "model-b": 50},
+		nil,
+		soA, soB, makeGPUQuota("q", "ns", 10),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{soA, soB}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicaCount(t, c, soA); got != 7 {
+		t.Errorf("model-a maxReplicaCount = %d, want 7", got)
+	}
+	if got := getMaxReplicaCount(t, c, soB); got != 3 {
+		t.Errorf("model-b maxReplicaCount = %d, want 3", got)
+	}
+}
+
+func TestRebalance_ReservesMixedMinimums(t *testing.T) {
+	hpaA := makeHPA("model-a", "ns", "model-a", 10)
+	hpaA.Spec.MinReplicas = ptr.To[int32](3)
+	soB := makeScaledObject("model-b", "model-b", 10)
+	soB.Spec.MinReplicaCount = ptr.To[int32](4)
+	p, c := newPlugin(t,
+		map[string]float64{"model-a": 20, "model-b": 80},
+		nil,
+		hpaA, soB, makeGPUQuota("q", "ns", 12),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{hpaA, soB}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicas(t, c, hpaA); got != 4 {
+		t.Errorf("model-a maxReplicas = %d, want 4", got)
+	}
+	if got := getMaxReplicaCount(t, c, soB); got != 8 {
+		t.Errorf("model-b maxReplicaCount = %d, want 8", got)
+	}
+}
+
+func TestRebalance_InfeasibleMinimumsLeaveNamespaceUnchanged(t *testing.T) {
+	hpaA := makeHPA("model-a", "ns", "model-a", 10)
+	hpaA.Spec.MinReplicas = ptr.To[int32](4)
+	soB := makeScaledObject("model-b", "model-b", 9)
+	soB.Spec.MinReplicaCount = ptr.To[int32](3)
+	p, c := newPlugin(t,
+		map[string]float64{"model-a": 90, "model-b": 10},
+		nil,
+		hpaA, soB, makeGPUQuota("q", "ns", 6),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{hpaA, soB}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicas(t, c, hpaA); got != 10 {
+		t.Errorf("model-a maxReplicas = %d, want 10 (infeasible namespace must be unchanged)", got)
+	}
+	if got := getMaxReplicaCount(t, c, soB); got != 9 {
+		t.Errorf("model-b maxReplicaCount = %d, want 9 (infeasible namespace must be unchanged)", got)
 	}
 }
 

--- a/internal/coordinator/plugins/gpurebalance/plugin_test.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin_test.go
@@ -514,6 +514,48 @@ func TestRebalance_ReservesMixedMinimums(t *testing.T) {
 	}
 }
 
+// TestRebalance_AllocationNeverExceedsQuota verifies that configured minima
+// are reserved before the remaining quota is distributed proportionally.
+func TestRebalance_AllocationNeverExceedsQuota(t *testing.T) {
+	const quota int64 = 12
+
+	hpaA := makeHPA("model-a", "ns", "model-a", 20)
+	hpaA.Spec.MinReplicas = ptr.To[int32](5)
+	soB := makeScaledObject("model-b", "model-b", 20)
+	soB.Spec.MinReplicaCount = ptr.To[int32](4)
+	hpaC := makeHPA("model-c", "ns", "model-c", 20)
+	p, c := newPlugin(t,
+		map[string]float64{
+			"model-a": 10,
+			"model-b": 10,
+			"model-c": 80,
+		},
+		nil,
+		hpaA, soB, hpaC, makeGPUQuota("q", "ns", quota),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{hpaA, soB, hpaC}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotA := getMaxReplicas(t, c, hpaA)
+	gotB := getMaxReplicaCount(t, c, soB)
+	gotC := getMaxReplicas(t, c, hpaC)
+	if gotA != 5 {
+		t.Errorf("model-a maxReplicas = %d, want 5", gotA)
+	}
+	if gotB != 4 {
+		t.Errorf("model-b maxReplicaCount = %d, want 4", gotB)
+	}
+	if gotC != 3 {
+		t.Errorf("model-c maxReplicas = %d, want 3", gotC)
+	}
+
+	if total := int64(gotA) + int64(gotB) + int64(gotC); total != quota {
+		t.Errorf("sum of target max replicas = %d, want quota %d", total, quota)
+	}
+}
+
 func TestRebalance_InfeasibleMinimumsLeaveNamespaceUnchanged(t *testing.T) {
 	hpaA := makeHPA("model-a", "ns", "model-a", 10)
 	hpaA.Spec.MinReplicas = ptr.To[int32](4)


### PR DESCRIPTION
This is a small implementation pass for the KEDA side of replica rebalancing.

The coordinator already discovers managed `ScaledObject`s, and it also avoids patching KEDA-owned generated HPAs directly. The missing piece was that `gpu-rebalance` only used the HPA path, so a managed ScaledObject selected by the coordinator was effectively ignored by the plugin.

This PR teaches `gpu-rebalance` to treat HPAs and ScaledObjects as the same kind of quota entry:

- direct HPAs still get `spec.maxReplicas` patched
- KEDA ScaledObjects get `spec.maxReplicaCount` patched instead
- HPAs and ScaledObjects in the same namespace share the same ResourceQuota calculation
- RBAC now allows patch/update on `keda.sh/scaledobjects`

I kept this as a draft because I want to confirm this is the expected implementation direction for #1364 before adding the guide updates.

Tested with:

```text
go test ./internal/coordinator/...
git diff --check
make manifests
```
