### PR TITLE
chore: use main image tag for base manager kustomization

### DIFF
--- a/config/base/manager/kustomization.yaml
+++ b/config/base/manager/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
-  newTag: v0.7.0
+  newTag: main


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
- on main branch we should not  use a fix image tag
- 0.7.0 went stable after 0.8.0 is release
- current we do not directly create manifests from here use main is better than use 0.8.0

## Proposed Changes
- :bug: Fix bug


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior
