### PR TITLE
chore: remove stale WVA helm chart references post-removal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,8 +97,6 @@ workload-variant-autoscaler/
 │   ├── e2e/             # End-to-end tests
 │   └── utils/           # Test utilities
 ├── hack/                 # Dev scripts (e.g. hack/burst_load_generator.sh for manual load)
-└── charts/               # Helm charts
-    └── workload-variant-autoscaler/
 ```
 
 ## WVA-Specific Development Tasks

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -268,14 +268,14 @@ extract_openshift_prometheus_ca() {
         fi
     fi
 
-    # Method 3: Fallback to thanos-querier-tls secret (as per Helm README)
+    # Method 3: Fallback to thanos-querier-tls secret
     # Note: This extracts the server certificate, which may work if the cert chain includes the CA
     # but it's not ideal - we should use the Service CA instead.
     if [ ! -s "$PROM_CA_CERT_PATH" ]; then
         log_warning "Service CA not found, falling back to server certificate from thanos-querier-tls"
         log_warning "This may cause TLS verification issues - Service CA is preferred"
         if kubectl get secret "$PROMETHEUS_SECRET_NAME" -n "$PROMETHEUS_SECRET_NS" &> /dev/null; then
-            log_info "Extracting certificate from thanos-querier-tls secret (as per Helm README)"
+            log_info "Extracting certificate from thanos-querier-tls secret"
             kubectl get secret "$PROMETHEUS_SECRET_NAME" -n "$PROMETHEUS_SECRET_NS" -o jsonpath='{.data.tls\.crt}' | base64 -d > "$PROM_CA_CERT_PATH"
             if [ -s "$PROM_CA_CERT_PATH" ]; then
                 log_success "Extracted certificate from thanos-querier-tls secret"

--- a/deploy/lib/verify.sh
+++ b/deploy/lib/verify.sh
@@ -103,7 +103,7 @@ print_summary() {
     echo "1. Deploy llm-d (EPP, gateway, ModelService) when needed:"
     echo "     See llm-d project guides at https://github.com/llm-d/llm-d"
     echo ""
-    echo "2. Create VariantAutoscaling / HPA via tests, operators, or helm with chart toggles."
+    echo "2. Create VariantAutoscaling / HPA via tests, operators, or kustomize overlays."
     echo ""
     echo "3. View WVA logs:"
     echo "   kubectl logs -n $WVA_NS -l app.kubernetes.io/name=workload-variant-autoscaler -f"

--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -178,7 +178,7 @@ WVA uses Kubernetes event watches to trigger reconciliation. Understanding how e
 Add the `-v=2` flag to see debug-level event logs:
 
 ```yaml
-# In deployment manifest or via Helm
+# In deployment manifest
 args:
 - --health-probe-bind-address=:8081
 - --metrics-bind-address=:8443

--- a/docs/developer-guide/development.md
+++ b/docs/developer-guide/development.md
@@ -74,8 +74,6 @@ workload-variant-autoscaler/
 ├── test/                  # Tests
 │   ├── e2e/                  # E2E tests (consolidated suite: Kind, OpenShift)
 │   └── utils/                 # Test utilities
-└── charts/                # Helm charts
-    └── workload-variant-autoscaler/
 ```
 
 ## Development Workflow
@@ -364,8 +362,8 @@ See [Agentic Workflows Guide](agentic-workflows.md) for detailed information on 
 See the [Release Process](release-process.md) guide for how to cut a release. It covers:
 
 - Pre-release checklist (changelog, optional version bumps, upstream pins)
-- Creating the tag and GitHub Release (which triggers image build and Helm chart publish)
-- What runs automatically: Docker image push, Helm chart version bump and publish to GHCR, and commit-back of chart files
+- Creating the tag and GitHub Release (which triggers the image build)
+- What runs automatically: Docker image build and push to GHCR
 - Post-release (required): update the llm-d [workload-autoscaling](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling) guide to the new WVA version
 - Enabling other team members to perform releases (permissions, secrets, documentation)
 

--- a/docs/developer-guide/release-process.md
+++ b/docs/developer-guide/release-process.md
@@ -90,9 +90,6 @@ The [llm-d](https://github.com/llm-d/llm-d) repo hosts a **workload-autoscaling 
 3. **Breaking changes and upgrading text**  
    - If the new release has breaking changes, add or update the "Breaking Changes" / "Upgrading" content and migration steps in the README.
 
-4. **Helmfile / values**  
-   - If the guide's `helmfile.yaml.gotmpl` or `workload-autoscaling/values.yaml` (or equivalent) pin the WVA image or chart version, update those to the new version.
-
 **Guide location:** [guides/workload-autoscaling](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling) (main branch). After editing, open a PR in the [llm-d/llm-d](https://github.com/llm-d/llm-d) repo so the guide stays in sync with the WVA release.
 
 ---

--- a/hack/benchmark/scenarios/wva_threshold/wva_saturation_v2_config.yaml
+++ b/hack/benchmark/scenarios/wva_threshold/wva_saturation_v2_config.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: workload-variant-autoscaler
     app.kubernetes.io/name: workload-variant-autoscaler
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/managed-by: kustomize
 data:
   default: |
     analyzerName: saturation

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -73,7 +73,7 @@ func SystemNamespace() string {
 	return DefaultNamespace
 }
 
-// ConfigMapName returns the main ConfigMap name from environment variable or default.
+// ConfigMapName returns the main ConfigMap name from environment variable or default (DefaultConfigMapName).
 // Set CONFIG_MAP_NAME in the deployment manifest to use a non-default name.
 func ConfigMapName() string {
 	if name := os.Getenv("CONFIG_MAP_NAME"); name != "" {

--- a/test/e2e/saturation_analyzer_path_test.go
+++ b/test/e2e/saturation_analyzer_path_test.go
@@ -88,9 +88,8 @@ func buildSaturationConfigYAMLWithThresholds(analyzerName string, kvCacheThresho
 
 // saturationConfigMapName resolves the active saturation ConfigMap name from controller runtime env.
 func saturationConfigMapName() string {
-	// Match the controller's runtime config map name. Helm deployments often
-	// override SATURATION_CONFIG_MAP_NAME with a release-prefixed value and can
-	// also change the controller deployment name, so discover it by label first.
+	// Match the controller's runtime config map name; discover by label first
+	// since the deployment name can vary across overlays.
 	deps, err := k8sClient.AppsV1().Deployments(cfg.WVANamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "control-plane=controller-manager",
 	})


### PR DESCRIPTION
Fixes #1214 (follow-up)

## Proposed Changes

- :broom: Remove stale `charts/` directory entries from repo structure trees in `CONTRIBUTING.md` and `docs/developer-guide/development.md`
- :broom: Update release process summary in `docs/developer-guide/development.md` to drop Helm chart publish steps
- :broom: Remove "or via Helm" from deployment manifest example in `docs/developer-guide/debugging.md`
- :broom: Update post-install next-steps message in `deploy/lib/verify.sh` to reference kustomize instead of helm chart toggles
- :broom: Drop "as per Helm README" from comments in `deploy/lib/infra_wva.sh` (README is deleted)
- :broom: Update stale comment in `test/e2e/saturation_analyzer_path_test.go` that referenced Helm deployment overrides
- :broom: Fix `app.kubernetes.io/managed-by: Helm` label in benchmark fixture `hack/benchmark/scenarios/wva_threshold/wva_saturation_v2_config.yaml`
- :broom: Remove stale "Helmfile / values" post-release step from `docs/developer-guide/release-process.md`
- :broom: Restore default value reference in `ConfigMapName()` doc comment in `internal/config/helpers.go`

### Pre-review Checklist

- [x] **E2E tests** for any new behavior — N/A, cleanup only
- [x] **Docs PR** for any user-facing impact — N/A, internal docs only
- [x] **Proposal PR** for any new enhancement or change to existing behavior — N/A

**Release Note**

```release-note
NONE
Docs

Follow-up to #1214 — sweeps remaining stale Helm chart references after the WVA Helm chart was removed.


