### PR TITLE
test(e2e): post-VA-removal cleanup - rename vaName, strengthen assertions

### DIFF
--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -228,11 +228,15 @@ var _ = Describe("Saturation Engine", func() {
 			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), fakeRecorder, sourceRegistry, testConfig)
 
 			By("Performing optimization loop")
-			// The variants are discovered from the annotated HPAs created above;
-			// the loop must complete without error. Metric emission (not CRD status)
-			// is the engine's output, so there is no VA status to assert on.
 			err := engine.optimize(ctx)
 			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Prometheus was queried for the discovered variants")
+			// Each annotated HPA is synthesized into an in-memory variant; the engine
+			// queries Prometheus for saturation metrics for each. Non-empty QueryCallCounts
+			// proves the variants were discovered and fed through the saturation pipeline.
+			Expect(mockPromAPI.QueryCallCounts).NotTo(BeEmpty(),
+				"engine should have queried Prometheus for at least one discovered variant")
 		})
 	})
 

--- a/test/e2e/annotation_discovery_test.go
+++ b/test/e2e/annotation_discovery_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 			})
 
 			By("Creating model service deployment WITH llm-d.ai/variant label")
-			// Pass hpaName as vaName so the pod template carries llm-d.ai/variant=<hpaName>.
+			// Pass hpaName as variantName so the pod template carries llm-d.ai/variant=<hpaName>.
 			err = fixtures.EnsureModelService(ctx, k8sClient, ns, modelServiceName, poolName, cfg.ModelID, hpaName, cfg.UseSimulator, cfg.MaxNumSeqs)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
 

--- a/test/e2e/fixtures/hpa_builder.go
+++ b/test/e2e/fixtures/hpa_builder.go
@@ -59,11 +59,11 @@ func WithScaleTargetRefKind(kind string) HPAOption {
 func CreateHPA(
 	ctx context.Context,
 	k8sClient *kubernetes.Clientset,
-	namespace, name, deploymentName, vaName string,
+	namespace, name, deploymentName, variantName string,
 	minReplicas, maxReplicas int32,
 	opts ...HPAOption,
 ) error {
-	hpa := buildHPA(namespace, name, deploymentName, vaName, minReplicas, maxReplicas, opts...)
+	hpa := buildHPA(namespace, name, deploymentName, variantName, minReplicas, maxReplicas, opts...)
 	_, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Create(ctx, hpa, metav1.CreateOptions{})
 	return err
 }
@@ -82,11 +82,11 @@ func DeleteHPA(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, 
 func EnsureHPA(
 	ctx context.Context,
 	k8sClient *kubernetes.Clientset,
-	namespace, name, deploymentName, vaName string,
+	namespace, name, deploymentName, variantName string,
 	minReplicas, maxReplicas int32,
 	opts ...HPAOption,
 ) error {
-	hpa := buildHPA(namespace, name, deploymentName, vaName, minReplicas, maxReplicas, opts...)
+	hpa := buildHPA(namespace, name, deploymentName, variantName, minReplicas, maxReplicas, opts...)
 	_, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(ctx, hpa.Name, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -109,7 +109,7 @@ func EnsureHPA(
 	return err
 }
 
-func buildHPA(namespace, name, deploymentName, vaName string, minReplicas, maxReplicas int32, opts ...HPAOption) *autoscalingv2.HorizontalPodAutoscaler {
+func buildHPA(namespace, name, deploymentName, variantName string, minReplicas, maxReplicas int32, opts ...HPAOption) *autoscalingv2.HorizontalPodAutoscaler {
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "-hpa",
@@ -132,7 +132,7 @@ func buildHPA(namespace, name, deploymentName, vaName string, minReplicas, maxRe
 							Name: "wva_desired_replicas",
 							Selector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"variant_name":       vaName,
+									"variant_name":       variantName,
 									"exported_namespace": namespace,
 								},
 							},

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -16,12 +16,11 @@ import (
 )
 
 // EnsureModelServiceLWS creates or replaces a LeaderWorkerSet for model service (idempotent for test setup).
-// vaName is the name of the VariantAutoscaling resource that will monitor this LWS;
-// it is stamped as the llm-d.ai/variant label on both leader and worker pod templates so
-// Prometheus metrics can be attributed to the correct VA. Pass "" if no VA monitors this LWS.
-func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespace, name, poolName, modelID, vaName string, useSimulator bool, maxNumSeqs int, groupSize int32) error {
+// variantName is stamped as the llm-d.ai/variant label on both leader and worker pod templates
+// so the collector can attribute pod metrics to the right annotated scaler. Pass "" to omit.
+func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespace, name, poolName, modelID, variantName string, useSimulator bool, maxNumSeqs int, groupSize int32) error {
 	lwsName := name + decodeNameSuffix
-	desiredLWS := buildModelServiceLWS(namespace, name, poolName, modelID, vaName, useSimulator, maxNumSeqs, groupSize)
+	desiredLWS := buildModelServiceLWS(namespace, name, poolName, modelID, variantName, useSimulator, maxNumSeqs, groupSize)
 
 	// Check if LWS already exists
 	existingLWS := &lwsv1.LeaderWorkerSet{}
@@ -104,7 +103,7 @@ func DeleteModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 	return nil
 }
 
-func buildModelServiceLWS(namespace, name, poolName, modelID, vaName string, useSimulator bool, maxNumSeqs int, groupSize int32) *lwsv1.LeaderWorkerSet {
+func buildModelServiceLWS(namespace, name, poolName, modelID, variantName string, useSimulator bool, maxNumSeqs int, groupSize int32) *lwsv1.LeaderWorkerSet {
 	appLabel := name + decodeNameSuffix
 	image := defaultModelServiceSimulatorImage
 	if !useSimulator {
@@ -121,8 +120,8 @@ func buildModelServiceLWS(namespace, name, poolName, modelID, vaName string, use
 		"llm-d.ai/inference-serving":   defaultLabelValueTrue,
 		"llm-d.ai/accelerator-variant": defaultAcceleratorVariantValue,
 	}
-	if vaName != "" {
-		labels["llm-d.ai/variant"] = vaName
+	if variantName != "" {
+		labels["llm-d.ai/variant"] = variantName
 	}
 
 	envVars := []corev1.EnvVar{

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -19,11 +19,11 @@ import (
 // CreateModelService creates the model-server Deployment only (name + "-decode").
 // It does not create a Kubernetes Service; callers must use CreateService or EnsureService
 // (typically naming the Service name + "-service") to expose the deployment.
-// vaName is the name of the VariantAutoscaling resource that will monitor this deployment;
-// it is stamped as the llm-d.ai/variant label on the pod template so Prometheus metrics
-// can be attributed to the correct VA. Pass "" if no VA monitors this deployment.
-func CreateModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID, vaName string, useSimulator bool, maxNumSeqs int) error {
-	return CreateModelServiceWithExtraArgs(ctx, k8sClient, namespace, name, poolName, modelID, vaName, useSimulator, maxNumSeqs, nil)
+// variantName is stamped as the llm-d.ai/variant label on the pod template so the
+// collector can attribute pod metrics to the right annotated scaler. Pass "" to omit
+// the label (no WVA-managed scaler targets this deployment).
+func CreateModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID, variantName string, useSimulator bool, maxNumSeqs int) error {
+	return CreateModelServiceWithExtraArgs(ctx, k8sClient, namespace, name, poolName, modelID, variantName, useSimulator, maxNumSeqs, nil)
 }
 
 // CreateModelServiceWithExtraArgs is like CreateModelService but appends additional
@@ -36,8 +36,8 @@ func CreateModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 // the container to crash-loop if passed to the wrong runtime. Tests that use
 // simulator-only flags should gate their suite on `cfg.UseSimulator` and Skip
 // otherwise.
-func CreateModelServiceWithExtraArgs(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID, vaName string, useSimulator bool, maxNumSeqs int, extraArgs []string) error {
-	deployment := buildModelServiceDeployment(namespace, name, poolName, modelID, vaName, useSimulator, maxNumSeqs, extraArgs)
+func CreateModelServiceWithExtraArgs(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID, variantName string, useSimulator bool, maxNumSeqs int, extraArgs []string) error {
+	deployment := buildModelServiceDeployment(namespace, name, poolName, modelID, variantName, useSimulator, maxNumSeqs, extraArgs)
 	_, err := k8sClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	return err
 }
@@ -54,13 +54,12 @@ func DeleteModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 
 // EnsureModelService creates or replaces the model-server Deployment only (name + "-decode").
 // It does not create a Kubernetes Service; pair with EnsureService for a ClusterIP Service.
-// vaName is the name of the VariantAutoscaling resource that will monitor this deployment;
-// it is stamped as the llm-d.ai/variant label on the pod template so Prometheus metrics
-// can be attributed to the correct VA. Pass "" if no VA monitors this deployment.
-func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID, vaName string, useSimulator bool, maxNumSeqs int) error {
+// variantName is stamped as the llm-d.ai/variant label on the pod template so the
+// collector can attribute pod metrics to the right annotated scaler. Pass "" to omit.
+func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID, variantName string, useSimulator bool, maxNumSeqs int) error {
 	appLabel := name + decodeNameSuffix
 	deploymentName := appLabel
-	desiredDeployment := buildModelServiceDeployment(namespace, name, poolName, modelID, vaName, useSimulator, maxNumSeqs, nil)
+	desiredDeployment := buildModelServiceDeployment(namespace, name, poolName, modelID, variantName, useSimulator, maxNumSeqs, nil)
 
 	existingDeployment, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 	if err != nil {
@@ -103,7 +102,7 @@ func modelServiceDeploymentMatchesDesired(existing, desired appsv1.Deployment) b
 		apiequality.Semantic.DeepEqual(existing.Spec.Template.Spec, desired.Spec.Template.Spec)
 }
 
-func buildModelServiceDeployment(namespace, name, poolName, modelID, vaName string, useSimulator bool, maxNumSeqs int, extraArgs []string) *appsv1.Deployment {
+func buildModelServiceDeployment(namespace, name, poolName, modelID, variantName string, useSimulator bool, maxNumSeqs int, extraArgs []string) *appsv1.Deployment {
 	appLabel := name + decodeNameSuffix
 	image := defaultModelServiceSimulatorImage
 	if !useSimulator {
@@ -120,8 +119,8 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID, vaName stri
 		"llm-d.ai/inference-serving":   defaultLabelValueTrue,
 		"llm-d.ai/accelerator-variant": defaultAcceleratorVariantValue,
 	}
-	if vaName != "" {
-		labels["llm-d.ai/variant"] = vaName
+	if variantName != "" {
+		labels["llm-d.ai/variant"] = variantName
 	}
 
 	envVars := []corev1.EnvVar{

--- a/test/e2e/fixtures/scaled_object_builder.go
+++ b/test/e2e/fixtures/scaled_object_builder.go
@@ -57,12 +57,12 @@ func WithScaledObjectWVAAnnotations(modelID, cost string) ScaledObjectOption {
 func CreateScaledObject(
 	ctx context.Context,
 	crClient client.Client,
-	namespace, name, scaleTargetName, vaName string,
+	namespace, name, scaleTargetName, variantName string,
 	minReplicas, maxReplicas int32,
 	monitoringNamespace string,
 	opts ...ScaledObjectOption,
 ) error {
-	return crClient.Create(ctx, buildScaledObject(namespace, name, scaleTargetName, vaName, minReplicas, maxReplicas, monitoringNamespace, opts...))
+	return crClient.Create(ctx, buildScaledObject(namespace, name, scaleTargetName, variantName, minReplicas, maxReplicas, monitoringNamespace, opts...))
 }
 
 // scaledObjectRef returns a minimal typed object for ScaledObject identity (Get/Delete).
@@ -89,12 +89,12 @@ func DeleteScaledObject(ctx context.Context, crClient client.Client, namespace, 
 func EnsureScaledObject(
 	ctx context.Context,
 	crClient client.Client,
-	namespace, name, scaleTargetName, vaName string,
+	namespace, name, scaleTargetName, variantName string,
 	minReplicas, maxReplicas int32,
 	monitoringNamespace string,
 	opts ...ScaledObjectOption,
 ) error {
-	obj := buildScaledObject(namespace, name, scaleTargetName, vaName, minReplicas, maxReplicas, monitoringNamespace, opts...)
+	obj := buildScaledObject(namespace, name, scaleTargetName, variantName, minReplicas, maxReplicas, monitoringNamespace, opts...)
 	existing := scaledObjectRef(namespace, name)
 	key := client.ObjectKey{Namespace: namespace, Name: obj.GetName()}
 	err := crClient.Get(ctx, key, existing)
@@ -119,12 +119,12 @@ func EnsureScaledObject(
 	return crClient.Create(ctx, obj)
 }
 
-func buildScaledObject(namespace, name, scaleTargetName, vaName string, minReplicas, maxReplicas int32, monitoringNamespace string, opts ...ScaledObjectOption) *kedav1alpha1.ScaledObject {
+func buildScaledObject(namespace, name, scaleTargetName, variantName string, minReplicas, maxReplicas int32, monitoringNamespace string, opts ...ScaledObjectOption) *kedav1alpha1.ScaledObject {
 	objName := name + scaledObjectSuffix
 	prometheusURL := "https://kube-prometheus-stack-prometheus." + monitoringNamespace + ".svc.cluster.local:9090"
 	// Use "namespace" not "exported_namespace": WVA controller emits the metric with label namespace;
 	// exported_namespace is only used by Prometheus Adapter for the external metrics API.
-	query := fmt.Sprintf("wva_desired_replicas{variant_name=%q,namespace=%q}", vaName, namespace)
+	query := fmt.Sprintf("wva_desired_replicas{variant_name=%q,namespace=%q}", variantName, namespace)
 
 	spec := kedav1alpha1.ScaledObjectSpec{
 		ScaleTargetRef: &kedav1alpha1.ScaleTarget{

--- a/test/e2e/fixtures/sglang_emulator_builder.go
+++ b/test/e2e/fixtures/sglang_emulator_builder.go
@@ -26,7 +26,7 @@ const (
 // sglangEmitterScript is served at :8000/metrics. Counters grow with elapsed time
 // so rate()/increase() are non-zero; gauges hold a fixed saturated operating
 // point. The served model name is read from the MODEL env var so it matches the
-// VariantAutoscaling's modelID.
+// model ID annotation on the annotated scaler.
 const sglangEmitterScript = `import os, time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -84,11 +84,10 @@ HTTPServer(("0.0.0.0", 8000), H).serve_forever()
 // it as SGLang. It creates a ConfigMap ("<name>-sglang-script") and a Deployment
 // ("<name>-decode").
 //
-// Pair it with CreateService/EnsureServiceMonitor (appLabel "<name>-decode") and a
-// VariantAutoscaling whose ScaleTargetRef.Name is "<name>-decode". vaName is
-// stamped as the llm-d.ai/variant pod label for metric attribution (pass "" to
-// skip). The emitted metrics carry model_name == modelID.
-func CreateSGLangEmulator(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, modelID, vaName string) error {
+// Pair it with CreateService/EnsureServiceMonitor (appLabel "<name>-decode").
+// variantName is stamped as the llm-d.ai/variant pod label for metric attribution
+// (pass "" to skip). The emitted metrics carry model_name == modelID.
+func CreateSGLangEmulator(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, modelID, variantName string) error {
 	appLabel := name + decodeNameSuffix
 	cmName := name + sglangScriptSuffix
 
@@ -109,8 +108,8 @@ func CreateSGLangEmulator(ctx context.Context, k8sClient *kubernetes.Clientset, 
 		"llm-d.ai/inferenceServing": defaultLabelValueTrue,
 		"test-resource":             defaultTestResourceLabelValue,
 	}
-	if vaName != "" {
-		labels["llm-d.ai/variant"] = vaName
+	if variantName != "" {
+		labels["llm-d.ai/variant"] = variantName
 	}
 
 	deployment := &appsv1.Deployment{

--- a/test/e2e/multi_controller_test.go
+++ b/test/e2e/multi_controller_test.go
@@ -250,10 +250,9 @@ var _ = Describe("Multi-controller Tests - Dual namespace-scoped isolation", Lab
 			})
 
 			// Stamp the controller-instance label on the secondary HPA so WVA's
-			// annotation discovery attributes its synthesized variant to the secondary
-			// controller (VariantAutoscalingFromHPA copies HPA labels; readyVariantAutoscalings
-			// filters by wva.llmd.ai/controller-instance). The primary HPA is left
-			// unlabeled so the cluster-scoped primary controller owns it.
+			// annotation discovery scopes it to the secondary controller.
+			// readyVariantAutoscalings filters synthesized variants by this label;
+			// the primary HPA is left unlabeled so the cluster-scoped primary controller owns it.
 			By("Labeling the secondary HPA with the controller-instance for isolation")
 			secondaryHPA, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(secondaryNamespace).Get(ctx, sharedVariantName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Failed to read secondary HPA for labeling")
@@ -297,9 +296,7 @@ var _ = Describe("Multi-controller Tests - Dual namespace-scoped isolation", Lab
 				g.Expect(json.Unmarshal(raw, &metricList)).To(Succeed())
 				g.Expect(metricList.Items).To(HaveLen(1))
 				g.Expect(metricList.Items[0].MetricLabels["exported_namespace"]).To(Equal(secondaryNamespace))
-				if ci, ok := metricList.Items[0].MetricLabels["controller_instance"]; ok {
-					g.Expect(ci).To(Equal(controllerInstance))
-				}
+				g.Expect(metricList.Items[0].MetricLabels["controller_instance"]).To(Equal(controllerInstance))
 			}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 			By("Verifying both HPAs report active metric scaling")

--- a/test/e2e/saturation_analyzer_path_test.go
+++ b/test/e2e/saturation_analyzer_path_test.go
@@ -10,13 +10,11 @@ import (
 	. "github.com/onsi/gomega"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
 	testutils "github.com/llm-d/llm-d-workload-variant-autoscaler/test/utils"
 )
@@ -141,7 +139,7 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		// scaler and uses its OBJECT name as the variant_name label on
 		// wva_desired_replicas — that is base+"-so" for a KEDA ScaledObject and
 		// base+"-hpa" for an HPA. The decode pods must carry
-		// llm-d.ai/variant=<scaler object name> for metric attribution, so vaName is
+		// llm-d.ai/variant=<scaler object name> for metric attribution, so variantName is
 		// derived from the backend below.
 		scalerBaseName = "saturation-path"
 		hpaObjectName  = scalerBaseName + "-hpa"
@@ -155,10 +153,10 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		cmExistedBefore bool
 		cmKey           string
 		cmNamespace     string
-		// vaName is the variant_name — the scaler's object name — stamped as the
+		// variantName is the variant_name — the scaler's object name — stamped as the
 		// decode pods' llm-d.ai/variant label so the collector attributes their
 		// metrics to the variant. Set from the backend in BeforeAll.
-		vaName string
+		variantName string
 	)
 
 	BeforeAll(func() {
@@ -168,9 +166,9 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		}
 
 		if cfg.ScalerBackend == scalerBackendKeda {
-			vaName = soObjectName
+			variantName = soObjectName
 		} else {
-			vaName = hpaObjectName
+			variantName = hpaObjectName
 		}
 
 		modelID = cfg.ModelID
@@ -191,7 +189,7 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 
 		By("Creating model service + service + ServiceMonitor for saturation path test")
 		_ = fixtures.DeleteModelService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName)
-		err = fixtures.CreateModelServiceWithExtraArgs(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, poolName, modelID, vaName,
+		err = fixtures.CreateModelServiceWithExtraArgs(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, poolName, modelID, variantName,
 			cfg.UseSimulator, cfg.MaxNumSeqs, []string{"--fake-metrics", v1FakeMetricsJSON})
 		Expect(err).NotTo(HaveOccurred())
 		err = fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, 8000)
@@ -207,15 +205,15 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 		By("Registering the saturation-path deployment with WVA via an annotated scaler")
-		// The scaler's vaName (variant name) matches the model service's vaName so the
+		// The scaler's variantName (variant name) matches the model service's variantName so the
 		// decode pods' llm-d.ai/variant label and wva_desired_replicas variant_name align.
 		if cfg.ScalerBackend == scalerBackendKeda {
-			err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerBaseName, modelDecodeDeployment, vaName, 1, 10, cfg.MonitoringNS,
+			err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerBaseName, modelDecodeDeployment, variantName, 1, 10, cfg.MonitoringNS,
 				fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"))
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerBaseName) })
 		} else {
-			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, scalerBaseName, modelDecodeDeployment, vaName, 1, 10,
+			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, scalerBaseName, modelDecodeDeployment, variantName, 1, 10,
 				fixtures.WithWVAAnnotations(modelID, "30.0"))
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func() {
@@ -272,45 +270,14 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 
 	It("propagates saturation results into wva_desired_replicas for the variant", func() {
 		// WVA no longer writes VA .status; its sole output is wva_desired_replicas.
-		// We observe that through the scaler surface rather than a VA status field:
+		// expectWVARaisesDesiredReplicas observes that through the scaler surface:
 		// for KEDA via the managed HPA's CurrentMetrics, for the Prometheus-adapter
-		// backend via the external metrics API.
-		if cfg.ScalerBackend == scalerBackendKeda {
-			By("Verifying KEDA read wva_desired_replicas for the saturation-path variant")
-			Eventually(func(g Gomega) {
-				hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
-				g.Expect(err).NotTo(HaveOccurred())
-				var kedaHPA *autoscalingv2.HorizontalPodAutoscaler
-				for i := range hpaList.Items {
-					if hpaList.Items[i].Spec.ScaleTargetRef.Name == modelDecodeDeployment {
-						kedaHPA = &hpaList.Items[i]
-						break
-					}
-				}
-				g.Expect(kedaHPA).NotTo(BeNil(), "KEDA should have created an HPA for the saturation-path deployment")
-				g.Expect(kedaHPA.Status.CurrentMetrics).NotTo(BeEmpty(),
-					"KEDA HPA should have CurrentMetrics populated from wva_desired_replicas")
-			}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
-		} else {
-			By("Querying the external metrics API for wva_desired_replicas")
-			Eventually(func(g Gomega) {
-				result, err := k8sClient.RESTClient().
-					Get().
-					AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + cfg.LLMDNamespace + "/" + constants.WVADesiredReplicas).
-					DoRaw(ctx)
-				if err != nil {
-					if errors.IsNotFound(err) {
-						_, discoveryErr := k8sClient.Discovery().ServerResourcesForGroupVersion("external.metrics.k8s.io/v1beta1")
-						g.Expect(discoveryErr).NotTo(HaveOccurred(), "External metrics API should be accessible")
-						return
-					}
-					g.Expect(err).NotTo(HaveOccurred())
-				}
-				g.Expect(strings.Contains(string(result), `"items":[]`)).To(BeFalse(),
-					"wva_desired_replicas should be emitted for the saturation-path variant")
-				g.Expect(string(result)).To(ContainSubstring(constants.WVADesiredReplicas))
-			}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
-		}
+		// backend via the external metrics API. The scaler was created with
+		// minReplicas=1, so the emitted value is floored at 1 and > 0 cannot flake.
+		By("Verifying wva_desired_replicas was emitted and consumed for the saturation-path variant")
+		Eventually(func(g Gomega) {
+			expectWVARaisesDesiredReplicas(g, cfg.LLMDNamespace, variantName, modelDecodeDeployment, 0)
+		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 	})
 
 	It("does not scale the target deployment up for bounded below-threshold V1 traffic", func() {
@@ -398,7 +365,7 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		// (formerly VariantAutoscaling.Status.DesiredOptimizedAlloc), decoupled from
 		// the separate scaler actuation loop.
 		Eventually(func(g Gomega) {
-			expectWVARaisesDesiredReplicas(g, cfg.LLMDNamespace, vaName, modelDecodeDeployment, int64(baseline))
+			expectWVARaisesDesiredReplicas(g, cfg.LLMDNamespace, variantName, modelDecodeDeployment, int64(baseline))
 		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 	})
 

--- a/test/e2e/smoke_keda_test.go
+++ b/test/e2e/smoke_keda_test.go
@@ -93,10 +93,10 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 		poolName         = "smoke-test-pool"
 		modelServiceName = "smoke-test-ms"
 		deploymentName   = modelServiceName + "-decode"
-		// vaName is the variant name: it is used as the ScaledObject's variantName
-		// (the variant_name label on wva_desired_replicas) and as the
-		// llm-d.ai/variant pod label on the model service. The two must match.
-		vaName      = "smoke-test-va"
+		// variantName is both the ScaledObject's variant_name label selector value
+		// (on wva_desired_replicas) and the model service's llm-d.ai/variant pod
+		// label. The two must match for metric attribution.
+		variantName = "smoke-test-va"
 		scalerName  = "smoke-test-hpa" // base name; ScaledObject will be scalerName+"-so"
 		minReplicas = int32(1)
 	)
@@ -130,7 +130,7 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 		}
 
 		By("Creating model service deployment")
-		err = fixtures.EnsureModelService(ctx, k8sClient, ns, modelServiceName, poolName, cfg.ModelID, vaName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		err = fixtures.EnsureModelService(ctx, k8sClient, ns, modelServiceName, poolName, cfg.ModelID, variantName, cfg.UseSimulator, cfg.MaxNumSeqs)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
 
 		By("Creating service to expose model server")
@@ -149,7 +149,7 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 		By("Creating annotated ScaledObject (both WVA discovery source and scaler)")
-		err = fixtures.EnsureScaledObject(ctx, crClient, ns, scalerName, deploymentName, vaName, minReplicas, 10, cfg.MonitoringNS,
+		err = fixtures.EnsureScaledObject(ctx, crClient, ns, scalerName, deploymentName, variantName, minReplicas, 10, cfg.MonitoringNS,
 			fixtures.WithScaledObjectWVAAnnotations(cfg.ModelID, "30.0"))
 		Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject")
 	})
@@ -242,10 +242,10 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 		errorTestPoolName         = "error-test-pool"
 		errorTestModelServiceName = "error-test-ms"
 		errorTestDeploymentName   = errorTestModelServiceName + "-decode"
-		// errorTestVAName is the variant name used as the ScaledObject's
+		// errorTestVariantName is the variant name used as the ScaledObject's
 		// variantName and the model service's llm-d.ai/variant pod label.
-		errorTestVAName = "error-test-va"
-		errorScalerName = "error-test-hpa" // base name; ScaledObject will be errorScalerName+"-so"
+		errorTestVariantName = "error-test-va"
+		errorScalerName      = "error-test-hpa" // base name; ScaledObject will be errorScalerName+"-so"
 	)
 
 	BeforeAll(func() {
@@ -264,7 +264,7 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 		})
 
 		By("Creating model service deployment for error handling tests")
-		err = fixtures.EnsureModelService(ctx, k8sClient, ns, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVAName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		err = fixtures.EnsureModelService(ctx, k8sClient, ns, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVariantName, cfg.UseSimulator, cfg.MaxNumSeqs)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
 
 		By("Waiting for model service to be ready")
@@ -275,7 +275,7 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 		By("Creating annotated ScaledObject (both WVA discovery source and scaler)")
-		err = fixtures.EnsureScaledObject(ctx, crClient, ns, errorScalerName, errorTestDeploymentName, errorTestVAName, 1, 10, cfg.MonitoringNS,
+		err = fixtures.EnsureScaledObject(ctx, crClient, ns, errorScalerName, errorTestDeploymentName, errorTestVariantName, 1, 10, cfg.MonitoringNS,
 			fixtures.WithScaledObjectWVAAnnotations(cfg.ModelID, "30.0"))
 		Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject")
 	})
@@ -302,7 +302,7 @@ var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "fu
 		Expect(err).NotTo(HaveOccurred(), "ScaledObject should continue to exist after deployment deletion")
 
 		By("Recreating the deployment")
-		err = fixtures.EnsureModelService(ctx, k8sClient, ns, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVAName, cfg.UseSimulator, cfg.MaxNumSeqs)
+		err = fixtures.EnsureModelService(ctx, k8sClient, ns, errorTestModelServiceName, errorTestPoolName, cfg.ModelID, errorTestVariantName, cfg.UseSimulator, cfg.MaxNumSeqs)
 		Expect(err).NotTo(HaveOccurred(), "Failed to recreate model service")
 
 		By("Waiting for deployment to be ready after recreation")

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 			By("Creating annotated HPAs in both namespaces with the same base name (overlapping variant name)")
 			// Both HPAs share sharedHPABase, so each is named sharedVariantName within
 			// its namespace and WVA emits wva_desired_replicas{variant_name=sharedVariantName}
-			// for both — isolated only by exported_namespace. The vaName arg wires the
+			// for both — isolated only by exported_namespace. The variantName arg wires the
 			// HPA's own external-metric selector to the same variant_name/namespace.
 			err = fixtures.EnsureHPA(ctx, k8sClient, primaryNamespace, sharedHPABase, primaryModelName+"-decode", sharedVariantName, 1, 10,
 				fixtures.WithWVAAnnotations(cfg.ModelID, "30.0"))

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -251,7 +251,7 @@ var _ = BeforeSuite(func() {
 	GinkgoWriter.Println("BeforeSuite completed successfully - infrastructure ready")
 })
 
-// ReportAfterEach dumps controller logs and VA status after a failed test.
+// ReportAfterEach dumps controller logs and managed scaler state after a failed test.
 // This makes E2E failures self-contained and easier to debug (why scaling happened / didn't happen).
 var _ = ReportAfterEach(func(report SpecReport) {
 	if !report.Failed() {

--- a/test/e2e/throughput_analyzer_test.go
+++ b/test/e2e/throughput_analyzer_test.go
@@ -232,9 +232,9 @@ var _ = Describe("ThroughputAnalyzer wiring health check", Label("smoke", "throu
 		cmExistedBefore bool
 		cmKey           string
 		cmNamespace     string
-		// vaName is the variant_name — the annotated scaler's OBJECT name — stamped
+		// variantName is the variant_name — the annotated scaler's OBJECT name — stamped
 		// as the decode pods' llm-d.ai/variant label for metric attribution.
-		vaName string
+		variantName string
 	)
 
 	BeforeAll(func() {
@@ -243,9 +243,9 @@ var _ = Describe("ThroughputAnalyzer wiring health check", Label("smoke", "throu
 		cmNamespace = cfg.WVANamespace
 		cmKey = defaultConfigKey
 		if cfg.ScalerBackend == scalerBackendKeda {
-			vaName = modelSvcName + "-so"
+			variantName = modelSvcName + "-so"
 		} else {
-			vaName = modelSvcName + "-hpa"
+			variantName = modelSvcName + "-hpa"
 		}
 
 		cm, err := k8sClient.CoreV1().ConfigMaps(cmNamespace).Get(ctx, cmName, metav1.GetOptions{})
@@ -266,7 +266,7 @@ var _ = Describe("ThroughputAnalyzer wiring health check", Label("smoke", "throu
 
 		By("Creating model service for throughput smoke test")
 		_ = fixtures.DeleteModelService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName)
-		Expect(fixtures.CreateModelService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, poolName, modelID, vaName, cfg.UseSimulator, 2)).To(Succeed())
+		Expect(fixtures.CreateModelService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, poolName, modelID, variantName, cfg.UseSimulator, 2)).To(Succeed())
 		Expect(fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, 8000)).To(Succeed())
 		Expect(fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment)).To(Succeed())
 
@@ -279,11 +279,11 @@ var _ = Describe("ThroughputAnalyzer wiring health check", Label("smoke", "throu
 
 		By("Registering the deployment with WVA via an annotated scaler (both analyzers enabled)")
 		if cfg.ScalerBackend == scalerBackendKeda {
-			Expect(fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, vaName, 1, 10, cfg.MonitoringNS,
+			Expect(fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, variantName, 1, 10, cfg.MonitoringNS,
 				fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"))).To(Succeed())
 			DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName) })
 		} else {
-			Expect(fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, vaName, 1, 10,
+			Expect(fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, variantName, 1, 10,
 				fixtures.WithWVAAnnotations(modelID, "30.0"))).To(Succeed())
 			DeferCleanup(func() {
 				_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, modelSvcName+"-hpa", metav1.DeleteOptions{})
@@ -358,7 +358,7 @@ var _ = Describe("ThroughputAnalyzer wiring health check", Label("smoke", "throu
 // ─── Scenario 2: Multi-Analyzer Engine Scale-Up (full/throughput) ─────────────
 //
 // Validates the multi-analyzer engine end-to-end: with BOTH analyzers registered,
-// the engine produces a scale-up decision that propagates to VA status. Scale-up is
+// the engine produces a scale-up decision that propagates to wva_desired_replicas. Scale-up is
 // driven by the SATURATION analyzer via a faked kv-cache-usage gauge — the throughput
 // analyzer's inputs are rates of counters/histograms that static --fake-metrics cannot
 // drive (zero rate), so throughput cannot be exercised here. Its own scale-up math is
@@ -381,11 +381,11 @@ var _ = Describe("Multi-analyzer engine scale-up (saturation-driven, throughput 
 		cmExistedBefore bool
 		cmKey           string
 		cmNamespace     string
-		// vaName is the variant_name — the annotated scaler's OBJECT name
+		// variantName is the variant_name — the annotated scaler's OBJECT name
 		// (modelSvcName+"-so" for KEDA, +"-hpa" for the adapter) — stamped as the
 		// decode pods' llm-d.ai/variant label so the collector attributes their
 		// metrics to the variant. Set from the backend below.
-		vaName string
+		variantName string
 	)
 
 	BeforeAll(func() {
@@ -394,9 +394,9 @@ var _ = Describe("Multi-analyzer engine scale-up (saturation-driven, throughput 
 		cmNamespace = cfg.WVANamespace
 		cmKey = defaultConfigKey
 		if cfg.ScalerBackend == scalerBackendKeda {
-			vaName = modelSvcName + "-so"
+			variantName = modelSvcName + "-so"
 		} else {
-			vaName = modelSvcName + "-hpa"
+			variantName = modelSvcName + "-hpa"
 		}
 
 		cm, err := k8sClient.CoreV1().ConfigMaps(cmNamespace).Get(ctx, cmName, metav1.GetOptions{})
@@ -422,7 +422,7 @@ var _ = Describe("Multi-analyzer engine scale-up (saturation-driven, throughput 
 
 		By("Creating model service with faked saturation metrics for scale-up")
 		_ = fixtures.DeleteModelService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName)
-		Expect(fixtures.CreateModelServiceWithExtraArgs(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, poolName, modelID, vaName,
+		Expect(fixtures.CreateModelServiceWithExtraArgs(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, poolName, modelID, variantName,
 			cfg.UseSimulator, 2, []string{"--fake-metrics", throughputScaleUpFakeMetricsJSON})).To(Succeed())
 		Expect(fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, 8000)).To(Succeed())
 		Expect(fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment)).To(Succeed())
@@ -436,11 +436,11 @@ var _ = Describe("Multi-analyzer engine scale-up (saturation-driven, throughput 
 
 		By("Registering the deployment with WVA via an annotated scaler (both analyzers enabled)")
 		if cfg.ScalerBackend == scalerBackendKeda {
-			Expect(fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, vaName, 1, 10, cfg.MonitoringNS,
+			Expect(fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, variantName, 1, 10, cfg.MonitoringNS,
 				fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"))).To(Succeed())
 			DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName) })
 		} else {
-			Expect(fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, vaName, 1, 10,
+			Expect(fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, variantName, 1, 10,
 				fixtures.WithWVAAnnotations(modelID, "30.0"))).To(Succeed())
 			DeferCleanup(func() {
 				_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, modelSvcName+"-hpa", metav1.DeleteOptions{})
@@ -481,7 +481,7 @@ var _ = Describe("Multi-analyzer engine scale-up (saturation-driven, throughput 
 		// (formerly VariantAutoscaling.Status.DesiredOptimizedAlloc), decoupled from
 		// the separate scaler actuation loop.
 		Eventually(func(g Gomega) {
-			expectWVARaisesDesiredReplicas(g, cfg.LLMDNamespace, vaName, modelDecodeDeployment, 1)
+			expectWVARaisesDesiredReplicas(g, cfg.LLMDNamespace, variantName, modelDecodeDeployment, 1)
 		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 	})
 })
@@ -505,9 +505,9 @@ var _ = Describe("ThroughputAnalyzer TA-only mode", Label("full", "throughput"),
 		cmExistedBefore bool
 		cmKey           string
 		cmNamespace     string
-		// vaName is the variant_name — the annotated scaler's OBJECT name — stamped
+		// variantName is the variant_name — the annotated scaler's OBJECT name — stamped
 		// as the decode pods' llm-d.ai/variant label for metric attribution.
-		vaName string
+		variantName string
 	)
 
 	BeforeAll(func() {
@@ -516,9 +516,9 @@ var _ = Describe("ThroughputAnalyzer TA-only mode", Label("full", "throughput"),
 		cmNamespace = cfg.WVANamespace
 		cmKey = defaultConfigKey
 		if cfg.ScalerBackend == scalerBackendKeda {
-			vaName = modelSvcName + "-so"
+			variantName = modelSvcName + "-so"
 		} else {
-			vaName = modelSvcName + "-hpa"
+			variantName = modelSvcName + "-hpa"
 		}
 
 		cm, err := k8sClient.CoreV1().ConfigMaps(cmNamespace).Get(ctx, cmName, metav1.GetOptions{})
@@ -539,7 +539,7 @@ var _ = Describe("ThroughputAnalyzer TA-only mode", Label("full", "throughput"),
 
 		By("Creating model service for TA-only test")
 		_ = fixtures.DeleteModelService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName)
-		Expect(fixtures.CreateModelService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, poolName, modelID, vaName, cfg.UseSimulator, 2)).To(Succeed())
+		Expect(fixtures.CreateModelService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, poolName, modelID, variantName, cfg.UseSimulator, 2)).To(Succeed())
 		Expect(fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, 8000)).To(Succeed())
 		Expect(fixtures.EnsureServiceMonitor(ctx, crClient, cfg.MonitoringNS, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment)).To(Succeed())
 
@@ -552,11 +552,11 @@ var _ = Describe("ThroughputAnalyzer TA-only mode", Label("full", "throughput"),
 
 		By("Registering the deployment with WVA via an annotated scaler (TA-only config)")
 		if cfg.ScalerBackend == scalerBackendKeda {
-			Expect(fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, vaName, 1, 10, cfg.MonitoringNS,
+			Expect(fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, variantName, 1, 10, cfg.MonitoringNS,
 				fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"))).To(Succeed())
 			DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, modelSvcName) })
 		} else {
-			Expect(fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, vaName, 1, 10,
+			Expect(fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, modelSvcName, modelDecodeDeployment, variantName, 1, 10,
 				fixtures.WithWVAAnnotations(modelID, "30.0"))).To(Succeed())
 			DeferCleanup(func() {
 				_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, modelSvcName+"-hpa", metav1.DeleteOptions{})


### PR DESCRIPTION
## Proposed Changes

Follow-up cleanup after #1390 removed the VariantAutoscaling CRD. No production code changes, test and fixture cleanup only.

- :broom: Rename `vaName` → `variantName` across all e2e fixture builders (`hpa_builder`, `scaled_object_builder`, `model_service_builder`, `lws_builder`, `sglang_emulator_builder`) and test locals; the parameter is the `variant_name` metric label / `llm-d.ai/variant` pod label, not a VA resource name
- :bug: Fix vacuous pass in `saturation_analyzer_path_test.go`: the NotFound branch inside `Eventually` returned early after a discovery check, so the test passed before `wva_desired_replicas` was ever emitted; the block now reuses `expectWVARaisesDesiredReplicas`, which retries on NotFound and asserts the value for both scaler backends
- :broom: Make the `controller_instance` label assertion in `multi_controller_test.go` unconditional — the old `if ok` guard silently passed when the label was missing, defeating the isolation check
- :broom: Strengthen the saturation engine unit test: after `optimize(ctx)`, assert `mockPromAPI.QueryCallCounts` is non-empty, proving annotation-discovered variants were fed through the pipeline (previously only "no error" was checked)
- :broom: Fix stale VA-era comments that misdescribed current behavior (engine output "propagates to VA status", `ReportAfterEach` "dumps VA status", sglang fixture "matches the VariantAutoscaling's modelID")

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A, no new behavior; this PR is e2e test cleanup
- [ ] **Docs PR** for any user-facing impact — N/A, no user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — N/A, internal test cleanup only

**Release Note**

```release-note
NONE
```

Docs

None needed — test-only cleanup with no user-facing impact.