### PR TITLE
test(e2e): assert replica magnitude on deterministic scale-up specs; harden a negative-path

### DIFF
--- a/test/e2e/saturation_analyzer_path_test.go
+++ b/test/e2e/saturation_analyzer_path_test.go
@@ -387,14 +387,18 @@ var _ = Describe("Saturation analyzer path and status propagation", Label("full"
 		By("Verifying controller is using V1 analyzer path")
 		expectAnalyzerPathLog("V1", modelID)
 
-		By("Verifying WVA emits wva_desired_replicas for the scaled-up variant")
-		// The engine's scale-up decision is surfaced via wva_desired_replicas,
-		// decoupled from the separate scaler actuation loop. This verifies emission/consumption via
-		// the KEDA HPA surface; the numeric magnitude relative to baseline is not
-		// asserted here (the HPA surface does not expose it reliably).
+		By("Asserting KEDA actuates scale-up above baseline")
+		// Aggressive V1 thresholds (kvCache=0.05, queue=1) against faked metrics
+		// (kv=0.3, queue=2) deterministically drive a scale-up; KEDA consumes
+		// wva_desired_replicas and drives the Deployment above its baseline. Assert the
+		// observable Deployment replica count — the ground truth — rather than the KEDA
+		// HPA CurrentMetrics surface, which only proves the metric was consumed.
 		Eventually(func(g Gomega) {
-			expectWVADesiredReplicasConsumed(g, cfg.LLMDNamespace, modelDecodeDeployment)
-		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+			dep, getErr := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
+			g.Expect(getErr).NotTo(HaveOccurred())
+			g.Expect(dep.Status.ReadyReplicas).To(BeNumerically(">", baseline),
+				"V1 above-threshold traffic should scale the target Deployment above baseline")
+		}, time.Duration(cfg.ScaleUpTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 	})
 
 })

--- a/test/e2e/sglang_backend_test.go
+++ b/test/e2e/sglang_backend_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
@@ -61,29 +60,20 @@ var _ = Describe("SGLang backend", Label("smoke", "full"), Ordered, func() {
 	})
 
 	It("detects SGLang and emits wva_desired_replicas from sglang:* metrics", func() {
-		// A correctly routed SGLang collection must produce wva_desired_replicas
-		// for the variant. vLLM queries would return nothing here, so the metric's
-		// presence proves the SGLang path collected sglang:* metrics.
-		//
-		// The fixture emits a saturated operating point (token_usage=0.85,
-		// num_queue_reqs=3), so the emitted value drives the managed scaler above a
-		// single replica. We observe that through the scaler surface rather than a
-		// VA status field: for KEDA via the managed HPA's CurrentMetrics.
-		By("Verifying KEDA read wva_desired_replicas for the SGLang variant")
+		// A correctly routed SGLang collection must produce wva_desired_replicas for
+		// the variant; vLLM queries would return nothing here, so a scale-up proves
+		// the SGLang path collected sglang:* metrics. The fixture emits a saturated
+		// operating point (token_usage=0.85, num_queue_reqs=3), so WVA recommends
+		// scale-up and KEDA drives the Deployment above a single replica. Assert the
+		// observable Deployment replica count — the ground truth — rather than the
+		// KEDA HPA CurrentMetrics surface, which only proves the metric was consumed.
+		By("Asserting KEDA actuates a scale-up above a single replica for the SGLang variant")
 		Eventually(func(g Gomega) {
-			hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
+			dep, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, appLabel, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
-			var kedaHPA *autoscalingv2.HorizontalPodAutoscaler
-			for i := range hpaList.Items {
-				if hpaList.Items[i].Spec.ScaleTargetRef.Name == appLabel {
-					kedaHPA = &hpaList.Items[i]
-					break
-				}
-			}
-			g.Expect(kedaHPA).NotTo(BeNil(), "KEDA should have created an HPA for the SGLang deployment")
-			g.Expect(kedaHPA.Status.CurrentMetrics).NotTo(BeEmpty(),
-				"KEDA HPA should have CurrentMetrics populated from wva_desired_replicas")
-		}).WithTimeout(time.Duration(cfg.EventuallyExtendedSec) * time.Second).
+			g.Expect(dep.Status.ReadyReplicas).To(BeNumerically(">=", int32(2)),
+				"saturated SGLang metrics (token_usage=0.85, num_queue_reqs=3) should drive the Deployment above a single replica")
+		}).WithTimeout(time.Duration(cfg.ScaleUpTimeout) * time.Second).
 			WithPolling(time.Duration(cfg.PollIntervalSlowSec) * time.Second).
 			Should(Succeed())
 	})

--- a/test/e2e/sglang_backend_test.go
+++ b/test/e2e/sglang_backend_test.go
@@ -21,7 +21,7 @@ import (
 // This exercises the same code path as vLLM, only with SGLang metric names and
 // flags. It runs in the kind-emulator environment (cfg.UseSimulator); a real
 // SGLang server requires a GPU.
-var _ = Describe("SGLang backend", Label("smoke", "full"), Ordered, func() {
+var _ = Describe("SGLang backend", Label("full"), Ordered, func() {
 	const (
 		baseName = "e2e-sglang"
 		// variantName MUST equal the annotated scaler's object name, which is

--- a/test/e2e/sglang_backend_test.go
+++ b/test/e2e/sglang_backend_test.go
@@ -24,9 +24,14 @@ import (
 var _ = Describe("SGLang backend", Label("smoke", "full"), Ordered, func() {
 	const (
 		baseName = "e2e-sglang"
-		// variantName is the annotated scaler's object name; WVA uses it as the
-		// variant_name label on wva_desired_replicas.
-		variantName = "e2e-sglang-hpa"
+		// variantName MUST equal the annotated scaler's object name, which is
+		// baseName+"-so" for a KEDA ScaledObject (see fixtures.EnsureScaledObject).
+		// WVA uses that object name as the variant identity: it attributes the decode
+		// pods' sglang:* metrics by matching their llm-d.ai/variant label to it, and
+		// emits wva_desired_replicas{variant_name=<object name>}. A mismatch leaves the
+		// pods unattributed, so WVA falls back to a safety-net desiredReplicas=current
+		// and never scales up. (Was the stale "e2e-sglang-hpa" from the HPA era.)
+		variantName = baseName + "-so"
 		// decodeSuffix mirrors the fixtures' "<base>-decode" naming convention.
 		decodeSuffix = "-decode"
 		// sglangEmulatorPort is the container/Service port the emitter serves on.

--- a/test/e2e/smoke_keda_test.go
+++ b/test/e2e/smoke_keda_test.go
@@ -223,10 +223,20 @@ var _ = Describe("KEDA Smoke Tests - Basic Autoscaling", Label("smoke", "full"),
 	})
 
 	It("should collect saturation metrics without triggering scale-up", func() {
-		By("Verifying the deployment's replica count stays put under steady state")
-		// With no engine-driven pressure the managed deployment should remain at
-		// its baseline replica count; we sample it repeatedly to confirm no
-		// scale-up is triggered.
+		// Guard against a vacuous pass: the Deployment starts at minReplicas, so a bare
+		// Consistently{<=1} would also succeed if WVA were dead and emitting nothing.
+		// First prove the pipeline is live — KEDA is consuming wva_desired_replicas for
+		// this variant — so the steady-state assertion means "WVA is actively
+		// recommending minReplicas under no load", not "nothing happened".
+		By("Confirming WVA is live: KEDA is consuming wva_desired_replicas for the variant")
+		Eventually(func(g Gomega) {
+			expectWVADesiredReplicasConsumed(g, ns, deploymentName)
+		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+
+		By("Verifying the deployment stays at its baseline replica count under no load")
+		// No load and no --fake-metrics pressure: the simulator's near-zero saturation
+		// signals keep WVA recommending minReplicas, so the managed Deployment must not
+		// scale up. Sampled repeatedly to confirm no scale-up is triggered.
 		Consistently(func(g Gomega) {
 			deployment, err := k8sClient.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/throughput_analyzer_test.go
+++ b/test/e2e/throughput_analyzer_test.go
@@ -427,13 +427,17 @@ var _ = Describe("Multi-analyzer engine scale-up (saturation-driven, throughput 
 		// desired count is no longer surfaced in VA status; the annotated scaler consumes
 		// wva_desired_replicas and drives the target Deployment above its MinReplicas floor,
 		// so we assert the observable Deployment replica count instead.
-		By("Waiting for WVA to emit wva_desired_replicas under faked saturation")
-		// The engine's scale-up decision is surfaced via wva_desired_replicas,
-		// decoupled from the separate scaler actuation loop. This verifies emission/consumption via
-		// the KEDA HPA surface; the numeric magnitude is not asserted here.
+		By("Asserting KEDA actuates scale-up above MinReplicas")
+		// Faked kv-cache-usage=0.9 > scaleUpThreshold=0.85 deterministically drives a
+		// V2 saturation scale-up; KEDA consumes wva_desired_replicas and drives the
+		// Deployment above its MinReplicas floor. Assert the observable replica count —
+		// the ground truth — rather than the KEDA HPA CurrentMetrics surface.
 		Eventually(func(g Gomega) {
-			expectWVADesiredReplicasConsumed(g, cfg.LLMDNamespace, modelDecodeDeployment)
-		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+			dep, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelDecodeDeployment, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dep.Status.ReadyReplicas).To(BeNumerically(">=", int32(2)),
+				"faked saturation (kv-cache-usage=0.9) should drive the Deployment above MinReplicas=1")
+		}, time.Duration(cfg.ScaleUpTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 	})
 })
 
@@ -533,6 +537,14 @@ var _ = Describe("ThroughputAnalyzer TA-only mode", Label("full", "throughput"),
 		// Post-CRD-removal WVA no longer writes VA .status; its sole output is the
 		// wva_desired_replicas external metric. A positive throughput-driven allocation
 		// is observed via the KEDA-managed HPA's CurrentMetrics.
+		//
+		// Unlike the saturation/SGLang scale-up specs (which use --fake-metrics to pin a
+		// deterministic operating point), this scenario is driven by a real sustained load
+		// job. The throughput analyzer's recommended replica count depends on measured
+		// token throughput vs SLO, which is not deterministic in CI — so this asserts that
+		// the metric is emitted and consumed (a positive allocation flows through the
+		// pipeline), not a specific replica magnitude, to avoid a load-timing-dependent
+		// flake.
 		By("Verifying KEDA read wva_desired_replicas for the throughput-driven variant")
 		Eventually(func(g Gomega) {
 			hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
The `CurrentMetrics NotTo(BeEmpty())` assertions across the e2e suite only prove KEDA *consumed* `wva_desired_replicas`, not its *value*, they passed even while the `exported_namespace` bug made KEDA read `0` and nothing scaled. This strengthens the specs whose outcome is deterministic to assert the observable
Deployment replica count (the ground truth of the full WVA→Prometheus→KEDA→HPA→Deployment pipeline), and closes a vacuous-pass hole in a negative-path spec.

## Proposed Changes

- :broom: Deterministic scale-up specs (driven by `--fake-metrics`) now assert `Deployment.Status.ReadyReplicas` instead of HPA `CurrentMetrics`:
  - `saturation_analyzer_path` "crosses V1 threshold" → `ReadyReplicas > baseline`
  - `throughput` multi-analyzer scale-up → `ReadyReplicas >= 2` (faked kv=0.9 > 0.85)
  - `sglang` → `ReadyReplicas >= 2` (faked token_usage=0.85, num_queue_reqs=3); removed the now-unused `autoscalingv2` import.
- :broom: `smoke_keda` "collect without triggering scale-up", add a liveness guard (`expectWVADesiredReplicasConsumed`) before the `Consistently`, so the steady-state assertion means "WVA is live and recommending minReplicas", not "nothing happened" (the bare check passed vacuously since the Deployment starts
  at minReplicas).
- :broom: `throughput` TA-only left as a consumption check **by design**, it is driven by a real sustained load job, not fake-metrics, so its replica recommendation depends on measured throughput vs SLO and is not deterministic in CI; asserting a magnitude would be a load-timing flake (rationale in the spec).

### Pre-review Checklist
- [x] **E2E tests** for any new behavior — this *is* e2e assertion hardening
- [ ] **Docs PR** for any user-facing impact — n/a (developer-facing test suite).
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — n/a.

**Release Note**
```
NONE
