### PR TITLE
update: harden TLS for openshift etc

### DIFF
--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -3,7 +3,7 @@ on: pull_request_target
 
 jobs:
   signed-commits:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yaml@991b7368b05664fdaa9788521e7482655323e0a4 # main
     permissions:
       contents: read
       pull-requests: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/projectquay/golang:1.25 AS builder
+FROM quay.io/projectquay/golang:1.25@sha256:94758a6003e442ccbed85c22533306c94e3b385231f554be53962d798ec5e087 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 
 LABEL org.opencontainers.image.source="https://github.com/llm-d/llm-d-workload-variant-autoscaler"
 LABEL org.opencontainers.image.description="Workload Variant Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads"

--- a/config/components/openshift/deployment-patch.yaml
+++ b/config/components/openshift/deployment-patch.yaml
@@ -18,3 +18,12 @@ spec:
           value: ""
         - name: PROMETHEUS_SERVER_NAME
           value: "thanos-querier.openshift-monitoring.svc"
+        volumeMounts:
+        - name: metrics-serving-cert
+          mountPath: /tmp/k8s-metrics-server/serving-certs
+          readOnly: true
+      volumes:
+      - name: metrics-serving-cert
+        secret:
+          secretName: metrics-server-cert
+          defaultMode: 420

--- a/config/components/openshift/deployment-patch.yaml
+++ b/config/components/openshift/deployment-patch.yaml
@@ -20,7 +20,7 @@ spec:
           value: "thanos-querier.openshift-monitoring.svc"
         volumeMounts:
         - name: metrics-serving-cert
-          mountPath: /tmp/k8s-metrics-server/serving-certs
+          mountPath: /etc/k8s-metrics-server/serving-certs
           readOnly: true
       volumes:
       - name: metrics-serving-cert

--- a/config/components/openshift/kustomization.yaml
+++ b/config/components/openshift/kustomization.yaml
@@ -31,19 +31,18 @@ patches:
 - patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: --metrics-cert-path=/tmp/k8s-metrics-server/serving-certs
+      value: --metrics-cert-path=/etc/k8s-metrics-server/serving-certs
   target:
     kind: Deployment
     name: controller-manager
 # Request a service-ca serving cert for the metrics Service (metrics-server-cert Secret).
 - patch: |-
-    - op: add
-      path: /metadata/annotations
-      value:
-        service.beta.openshift.io/serving-cert-secret-name: metrics-server-cert
-  target:
+    apiVersion: v1
     kind: Service
-    name: controller-manager-metrics-service
+    metadata:
+      name: controller-manager-metrics-service
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: metrics-server-cert
 # Grant the WVA controller manager SA read access to its own /metrics endpoint
 # so the ServiceMonitor can scrape it.
 - patch: |-

--- a/config/components/openshift/kustomization.yaml
+++ b/config/components/openshift/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
 - prometheus-cluster-monitoring-view-clusterrolebinding.yaml
 # Long-lived SA token referenced by the ServiceMonitor's bearerTokenSecret.
 - controller-manager-token-secret.yaml
+# Service-ca CA bundle used by the ServiceMonitor to verify the controller's
+# metrics serving certificate (replaces insecureSkipVerify).
+- metrics-server-ca-configmap.yaml
 
 patches:
 # Point WVA at the in-cluster Thanos Querier (OpenShift's user-workload-monitoring
@@ -24,6 +27,23 @@ patches:
   target:
     kind: Deployment
     name: controller-manager
+# Append the metrics cert path arg (JSON patch to avoid replacing the args list).
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --metrics-cert-path=/tmp/k8s-metrics-server/serving-certs
+  target:
+    kind: Deployment
+    name: controller-manager
+# Request a service-ca serving cert for the metrics Service (metrics-server-cert Secret).
+- patch: |-
+    - op: add
+      path: /metadata/annotations
+      value:
+        service.beta.openshift.io/serving-cert-secret-name: metrics-server-cert
+  target:
+    kind: Service
+    name: controller-manager-metrics-service
 # Grant the WVA controller manager SA read access to its own /metrics endpoint
 # so the ServiceMonitor can scrape it.
 - patch: |-
@@ -53,6 +73,19 @@ patches:
         key: token
     - op: remove
       path: /spec/endpoints/0/bearerTokenFile
+    # Enable TLS verification of the metrics serving cert.
+    - op: replace
+      path: /spec/endpoints/0/tlsConfig/insecureSkipVerify
+      value: false
+    - op: add
+      path: /spec/endpoints/0/tlsConfig/serverName
+      value: wva-controller-manager-metrics-service.wva-system.svc
+    - op: add
+      path: /spec/endpoints/0/tlsConfig/ca
+      value:
+        configMap:
+          name: wva-metrics-server-ca
+          key: service-ca.crt
   target:
     kind: ServiceMonitor
     name: controller-manager-metrics-monitor

--- a/config/components/openshift/metrics-server-ca-configmap.yaml
+++ b/config/components/openshift/metrics-server-ca-configmap.yaml
@@ -1,0 +1,8 @@
+# service-ca injects the CA bundle (service-ca.crt) here; the ServiceMonitor
+# uses it to verify the metrics serving cert.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-server-ca
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"


### PR DESCRIPTION
These requirements are from security scan in product:
- Flip PROMETHEUS_TLS_INSECURE_SKIP_VERIFY default to false in config/manager/configmap.yaml and Helm values.yaml.
- Pin the ci-signed-commits.yaml reusable-workflow ref to a SHA.
- Set ServiceMonitor insecureSkipVerify: false (or wire CA/serving-cert).
- Digest-pin the upstream Dockerfile builder stage.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- pin image and GHAction with SHA1
- disable insecureSkipVerify by inject service-ca bundle

- :broom: Update or clean up current behavior


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->


cc @shuynh2017 