### PR TITLE
RBAC: remove update, watch privs for node, node/status

### DIFF
--- a/config/base/rbac/manager-clusterrole.yaml
+++ b/config/base/rbac/manager-clusterrole.yaml
@@ -9,6 +9,8 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - nodes
+  - nodes/status
   - pods
   - resourcequotas
   - secrets
@@ -30,17 +32,6 @@ rules:
   verbs:
   - create
   - patch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  - nodes/status
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - apps
   resources:

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -16,8 +16,8 @@ package controller
 // +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets/scale,verbs=get;update
 
 // Node inventory for accelerator/capacity discovery.
-// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups="",resources=nodes/status,verbs=get;list;update;patch;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes/status,verbs=get;list;watch
 
 // Core resources read during optimization and metrics collection.
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch

--- a/internal/controller/rbac_test.go
+++ b/internal/controller/rbac_test.go
@@ -1,0 +1,52 @@
+package controller_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRBACMarkersLeastPrivilege verifies kubebuilder:rbac markers follow least-privilege.
+func TestRBACMarkersLeastPrivilege(t *testing.T) {
+	rbacFile := "rbac.go"
+	content, err := os.ReadFile(rbacFile)
+	require.NoError(t, err, "Failed to read rbac.go")
+
+	rbacContent := string(content)
+
+	// Nodes should only have read verbs (get;list;watch), not write (update;patch)
+	t.Run("nodes permissions are read-only", func(t *testing.T) {
+		assert.NotContains(t, rbacContent, `resources=nodes,verbs=get;list;watch;update;patch`,
+			"nodes should not have update;patch verbs (controller only lists nodes for GPU discovery)")
+		assert.Contains(t, rbacContent, `resources=nodes,verbs=get;list;watch`,
+			"nodes should have read-only verbs")
+	})
+
+	// nodes/status should only have read verbs
+	t.Run("nodes/status permissions are read-only", func(t *testing.T) {
+		assert.NotContains(t, rbacContent, `resources=nodes/status,verbs=get;list;update;patch;watch`,
+			"nodes/status should not have update;patch verbs (unused write permissions)")
+		assert.Contains(t, rbacContent, `resources=nodes/status,verbs=get;list;watch`,
+			"nodes/status should have read-only verbs")
+	})
+
+	// ConfigMaps cluster-wide should only have read verbs (reconciler is read-only)
+	t.Run("configmaps permissions are read-only at cluster scope", func(t *testing.T) {
+		// The rbac.go file grants cluster-wide configmap permissions
+		// configmap_reconciler.go has its own read-only marker, but rbac.go shouldn't grant update
+		lines := strings.Split(rbacContent, "\n")
+		for i, line := range lines {
+			if strings.Contains(line, `resources=configmaps`) &&
+				!strings.Contains(line, "configmaps/status") &&
+				strings.Contains(line, "rbac.go") {
+				// Check that this line or nearby context doesn't grant update verb
+				context := strings.Join(lines[max(0, i-2):min(len(lines), i+3)], "\n")
+				assert.NotContains(t, context, "update",
+					"configmaps should not have update verb in cluster-wide RBAC marker")
+			}
+		}
+	})
+}


### PR DESCRIPTION
Fixes #

- This issue was flagged by a security scan in downstream to reduce privileges on node, node/status to minimum required by WVA manager.
- Verified the fix by enabled limiter mode and ensured the WVA still can list nodes.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [N/A] **E2E tests** for any new behavior
- [N/A] **Docs PR** for any user-facing impact
- [N/A] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
N/A
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
N/A
