### PR TITLE
Security Tighten: remove /debug/pprof/*

### DIFF
--- a/config/base/rbac/epp-metrics-reader-clusterrole.yaml
+++ b/config/base/rbac/epp-metrics-reader-clusterrole.yaml
@@ -7,6 +7,5 @@ metadata:
 rules:
 - nonResourceURLs:
   - /metrics
-  - /debug/pprof/*
   verbs:
   - get

--- a/docs/developer-guide/pod-scraping-source.md
+++ b/docs/developer-guide/pod-scraping-source.md
@@ -23,7 +23,7 @@
    - `get`, `list`, `watch` on `services`
    - `get`, `list`, `watch` on `pods`
    - `get` on `secrets` (if using authentication)
-   - For EPP metrics: `get` on non-resource URLs `/metrics` and `/debug/pprof/*` (see [official RBAC guide](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/metrics-and-observability.md#scrape-metrics--pprof-profiles))
+   - For EPP metrics: `get` on non-resource URLs `/metrics`
 5. **Authentication Secret** (optional): If metrics endpoint requires authentication
    - For EPP: Typically `inference-gateway-sa-metrics-reader-secret` (see [official authentication guide](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/metrics-and-observability.md#scrape-metrics--pprof-profiles))
 


### PR DESCRIPTION
Fixes #

This issue was flagged by a security scan in downstream. Here are some security concerns with `/debug/pprof/*` endpoint:

```
Pprof endpoints expose internal runtime details that an attacker could exploit:

  - Memory contents: /debug/pprof/heap can leak sensitive data sitting in memory — API keys, tokens, request payloads, credentials.
  - Source code insight: Stack traces from /debug/pprof/goroutine reveal internal function names, file paths, and code structure, making it easier to find
  attack vectors.
  - Denial of service: /debug/pprof/profile runs the CPU profiler for 30 seconds by default, consuming resources. Repeated calls can degrade the service.
  - Symbol table: /debug/pprof/symbol exposes the binary's symbol table, further mapping out internals.
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🧹 

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [N/A] **E2E tests** for any new behavior
- [N/A] **Docs PR** for any user-facing impact
- [N/A] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
N/A
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
N/A
