### PR TITLE
feat(e2e): full e2e KEDA parity with namespace isolation

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -287,3 +287,57 @@ jobs:
           QUEUE_SPARE_TRIGGER: "4.5"
         run: |
           make test-e2e-full-with-setup
+
+  # Full Kind E2E with KEDA backend - non-blocking; add to required checks once stable.
+  e2e-tests-full-keda:
+    runs-on: ubuntu-latest
+    needs: [lint-and-test, check-code-changes]
+    if: github.event_name == 'pull_request' && needs.check-code-changes.outputs.has_code_changes == 'true'
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Extract Go version from go.mod
+        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+
+      - name: Set up Go with cache
+        uses: actions/setup-go@v6
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: ./go.sum
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Install Kind
+        run: deploy/ci-pr-checks/install-kind.sh
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build WVA image locally
+        id: build-image
+        env:
+          CHECKOUT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: deploy/ci-pr-checks/build-wva-image-local.sh
+
+      - name: Run e2e tests (full, KEDA backend)
+        shell: bash
+        env:
+          ENVIRONMENT: kind-emulator
+          USE_SIMULATOR: "true"
+          SCALE_TO_ZERO_ENABLED: "true"
+          CREATE_CLUSTER: "true"
+          SCALER_BACKEND: keda
+          LLM_D_ROUTER_VERSION: "v0.9.0"
+          DEPLOY_LWS: "true"
+          IMG: ${{ steps.build-image.outputs.image }}
+          SKIP_BUILD: "true"
+          DELETE_CLUSTER: "false"
+          KV_SPARE_TRIGGER: "0.5"
+          QUEUE_SPARE_TRIGGER: "4.5"
+        run: |
+          make test-e2e-full-keda-with-setup

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ KV_SPARE_TRIGGER           ?=
 QUEUE_SPARE_TRIGGER         ?=
 E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
+E2E_KEDA_NAMESPACE          ?= keda-system
 E2E_WVA_SECONDARY_OVERLAY_PATH ?= $(CURDIR)/test/e2e/testdata/secondary-controller
 # llm-d-benchmark CLI configuration
 # Ensure brew-installed tools (helm >=3.19) take precedence over Rancher Desktop
@@ -351,6 +352,36 @@ test-e2e-multi-controller-with-setup: deploy-e2e-infra test-e2e-multi-controller
 test-e2e-full-with-setup:
 	DEPLOY_LWS=true $(MAKE) deploy-e2e-infra
 	$(MAKE) test-e2e-full
+
+# Runs the full e2e suite against a KEDA backend (no Prometheus Adapter).
+# Label filter includes keda-labeled tests since KEDA is installed on the cluster.
+.PHONY: test-e2e-full-keda
+test-e2e-full-keda: ## Run full e2e test suite against KEDA backend
+	@echo "Running full e2e test suite (KEDA backend)..."
+	$(eval FOCUS_ARGS := $(if $(FOCUS),-ginkgo.focus="$(FOCUS)",))
+	$(eval SKIP_ARGS := $(if $(SKIP),-ginkgo.skip="$(SKIP)",))
+	KUBECONFIG=$(KUBECONFIG) \
+	ENVIRONMENT=$(ENVIRONMENT) \
+	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
+	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
+	USE_SIMULATOR=$(USE_SIMULATOR) \
+	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
+	SCALER_BACKEND=keda \
+	KEDA_NAMESPACE=$(E2E_KEDA_NAMESPACE) \
+	MODEL_ID=$(MODEL_ID) \
+	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
+		-ginkgo.label-filter="full && !flaky" $(FOCUS_ARGS) $(SKIP_ARGS); \
+	TEST_EXIT_CODE=$$?; \
+	echo ""; \
+	echo "=========================================="; \
+	echo "Test execution completed. Exit code: $$TEST_EXIT_CODE"; \
+	echo "=========================================="; \
+	exit $$TEST_EXIT_CODE
+
+.PHONY: test-e2e-full-keda-with-setup
+test-e2e-full-keda-with-setup: ## Deploy KEDA infra and run full e2e test suite
+	DEPLOY_LWS=true SCALER_BACKEND=keda $(MAKE) deploy-e2e-infra
+	$(MAKE) test-e2e-full-keda
 
 
 ##@ llm-d-benchmark CLI (standup / run / teardown)

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ test-e2e-full-keda: ## Run full e2e test suite against KEDA backend
 	KEDA_NAMESPACE=$(E2E_KEDA_NAMESPACE) \
 	MODEL_ID=$(MODEL_ID) \
 	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
-		-ginkgo.label-filter="full && !flaky" $(FOCUS_ARGS) $(SKIP_ARGS); \
+		-ginkgo.label-filter="full && !smoke && !flaky" $(FOCUS_ARGS) $(SKIP_ARGS); \
 	TEST_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=========================================="; \

--- a/test/e2e/annotation_discovery_test.go
+++ b/test/e2e/annotation_discovery_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,44 +35,49 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 			// WVA discovers that HPA and uses its object name as variant_name in wva_desired_replicas.
 			hpaBaseName = "ann-disc-basic"
 			hpaName     = hpaBaseName + "-hpa"
+			ns          string
 		)
 
 		BeforeAll(func() {
-			By("Creating model service deployment")
-			err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, "", cfg.UseSimulator, cfg.MaxNumSeqs)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
-
+			nsObj, err := k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "ann-disc-a-"},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create isolated test namespace")
+			ns = nsObj.Name
+			By("Using isolated test namespace " + ns)
 			DeferCleanup(func() {
-				_ = k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, deploymentName, metav1.DeleteOptions{})
-				_ = k8sClient.CoreV1().Services(cfg.LLMDNamespace).Delete(ctx, modelServiceName+"-service", metav1.DeleteOptions{})
+				By("Deleting isolated namespace " + ns)
+				if err := k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{}); err != nil {
+					GinkgoWriter.Printf("Warning: failed to delete namespace %s: %v\n", ns, err)
+				}
 			})
+
+			By("Creating model service deployment")
+			err = fixtures.EnsureModelService(ctx, k8sClient, ns, modelServiceName, poolName, cfg.ModelID, "", cfg.UseSimulator, cfg.MaxNumSeqs)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
 
 			By("Waiting for deployment to be ready")
 			Eventually(func(g Gomega) {
-				d, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+				d, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(d.Status.ReadyReplicas).To(Equal(int32(1)))
 			}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 			By("Creating annotated scaler (no VA CR)")
 			if cfg.ScalerBackend == scalerBackendKeda {
-				err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaBaseName, deploymentName, hpaName, 1, 10, cfg.MonitoringNS,
+				err = fixtures.EnsureScaledObject(ctx, crClient, ns, hpaBaseName, deploymentName, hpaName, 1, 10, cfg.MonitoringNS,
 					fixtures.WithScaledObjectWVAAnnotations(cfg.ModelID, "30.0"))
 				Expect(err).NotTo(HaveOccurred(), "Failed to create annotated ScaledObject")
-				DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaBaseName) })
 			} else {
-				err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaBaseName, deploymentName, hpaName, 1, 10,
+				err = fixtures.EnsureHPA(ctx, k8sClient, ns, hpaBaseName, deploymentName, hpaName, 1, 10,
 					fixtures.WithWVAAnnotations(cfg.ModelID, "30.0"))
 				Expect(err).NotTo(HaveOccurred(), "Failed to create annotated HPA")
-				DeferCleanup(func() {
-					_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, hpaName, metav1.DeleteOptions{})
-				})
 			}
 		})
 
 		It("should not create a VariantAutoscaling CR", func() {
 			vaList := &variantautoscalingv1alpha1.VariantAutoscalingList{}
-			err := crClient.List(ctx, vaList, client.InNamespace(cfg.LLMDNamespace))
+			err := crClient.List(ctx, vaList, client.InNamespace(ns))
 			Expect(err).NotTo(HaveOccurred())
 			for _, va := range vaList.Items {
 				Expect(va.Name).NotTo(Equal(hpaName),
@@ -88,7 +94,7 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 			if cfg.ScalerBackend == scalerBackendKeda {
 				By("Verifying KEDA has read wva_desired_replicas from Prometheus")
 				Eventually(func(g Gomega) {
-					hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
+					hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(ns).List(ctx, metav1.ListOptions{})
 					g.Expect(err).NotTo(HaveOccurred())
 					var kedaHPA *autoscalingv2.HorizontalPodAutoscaler
 					for i := range hpaList.Items {
@@ -108,7 +114,7 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 				Eventually(func(g Gomega) {
 					result, err := k8sClient.RESTClient().
 						Get().
-						AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + cfg.LLMDNamespace + "/" + constants.WVADesiredReplicas).
+						AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + ns + "/" + constants.WVADesiredReplicas).
 						DoRaw(ctx)
 					if err != nil {
 						if errors.IsNotFound(err) {
@@ -140,22 +146,31 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 			deploymentName   = modelServiceName + "-decode"
 			hpaBaseName      = "ann-disc-label"
 			hpaName          = hpaBaseName + "-hpa"
+			ns               string
 		)
 
 		BeforeAll(func() {
+			nsObj, err := k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "ann-disc-b-"},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create isolated test namespace")
+			ns = nsObj.Name
+			By("Using isolated test namespace " + ns)
+			DeferCleanup(func() {
+				By("Deleting isolated namespace " + ns)
+				if err := k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{}); err != nil {
+					GinkgoWriter.Printf("Warning: failed to delete namespace %s: %v\n", ns, err)
+				}
+			})
+
 			By("Creating model service deployment WITH llm-d.ai/variant label")
 			// Pass hpaName as vaName so the pod template carries llm-d.ai/variant=<hpaName>.
-			err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, hpaName, cfg.UseSimulator, cfg.MaxNumSeqs)
+			err = fixtures.EnsureModelService(ctx, k8sClient, ns, modelServiceName, poolName, cfg.ModelID, hpaName, cfg.UseSimulator, cfg.MaxNumSeqs)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
-
-			DeferCleanup(func() {
-				_ = k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, deploymentName, metav1.DeleteOptions{})
-				_ = k8sClient.CoreV1().Services(cfg.LLMDNamespace).Delete(ctx, modelServiceName+"-service", metav1.DeleteOptions{})
-			})
 
 			By("Verifying pod template carries llm-d.ai/variant label")
 			Eventually(func(g Gomega) {
-				d, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+				d, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(d.Spec.Template.Labels).To(HaveKeyWithValue("llm-d.ai/variant", hpaName),
 					"Pod template must carry llm-d.ai/variant=%s", hpaName)
@@ -163,30 +178,26 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 
 			By("Waiting for deployment to be ready")
 			Eventually(func(g Gomega) {
-				d, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+				d, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(d.Status.ReadyReplicas).To(Equal(int32(1)))
 			}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 			By("Creating annotated scaler (no VA CR)")
 			if cfg.ScalerBackend == scalerBackendKeda {
-				err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaBaseName, deploymentName, hpaName, 1, 10, cfg.MonitoringNS,
+				err = fixtures.EnsureScaledObject(ctx, crClient, ns, hpaBaseName, deploymentName, hpaName, 1, 10, cfg.MonitoringNS,
 					fixtures.WithScaledObjectWVAAnnotations(cfg.ModelID, "30.0"))
 				Expect(err).NotTo(HaveOccurred(), "Failed to create annotated ScaledObject")
-				DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaBaseName) })
 			} else {
-				err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaBaseName, deploymentName, hpaName, 1, 10,
+				err = fixtures.EnsureHPA(ctx, k8sClient, ns, hpaBaseName, deploymentName, hpaName, 1, 10,
 					fixtures.WithWVAAnnotations(cfg.ModelID, "30.0"))
 				Expect(err).NotTo(HaveOccurred(), "Failed to create annotated HPA")
-				DeferCleanup(func() {
-					_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, hpaName, metav1.DeleteOptions{})
-				})
 			}
 		})
 
 		It("should not create a VariantAutoscaling CR", func() {
 			vaList := &variantautoscalingv1alpha1.VariantAutoscalingList{}
-			err := crClient.List(ctx, vaList, client.InNamespace(cfg.LLMDNamespace))
+			err := crClient.List(ctx, vaList, client.InNamespace(ns))
 			Expect(err).NotTo(HaveOccurred())
 			for _, va := range vaList.Items {
 				Expect(va.Name).NotTo(Equal(hpaName),
@@ -198,7 +209,7 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 			if cfg.ScalerBackend == scalerBackendKeda {
 				By("Verifying KEDA has read wva_desired_replicas from Prometheus")
 				Eventually(func(g Gomega) {
-					hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
+					hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(ns).List(ctx, metav1.ListOptions{})
 					g.Expect(err).NotTo(HaveOccurred())
 					var kedaHPA *autoscalingv2.HorizontalPodAutoscaler
 					for i := range hpaList.Items {
@@ -217,7 +228,7 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 				Eventually(func(g Gomega) {
 					result, err := k8sClient.RESTClient().
 						Get().
-						AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + cfg.LLMDNamespace + "/" + constants.WVADesiredReplicas).
+						AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + ns + "/" + constants.WVADesiredReplicas).
 						DoRaw(ctx)
 					if err != nil {
 						if errors.IsNotFound(err) {

--- a/test/e2e/limiter_test.go
+++ b/test/e2e/limiter_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,79 +30,72 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 		vaB           = "limiter-va-amd"
 		hpaA          = "limiter-hpa-nvidia"
 		hpaB          = "limiter-hpa-amd"
+		ns            string
 	)
 
 	BeforeAll(func() {
-		// Note: InferencePools should already exist from infra-only deployment
-		// We no longer create InferencePools in individual tests
+		nsObj, err := k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "limiter-"},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create isolated test namespace")
+		ns = nsObj.Name
+		By("Using isolated test namespace " + ns)
+		DeferCleanup(func() {
+			By("Deleting isolated namespace " + ns)
+			if err := k8sClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{}); err != nil {
+				GinkgoWriter.Printf("Warning: failed to delete namespace %s: %v\n", ns, err)
+			}
+		})
 
 		By("Creating two model services with different accelerator requirements")
 
 		// Pool A - NVIDIA GPUs
-		err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceA, poolA, cfg.ModelID, vaA, cfg.UseSimulator, cfg.MaxNumSeqs)
+		err = fixtures.EnsureModelService(ctx, k8sClient, ns, modelServiceA, poolA, cfg.ModelID, vaA, cfg.UseSimulator, cfg.MaxNumSeqs)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create model service A")
 
-		err = fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceA, modelServiceA+"-decode", 8000)
+		err = fixtures.EnsureService(ctx, k8sClient, ns, modelServiceA, modelServiceA+"-decode", 8000)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create service A")
 
 		By("Creating ServiceMonitor for service A")
-		err = fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, cfg.LLMDNamespace, modelServiceA, modelServiceA+"-decode")
+		err = fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, ns, modelServiceA, modelServiceA+"-decode")
 		Expect(err).NotTo(HaveOccurred(), "Failed to create ServiceMonitor A")
 
-		// Register cleanup for ServiceMonitor A
 		DeferCleanup(func() {
-			serviceMonitorName := modelServiceA + "-monitor"
-			cleanupResource(ctx, "ServiceMonitor", cfg.MonitoringNS, serviceMonitorName,
-				func() error {
-					return crClient.Delete(ctx, &promoperator.ServiceMonitor{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      serviceMonitorName,
-							Namespace: cfg.MonitoringNS,
-						},
-					})
+			_ = crClient.Delete(ctx, &promoperator.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelServiceA + "-monitor",
+					Namespace: cfg.MonitoringNS,
 				},
-				func() bool {
-					err := crClient.Get(ctx, client.ObjectKey{Name: serviceMonitorName, Namespace: cfg.MonitoringNS}, &promoperator.ServiceMonitor{})
-					return errors.IsNotFound(err)
-				})
+			})
 		})
 
 		// Pool B - AMD GPUs
-		err = fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceB, poolB, cfg.ModelID, vaB, cfg.UseSimulator, cfg.MaxNumSeqs)
+		err = fixtures.EnsureModelService(ctx, k8sClient, ns, modelServiceB, poolB, cfg.ModelID, vaB, cfg.UseSimulator, cfg.MaxNumSeqs)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create model service B")
 
-		err = fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceB, modelServiceB+"-decode", 8000)
+		err = fixtures.EnsureService(ctx, k8sClient, ns, modelServiceB, modelServiceB+"-decode", 8000)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create service B")
 
 		By("Creating ServiceMonitor for service B")
-		err = fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, cfg.LLMDNamespace, modelServiceB, modelServiceB+"-decode")
+		err = fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, ns, modelServiceB, modelServiceB+"-decode")
 		Expect(err).NotTo(HaveOccurred(), "Failed to create ServiceMonitor B")
 
-		// Register cleanup for ServiceMonitor B
 		DeferCleanup(func() {
-			serviceMonitorName := modelServiceB + "-monitor"
-			cleanupResource(ctx, "ServiceMonitor", cfg.MonitoringNS, serviceMonitorName,
-				func() error {
-					return crClient.Delete(ctx, &promoperator.ServiceMonitor{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      serviceMonitorName,
-							Namespace: cfg.MonitoringNS,
-						},
-					})
+			_ = crClient.Delete(ctx, &promoperator.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelServiceB + "-monitor",
+					Namespace: cfg.MonitoringNS,
 				},
-				func() bool {
-					err := crClient.Get(ctx, client.ObjectKey{Name: serviceMonitorName, Namespace: cfg.MonitoringNS}, &promoperator.ServiceMonitor{})
-					return errors.IsNotFound(err)
-				})
+			})
 		})
 
 		By("Waiting for both model services to be ready")
 		Eventually(func(g Gomega) {
-			depA, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelServiceA+"-decode", metav1.GetOptions{})
+			depA, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, modelServiceA+"-decode", metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(depA.Status.ReadyReplicas).To(Equal(int32(1)))
 
-			depB, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelServiceB+"-decode", metav1.GetOptions{})
+			depB, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, modelServiceB+"-decode", metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(depB.Status.ReadyReplicas).To(Equal(int32(1)))
 		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
@@ -111,7 +104,7 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 
 		// VA A - NVIDIA accelerator
 		err = fixtures.EnsureVariantAutoscaling(
-			ctx, crClient, cfg.LLMDNamespace, vaA,
+			ctx, crClient, ns, vaA,
 			modelServiceA+"-decode", cfg.ModelID, "H100", 30.0,
 			cfg.ControllerInstance,
 		)
@@ -119,7 +112,7 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 
 		// VA B - AMD accelerator
 		err = fixtures.EnsureVariantAutoscaling(
-			ctx, crClient, cfg.LLMDNamespace, vaB,
+			ctx, crClient, ns, vaB,
 			modelServiceB+"-decode", cfg.ModelID, "MI300X", 40.0,
 			cfg.ControllerInstance,
 		)
@@ -127,115 +120,20 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 
 		By("Creating scalers for both deployments (HPA or ScaledObject per backend)")
 		if cfg.ScalerBackend == scalerBackendKeda {
-			_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, hpaA+"-hpa", metav1.DeleteOptions{})
-			_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, hpaB+"-hpa", metav1.DeleteOptions{})
-			err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaA, modelServiceA+"-decode", vaA, 1, 10, cfg.MonitoringNS)
+			_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Delete(ctx, hpaA+"-hpa", metav1.DeleteOptions{})
+			_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Delete(ctx, hpaB+"-hpa", metav1.DeleteOptions{})
+			err = fixtures.EnsureScaledObject(ctx, crClient, ns, hpaA, modelServiceA+"-decode", vaA, 1, 10, cfg.MonitoringNS)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject A")
-			err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaB, modelServiceB+"-decode", vaB, 1, 10, cfg.MonitoringNS)
+			err = fixtures.EnsureScaledObject(ctx, crClient, ns, hpaB, modelServiceB+"-decode", vaB, 1, 10, cfg.MonitoringNS)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject B")
 		} else {
-			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaA, modelServiceA+"-decode", vaA, 1, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, ns, hpaA, modelServiceA+"-decode", vaA, 1, 10)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA A")
-			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaB, modelServiceB+"-decode", vaB, 1, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, ns, hpaB, modelServiceB+"-decode", vaB, 1, 10)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA B")
 		}
 
 		GinkgoWriter.Println("GPU Limiter test setup complete with two VAs (NVIDIA and AMD accelerators)")
-	})
-
-	AfterAll(func() {
-		By("Cleaning up GPU limiter test resources")
-
-		// Delete in reverse dependency order: scaler -> VA -> Service -> Deployment
-		// ServiceMonitor cleanup is handled by DeferCleanup registered in BeforeAll
-
-		if cfg.ScalerBackend == scalerBackendKeda {
-			_ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaA)
-			_ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaB)
-		} else {
-			hpaNameA := hpaA + "-hpa"
-			hpaNameB := hpaB + "-hpa"
-			cleanupResource(ctx, "HPA", cfg.LLMDNamespace, hpaNameA,
-				func() error {
-					return k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, hpaNameA, metav1.DeleteOptions{})
-				},
-				func() bool {
-					_, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(ctx, hpaNameA, metav1.GetOptions{})
-					return errors.IsNotFound(err)
-				})
-			cleanupResource(ctx, "HPA", cfg.LLMDNamespace, hpaNameB,
-				func() error {
-					return k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, hpaNameB, metav1.DeleteOptions{})
-				},
-				func() bool {
-					_, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(ctx, hpaNameB, metav1.GetOptions{})
-					return errors.IsNotFound(err)
-				})
-		}
-
-		// Delete VAs
-		vaAObj := &variantautoscalingv1alpha1.VariantAutoscaling{
-			ObjectMeta: metav1.ObjectMeta{Name: vaA, Namespace: cfg.LLMDNamespace},
-		}
-		cleanupResource(ctx, "VA", cfg.LLMDNamespace, vaA,
-			func() error {
-				return crClient.Delete(ctx, vaAObj)
-			},
-			func() bool {
-				err := crClient.Get(ctx, client.ObjectKey{Name: vaA, Namespace: cfg.LLMDNamespace}, vaAObj)
-				return errors.IsNotFound(err)
-			})
-		vaBObj := &variantautoscalingv1alpha1.VariantAutoscaling{
-			ObjectMeta: metav1.ObjectMeta{Name: vaB, Namespace: cfg.LLMDNamespace},
-		}
-		cleanupResource(ctx, "VA", cfg.LLMDNamespace, vaB,
-			func() error {
-				return crClient.Delete(ctx, vaBObj)
-			},
-			func() bool {
-				err := crClient.Get(ctx, client.ObjectKey{Name: vaB, Namespace: cfg.LLMDNamespace}, vaBObj)
-				return errors.IsNotFound(err)
-			})
-
-		// Delete services
-		serviceNameA := modelServiceA + "-service"
-		serviceNameB := modelServiceB + "-service"
-		cleanupResource(ctx, "Service", cfg.LLMDNamespace, serviceNameA,
-			func() error {
-				return k8sClient.CoreV1().Services(cfg.LLMDNamespace).Delete(ctx, serviceNameA, metav1.DeleteOptions{})
-			},
-			func() bool {
-				_, err := k8sClient.CoreV1().Services(cfg.LLMDNamespace).Get(ctx, serviceNameA, metav1.GetOptions{})
-				return errors.IsNotFound(err)
-			})
-		cleanupResource(ctx, "Service", cfg.LLMDNamespace, serviceNameB,
-			func() error {
-				return k8sClient.CoreV1().Services(cfg.LLMDNamespace).Delete(ctx, serviceNameB, metav1.DeleteOptions{})
-			},
-			func() bool {
-				_, err := k8sClient.CoreV1().Services(cfg.LLMDNamespace).Get(ctx, serviceNameB, metav1.GetOptions{})
-				return errors.IsNotFound(err)
-			})
-
-		// Delete deployments
-		deploymentNameA := modelServiceA + "-decode"
-		deploymentNameB := modelServiceB + "-decode"
-		cleanupResource(ctx, "Deployment", cfg.LLMDNamespace, deploymentNameA,
-			func() error {
-				return k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, deploymentNameA, metav1.DeleteOptions{})
-			},
-			func() bool {
-				_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentNameA, metav1.GetOptions{})
-				return errors.IsNotFound(err)
-			})
-		cleanupResource(ctx, "Deployment", cfg.LLMDNamespace, deploymentNameB,
-			func() error {
-				return k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, deploymentNameB, metav1.DeleteOptions{})
-			},
-			func() bool {
-				_, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentNameB, metav1.GetOptions{})
-				return errors.IsNotFound(err)
-			})
 	})
 
 	Context("VA creation and reconciliation", func() {
@@ -243,7 +141,7 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 			By("Verifying VA A (NVIDIA)")
 			vaAObj := &variantautoscalingv1alpha1.VariantAutoscaling{}
 			err := crClient.Get(ctx, client.ObjectKey{
-				Namespace: cfg.LLMDNamespace,
+				Namespace: ns,
 				Name:      vaA,
 			}, vaAObj)
 			Expect(err).NotTo(HaveOccurred())
@@ -252,7 +150,7 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 			By("Verifying VA B (AMD)")
 			vaBObj := &variantautoscalingv1alpha1.VariantAutoscaling{}
 			err = crClient.Get(ctx, client.ObjectKey{
-				Namespace: cfg.LLMDNamespace,
+				Namespace: ns,
 				Name:      vaB,
 			}, vaBObj)
 			Expect(err).NotTo(HaveOccurred())
@@ -268,7 +166,7 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 				va := &variantautoscalingv1alpha1.VariantAutoscaling{}
 				err := crClient.Get(ctx, client.ObjectKey{
 					Name:      vaA,
-					Namespace: cfg.LLMDNamespace,
+					Namespace: ns,
 				}, va)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(va.Status.Conditions).NotTo(BeEmpty())
@@ -279,7 +177,7 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 				va := &variantautoscalingv1alpha1.VariantAutoscaling{}
 				err := crClient.Get(ctx, client.ObjectKey{
 					Name:      vaB,
-					Namespace: cfg.LLMDNamespace,
+					Namespace: ns,
 				}, va)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(va.Status.Conditions).NotTo(BeEmpty())
@@ -294,10 +192,10 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 			By("Checking deployment replicas don't exceed expected limits")
 
 			// Get deployment replica counts
-			depA, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelServiceA+"-decode", metav1.GetOptions{})
+			depA, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, modelServiceA+"-decode", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			depB, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelServiceB+"-decode", metav1.GetOptions{})
+			depB, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, modelServiceB+"-decode", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			replicasA := depA.Status.Replicas


### PR DESCRIPTION
Fixes # 

## Proposed Changes

:gift: Add `test-e2e-full-keda` / `test-e2e-full-keda-with-setup` Makefile targets and a non-blocking `e2e-tests-full-keda` Kind CI job so the full e2e suite runs end-to-end against a KEDA backend on every PR.

:broom: Apply per-namespace isolation to `annotation_discovery_test.go` and `limiter_test.go`: each Describe/Context creates a fresh namespace via `GenerateName` and a `DeferCleanup` that deletes it, replacing all per-resource `AfterAll` / `DeferCleanup` boilerplate. Namespace deletions now log errors instead of silently discarding them.

### Pre-review Checklist

- [x] **E2E tests** for any new behavior — existing KEDA branches in the affected files cover this; the new CI job runs them
- [ ] **Docs PR** for any user-facing impact — N/A (internal test infrastructure only)
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

```release-note
NONE

Docs

N/A — internal e2e test infrastructure change; no user-facing autoscaling behavior is modified.