### PR TITLE
test(e2e): isolate KEDA smoke tests in per-Describe namespaces

### DIFF
--- a/test/e2e/smoke_keda_test.go
+++ b/test/e2e/smoke_keda_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -90,6 +89,7 @@ var _ = Describe("KEDA Smoke Tests - Infrastructure Readiness", Label("smoke", "
 
 var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", "full"), Ordered, func() {
 	var (
+		ns               string
 		poolName         = "smoke-test-pool"
 		modelServiceName = "smoke-test-ms"
 		deploymentName   = modelServiceName + "-decode"
@@ -99,105 +99,65 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 	)
 
 	BeforeAll(func() {
-		By("Cleaning up any existing smoke test resources")
-		cleanupSmokeTestResources()
+		nsObj, err := k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "smoke-keda-basic-"},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create isolated test namespace")
+		ns = nsObj.Name
+		By("Using isolated test namespace " + ns)
+
+		DeferCleanup(func() {
+			_ = k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+		})
+		DeferCleanup(func() {
+			_ = crClient.Delete(ctx, &promoperator.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelServiceName + "-monitor",
+					Namespace: cfg.MonitoringNS,
+				},
+			})
+		})
 
 		if cfg.ScaleToZeroEnabled {
 			minReplicas = 0
 		}
 
 		By("Creating model service deployment")
-		err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, vaName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		err = fixtures.EnsureModelService(ctx, k8sClient, ns, modelServiceName, poolName, cfg.ModelID, vaName, cfg.UseSimulator, cfg.MaxNumSeqs)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
 
-		DeferCleanup(func() {
-			cleanupResource(ctx, "Deployment", cfg.LLMDNamespace, deploymentName,
-				func() error {
-					return k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, deploymentName, metav1.DeleteOptions{})
-				},
-				func() bool {
-					_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
-					return errors.IsNotFound(err)
-				})
-		})
-
 		By("Creating service to expose model server")
-		err = fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceName, deploymentName, 8000)
+		err = fixtures.EnsureService(ctx, k8sClient, ns, modelServiceName, deploymentName, 8000)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create service")
 
-		DeferCleanup(func() {
-			serviceName := modelServiceName + "-service"
-			cleanupResource(ctx, "Service", cfg.LLMDNamespace, serviceName,
-				func() error {
-					return k8sClient.CoreV1().Services(cfg.LLMDNamespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
-				},
-				func() bool {
-					_, err := k8sClient.CoreV1().Services(cfg.LLMDNamespace).Get(ctx, serviceName, metav1.GetOptions{})
-					return errors.IsNotFound(err)
-				})
-		})
-
 		By("Creating ServiceMonitor for metrics scraping")
-		err = fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, cfg.LLMDNamespace, modelServiceName, deploymentName)
+		err = fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, ns, modelServiceName, deploymentName)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create ServiceMonitor")
-
-		DeferCleanup(func() {
-			serviceMonitorName := modelServiceName + "-monitor"
-			cleanupResource(ctx, "ServiceMonitor", cfg.MonitoringNS, serviceMonitorName,
-				func() error {
-					return crClient.Delete(ctx, &promoperator.ServiceMonitor{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      serviceMonitorName,
-							Namespace: cfg.MonitoringNS,
-						},
-					})
-				},
-				func() bool {
-					err := crClient.Get(ctx, client.ObjectKey{Name: serviceMonitorName, Namespace: cfg.MonitoringNS}, &promoperator.ServiceMonitor{})
-					return errors.IsNotFound(err)
-				})
-		})
 
 		By("Waiting for model service to be ready")
 		Eventually(func(g Gomega) {
-			deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			deployment, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)), "Model service should have 1 ready replica")
 		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 		By("Creating VariantAutoscaling resource")
 		err = fixtures.EnsureVariantAutoscalingWithDefaults(
-			ctx, crClient, cfg.LLMDNamespace, vaName,
+			ctx, crClient, ns, vaName,
 			deploymentName, cfg.ModelID, cfg.AcceleratorType,
 			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 
 		By("Creating ScaledObject")
-		err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerName, deploymentName, vaName, minReplicas, 10, cfg.MonitoringNS)
+		err = fixtures.EnsureScaledObject(ctx, crClient, ns, scalerName, deploymentName, vaName, minReplicas, 10, cfg.MonitoringNS)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject")
-	})
-
-	AfterAll(func() {
-		By("Cleaning up KEDA smoke test resources")
-		err := fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerName)
-		Expect(err).NotTo(HaveOccurred())
-
-		va := &variantautoscalingv1alpha1.VariantAutoscaling{
-			ObjectMeta: metav1.ObjectMeta{Name: vaName, Namespace: cfg.LLMDNamespace},
-		}
-		cleanupResource(ctx, "VA", cfg.LLMDNamespace, vaName,
-			func() error { return crClient.Delete(ctx, va) },
-			func() bool {
-				err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
-				return errors.IsNotFound(err)
-			})
 	})
 
 	It("should reconcile the VA successfully", func() {
 		Eventually(func(g Gomega) {
 			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
-			err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+			err := crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: vaName}, va)
 			g.Expect(err).NotTo(HaveOccurred())
 			condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeTargetResolved)
 			g.Expect(condition).NotTo(BeNil(), "VA should have TargetResolved condition")
@@ -208,7 +168,7 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 	It("should have MetricsAvailable condition set", func() {
 		Eventually(func(g Gomega) {
 			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
-			err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+			err := crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: vaName}, va)
 			g.Expect(err).NotTo(HaveOccurred())
 			condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeMetricsAvailable)
 			g.Expect(condition).NotTo(BeNil(), "MetricsAvailable condition should exist")
@@ -221,7 +181,7 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 		soName := scalerName + "-so"
 		Eventually(func(g Gomega) {
 			so := &kedav1alpha1.ScaledObject{}
-			err := crClient.Get(ctx, client.ObjectKey{Namespace: cfg.LLMDNamespace, Name: soName}, so)
+			err := crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: soName}, so)
 			g.Expect(err).NotTo(HaveOccurred(), "ScaledObject %s should exist", soName)
 			ready := so.Status.Conditions.GetReadyCondition()
 			g.Expect(ready.Status).To(Equal(metav1.ConditionTrue), "ScaledObject should have Ready=True")
@@ -230,7 +190,7 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 
 	It("should have KEDA create an HPA for the deployment", func() {
 		Eventually(func(g Gomega) {
-			hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
+			hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(ns).List(ctx, metav1.ListOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			var found bool
 			for _, h := range hpaList.Items {
@@ -246,7 +206,7 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 
 	It("should verify Prometheus is scraping model server pods", func() {
 		Eventually(func(g Gomega) {
-			pods, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{
+			pods, err := k8sClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 				LabelSelector: "app=" + deploymentName,
 			})
 			g.Expect(err).NotTo(HaveOccurred())
@@ -268,14 +228,14 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 		By("Verifying VA is reconciled and has conditions")
 		Eventually(func(g Gomega) {
 			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
-			err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+			err := crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: vaName}, va)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(va.Status.Conditions).NotTo(BeEmpty(), "VA should have status conditions")
 		}).Should(Succeed())
 
 		By("Verifying MetricsAvailable condition indicates metrics collection")
 		va := &variantautoscalingv1alpha1.VariantAutoscaling{}
-		err := crClient.Get(ctx, client.ObjectKey{Name: vaName, Namespace: cfg.LLMDNamespace}, va)
+		err := crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: vaName}, va)
 		Expect(err).NotTo(HaveOccurred())
 
 		condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeMetricsAvailable)
@@ -299,8 +259,9 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 	})
 })
 
-var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "full"), Serial, Ordered, func() {
+var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "full"), Ordered, func() {
 	var (
+		ns                        string
 		errorTestPoolName         = "error-test-pool"
 		errorTestModelServiceName = "error-test-ms"
 		errorTestDeploymentName   = errorTestModelServiceName + "-decode"
@@ -308,34 +269,31 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 	)
 
 	BeforeAll(func() {
-		By("Cleaning up any existing smoke test resources")
-		cleanupSmokeTestResources()
-
-		By("Creating model service deployment for error handling tests")
-		err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVAName, cfg.UseSimulator, cfg.MaxNumSeqs)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
+		nsObj, err := k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "smoke-keda-error-"},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create isolated test namespace")
+		ns = nsObj.Name
+		By("Using isolated test namespace " + ns)
 
 		DeferCleanup(func() {
-			cleanupResource(ctx, "Deployment", cfg.LLMDNamespace, errorTestDeploymentName,
-				func() error {
-					return k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, errorTestDeploymentName, metav1.DeleteOptions{})
-				},
-				func() bool {
-					_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
-					return errors.IsNotFound(err)
-				})
+			_ = k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
 		})
+
+		By("Creating model service deployment for error handling tests")
+		err = fixtures.EnsureModelService(ctx, k8sClient, ns, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVAName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
 
 		By("Waiting for model service to be ready")
 		Eventually(func(g Gomega) {
-			deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+			deployment, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)), "Model service should have 1 ready replica")
 		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 		By("Creating VariantAutoscaling resource")
 		err = fixtures.EnsureVariantAutoscalingWithDefaults(
-			ctx, crClient, cfg.LLMDNamespace, errorTestVAName,
+			ctx, crClient, ns, errorTestVAName,
 			errorTestDeploymentName, cfg.ModelID, cfg.AcceleratorType,
 			cfg.ControllerInstance,
 		)
@@ -344,51 +302,39 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 		By("Waiting for VA to reconcile initially")
 		Eventually(func(g Gomega) {
 			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
-			err := crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+			err := crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: errorTestVAName}, va)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(va.Status.Conditions).NotTo(BeEmpty(), "VA should have status conditions")
 		}).Should(Succeed())
 	})
 
-	AfterAll(func() {
-		va := &variantautoscalingv1alpha1.VariantAutoscaling{
-			ObjectMeta: metav1.ObjectMeta{Name: errorTestVAName, Namespace: cfg.LLMDNamespace},
-		}
-		cleanupResource(ctx, "VA", cfg.LLMDNamespace, errorTestVAName,
-			func() error { return crClient.Delete(ctx, va) },
-			func() bool {
-				err := crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
-				return errors.IsNotFound(err)
-			})
-	})
-
 	It("should handle deployment deletion and recreation gracefully", func() {
 		By("Verifying deployment exists before deletion")
-		_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+		_, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "Deployment should exist before deletion")
 
 		By("Deleting the deployment")
-		err = k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, errorTestDeploymentName, metav1.DeleteOptions{})
+		err = k8sClient.AppsV1().Deployments(ns).Delete(ctx, errorTestDeploymentName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred(), "Should be able to delete deployment")
 
 		By("Waiting for deployment to be fully deleted")
 		Eventually(func(g Gomega) {
-			_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
-			g.Expect(errors.IsNotFound(err)).To(BeTrue(), "Deployment should be deleted")
+			_, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+			g.Expect(err).To(MatchError(ContainSubstring("not found")), "Deployment should be deleted")
 		}, time.Duration(cfg.EventuallyShortSec)*time.Second, time.Duration(cfg.PollIntervalQuickSec)*time.Second).Should(Succeed())
 
 		By("Verifying VA continues to exist after deployment deletion")
 		va := &variantautoscalingv1alpha1.VariantAutoscaling{}
-		err = crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+		err = crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: errorTestVAName}, va)
 		Expect(err).NotTo(HaveOccurred(), "VA should continue to exist after deployment deletion")
 
 		By("Recreating the deployment")
-		err = fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVAName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		err = fixtures.EnsureModelService(ctx, k8sClient, ns, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVAName, cfg.UseSimulator, cfg.MaxNumSeqs)
 		Expect(err).NotTo(HaveOccurred(), "Failed to recreate model service")
 
 		By("Waiting for deployment to be ready after recreation")
 		Eventually(func(g Gomega) {
-			deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
+			deployment, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, errorTestDeploymentName, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)),
 				"Model service should have 1 ready replica after recreation")
@@ -397,7 +343,7 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 		By("Verifying VA automatically resumes operation")
 		Eventually(func(g Gomega) {
 			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
-			err := crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+			err := crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: errorTestVAName}, va)
 			g.Expect(err).NotTo(HaveOccurred())
 			condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeTargetResolved)
 			g.Expect(condition).NotTo(BeNil(), "TargetResolved condition should exist")
@@ -408,7 +354,7 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 	It("should handle metrics unavailability gracefully", func() {
 		Eventually(func(g Gomega) {
 			va := &variantautoscalingv1alpha1.VariantAutoscaling{}
-			err := crClient.Get(ctx, client.ObjectKey{Name: errorTestVAName, Namespace: cfg.LLMDNamespace}, va)
+			err := crClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: errorTestVAName}, va)
 			g.Expect(err).NotTo(HaveOccurred())
 			condition := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeMetricsAvailable)
 			g.Expect(condition).NotTo(BeNil(), "MetricsAvailable condition should exist")

--- a/test/e2e/smoke_keda_test.go
+++ b/test/e2e/smoke_keda_test.go
@@ -107,15 +107,19 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 		By("Using isolated test namespace " + ns)
 
 		DeferCleanup(func() {
-			_ = k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+			By("Deleting isolated namespace " + ns)
+			if err := k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{}); err != nil {
+				GinkgoWriter.Printf("WARNING: failed to delete namespace %s: %v\n", ns, err)
+			}
 		})
 		DeferCleanup(func() {
-			_ = crClient.Delete(ctx, &promoperator.ServiceMonitor{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      modelServiceName + "-monitor",
-					Namespace: cfg.MonitoringNS,
-				},
-			})
+			smName := modelServiceName + "-monitor"
+			By("Deleting ServiceMonitor " + smName)
+			if err := crClient.Delete(ctx, &promoperator.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{Name: smName, Namespace: cfg.MonitoringNS},
+			}); err != nil {
+				GinkgoWriter.Printf("WARNING: failed to delete ServiceMonitor %s: %v\n", smName, err)
+			}
 		})
 
 		if cfg.ScaleToZeroEnabled {
@@ -277,7 +281,10 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 		By("Using isolated test namespace " + ns)
 
 		DeferCleanup(func() {
-			_ = k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+			By("Deleting isolated namespace " + ns)
+			if err := k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{}); err != nil {
+				GinkgoWriter.Printf("WARNING: failed to delete namespace %s: %v\n", ns, err)
+			}
 		})
 
 		By("Creating model service deployment for error handling tests")


### PR DESCRIPTION
Fixes #

## Proposed Changes

:broom: Isolate KEDA smoke tests in per-Describe namespaces so tests do not share state and do not require explicit resource cleanup

- Create a fresh namespace per `Describe` block using `GenerateName` and delete it via `DeferCleanup`, replacing all per-resource cleanup and `AfterAll` blocks
- Remove `Serial` from Error Handling suite — it no longer competes with Basic Autoscaling for shared resources
- Remove `cleanupSmokeTestResources()` calls from KEDA smoke setup

### Pre-review Checklist

- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

```release-note
NONE
