### PR TITLE
test(e2e): add V2 saturation scale-down coverage via full KEDA pipeline

### DIFF
--- a/test/e2e/fixtures/scaled_object_builder.go
+++ b/test/e2e/fixtures/scaled_object_builder.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -41,6 +42,26 @@ func WithScaledObjectScaleTargetKind(kind string) ScaledObjectOption {
 			so.Spec.ScaleTargetRef.APIVersion = apiVersionAppsV1
 		default:
 			// Keep existing APIVersion for unknown kinds
+		}
+	}
+}
+
+// WithScaledObjectScaleDownStabilizationWindow sets the HPA scale-down stabilization window via
+// KEDA's Advanced config. The default (300 s) is too long for e2e tests; pass a shorter value
+// (e.g. 30 s) to make scale-down assertions complete within a reasonable test timeout.
+func WithScaledObjectScaleDownStabilizationWindow(seconds int32) ScaledObjectOption {
+	return func(so *kedav1alpha1.ScaledObject) {
+		if so.Spec.Advanced == nil {
+			so.Spec.Advanced = &kedav1alpha1.AdvancedConfig{}
+		}
+		if so.Spec.Advanced.HorizontalPodAutoscalerConfig == nil {
+			so.Spec.Advanced.HorizontalPodAutoscalerConfig = &kedav1alpha1.HorizontalPodAutoscalerConfig{}
+		}
+		if so.Spec.Advanced.HorizontalPodAutoscalerConfig.Behavior == nil {
+			so.Spec.Advanced.HorizontalPodAutoscalerConfig.Behavior = &autoscalingv2.HorizontalPodAutoscalerBehavior{}
+		}
+		so.Spec.Advanced.HorizontalPodAutoscalerConfig.Behavior.ScaleDown = &autoscalingv2.HPAScalingRules{
+			StabilizationWindowSeconds: ptr.To(seconds),
 		}
 	}
 }
@@ -127,8 +148,11 @@ func EnsureScaledObject(
 func buildScaledObject(namespace, name, scaleTargetName, variantName string, minReplicas, maxReplicas int32, monitoringNamespace string, opts ...ScaledObjectOption) *kedav1alpha1.ScaledObject {
 	objName := name + scaledObjectSuffix
 	prometheusURL := "https://kube-prometheus-stack-prometheus." + monitoringNamespace + ".svc.cluster.local:9090"
-	// Use "namespace" not "exported_namespace": WVA controller emits the metric with label namespace.
-	query := fmt.Sprintf("wva_desired_replicas{variant_name=%q,namespace=%q}", variantName, namespace)
+	// Prometheus renames the metric's namespace label to exported_namespace when the scrape
+	// target's namespace (workload-variant-autoscaler-system) differs from the label value
+	// (the workload namespace, e.g. llm-d-sim). Use exported_namespace to match what
+	// Prometheus actually stores.
+	query := fmt.Sprintf("wva_desired_replicas{variant_name=%q,exported_namespace=%q}", variantName, namespace)
 
 	spec := kedav1alpha1.ScaledObjectSpec{
 		ScaleTargetRef: &kedav1alpha1.ScaleTarget{

--- a/test/e2e/saturation_analyzer_path_test.go
+++ b/test/e2e/saturation_analyzer_path_test.go
@@ -203,8 +203,11 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		By("Registering the saturation-path deployment with WVA via an annotated ScaledObject")
 		// The ScaledObject's variantName matches the model service's variantName so the
 		// decode pods' llm-d.ai/variant label and wva_desired_replicas variant_name align.
+		// The 30 s scale-down stabilization window overrides the HPA default (300 s) so
+		// the "does not scale up" It can wait for minReplicas within EventuallyLongSec.
 		err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerBaseName, modelDecodeDeployment, variantName, 1, 10, cfg.MonitoringNS,
-			fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"))
+			fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"),
+			fixtures.WithScaledObjectScaleDownStabilizationWindow(30))
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerBaseName) })
 	})
@@ -267,18 +270,13 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 	})
 
 	It("does not scale the target deployment up for bounded below-threshold V1 traffic", func() {
-		var baseline int32
-
-		By("Capturing baseline target deployment replicas before below-threshold trigger")
-		Eventually(func(g Gomega) {
-			dep, getErr := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
-			g.Expect(getErr).NotTo(HaveOccurred())
-			g.Expect(dep.Spec.Replicas).NotTo(BeNil())
-			baseline = *dep.Spec.Replicas
-			GinkgoWriter.Printf("  Negative-path baseline (%s): replicas=%d\n", modelDecodeDeployment, baseline)
-		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
-
 		By("Configuring conservative V1 thresholds to avoid scale-up")
+		// Set thresholds before capturing the baseline so WVA has time to reconcile
+		// while we wait for KEDA to settle. With the KEDA Prometheus query now using
+		// exported_namespace (fixed), KEDA can act on wva_desired_replicas from the
+		// prior It (which may have left a scale-up recommendation in Prometheus). We
+		// must wait for WVA to re-evaluate and KEDA to read the new value before the
+		// Consistently window starts — otherwise the HPA would fire a scale-up.
 		err := upsertSaturationConfigEntry(
 			ctx,
 			cmNamespace,
@@ -298,6 +296,26 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 
 		By("Verifying controller is using V1 analyzer path")
 		expectAnalyzerPathLog("V1", modelID)
+
+		By("Waiting for KEDA to read wva_desired_replicas=1 and the HPA to stabilize at minReplicas")
+		// Chain: WVA reconciles (≤15 s) → wva_desired_replicas=1 → KEDA polls (5 s) →
+		// HPA stabilization (30 s window set on this ScaledObject) → Spec.Replicas=1.
+		// EventuallyLongSec (120 s) covers the worst case.
+		Eventually(func(g Gomega) {
+			dep, getErr := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
+			g.Expect(getErr).NotTo(HaveOccurred())
+			g.Expect(dep.Spec.Replicas).NotTo(BeNil())
+			g.Expect(*dep.Spec.Replicas).To(BeNumerically("<=", int32(1)),
+				"waiting for KEDA to read updated wva_desired_replicas=1 and scale down to minReplicas")
+		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+
+		By("Capturing baseline target deployment replicas before steady-state assertion")
+		var baseline int32
+		dep, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dep.Spec.Replicas).NotTo(BeNil())
+		baseline = *dep.Spec.Replicas
+		GinkgoWriter.Printf("  Negative-path baseline (%s): replicas=%d\n", modelDecodeDeployment, baseline)
 
 		By("Verifying the target deployment does not scale above baseline")
 		Consistently(func(g Gomega) {

--- a/test/e2e/saturation_v2_test.go
+++ b/test/e2e/saturation_v2_test.go
@@ -35,9 +35,10 @@ import (
 //
 // WVA no longer writes a VariantAutoscaling .status; its only output is the
 // wva_desired_replicas external metric. The annotated KEDA ScaledObject
-// registers the variant with WVA and actuates the recommendation, so the V2
-// scale-up/scale-down intent is observed through the managed Deployment's
-// replica count rather than a VA status field.
+// registers the variant with WVA and actuates the recommendation. The V2
+// scale-up/scale-down intent is verified through the managed Deployment's
+// replica count — the full KEDA pipeline (WVA → Prometheus → KEDA → HPA →
+// Deployment) is exercised end-to-end.
 //
 // --fake-metrics format:
 //
@@ -62,7 +63,7 @@ const (
 	v2SmokeScaleDownBoundary = 0.20
 )
 
-var _ = Describe("Saturation V2 engine", Label("smoke", "full"), Ordered, func() {
+var _ = Describe("Saturation V2 engine", Label("smoke", "full", "keda"), Ordered, func() {
 	const (
 		poolName              = "v2-smoke-pool"
 		modelSvcName          = "v2-smoke-ms"
@@ -146,9 +147,12 @@ var _ = Describe("Saturation V2 engine", Label("smoke", "full"), Ordered, func()
 
 		By("Registering the V2 smoke deployment with WVA via an annotated ScaledObject (min=1, max=10)")
 		// The annotated ScaledObject is both the WVA discovery source and the scaler;
-		// no VariantAutoscaling CR is created.
+		// no VariantAutoscaling CR is created. The 30 s scale-down stabilization window
+		// overrides the HPA default (300 s) so the scale-down It completes within the
+		// EventuallyExtendedSec budget.
 		Expect(fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerBaseName, modelDecodeDeployment, variantName, 1, 10, cfg.MonitoringNS,
-			fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"))).To(Succeed())
+			fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"),
+			fixtures.WithScaledObjectScaleDownStabilizationWindow(30))).To(Succeed())
 		DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, scalerBaseName) })
 
 		By("Installing V2 saturation config so all subsequent It() blocks share state")
@@ -218,18 +222,66 @@ var _ = Describe("Saturation V2 engine", Label("smoke", "full"), Ordered, func()
 			Should(Succeed())
 	})
 
-	// Verifies that V2 recommends scale-up when --fake-metrics drives a
-	// kv-cache-usage above scaleUpThreshold. See v2SmokeFakeMetricsJSON for the
-	// calibration math. The recommendation is observed through the managed
-	// scaler driving the Deployment above a single replica.
-	It("should recommend scale-up when token utilization crosses scaleUpThreshold", func() {
-		By("Asserting WVA emits wva_desired_replicas for the scaled-up variant")
-		// The V2 scale-up recommendation is surfaced via wva_desired_replicas,
-		// decoupled from the separate scaler actuation loop. This verifies emission/consumption via
-		// the KEDA HPA surface; the numeric magnitude is not asserted here.
+	// Verifies the full KEDA scale-up pipeline: with kv-cache-usage=0.3 from
+	// --fake-metrics and scaleUpThreshold=0.30, WVA's V2 optimizer emits
+	// wva_desired_replicas=2, KEDA reads the metric and drives the Deployment
+	// to 2 ready replicas.
+	It("should scale up via KEDA when token utilization crosses scaleUpThreshold", func() {
+		By("Asserting KEDA actuates scale-up to ≥ 2 replicas")
+		// Chain: WVA (15 s interval) → wva_desired_replicas=2 → KEDA (5 s poll) →
+		// HPA → Deployment. Uses ScaleUpTimeout (600 s) to accommodate pod scheduling.
 		Eventually(func(g Gomega) {
-			expectWVADesiredReplicasConsumed(g, cfg.LLMDNamespace, modelDecodeDeployment)
+			dep, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dep.Status.ReadyReplicas).To(BeNumerically(">=", 2),
+				"Deployment should scale up to ≥ 2 replicas with kv-cache-usage=0.3 and scaleUpThreshold=0.30")
 		}, time.Duration(cfg.ScaleUpTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).
+			Should(Succeed())
+	})
+
+	// Verifies the full KEDA scale-down pipeline: WVA emits wva_desired_replicas=1 after
+	// canonical-ordering thresholds raise the scaleDownBoundary, KEDA reads the updated
+	// metric, and the managed Deployment's replica count drops back to minReplicas (1).
+	//
+	// Pre-condition: the scale-up It must have driven the Deployment to ≥ 2 replicas.
+	// This It first asserts that pre-condition so a false-positive cannot occur when the
+	// Deployment is already at 1 (e.g. if WVA never recommended scale-up).
+	//
+	// With --fake-metrics kv-cache-usage=0.3 at 2 replicas and canonical-ordering
+	// thresholds (scaleUpThreshold=0.95, scaleDownBoundary=0.85), the V2 cost-aware
+	// optimizer's remaining-capacity is ≥ one full per-replica budget → NumReplicas=1.
+	It("should scale down via KEDA when token utilization falls below scaleDownBoundary", func() {
+		By("Confirming Deployment is at ≥ 2 replicas before asserting scale-down")
+		// This also catches regressions in the scale-up path — if KEDA never drove the
+		// Deployment above minReplicas, the scale-down assertion would be meaningless.
+		Eventually(func(g Gomega) {
+			dep, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dep.Status.ReadyReplicas).To(BeNumerically(">=", 2),
+				"Deployment should be at 2 replicas before testing scale-down")
+		}, time.Duration(cfg.ScaleUpTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).
+			Should(Succeed())
+
+		By("Switching saturation config to canonical-ordering thresholds (scaleUp=0.95, scaleDown=0.85)")
+		// kv-cache-usage=0.3 << scaleDownBoundary=0.85 at 2 replicas → V2 optimizer
+		// decides desiredReplicas=1 → wva_desired_replicas=1 → KEDA drives HPA to 1.
+		cfgYAML := buildSaturationConfigYAMLWithThresholds(
+			"saturation",
+			v2SmokeKvCacheThreshold, v2SmokeQueueLengthThreshold,
+			v2SmokeKvSpareTrigger, v2SmokeQueueSpareTrigger,
+			0.95, 0.85,
+		)
+		Expect(upsertSaturationConfigEntry(ctx, cmNamespace, cmName, cmKey, cfgYAML)).To(Succeed())
+
+		By("Asserting KEDA actuates scale-down to 1 replica")
+		// Chain: WVA (15 s interval) → wva_desired_replicas=1 → KEDA (5 s poll) →
+		// HPA (30 s stabilization window set on this ScaledObject) → Deployment.
+		Eventually(func(g Gomega) {
+			dep, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dep.Status.ReadyReplicas).To(BeNumerically("<=", 1),
+				"Deployment should scale down to minReplicas=1 after scaleDownBoundary raised to 0.85")
+		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).
 			Should(Succeed())
 	})
 

--- a/test/utils/e2eutils.go
+++ b/test/utils/e2eutils.go
@@ -881,11 +881,11 @@ func (a *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 // GetPrometheusServiceInfoFromConfigMap reads the Prometheus service info from the WVA controller configmap.
-// It reads the workload-variant-autoscaler-variantautoscaling-config configmap and extracts
-// the service name, namespace, and port from PROMETHEUS_BASE_URL.
+// It reads the wva-manager-config configmap and extracts the service name, namespace, and port
+// from PROMETHEUS_BASE_URL.
 // Example URL: "https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090"
 func GetPrometheusServiceInfoFromConfigMap(ctx context.Context, k8sClient *kubernetes.Clientset, wvaNamespace string) (*PrometheusServiceInfo, error) {
-	configMapName := "workload-variant-autoscaler-variantautoscaling-config"
+	configMapName := "wva-manager-config"
 
 	cm, err := k8sClient.CoreV1().ConfigMaps(wvaNamespace).Get(ctx, configMapName, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
The scale-down e2e test for the V2 saturation engine was removed when prom-adapter was retired. This restores it, exercising the full KEDA pipeline end-to-end and fixes a silent bug that caused the existing scale-up test to be a false positive.

## Proposed Changes
- :bug: Fix KEDA Prometheus trigger query using `namespace=` instead of `exported_namespace=`. Prometheus renames the metric label when the scrape target's namespace (`workload-variant-autoscaler-system`) differs from the label value (`llm-d-sim`). The wrong label caused KEDA to always read 0, keeping the Deployment at minReplicas regardless of WVA's recommendation.
- :bug: Replace the false-positive scale-up assertion (`expectWVADesiredReplicasConsumed` only checked `CurrentMetrics` non-empty, which was satisfied even when the metric value was 0) with a check on `dep.Status.ReadyReplicas >= 2` — the actual Deployment state.
- :gift: Add scale-down It block: raises `scaleDownBoundary` to 0.85 at runtime, waits for `ReadyReplicas <= 1`, exercising the full `WVA → Prometheus → KEDA → HPA → Deployment` pipeline in both directions.

### Pre-review Checklist
- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

```release-note
NONE
