### PR TITLE
feat: support inference-perf workload-catalog workloads in benchmark-run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,10 +423,23 @@ benchmark-standup: ## Stand up the benchmark environment (set BENCHMARK_NAMESPAC
 	exit $$rc
 
 .PHONY: benchmark-run
-benchmark-run: ## Run a single benchmark workload (set BENCHMARK_NAMESPACE=<namespace>, MODEL_ID=<model>)
+benchmark-run: ## Run a single benchmark workload (set BENCHMARK_NAMESPACE=<namespace>, MODEL_ID=<model>, BENCHMARK_HARNESS=guidellm|inference-perf)
 	@if [ -z "$(BENCHMARK_NAMESPACE)" ]; then \
 		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-run BENCHMARK_NAMESPACE=<namespace>"; \
 		exit 1; \
+	fi
+	@mkdir -p "$(BENCHMARK_SCENARIOS_DIR)"
+	@# Fetch workload from inference-perf catalog if not found locally and harness is inference-perf
+	@if [ "$(BENCHMARK_HARNESS)" = "inference-perf" ] && [ ! -f "$(BENCHMARK_SCENARIOS_DIR)/$(BENCHMARK_WORKLOAD)" ] && [ ! -f "$(BENCHMARK_SCENARIOS_DIR)/$(BENCHMARK_WORKLOAD).in" ]; then \
+		echo "Fetching $(BENCHMARK_WORKLOAD) from inference-perf workload-catalog..."; \
+		if curl -sfL "https://raw.githubusercontent.com/kubernetes-sigs/inference-perf/main/workload-catalog/$(BENCHMARK_WORKLOAD)/inference-perf.yaml" \
+			-o "$(BENCHMARK_SCENARIOS_DIR)/$(BENCHMARK_WORKLOAD)"; then \
+			echo "Successfully fetched $(BENCHMARK_WORKLOAD)"; \
+		else \
+			echo "ERROR: Could not fetch $(BENCHMARK_WORKLOAD) from inference-perf workload-catalog"; \
+			echo "Available workloads: interactive-chat, code-generation, deep-research, reasoning, batch-summarization-rag, batch-synthetic-data-generation"; \
+			exit 1; \
+		fi; \
 	fi
 	@if [ -f "$(BENCHMARK_SCENARIOS_DIR)/$(BENCHMARK_WORKLOAD).in" ]; then \
 		cp "$(BENCHMARK_SCENARIOS_DIR)/$(BENCHMARK_WORKLOAD).in" \


### PR DESCRIPTION
## Summary

Enable `make benchmark-run` to automatically fetch workloads from the [inference-perf workload-catalog](https://github.com/kubernetes-sigs/inference-perf/tree/main/workload-catalog) when using the `inference-perf` harness.

## What Changed

**Makefile changes:**
- Auto-download workloads from inference-perf catalog if not found locally
- Only applies when `BENCHMARK_HARNESS=inference-perf`
- Local workloads in `hack/benchmark/scenarios/` take precedence
- Graceful error handling with available workload list
- Updated help text to document `BENCHMARK_HARNESS` option

## Key Features

✅ **Backwards compatible** — Existing `make benchmark-run` calls unchanged  
✅ **Zero new variables** — Works with existing Makefile variables  
✅ **Local override** — Custom workloads always take precedence  
✅ **Robust** — Validates harness type and file existence before fetching  
✅ **User-friendly** — Shows available workloads on error  

## Usage Examples

\`\`\`bash
# Existing usage (unchanged)
make benchmark-run BENCHMARK_NAMESPACE=bench MODEL_ID=my-model

# New: Run with inference-perf catalog workload (auto-downloads)
make benchmark-run BENCHMARK_NAMESPACE=bench MODEL_ID=my-model \\
  BENCHMARK_HARNESS=inference-perf BENCHMARK_WORKLOAD=interactive-chat

# Other available catalog workloads
make benchmark-run ... BENCHMARK_WORKLOAD=code-generation
make benchmark-run ... BENCHMARK_WORKLOAD=deep-research
make benchmark-run ... BENCHMARK_WORKLOAD=reasoning
make benchmark-run ... BENCHMARK_WORKLOAD=batch-summarization-rag
make benchmark-run ... BENCHMARK_WORKLOAD=batch-synthetic-data-generation
\`\`\`

## Testing

All logic verified:
- ✓ Curl fetch works for all 6 catalog workloads
- ✓ Error handling for invalid workloads
- ✓ Directory creation logic
- ✓ Conditions for fetching (only inference-perf harness, file doesn't exist)
- ✓ Skips fetch when file already exists
- ✓ Skips fetch for non-inference-perf harnesses

Closes #1429

🤖 Generated with [Claude Code](https://claude.com/claude-code)