### PR TITLE
Bug fix: Calculate missing V1 saturation utilization metric

### DIFF
--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1074,6 +1074,8 @@ func (e *Engine) convertSaturationTargetsToDecisions(
 			decision.Cost = va.Cost
 			// Use average spare KV capacity as the SpareCapacity indicator for limiter prioritization
 			decision.SpareCapacity = va.AvgSpareKvCapacity
+			// V1 Utilization: mean of per-replica KvCacheUsage fractions
+			decision.Utilization = va.AvgKvCacheUsage
 		} else {
 			logger.Info("No variant analysis found for decision (metrics may be unavailable)",
 				"variant", variantName)

--- a/internal/engines/saturation/engine_v1_utilization_test.go
+++ b/internal/engines/saturation/engine_v1_utilization_test.go
@@ -1,0 +1,91 @@
+package saturation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+)
+
+func init() {
+	logging.NewTestLogger()
+}
+
+func TestConvertSaturationTargetsToDecisions_V1Utilization(t *testing.T) {
+	engine := &Engine{}
+	ctx := context.Background()
+
+	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+		ModelID:   "test-model",
+		Namespace: "test-ns",
+		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+			{
+				VariantName:        "variant-a",
+				AcceleratorName:    "nvidia-a100",
+				Cost:               10.0,
+				AvgKvCacheUsage:    0.65,
+				AvgSpareKvCapacity: 0.15,
+			},
+			{
+				VariantName:        "variant-b",
+				AcceleratorName:    "nvidia-h100",
+				Cost:               15.0,
+				AvgKvCacheUsage:    0.80,
+				AvgSpareKvCapacity: 0.05,
+			},
+		},
+	}
+
+	saturationTargets := map[string]int{
+		"variant-a": 3,
+		"variant-b": 5,
+	}
+
+	variantStates := []interfaces.VariantReplicaState{
+		{VariantName: "variant-a", CurrentReplicas: 2, DesiredReplicas: 0, GPUsPerReplica: 1},
+		{VariantName: "variant-b", CurrentReplicas: 4, DesiredReplicas: 0, GPUsPerReplica: 2},
+	}
+
+	decisions := engine.convertSaturationTargetsToDecisions(ctx, saturationTargets, saturationAnalysis, variantStates)
+
+	if len(decisions) != 2 {
+		t.Fatalf("expected 2 decisions, got %d", len(decisions))
+	}
+
+	// Find decisions by variant name
+	decisionMap := make(map[string]interfaces.VariantDecision)
+	for _, d := range decisions {
+		decisionMap[d.VariantName] = d
+	}
+
+	// Verify variant-a decision
+	if d, ok := decisionMap["variant-a"]; ok {
+		if d.Utilization != 0.65 {
+			t.Errorf("variant-a: expected Utilization=0.65, got %.2f", d.Utilization)
+		}
+		if d.SpareCapacity != 0.15 {
+			t.Errorf("variant-a: expected SpareCapacity=0.15, got %.2f", d.SpareCapacity)
+		}
+		if d.AcceleratorName != "nvidia-a100" {
+			t.Errorf("variant-a: expected AcceleratorName=nvidia-a100, got %s", d.AcceleratorName)
+		}
+	} else {
+		t.Error("variant-a decision not found")
+	}
+
+	// Verify variant-b decision
+	if d, ok := decisionMap["variant-b"]; ok {
+		if d.Utilization != 0.80 {
+			t.Errorf("variant-b: expected Utilization=0.80, got %.2f", d.Utilization)
+		}
+		if d.SpareCapacity != 0.05 {
+			t.Errorf("variant-b: expected SpareCapacity=0.05, got %.2f", d.SpareCapacity)
+		}
+		if d.AcceleratorName != "nvidia-h100" {
+			t.Errorf("variant-b: expected AcceleratorName=nvidia-h100, got %s", d.AcceleratorName)
+		}
+	} else {
+		t.Error("variant-b decision not found")
+	}
+}

--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -185,6 +185,7 @@ type VariantSaturationAnalysis struct {
 	ReplicaCount        int
 	NonSaturatedCount   int
 	MaxKvCacheUsage     float64
+	AvgKvCacheUsage     float64 // Mean KV cache utilization across all replicas (for V1 Utilization)
 	MaxQueueLength      int
 	AvgSpareKvCapacity  float64
 	AvgSpareQueueLength float64

--- a/internal/saturation/analyzer.go
+++ b/internal/saturation/analyzer.go
@@ -157,6 +157,7 @@ func (a *Analyzer) analyzeVariant(
 
 	var totalSpareKv float64
 	var totalSpareQueue float64
+	var totalKvUsage float64
 	var nonSaturatedCount int
 
 	for _, metric := range metrics {
@@ -176,10 +177,11 @@ func (a *Analyzer) analyzeVariant(
 			nonSaturatedCount++
 		}
 
-		// Track max usage
+		// Track max usage and total usage across all replicas
 		if metric.KvCacheUsage > analysis.MaxKvCacheUsage {
 			analysis.MaxKvCacheUsage = metric.KvCacheUsage
 		}
+		totalKvUsage += metric.KvCacheUsage
 		if metric.QueueLength > analysis.MaxQueueLength {
 			analysis.MaxQueueLength = metric.QueueLength
 		}
@@ -191,6 +193,11 @@ func (a *Analyzer) analyzeVariant(
 	if nonSaturatedCount > 0 {
 		analysis.AvgSpareKvCapacity = totalSpareKv / float64(nonSaturatedCount)
 		analysis.AvgSpareQueueLength = totalSpareQueue / float64(nonSaturatedCount)
+	}
+
+	// Calculate mean KV cache usage across all replicas for Utilization field
+	if len(metrics) > 0 {
+		analysis.AvgKvCacheUsage = totalKvUsage / float64(len(metrics))
 	}
 
 	return analysis

--- a/internal/saturation/analyzer_test.go
+++ b/internal/saturation/analyzer_test.go
@@ -541,3 +541,71 @@ func TestCalculatesaturationTargets_LWSGroupSizeDoesNotBlock(t *testing.T) {
 		t.Errorf("expected lws-variant target=2 (1 group scaled up by 1, in group units), got %d", targets["lws-variant"])
 	}
 }
+
+func TestAnalyzeVariant_AvgKvCacheUsage(t *testing.T) {
+	analyzer := &Analyzer{}
+	config := config.SaturationScalingConfig{
+		KvCacheThreshold:     0.80,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.10,
+		QueueSpareTrigger:    3,
+	}
+
+	tests := []struct {
+		name               string
+		metrics            []interfaces.ReplicaMetrics
+		expectedAvgKvUsage float64
+		expectedMaxKvUsage float64
+	}{
+		{
+			name: "uniform KV cache usage",
+			metrics: []interfaces.ReplicaMetrics{
+				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 2},
+				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 2},
+				{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 2},
+			},
+			expectedAvgKvUsage: 0.50,
+			expectedMaxKvUsage: 0.50,
+		},
+		{
+			name: "mixed KV cache usage",
+			metrics: []interfaces.ReplicaMetrics{
+				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.30, QueueLength: 2},
+				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.60, QueueLength: 2},
+				{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.90, QueueLength: 2},
+			},
+			expectedAvgKvUsage: 0.60, // (0.30 + 0.60 + 0.90) / 3
+			expectedMaxKvUsage: 0.90,
+		},
+		{
+			name: "mixed saturated and non-saturated",
+			metrics: []interfaces.ReplicaMetrics{
+				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.85, QueueLength: 2}, // Saturated
+				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.40, QueueLength: 2}, // Not saturated
+				{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.55, QueueLength: 2}, // Not saturated
+			},
+			expectedAvgKvUsage: 0.60, // (0.85 + 0.40 + 0.55) / 3 - includes ALL replicas
+			expectedMaxKvUsage: 0.85,
+		},
+		{
+			name:               "empty metrics",
+			metrics:            []interfaces.ReplicaMetrics{},
+			expectedAvgKvUsage: 0.0,
+			expectedMaxKvUsage: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			analysis := analyzer.analyzeVariant(context.Background(), "v1", tt.metrics, config)
+
+			if analysis.AvgKvCacheUsage != tt.expectedAvgKvUsage {
+				t.Errorf("expected AvgKvCacheUsage=%.2f, got %.2f", tt.expectedAvgKvUsage, analysis.AvgKvCacheUsage)
+			}
+
+			if analysis.MaxKvCacheUsage != tt.expectedMaxKvUsage {
+				t.Errorf("expected MaxKvCacheUsage=%.2f, got %.2f", tt.expectedMaxKvUsage, analysis.MaxKvCacheUsage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #
- Before the fix, in a scale test, there's scaling action as shown in `Scaling Decision Rate` panel, but strangely the `Saturation Utilization`  panel shows `0` utilization!
<img width="1429" height="578" alt="saturation-utilization-before" src="https://github.com/user-attachments/assets/45637a5e-557e-46af-96de-5a1d4fff2b8f" />

- The problem is that the metric wasn't calculated. The fix is to calculate the metric as original intended. Here's the original intention:

  ```
	  // Utilization is the variant-level utilization ratio (0.0-1.0) reported for
	  // observability. The exact formula differs by analyzer because V1 and V2
	  // reason about saturation differently:
	  //   V1: mean of per-replica KvCacheUsage fractions (matches what V1's
	  //       per-replica threshold check operates on).
	  //   V2: ...
	  Utilization float64
  ```

- After the fix:

<img width="1516" height="783" alt="image" src="https://github.com/user-attachments/assets/63955747-c97e-41ce-8039-2a6488570f9c" />


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
- :bug: Fix bug

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [N/A] **E2E tests** for any new behavior
- [N/A] **Docs PR** for any user-facing impact
- [N/A] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
N/A
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
N/A
