### PR TITLE
test(e2e): remove keda label, collapse e2e make targets to KEDA-only

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -166,7 +166,7 @@ jobs:
           KV_SPARE_TRIGGER: "0.5"
           QUEUE_SPARE_TRIGGER: "4.5"
         run: |
-          make test-e2e-smoke-keda-with-setup
+          make test-e2e-smoke-with-setup
 
   # Full Kind E2E - runs automatically on every PR with code changes.
   # Add "e2e-tests-full" as a required status check in branch protection so it appears on every PR
@@ -223,4 +223,4 @@ jobs:
           KV_SPARE_TRIGGER: "0.5"
           QUEUE_SPARE_TRIGGER: "4.5"
         run: |
-          make test-e2e-full-keda-with-setup
+          make test-e2e-full-with-setup

--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,7 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + EPP; no model server 
 	fi
 
 
-# Deploy e2e infrastructure with KEDA as scaler backend (installs KEDA, skips Prometheus Adapter).
-# Runs a subset of smoke tests from the e2e suite.
+# Runs the smoke subset of the e2e suite. KEDA is the only scaler backend.
 .PHONY: test-e2e-smoke
 test-e2e-smoke: ## Run smoke e2e tests
 	@echo "Running smoke e2e tests..."
@@ -250,34 +249,10 @@ test-e2e-smoke: ## Run smoke e2e tests
 	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
-	SCALER_BACKEND=$(SCALER_BACKEND) \
-	MODEL_ID=$(MODEL_ID) \
-	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
-		-ginkgo.label-filter="smoke && !keda" $(FOCUS_ARGS) $(SKIP_ARGS); \
-	TEST_EXIT_CODE=$$?; \
-	echo ""; \
-	echo "=========================================="; \
-	echo "Test execution completed. Exit code: $$TEST_EXIT_CODE"; \
-	echo "=========================================="; \
-	exit $$TEST_EXIT_CODE
-
-.PHONY: test-e2e-smoke-keda
-test-e2e-smoke-keda: ## Run KEDA smoke e2e tests (requires SCALER_BACKEND=keda infra)
-	@echo "Running KEDA smoke e2e tests..."
-	$(eval FOCUS_ARGS := $(if $(FOCUS),-ginkgo.focus="$(FOCUS)",))
-	$(eval SKIP_ARGS := $(if $(SKIP),-ginkgo.skip="$(SKIP)",))
-	KUBECONFIG=$(KUBECONFIG) \
-	ENVIRONMENT=$(ENVIRONMENT) \
-	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
-	LLMD_NAMESPACE=$(E2E_EMULATED_LLMD_NAMESPACE) \
-	MONITORING_NAMESPACE=$(E2E_MONITORING_NAMESPACE) \
-	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
-	USE_SIMULATOR=$(USE_SIMULATOR) \
-	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 	SCALER_BACKEND=keda \
 	MODEL_ID=$(MODEL_ID) \
 	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
-		-ginkgo.label-filter="smoke && keda" $(FOCUS_ARGS) $(SKIP_ARGS); \
+		-ginkgo.label-filter="smoke" $(FOCUS_ARGS) $(SKIP_ARGS); \
 	TEST_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=========================================="; \
@@ -285,12 +260,7 @@ test-e2e-smoke-keda: ## Run KEDA smoke e2e tests (requires SCALER_BACKEND=keda i
 	echo "=========================================="; \
 	exit $$TEST_EXIT_CODE
 
-.PHONY: test-e2e-smoke-keda-with-setup
-test-e2e-smoke-keda-with-setup: ## Deploy KEDA infra and run KEDA smoke e2e tests
-	$(MAKE) deploy-e2e-infra SCALER_BACKEND=keda
-	$(MAKE) test-e2e-smoke-keda
-
-# Runs the complete e2e test suite (excluding flaky tests).
+# Runs the complete e2e test suite (KEDA backend, excluding smoke and flaky tests).
 .PHONY: test-e2e-full
 test-e2e-full: ## Run full e2e test suite
 	@echo "Running full e2e test suite..."
@@ -302,10 +272,11 @@ test-e2e-full: ## Run full e2e test suite
 	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
-	SCALER_BACKEND=$(SCALER_BACKEND) \
+	SCALER_BACKEND=keda \
+	KEDA_NAMESPACE=$(E2E_KEDA_NAMESPACE) \
 	MODEL_ID=$(MODEL_ID) \
 	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
-		-ginkgo.label-filter="full && !flaky && !keda" $(FOCUS_ARGS) $(SKIP_ARGS); \
+		-ginkgo.label-filter="full && !smoke && !flaky" $(FOCUS_ARGS) $(SKIP_ARGS); \
 	TEST_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=========================================="; \
@@ -315,10 +286,12 @@ test-e2e-full: ## Run full e2e test suite
 
 # Convenience targets for local e2e testing
 
-# Convenience target that deploys infra + runs smoke tests (HPA / Prometheus Adapter path).
+# Convenience target that deploys KEDA infra + runs smoke tests.
 # Set DELETE_CLUSTER=true to delete Kind cluster after tests (default: keep cluster for debugging).
 .PHONY: test-e2e-smoke-with-setup
-test-e2e-smoke-with-setup: deploy-e2e-infra test-e2e-smoke
+test-e2e-smoke-with-setup:
+	$(MAKE) deploy-e2e-infra SCALER_BACKEND=keda
+	$(MAKE) test-e2e-smoke
 
 # Runs only the multi-controller (dual namespace-scoped) e2e tests.
 .PHONY: test-e2e-multi-controller
@@ -349,43 +322,13 @@ test-e2e-multi-controller: ## Run multi-controller e2e tests
 .PHONY: test-e2e-multi-controller-with-setup
 test-e2e-multi-controller-with-setup: deploy-e2e-infra test-e2e-multi-controller
 
-# Convenience target that deploys infra + runs full test suite.
+# Convenience target that deploys KEDA infra + runs full test suite.
 # Set DELETE_CLUSTER=true to delete Kind cluster after tests (default: keep cluster for debugging).
 # LWS is installed because the full suite includes LeaderWorkerSet scale-from-zero tests.
 .PHONY: test-e2e-full-with-setup
 test-e2e-full-with-setup:
-	DEPLOY_LWS=true $(MAKE) deploy-e2e-infra
-	$(MAKE) test-e2e-full
-
-# Runs the full e2e suite against a KEDA backend (no Prometheus Adapter).
-# Label filter includes keda-labeled tests since KEDA is installed on the cluster.
-.PHONY: test-e2e-full-keda
-test-e2e-full-keda: ## Run full e2e test suite against KEDA backend
-	@echo "Running full e2e test suite (KEDA backend)..."
-	$(eval FOCUS_ARGS := $(if $(FOCUS),-ginkgo.focus="$(FOCUS)",))
-	$(eval SKIP_ARGS := $(if $(SKIP),-ginkgo.skip="$(SKIP)",))
-	KUBECONFIG=$(KUBECONFIG) \
-	ENVIRONMENT=$(ENVIRONMENT) \
-	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
-	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
-	USE_SIMULATOR=$(USE_SIMULATOR) \
-	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
-	SCALER_BACKEND=keda \
-	KEDA_NAMESPACE=$(E2E_KEDA_NAMESPACE) \
-	MODEL_ID=$(MODEL_ID) \
-	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
-		-ginkgo.label-filter="full && !smoke && !flaky" $(FOCUS_ARGS) $(SKIP_ARGS); \
-	TEST_EXIT_CODE=$$?; \
-	echo ""; \
-	echo "=========================================="; \
-	echo "Test execution completed. Exit code: $$TEST_EXIT_CODE"; \
-	echo "=========================================="; \
-	exit $$TEST_EXIT_CODE
-
-.PHONY: test-e2e-full-keda-with-setup
-test-e2e-full-keda-with-setup: ## Deploy KEDA infra and run full e2e test suite
 	DEPLOY_LWS=true SCALER_BACKEND=keda $(MAKE) deploy-e2e-infra
-	$(MAKE) test-e2e-full-keda
+	$(MAKE) test-e2e-full
 
 
 ##@ llm-d-benchmark CLI (standup / run / teardown)

--- a/test/e2e/saturation_analyzer_path_test.go
+++ b/test/e2e/saturation_analyzer_path_test.go
@@ -297,17 +297,40 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		By("Verifying controller is using V1 analyzer path")
 		expectAnalyzerPathLog("V1", modelID)
 
-		By("Waiting for KEDA to read wva_desired_replicas=1 and the HPA to stabilize at minReplicas")
-		// Chain: WVA reconciles (≤15 s) → wva_desired_replicas=1 → KEDA polls (5 s) →
-		// HPA stabilization (30 s window set on this ScaledObject) → Spec.Replicas=1.
-		// EventuallyLongSec (120 s) covers the worst case.
+		By("Waiting for the pipeline to converge to a sustained minReplicas (drain any in-flight scale-up)")
+		// A single Spec.Replicas <= 1 reading is NOT proof of convergence: the deployment
+		// starts at minReplicas, so that check passes on the pre-existing state while a
+		// scale-up recommendation left in flight by the prior It (default config:
+		// queueLengthThreshold=1 vs faked queue=2 → V1 scale-up) is still working through
+		// WVA (≤15 s reconcile) → Prometheus → KEDA (5 s poll) → HPA. That stale
+		// recommendation actuates a scale-up mid-assertion unless it has fully drained.
+		//
+		// Require the deployment to HOLD at <=1 continuously for stableWindow before
+		// trusting it: any bump resets the stability clock, and stableWindow outlasts the
+		// full pipeline latency (reconcile + poll + the 30 s scale-down stabilization set
+		// on this ScaledObject) so the old recommendation is guaranteed drained.
+		const stableWindow = 45 * time.Second
+		var stableSince *time.Time
 		Eventually(func(g Gomega) {
 			dep, getErr := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
 			g.Expect(getErr).NotTo(HaveOccurred())
 			g.Expect(dep.Spec.Replicas).NotTo(BeNil())
-			g.Expect(*dep.Spec.Replicas).To(BeNumerically("<=", int32(1)),
-				"waiting for KEDA to read updated wva_desired_replicas=1 and scale down to minReplicas")
-		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+			now := time.Now()
+			if *dep.Spec.Replicas > 1 {
+				stableSince = nil // reset the stability clock on any in-flight scale-up
+				GinkgoWriter.Printf("  Convergence (%s): replicas=%d (>1) — resetting stability clock\n", modelDecodeDeployment, *dep.Spec.Replicas)
+				g.Expect(*dep.Spec.Replicas).To(BeNumerically("<=", int32(1)),
+					"waiting for the in-flight scale-up recommendation to drain")
+				return
+			}
+			if stableSince == nil {
+				stableSince = &now
+			}
+			held := now.Sub(*stableSince)
+			GinkgoWriter.Printf("  Convergence (%s): replicas<=1 held for %s (need %s)\n", modelDecodeDeployment, held.Round(time.Second), stableWindow)
+			g.Expect(held).To(BeNumerically(">=", stableWindow),
+				"waiting for minReplicas to hold long enough to confirm the pipeline converged")
+		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 		By("Capturing baseline target deployment replicas before steady-state assertion")
 		var baseline int32

--- a/test/e2e/saturation_v2_test.go
+++ b/test/e2e/saturation_v2_test.go
@@ -63,7 +63,7 @@ const (
 	v2SmokeScaleDownBoundary = 0.20
 )
 
-var _ = Describe("Saturation V2 engine", Label("smoke", "full", "keda"), Ordered, func() {
+var _ = Describe("Saturation V2 engine", Label("smoke", "full"), Ordered, func() {
 	const (
 		poolName              = "v2-smoke-pool"
 		modelSvcName          = "v2-smoke-ms"

--- a/test/e2e/smoke_keda_test.go
+++ b/test/e2e/smoke_keda_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
 )
 
-var _ = Describe("KEDA Smoke Tests - Infrastructure Readiness", Label("smoke", "keda", "full"), func() {
+var _ = Describe("KEDA Smoke Tests - Infrastructure Readiness", Label("smoke", "full"), func() {
 	Context("Basic infrastructure validation", func() {
 		It("should have WVA controller running and ready", func() {
 			Eventually(func(g Gomega) {
@@ -87,7 +87,7 @@ var _ = Describe("KEDA Smoke Tests - Infrastructure Readiness", Label("smoke", "
 	})
 })
 
-var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", "full"), Ordered, func() {
+var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "full"), Ordered, func() {
 	var (
 		ns               string
 		poolName         = "smoke-test-pool"
@@ -236,7 +236,7 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "keda", 
 	})
 })
 
-var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "keda", "full"), Ordered, func() {
+var _ = Describe("KEDA Smoke Tests - Error Handling", Label("smoke", "full"), Ordered, func() {
 	var (
 		ns                        string
 		errorTestPoolName         = "error-test-pool"


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
KEDA is the only scaler backend. The `keda` Ginkgo label was a migration-era artifact that no longer names a meaningful axis and it was actively harmful: specs carrying `smoke` but not `keda` (`SGLang backend`, `ThroughputAnalyzer wiring`) ran in **neither** PR CI job excluded from the smoke job (`smoke && keda`) for lacking `keda`, and excluded from the full job (`full && !smoke && !flaky`) for having `smoke`. Those specs never ran under a live KEDA backend. The label also caused the documented local command (`make test-e2e-smoke`, filter `smoke && !keda`) to run a different, KEDA-blind subset than CI.

## Proposed Changes

- :wastebasket: Remove the `keda` Ginkgo label from all Describe blocks (`saturation_v2_test.go`, `smoke_keda_test.go` ×3).
- :broom: Collapse the e2e make targets to KEDA-only: `test-e2e-smoke` now filters `smoke`; `test-e2e-full` filters `full && !smoke && !flaky` on the proven KEDA body (`SCALER_BACKEND=keda`, `KEDA_NAMESPACE`). Delete the redundant `test-e2e-{smoke,full}-keda*` variants; the `*-with-setup` targets deploy KEDA
  explicitly.
- :broom: Repoint `ci-pr-checks.yaml` to the collapsed `*-with-setup` targets, so `SGLang backend` and `ThroughputAnalyzer wiring` now run under live KEDA in the smoke job for the first time.

### Pre-review Checklist 
- [x] **E2E tests** for any new behavior — routing-only; verified via `ginkgo
      --dry-run` (`smoke` = 16 specs incl. the two previously-dead specs; `full &&
      !smoke && !flaky` = 34 specs, no overlap) and `go build`.
- [ ] **Docs PR** for any user-facing impact — n/a (developer-facing test tooling).
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — n/a.

**Release Note**

```release-note
NONE
```

Docs
No user-facing impact. docs/developer-guide/testing.md already documents the plain target names, so it now matches reality