### PR TITLE
Bug fix: correctly record the metric showing number of pods with metrics 

### DIFF
--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -879,9 +879,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		// This replaces the previous ownership traversal approach
 		vaName := data.vaName
 
-		// Track freshness for metrics in this pod for this variant right away
-		trackMetricFreshness(vaName, data, collectedAt, vaMetricsFreshnessStatus)
-
 		// Skip pods that have no metrics at all. This can happen when the query returns pods that
 		// were scaled up then scaled down, i.e. no longer running in the namespace.
 		if !data.hasKv && !data.hasQueue {
@@ -920,6 +917,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 				"scale targets", getScaleTargetNames(scaleTargets))
 			continue
 		}
+
 		variantKey := utils.GetNamespacedKey(namespace, vaName)
 		// Get accelerator name from Deployment/LWS nodeSelector/nodeAffinity or VA label
 		acceleratorName := ""
@@ -976,6 +974,8 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			logger.Info("Pod has engine metrics but no dispatch rate — possible pod/pod_name label mismatch", "pod", podName, "model", modelID, "namespace", namespace)
 		}
 
+		// Track freshness for metrics in this pod
+		trackMetricFreshness(vaName, data, collectedAt, vaMetricsFreshnessStatus)
 		metric := interfaces.ReplicaMetrics{
 			PodName:               podName,
 			ModelID:               modelID,
@@ -1016,7 +1016,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	}
 
 	// Only set this after all pods have been processed, making sure not to include pods without metrics (which are skipped above).
-	// This ensures that the discovered pod count reflects only those pods for which metrics were actually collected.
+	// This ensures that the discovered pod count reflects only those pods that produced replica metrics.
 	metrics.SetMetricsPodsDiscovered(namespace, len(replicaMetrics))
 	logger.V(logging.DEBUG).Info("Collected replica metrics",
 		"modelID", modelID,

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -864,7 +864,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 
 	// Build replica metrics from pod data
 	replicaMetrics := make([]interfaces.ReplicaMetrics, 0, len(podData))
-	metrics.SetMetricsPodsDiscovered(namespace, len(podData))
 	collectedAt := time.Now()
 
 	for instanceKey, data := range podData {
@@ -883,7 +882,8 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		// Track freshness for metrics in this pod for this variant right away
 		trackMetricFreshness(vaName, data, collectedAt, vaMetricsFreshnessStatus)
 
-		// Skip pods that have no metrics at all
+		// Skip pods that have no metrics at all. This can happen when the query returns pods that
+		// were scaled up then scaled down, i.e. no longer running in the namespace.
 		if !data.hasKv && !data.hasQueue {
 			continue
 		}
@@ -1015,6 +1015,9 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 	}
 
+	// Only set this after all pods have been processed, making sure not to include pods without metrics (which are skipped above).
+	// This ensures that the discovered pod count reflects only those pods for which metrics were actually collected.
+	metrics.SetMetricsPodsDiscovered(namespace, len(replicaMetrics))
 	logger.V(logging.DEBUG).Info("Collected replica metrics",
 		"modelID", modelID,
 		"namespace", namespace,

--- a/internal/collector/replica_metrics_test.go
+++ b/internal/collector/replica_metrics_test.go
@@ -1032,3 +1032,128 @@ func TestCollectReplicaMetrics_ThroughputOrphanSkipped(t *testing.T) {
 	assert.Equal(t, "pod-known", results[0].PodName)
 	assert.Equal(t, float64(0), results[0].GenerationTokenRate, "orphan entry must not contaminate pod-known")
 }
+
+func TestCollectReplicaMetrics_PodsDiscoveredCount(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ts := time.Now()
+
+	// Create mock data with 3 pods:
+	// - pod-1: has both KV and queue metrics (should be counted)
+	// - pod-2: has only KV metric (should be counted)
+	// - pod-3: has neither KV nor queue metrics (should NOT be counted)
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			return map[string]*source.MetricResult{
+				"kv_cache_usage": {
+					Values: []source.MetricValue{
+						{
+							Labels: map[string]string{
+								"pod":                               "pod-1",
+								"instance":                          "10.0.0.1:8000",
+								constants.VariantLabelPrometheusKey: "va-1",
+							},
+							Value:     0.55,
+							Timestamp: ts,
+						},
+						{
+							Labels: map[string]string{
+								"pod":                               "pod-2",
+								"instance":                          "10.0.0.2:8000",
+								constants.VariantLabelPrometheusKey: "va-1",
+							},
+							Value:     0.60,
+							Timestamp: ts,
+						},
+					},
+				},
+				"queue_length": {
+					Values: []source.MetricValue{
+						{
+							Labels: map[string]string{
+								"pod":                               "pod-1",
+								"instance":                          "10.0.0.1:8000",
+								constants.VariantLabelPrometheusKey: "va-1",
+							},
+							Value:     5.0,
+							Timestamp: ts,
+						},
+					},
+				},
+				// Pod-3 has only throughput metrics (no KV or queue)
+				"generation_token_rate": {
+					Values: []source.MetricValue{
+						{
+							Labels: map[string]string{
+								"pod":                               "pod-3",
+								"instance":                          "10.0.0.3:8000",
+								constants.VariantLabelPrometheusKey: "va-1",
+							},
+							Value:     1000.0,
+							Timestamp: ts,
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	collector := NewReplicaMetricsCollector(mockSource, k8sClient, nil, nil)
+	results, err := collector.CollectReplicaMetrics(
+		context.Background(),
+		"test-model",
+		"test-ns",
+		make(map[string]scaletarget.ScaleTargetAccessor),
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil,
+		make(map[string]float64),
+	)
+	require.NoError(t, err)
+
+	// Only pod-1 and pod-2 should be in results (pod-3 has no KV/queue metrics)
+	require.Len(t, results, 2, "only pods with KV or queue metrics should produce ReplicaMetrics")
+
+	// Gather metrics from the registry
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	// Find the pods_discovered metric and verify its value
+	var foundPodsDiscovered bool
+	for _, mf := range metricFamilies {
+		if mf.GetName() == constants.WVAMetricsPodsDiscovered {
+			foundPodsDiscovered = true
+			require.NotEmpty(t, mf.GetMetric(), "pods_discovered metric should have at least one entry")
+
+			// Find the metric for test-ns namespace
+			for _, m := range mf.GetMetric() {
+				var namespace string
+				for _, label := range m.GetLabel() {
+					if label.GetName() == constants.LabelNamespace && label.GetValue() == "test-ns" {
+						namespace = label.GetValue()
+						break
+					}
+				}
+				if namespace == "test-ns" {
+					gauge := m.GetGauge()
+					require.NotNil(t, gauge, "pods_discovered should be a gauge metric")
+					// The fix ensures this is len(replicaMetrics) = 2, not len(podData) = 3
+					assert.Equal(t, float64(2), gauge.GetValue(),
+						"pods_discovered should count only pods with KV or queue metrics, not all pods in podData")
+					return
+				}
+			}
+			t.Error("pods_discovered metric for test-ns namespace not found")
+		}
+	}
+
+	require.True(t, foundPodsDiscovered, "pods_discovered metric not found")
+}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## The Problem:
- In my cluster, there's only `1` model pod running, but the dashboard shows `7` pods with metrics!



## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
- :bug: Fix bug

The Fix:
- After some tracing, it turns out that the query for metrics return 7 pods, and 6 of them no longer run in the namespace. They are the pods that were scaled up then scaled down yesterday.
- There's code to filter out pods w/o metrics, and these 6 pods are filtered out in the metric collector. The fix is to move the code recoding the metric to after the filter. The dashboard now shows correctly:

<img width="382" height="104" alt="image" src="https://github.com/user-attachments/assets/5a43518b-2b2b-4755-9c91-e7e57091ff4c" />

- Addition, there's also a change to move where we determine metric freshness (trackMetricFreshness) in the same function but just a bit later - just before building the replicaMetric. This makes sure we only track metric freshness for the metrics that will be returned from the function.

- ### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ N/A] **E2E tests** for any new behavior
- [ N/A] **Docs PR** for any user-facing impact
- [ N/A] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
N/A
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
N/A