### PR TITLE
chore: strip transitional VA-CRD comments from e2e tests

### DIFF
--- a/test/e2e/annotation_discovery_test.go
+++ b/test/e2e/annotation_discovery_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 				g.Expect(d.Status.ReadyReplicas).To(Equal(int32(1)))
 			}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
-			By("Creating annotated ScaledObject (no VA CR)")
+			By("Creating annotated ScaledObject")
 			err = fixtures.EnsureScaledObject(ctx, crClient, ns, hpaBaseName, deploymentName, hpaName, 1, 10, cfg.MonitoringNS,
 				fixtures.WithScaledObjectWVAAnnotations(cfg.ModelID, "30.0"))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create annotated ScaledObject")
@@ -133,7 +133,7 @@ var _ = Describe("Annotation-based variant discovery", Serial, func() {
 				g.Expect(d.Status.ReadyReplicas).To(Equal(int32(1)))
 			}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
-			By("Creating annotated ScaledObject (no VA CR)")
+			By("Creating annotated ScaledObject")
 			err = fixtures.EnsureScaledObject(ctx, crClient, ns, hpaBaseName, deploymentName, hpaName, 1, 10, cfg.MonitoringNS,
 				fixtures.WithScaledObjectWVAAnnotations(cfg.ModelID, "30.0"))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create annotated ScaledObject")

--- a/test/e2e/saturation_analyzer_path_test.go
+++ b/test/e2e/saturation_analyzer_path_test.go
@@ -347,9 +347,8 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		expectAnalyzerPathLog("V1", modelID)
 
 		By("Verifying WVA emits wva_desired_replicas for the scaled-up variant")
-		// The engine's scale-up decision is surfaced via wva_desired_replicas
-		// (formerly VariantAutoscaling.Status.DesiredOptimizedAlloc), decoupled from
-		// the separate scaler actuation loop. This verifies emission/consumption via
+		// The engine's scale-up decision is surfaced via wva_desired_replicas,
+		// decoupled from the separate scaler actuation loop. This verifies emission/consumption via
 		// the KEDA HPA surface; the numeric magnitude relative to baseline is not
 		// asserted here (the HPA surface does not expose it reliably).
 		Eventually(func(g Gomega) {

--- a/test/e2e/saturation_v2_test.go
+++ b/test/e2e/saturation_v2_test.go
@@ -224,9 +224,8 @@ var _ = Describe("Saturation V2 engine", Label("smoke", "full"), Ordered, func()
 	// scaler driving the Deployment above a single replica.
 	It("should recommend scale-up when token utilization crosses scaleUpThreshold", func() {
 		By("Asserting WVA emits wva_desired_replicas for the scaled-up variant")
-		// The V2 scale-up recommendation is surfaced via wva_desired_replicas
-		// (formerly VariantAutoscaling.Status.DesiredOptimizedAlloc), decoupled from
-		// the separate scaler actuation loop. This verifies emission/consumption via
+		// The V2 scale-up recommendation is surfaced via wva_desired_replicas,
+		// decoupled from the separate scaler actuation loop. This verifies emission/consumption via
 		// the KEDA HPA surface; the numeric magnitude is not asserted here.
 		Eventually(func(g Gomega) {
 			expectWVADesiredReplicasConsumed(g, cfg.LLMDNamespace, modelDecodeDeployment)

--- a/test/e2e/throughput_analyzer_test.go
+++ b/test/e2e/throughput_analyzer_test.go
@@ -428,9 +428,8 @@ var _ = Describe("Multi-analyzer engine scale-up (saturation-driven, throughput 
 		// wva_desired_replicas and drives the target Deployment above its MinReplicas floor,
 		// so we assert the observable Deployment replica count instead.
 		By("Waiting for WVA to emit wva_desired_replicas under faked saturation")
-		// The engine's scale-up decision is surfaced via wva_desired_replicas
-		// (formerly VariantAutoscaling.Status.DesiredOptimizedAlloc), decoupled from
-		// the separate scaler actuation loop. This verifies emission/consumption via
+		// The engine's scale-up decision is surfaced via wva_desired_replicas,
+		// decoupled from the separate scaler actuation loop. This verifies emission/consumption via
 		// the KEDA HPA surface; the numeric magnitude is not asserted here.
 		Eventually(func(g Gomega) {
 			expectWVADesiredReplicasConsumed(g, cfg.LLMDNamespace, modelDecodeDeployment)
@@ -551,12 +550,6 @@ var _ = Describe("ThroughputAnalyzer TA-only mode", Label("full", "throughput"),
 		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 	})
 
-	// The "preserves accelerator info from VariantCapacities even with saturation disabled"
-	// It was dropped: it asserted on VariantAutoscaling.Status.DesiredOptimizedAlloc.Accelerator,
-	// an internal field that no longer exists after the VA CRD removal. WVA no longer surfaces
-	// per-variant accelerator info in status, and it is not observable via any external signal
-	// (wva_desired_replicas carries an accelerator_type label, but it is not populated from the
-	// saturation VariantCapacities path this It was exercising), so there is nothing to assert.
 })
 
 // ─── Shared helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Proposed Changes

- :broom: Remove `(no VA CR)` suffixes from two `By(...)` step strings in `annotation_discovery_test.go`
- :broom: Drop `(formerly VariantAutoscaling.Status.DesiredOptimizedAlloc)` parentheticals from `saturation_v2_test.go`, `saturation_analyzer_path_test.go`, and `throughput_analyzer_test.go`
- :wastebasket: Delete the "It was dropped: it asserted on VariantAutoscaling.Status..." tombstone comment block from `throughput_analyzer_test.go`

### Pre-review Checklist

- [ ] **E2E tests** — N/A, comments-only change
- [ ] **Docs PR** — N/A, no user-facing impact
- [ ] **Proposal PR** — N/A, cleanup only

**Release Note**

```release-note
NONE
