### PR TITLE
RBAC: reduce WVA manager Secret privs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -333,7 +333,6 @@ func main() {
 	}
 
 	watchNS := cfg.WatchNamespace()
-	secretNS := config.SystemNamespace()
 	if watchNS != "" {
 		setupLog.Info("Watching single namespace", "namespace", watchNS)
 		mgrOptions.Cache = cache.Options{
@@ -348,12 +347,10 @@ func main() {
 			"app.kubernetes.io/name": "workload-variant-autoscaler",
 		})
 
-		setupLog.Info("Configuring cache with label selector for ConfigMaps and namespace-scoped Secrets",
-			"labelSelector", wvaConfigSelector.String(),
-			"secretNamespace", secretNS)
+		setupLog.Info("Configuring cache with label selector for ConfigMaps",
+			"labelSelector", wvaConfigSelector.String())
 
-		// Configure cache to only watch configmaps with the WVA labels and
-		// secrets in the controller namespace (for epp-metrics-token).
+		// Configure cache to only watch configmaps with the WVA labels.
 		// Other resource types are cached normally without filtering.
 		mgrOptions.Cache = cache.Options{
 			ByObject: map[client.Object]cache.ByObject{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -333,6 +333,7 @@ func main() {
 	}
 
 	watchNS := cfg.WatchNamespace()
+	secretNS := config.SystemNamespace()
 	if watchNS != "" {
 		setupLog.Info("Watching single namespace", "namespace", watchNS)
 		mgrOptions.Cache = cache.Options{
@@ -347,17 +348,24 @@ func main() {
 			"app.kubernetes.io/name": "workload-variant-autoscaler",
 		})
 
-		setupLog.Info("Configuring cache with label selector for ConfigMaps",
-			"labelSelector", wvaConfigSelector.String())
+		setupLog.Info("Configuring cache with label selector for ConfigMaps and namespace-scoped Secrets",
+			"labelSelector", wvaConfigSelector.String(),
+			"secretNamespace", secretNS)
 
-		// Configure cache to only watch configmaps with the WVA labels
-		// Other resource types are cached normally without filtering
+		// Configure cache to only watch configmaps with the WVA labels and
+		// secrets in the controller namespace (for epp-metrics-token).
+		// Other resource types are cached normally without filtering.
 		mgrOptions.Cache = cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.ConfigMap{}: {
 					// Empty map means cache all namespaces, but filter by label
 					Namespaces: map[string]cache.Config{},
 					Label:      wvaConfigSelector,
+				},
+				&corev1.Secret{}: {
+					Namespaces: map[string]cache.Config{
+						secretNS: {}, // tells the informer to only sync secrets from the one namespace
+					},
 				},
 			},
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -362,11 +362,6 @@ func main() {
 					Namespaces: map[string]cache.Config{},
 					Label:      wvaConfigSelector,
 				},
-				&corev1.Secret{}: {
-					Namespaces: map[string]cache.Config{
-						secretNS: {}, // tells the informer to only sync secrets from the one namespace
-					},
-				},
 			},
 		}
 	}
@@ -540,6 +535,7 @@ func main() {
 	inferencePoolReconciler := &controller.InferencePoolReconciler{
 		Datastore: ds,
 		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
 		PoolGKNN:  poolGKNN,
 	}
 

--- a/config/base/kustomizeconfig.yaml
+++ b/config/base/kustomizeconfig.yaml
@@ -5,6 +5,12 @@ nameReference:
   - kind: Secret
     path: metadata/annotations/kubernetes.io\/service-account.name
     create: false
+- kind: Secret
+  version: v1
+  fieldSpecs:
+  - kind: Role
+    path: rules/resourceNames
+    create: false
 # Track Secret renames inside ServiceMonitor's bearerTokenSecret.name so
 # overlay JSON patches can use the unprefixed Secret name and have kustomize
 # apply namePrefix/nameSuffix automatically.

--- a/config/base/rbac/epp-metrics-role.yaml
+++ b/config/base/rbac/epp-metrics-role.yaml
@@ -10,7 +10,7 @@ rules:
   - ""
   resources:
   - secrets
+  resourceNames:
+  - epp-metrics-token
   verbs:
   - get
-  - list
-  - watch

--- a/config/base/rbac/epp-metrics-role.yaml
+++ b/config/base/rbac/epp-metrics-role.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: epp-metrics-role
+  labels:
+    app.kubernetes.io/name: workload-variant-autoscaler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/base/rbac/epp-metrics-rolebinding.yaml
+++ b/config/base/rbac/epp-metrics-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: epp-metrics-rolebinding
+  labels:
+    app.kubernetes.io/name: workload-variant-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: epp-metrics-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager

--- a/config/base/rbac/kustomization.yaml
+++ b/config/base/rbac/kustomization.yaml
@@ -16,3 +16,6 @@ resources:
 - epp-metrics-reader-clusterrole.yaml
 - epp-metrics-reader-clusterrolebinding.yaml
 - epp-metrics-token-secret.yaml
+# EPP metrics token: namespaced Role for epp-metrics-token Secret access.
+- epp-metrics-role.yaml
+- epp-metrics-rolebinding.yaml

--- a/config/base/rbac/manager-clusterrole.yaml
+++ b/config/base/rbac/manager-clusterrole.yaml
@@ -13,7 +13,6 @@ rules:
   - nodes/status
   - pods
   - resourcequotas
-  - secrets
   - services
   verbs:
   - get

--- a/internal/collector/source/pod/pod_scraping_source.go
+++ b/internal/collector/source/pod/pod_scraping_source.go
@@ -32,6 +32,7 @@ import (
 type PodScrapingSource struct {
 	config     PodScrapingSourceConfig
 	k8sClient  client.Client
+	apiReader  client.Reader
 	httpClient *http.Client
 	registry   *source.QueryList
 
@@ -43,6 +44,7 @@ type PodScrapingSource struct {
 func NewPodScrapingSource(
 	ctx context.Context,
 	k8sClient client.Client,
+	apiReader client.Reader,
 	config PodScrapingSourceConfig,
 ) (*PodScrapingSource, error) {
 	// Validate required fields
@@ -81,6 +83,7 @@ func NewPodScrapingSource(
 	podSource := &PodScrapingSource{
 		config:     config,
 		k8sClient:  k8sClient,
+		apiReader:  apiReader,
 		httpClient: httpClient,
 		registry:   source.NewQueryList(),
 		cache:      source.NewCache(ctx, config.DefaultTTL, 1*time.Second),
@@ -335,7 +338,7 @@ func (p *PodScrapingSource) getAuthToken(ctx context.Context) (string, bool, err
 		Namespace: secretNamespace,
 	}
 
-	if err := p.k8sClient.Get(ctx, secretKey, secret); err != nil {
+	if err := p.apiReader.Get(ctx, secretKey, secret); err != nil {
 		// Secret doesn't exist - treat authentication as optional
 		// Return no error, just indicate auth should not be used
 		return "", false, nil

--- a/internal/collector/source/pod/pod_scraping_source_test.go
+++ b/internal/collector/source/pod/pod_scraping_source_test.go
@@ -43,7 +43,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			source, err := NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(source).NotTo(BeNil())
 			Expect(source.config.ServiceName).To(Equal("test-pool-epp"))
@@ -54,7 +54,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			_, err := NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			_, err := NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("ServiceName is required"))
 		})
@@ -64,7 +64,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceName: "test-pool-epp",
 				MetricsPort: 9090,
 			}
-			_, err := NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			_, err := NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("ServiceNamespace is required"))
 		})
@@ -75,7 +75,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			source, err := NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(source.config.MetricsPath).To(Equal("/metrics"))
 			Expect(source.config.MetricsScheme).To(Equal("http"))
@@ -93,7 +93,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			_, err := NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			_, err := NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("ServiceName is required"))
 		})
@@ -232,7 +232,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			pods, err := source.discoverPods(ctx)
@@ -250,7 +250,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = source.discoverPods(ctx)
@@ -268,7 +268,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			pods, err := source.discoverPods(ctx)
@@ -298,7 +298,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			pods, err := source.discoverPods(ctx)
@@ -327,7 +327,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			pods, err := source.discoverPods(ctx)
@@ -362,7 +362,7 @@ var _ = Describe("PodScrapingSource", func() {
 				MetricsPort:             9090,
 				MetricsReaderSecretName: "inference-gateway-sa-metrics-reader-secret",
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			token, useAuth, err := source.getAuthToken(ctx)
@@ -380,7 +380,7 @@ var _ = Describe("PodScrapingSource", func() {
 				BearerToken:      "explicit-token",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			token, useAuth, err := source.getAuthToken(ctx)
@@ -397,7 +397,7 @@ var _ = Describe("PodScrapingSource", func() {
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			token, useAuth, err := source.getAuthToken(ctx)
@@ -418,7 +418,7 @@ var _ = Describe("PodScrapingSource", func() {
 				MetricsPort:             9090,
 				MetricsReaderSecretName: "inference-gateway-sa-metrics-reader-secret",
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			token, useAuth, err := source.getAuthToken(ctx)
@@ -436,7 +436,7 @@ var _ = Describe("PodScrapingSource", func() {
 				MetricsPort:             9090,
 				MetricsReaderSecretName: "", // Empty - no auth
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			token, useAuth, err := source.getAuthToken(ctx)
@@ -456,7 +456,7 @@ var _ = Describe("PodScrapingSource", func() {
 				MetricsPort:      9090,
 			}
 			var err error
-			source, err = NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			source, err = NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -677,7 +677,7 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 				MaxConcurrentScrapes:    10,
 				MetricsReaderSecretName: "inference-gateway-sa-metrics-reader-secret",
 			}
-			source1, err := NewPodScrapingSource(ctx, client1, config1)
+			source1, err := NewPodScrapingSource(ctx, client1, client1, config1)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Test scraping from first pod
@@ -735,7 +735,7 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 				MetricsPort:      9090,
 				ScrapeTimeout:    1 * time.Second, // Short timeout
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should return empty results (not error) when pods are unreachable
@@ -804,7 +804,7 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 				ScrapeTimeout:           1 * time.Second,
 				MetricsReaderSecretName: "inference-gateway-sa-metrics-reader-secret",
 			}
-			source, err := NewPodScrapingSource(ctx, client, config)
+			source, err := NewPodScrapingSource(ctx, client, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should handle auth failure gracefully (empty results, not error)
@@ -826,7 +826,7 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 				MetricsPort:      9090,
 			}
 			var err error
-			source, err = NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			source, err = NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -956,7 +956,7 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 				DefaultTTL:       1 * time.Hour, // Long TTL for testing
 			}
 			var err error
-			source, err = NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			source, err = NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -1030,7 +1030,7 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 				ServiceNamespace: "test-ns",
 				MetricsPort:      9090,
 			}
-			source, err := NewPodScrapingSource(ctx, fakeClient.Build(), config)
+			source, err := NewPodScrapingSource(ctx, fakeClient.Build(), nil, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			registry := source.QueryList()
@@ -1120,7 +1120,7 @@ var _ = Describe("Error metrics recording", func() {
 			ScrapeTimeout:    500 * time.Millisecond,
 		}
 
-		source, err := NewPodScrapingSource(ctx, client, config)
+		source, err := NewPodScrapingSource(ctx, client, client, config)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Refresh should not error but scraping will fail

--- a/internal/controller/inferencepool_reconciler.go
+++ b/internal/controller/inferencepool_reconciler.go
@@ -34,6 +34,7 @@ import (
 
 type InferencePoolReconciler struct {
 	client.Client
+	APIReader client.Reader
 	Datastore datastore.Datastore
 	PoolGKNN  common.GKNN
 }
@@ -94,7 +95,7 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if endpointPool != nil {
-		if err := c.Datastore.PoolSet(ctx, c.Client, endpointPool); err != nil {
+		if err := c.Datastore.PoolSet(ctx, c.Client, c.APIReader, endpointPool); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add endpoint into the datastore: - %w", err)
 		}
 	}

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -22,7 +22,8 @@ package controller
 // Core resources read during optimization and metrics collection.
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// Secrets: namespaced Role (config/base/rbac/epp-metrics-role.yaml) grants
+// get on epp-metrics-token in the controller namespace.
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // Note: Namespace watch permission is required for label-based namespace opt-in for namespace-local ConfigMaps.
 

--- a/internal/controller/rbac_test.go
+++ b/internal/controller/rbac_test.go
@@ -50,7 +50,7 @@ func TestRBACMarkersLeastPrivilege(t *testing.T) {
 }
 
 // TestSecretRBACIsNamespaced verifies cluster-wide Secret permissions are replaced
-// with a namespaced Role for epp-metrics-token.
+// with a namespaced Role scoped to the epp-metrics-token secret.
 func TestSecretRBACIsNamespaced(t *testing.T) {
 	rbacDir := filepath.Join("..", "..", "config", "base", "rbac")
 
@@ -69,11 +69,10 @@ func TestSecretRBACIsNamespaced(t *testing.T) {
 		role := string(content)
 		assert.Contains(t, role, "kind: Role", "Should be a namespaced Role, not ClusterRole")
 		assert.Contains(t, role, "- secrets", "Should grant permissions on secrets")
-		assert.NotContains(t, role, "resourceNames",
-			"Should not use resourceNames (incompatible with list/watch verbs)")
+		assert.Contains(t, role, "- epp-metrics-token", "Should scope to specific secret name")
 		assert.Contains(t, role, "- get", "Should grant get verb")
-		assert.Contains(t, role, "- list", "Should grant list verb (required by informer cache)")
-		assert.Contains(t, role, "- watch", "Should grant watch verb (required by informer cache)")
+		assert.NotContains(t, role, "- list", "Should not grant list (not needed with resourceNames)")
+		assert.NotContains(t, role, "- watch", "Should not grant watch (not needed with resourceNames)")
 	})
 
 	t.Run("RoleBinding binds manager ServiceAccount to Role", func(t *testing.T) {

--- a/internal/controller/rbac_test.go
+++ b/internal/controller/rbac_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -35,18 +36,64 @@ func TestRBACMarkersLeastPrivilege(t *testing.T) {
 
 	// ConfigMaps cluster-wide should only have read verbs (reconciler is read-only)
 	t.Run("configmaps permissions are read-only at cluster scope", func(t *testing.T) {
-		// The rbac.go file grants cluster-wide configmap permissions
-		// configmap_reconciler.go has its own read-only marker, but rbac.go shouldn't grant update
 		lines := strings.Split(rbacContent, "\n")
 		for i, line := range lines {
 			if strings.Contains(line, `resources=configmaps`) &&
 				!strings.Contains(line, "configmaps/status") &&
 				strings.Contains(line, "rbac.go") {
-				// Check that this line or nearby context doesn't grant update verb
 				context := strings.Join(lines[max(0, i-2):min(len(lines), i+3)], "\n")
 				assert.NotContains(t, context, "update",
 					"configmaps should not have update verb in cluster-wide RBAC marker")
 			}
 		}
+	})
+}
+
+// TestSecretRBACIsNamespaced verifies cluster-wide Secret permissions are replaced
+// with a namespaced Role for epp-metrics-token.
+func TestSecretRBACIsNamespaced(t *testing.T) {
+	rbacDir := filepath.Join("..", "..", "config", "base", "rbac")
+
+	t.Run("cluster-wide secret permissions removed from ClusterRole", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(rbacDir, "manager-clusterrole.yaml"))
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(content), "- secrets",
+			"Secrets should not have cluster-wide permissions in ClusterRole")
+	})
+
+	t.Run("namespaced Role grants get on epp-metrics-token", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(rbacDir, "epp-metrics-role.yaml"))
+		require.NoError(t, err)
+
+		role := string(content)
+		assert.Contains(t, role, "kind: Role", "Should be a namespaced Role, not ClusterRole")
+		assert.Contains(t, role, "- secrets", "Should grant permissions on secrets")
+		assert.NotContains(t, role, "resourceNames",
+			"Should not use resourceNames (incompatible with list/watch verbs)")
+		assert.Contains(t, role, "- get", "Should grant get verb")
+		assert.Contains(t, role, "- list", "Should grant list verb (required by informer cache)")
+		assert.Contains(t, role, "- watch", "Should grant watch verb (required by informer cache)")
+	})
+
+	t.Run("RoleBinding binds manager ServiceAccount to Role", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(rbacDir, "epp-metrics-rolebinding.yaml"))
+		require.NoError(t, err)
+
+		binding := string(content)
+		assert.Contains(t, binding, "kind: RoleBinding", "Should be a RoleBinding")
+		assert.Contains(t, binding, "name: controller-manager", "Should bind controller-manager ServiceAccount")
+		assert.Contains(t, binding, "name: epp-metrics-role", "Should reference epp-metrics-role")
+	})
+
+	t.Run("cluster-wide secret marker removed from rbac.go", func(t *testing.T) {
+		content, err := os.ReadFile("rbac.go")
+		require.NoError(t, err)
+
+		rbacContent := string(content)
+		assert.NotContains(t, rbacContent, `resources=secrets`,
+			"rbac.go should not have a kubebuilder:rbac marker for secrets (moved to namespaced Role)")
+		assert.Contains(t, rbacContent, "epp-metrics-role.yaml",
+			"rbac.go should reference the namespaced Role file")
 	})
 }

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -72,7 +72,7 @@ func getEPPMetricsToken() string {
 // It also tracks namespaces that should be watched for ConfigMaps (namespaces with VariantAutoscaling or InferencePool resources).
 type Datastore interface {
 	// InferencePool operations
-	PoolSet(ctx context.Context, client client.Client, pool *poolutil.EndpointPool) error
+	PoolSet(ctx context.Context, client client.Client, apiReader client.Reader, pool *poolutil.EndpointPool) error
 	PoolGet(name string) (*poolutil.EndpointPool, error)
 	PoolGetMetricsSource(name string) source.MetricsSource
 	PoolList() []*poolutil.EndpointPool
@@ -113,7 +113,7 @@ type datastore struct {
 }
 
 // Datastore operations
-func (ds *datastore) PoolSet(ctx context.Context, client client.Client, pool *poolutil.EndpointPool) error {
+func (ds *datastore) PoolSet(ctx context.Context, client client.Client, apiReader client.Reader, pool *poolutil.EndpointPool) error {
 	if pool == nil {
 		return errPoolIsNull
 	}
@@ -131,7 +131,7 @@ func (ds *datastore) PoolSet(ctx context.Context, client client.Client, pool *po
 		BearerToken:      getEPPMetricsToken(),
 	}
 
-	podSource, err := pod.NewPodScrapingSource(ctx, client, podConfig)
+	podSource, err := pod.NewPodScrapingSource(ctx, client, apiReader, podConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -94,7 +94,7 @@ func TestDatastore(t *testing.T) {
 			}
 
 			// Test PoolSet
-			gotErr := ds.PoolSet(ctx, fakeClient, ep)
+			gotErr := ds.PoolSet(ctx, fakeClient, fakeClient, ep)
 			if diff := cmp.Diff(tt.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error diff (+got/-want): %s", diff)
 			}
@@ -146,7 +146,7 @@ func TestDatastore(t *testing.T) {
 				metricsSourceAfterDelete := ds.PoolGetMetricsSource(namespacedName)
 				assert.Nil(t, metricsSourceAfterDelete, "Metrics source should be removed from registry after pool deletion")
 
-				if err := ds.PoolSet(ctx, fakeClient, ep); err != nil {
+				if err := ds.PoolSet(ctx, fakeClient, fakeClient, ep); err != nil {
 					t.Errorf("failed to add endpoint into the datastore: %v", err)
 				}
 				assert.Equal(t, len(ds.PoolList()), tt.listResultLen, "Pools map should have the expected length after item added")

--- a/test/e2e/rbac_least_privilege_test.go
+++ b/test/e2e/rbac_least_privilege_test.go
@@ -20,16 +20,16 @@ var _ = Describe("RBAC Least-Privilege Security", Label("full"), func() {
 		}
 	})
 
-	It("namespaced Role should grant get/list/watch on secrets", func() {
+	It("namespaced Role should grant get on specific secret", func() {
 		role, err := k8sClient.RbacV1().Roles(cfg.WVANamespace).Get(ctx, "wva-epp-metrics-role", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(role.Rules).To(HaveLen(1), "Role should have exactly one rule")
 		Expect(role.Rules[0].Resources).To(ContainElement("secrets"))
-		Expect(role.Rules[0].ResourceNames).To(BeEmpty(),
-			"Role should not use resourceNames (incompatible with list/watch)")
-		Expect(role.Rules[0].Verbs).To(ConsistOf("get", "list", "watch"),
-			"Role should grant get/list/watch on secrets (informer cache requires list/watch)")
+		Expect(role.Rules[0].ResourceNames).To(ConsistOf("wva-epp-metrics-token"),
+			"Role should scope access to the specific secret")
+		Expect(role.Rules[0].Verbs).To(ConsistOf("get"),
+			"Role should only grant get (apiReader bypasses informer cache)")
 	})
 
 	It("RoleBinding should bind controller-manager ServiceAccount to epp-metrics Role", func() {

--- a/test/e2e/rbac_least_privilege_test.go
+++ b/test/e2e/rbac_least_privilege_test.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("RBAC Least-Privilege Security", Label("full"), func() {
+
+	It("ClusterRole should not grant cluster-wide Secret permissions", func() {
+		clusterRole, err := k8sClient.RbacV1().ClusterRoles().Get(ctx, "wva-manager-role", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, rule := range clusterRole.Rules {
+			for _, resource := range rule.Resources {
+				Expect(resource).NotTo(Equal("secrets"),
+					"ClusterRole should not grant cluster-wide Secret permissions")
+			}
+		}
+	})
+
+	It("namespaced Role should grant get/list/watch on secrets", func() {
+		role, err := k8sClient.RbacV1().Roles(cfg.WVANamespace).Get(ctx, "wva-epp-metrics-role", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(role.Rules).To(HaveLen(1), "Role should have exactly one rule")
+		Expect(role.Rules[0].Resources).To(ContainElement("secrets"))
+		Expect(role.Rules[0].ResourceNames).To(BeEmpty(),
+			"Role should not use resourceNames (incompatible with list/watch)")
+		Expect(role.Rules[0].Verbs).To(ConsistOf("get", "list", "watch"),
+			"Role should grant get/list/watch on secrets (informer cache requires list/watch)")
+	})
+
+	It("RoleBinding should bind controller-manager ServiceAccount to epp-metrics Role", func() {
+		roleBinding, err := k8sClient.RbacV1().RoleBindings(cfg.WVANamespace).Get(ctx, "wva-epp-metrics-rolebinding", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(roleBinding.RoleRef.Name).To(Equal("wva-epp-metrics-role"))
+		Expect(roleBinding.RoleRef.Kind).To(Equal("Role"))
+		Expect(roleBinding.Subjects).To(HaveLen(1))
+		Expect(roleBinding.Subjects[0].Kind).To(Equal("ServiceAccount"))
+		Expect(roleBinding.Subjects[0].Name).To(Equal("wva-controller-manager"))
+	})
+})

--- a/test/utils/pod_scraping_test_helpers.go
+++ b/test/utils/pod_scraping_test_helpers.go
@@ -104,6 +104,7 @@ type PodScrapingTestConfig struct {
 	// Kubernetes clients
 	K8sClient *kubernetes.Clientset
 	CRClient  client.Client
+	APIReader client.Reader
 
 	// Context
 	Ctx context.Context
@@ -130,7 +131,7 @@ func CreatePodScrapingSource(config PodScrapingTestConfig) (*pod.PodScrapingSour
 		DefaultTTL:              30 * time.Second,
 	}
 
-	return pod.NewPodScrapingSource(ctx, config.CRClient, podConfig)
+	return pod.NewPodScrapingSource(ctx, config.CRClient, config.APIReader, podConfig)
 }
 
 // TestPodScrapingServiceDiscovery tests that PodScrapingSource can discover the EPP service


### PR DESCRIPTION
Fixes #

This issue was flagged by a security scan in downstream to reduce privileges on secret to minimum required by WVA manager.

- Currently WVA manager has **clusterwide** `get,list,watch` on `secrets` as defined in `manager-role` `ClusterRole`. It can `get,list,watch` any secrets in any namespace ! 
- But actually, WVA manager only need to reads 1 secret in 1 namespce: `wva-epp-metrics-token` in `workload-variant-autoscaler-system`.
- To address this security concern, we will reduce it to be able to read  1 secret in 1 namespce: `wva-epp-metrics-token` in `workload-variant-autoscaler-system`. This is done by creating a new `Role` and bind the new role to WVA manager service account:
```
 kind: Role
metadata:
  name: wva-epp-metrics-role
  labels:
    app.kubernetes.io/name: workload-variant-autoscaler
rules:
- apiGroups:
  - ""
  resources:
  - secrets              <=== secrets
  resourceNames:
  - epp-metrics-token  <=== exact secret name
```
```
kind: RoleBinding
metadata:
  annotations:
   
  labels:
    app.kubernetes.io/name: workload-variant-autoscaler
  name: wva-epp-metrics-rolebinding
  namespace: workload-variant-autoscaler-system
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: wva-epp-metrics-role
subjects:
- kind: ServiceAccount
  name: wva-controller-manager
  namespace: workload-variant-autoscaler-system
```
- As a consequence, WVA manager can only get 1 secret in 1 namespace.
- Implementation Notes:
  - `list,watch` are removed since we can't have these with `resourceNames`.
  - With `list,watch` are removed, we also need to change API call from `k8sClient.Get` to `apiReader.Get`. The rest of the changes are due to this.
- Manual Testing:
  - can get `wva-epp-metrics-token` in `workload-variant-autoscaler-system`.
  - can't get an existing secret  `wva-epp-metrics-token2` in `workload-variant-autoscaler-system`.
  - can't get an existing secret `llm-d-hf-token`  in `llm-d-sim`


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
- 🧹 

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [Y] **E2E tests** for any new behavior
- [N/A] **Docs PR** for any user-facing impact
- [N/A] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
N/A
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
N/A