### PR TITLE
Fix: remove WVA manager RBAC for secrets

### DIFF
--- a/config/base/rbac/manager-clusterrole.yaml
+++ b/config/base/rbac/manager-clusterrole.yaml
@@ -13,7 +13,6 @@ rules:
   - nodes/status
   - pods
   - resourcequotas
-  - secrets
   - services
   verbs:
   - get

--- a/internal/collector/source/pod/config.go
+++ b/internal/collector/source/pod/config.go
@@ -17,10 +17,7 @@ type PodScrapingSourceConfig struct {
 	MetricsScheme string // provided by client, default: "http"
 
 	// Authentication
-	MetricsReaderSecretName      string
-	MetricsReaderSecretNamespace string // namespace where the secret is located; defaults to ServiceNamespace if empty
-	MetricsReaderSecretKey       string // default: "token"
-	BearerToken                  string // optional: explicit token override
+	BearerToken string
 
 	// Scraping behavior
 	ScrapeTimeout        time.Duration // default: 5s per pod
@@ -28,16 +25,4 @@ type PodScrapingSourceConfig struct {
 
 	// Cache configuration
 	DefaultTTL time.Duration // default: 30s
-}
-
-// DefaultPodScrapingSourceConfig returns sensible defaults.
-func DefaultPodScrapingSourceConfig() PodScrapingSourceConfig {
-	return PodScrapingSourceConfig{
-		MetricsPath:            "/metrics",
-		MetricsScheme:          "http",
-		MetricsReaderSecretKey: "token",
-		ScrapeTimeout:          5 * time.Second,
-		MaxConcurrentScrapes:   10,
-		DefaultTTL:             30 * time.Second,
-	}
 }

--- a/internal/collector/source/pod/pod_scraping_source.go
+++ b/internal/collector/source/pod/pod_scraping_source.go
@@ -60,9 +60,6 @@ func NewPodScrapingSource(
 	if config.MetricsScheme == "" {
 		config.MetricsScheme = "http"
 	}
-	if config.MetricsReaderSecretKey == "" {
-		config.MetricsReaderSecretKey = "token"
-	}
 	if config.ScrapeTimeout == 0 {
 		config.ScrapeTimeout = 5 * time.Second
 	}
@@ -283,11 +280,8 @@ func (p *PodScrapingSource) scrapePodMetrics(ctx context.Context, pod *corev1.Po
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Add authentication header if available (authentication is optional)
-	token, useAuth, err := p.getAuthToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get auth token: %w", err)
-	}
+	// Add authentication header if a bearer token is configured.
+	token, useAuth := p.getAuthToken()
 	if useAuth {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
@@ -309,45 +303,13 @@ func (p *PodScrapingSource) scrapePodMetrics(ctx context.Context, pod *corev1.Po
 	return p.parsePrometheusMetrics(resp.Body, pod.Name)
 }
 
-// getAuthToken retrieves the authentication token.
-// Returns (token, useAuth, error) where useAuth indicates if authentication should be used.
-// Authentication is optional - if no token is configured or secret doesn't exist, useAuth will be false.
-func (p *PodScrapingSource) getAuthToken(ctx context.Context) (string, bool, error) { //nolint:unparam // error return kept for future use
-	// If explicit token provided, use it
+// getAuthToken returns the bearer token and whether authentication should be used.
+// If BearerToken is configured, it is returned; otherwise authentication is skipped.
+func (p *PodScrapingSource) getAuthToken() (string, bool) {
 	if p.config.BearerToken != "" {
-		return p.config.BearerToken, true, nil
+		return p.config.BearerToken, true
 	}
-
-	// If no secret name configured, skip authentication
-	if p.config.MetricsReaderSecretName == "" {
-		return "", false, nil
-	}
-
-	// Try to read from secret
-	secret := &corev1.Secret{}
-	// Use the specified secret namespace, or fall back to service namespace
-	secretNamespace := p.config.MetricsReaderSecretNamespace
-	if secretNamespace == "" {
-		secretNamespace = p.config.ServiceNamespace
-	}
-	secretKey := types.NamespacedName{
-		Name:      p.config.MetricsReaderSecretName,
-		Namespace: secretNamespace,
-	}
-
-	if err := p.k8sClient.Get(ctx, secretKey, secret); err != nil {
-		// Secret doesn't exist - treat authentication as optional
-		// Return no error, just indicate auth should not be used
-		return "", false, nil
-	}
-
-	tokenBytes, ok := secret.Data[p.config.MetricsReaderSecretKey]
-	if !ok {
-		// Token key not found - treat as optional, skip auth
-		return "", false, nil
-	}
-
-	return string(tokenBytes), true, nil
+	return "", false
 }
 
 // parsePrometheusMetrics parses Prometheus text format into MetricResult.

--- a/internal/collector/source/pod/pod_scraping_source_test.go
+++ b/internal/collector/source/pod/pod_scraping_source_test.go
@@ -79,8 +79,6 @@ var _ = Describe("PodScrapingSource", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(source.config.MetricsPath).To(Equal("/metrics"))
 			Expect(source.config.MetricsScheme).To(Equal("http"))
-			Expect(source.config.MetricsReaderSecretName).To(BeEmpty(), "MetricsReaderSecretName should be empty by default (no EPP-specific default)")
-			Expect(source.config.MetricsReaderSecretKey).To(Equal("token"))
 			Expect(source.config.ScrapeTimeout).To(Equal(5 * time.Second))
 			Expect(source.config.MaxConcurrentScrapes).To(Equal(10))
 			Expect(source.config.DefaultTTL).To(Equal(30 * time.Second))
@@ -337,41 +335,7 @@ var _ = Describe("PodScrapingSource", func() {
 	})
 
 	Describe("getAuthToken", func() {
-		var secret *corev1.Secret
-
-		BeforeEach(func() {
-			secret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "inference-gateway-sa-metrics-reader-secret",
-					Namespace: "test-ns",
-				},
-				Data: map[string][]byte{
-					"token": []byte("test-bearer-token"),
-				},
-			}
-		})
-
-		It("should read token from secret", func() {
-			client := fakeClient.
-				WithObjects(secret).
-				Build()
-
-			config := PodScrapingSourceConfig{
-				ServiceName:             "test-pool-epp",
-				ServiceNamespace:        "test-ns",
-				MetricsPort:             9090,
-				MetricsReaderSecretName: "inference-gateway-sa-metrics-reader-secret",
-			}
-			source, err := NewPodScrapingSource(ctx, client, config)
-			Expect(err).NotTo(HaveOccurred())
-
-			token, useAuth, err := source.getAuthToken(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(useAuth).To(BeTrue())
-			Expect(token).To(Equal("test-bearer-token"))
-		})
-
-		It("should use explicit BearerToken if provided", func() {
+		It("should return the BearerToken when configured", func() {
 			client := fakeClient.Build()
 
 			config := PodScrapingSourceConfig{
@@ -383,13 +347,12 @@ var _ = Describe("PodScrapingSource", func() {
 			source, err := NewPodScrapingSource(ctx, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			token, useAuth, err := source.getAuthToken(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			token, useAuth := source.getAuthToken()
 			Expect(useAuth).To(BeTrue())
 			Expect(token).To(Equal("explicit-token"))
 		})
 
-		It("should skip authentication if secret not found (optional auth)", func() {
+		It("should skip authentication when no BearerToken is configured", func() {
 			client := fakeClient.Build()
 
 			config := PodScrapingSourceConfig{
@@ -400,47 +363,7 @@ var _ = Describe("PodScrapingSource", func() {
 			source, err := NewPodScrapingSource(ctx, client, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			token, useAuth, err := source.getAuthToken(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(useAuth).To(BeFalse())
-			Expect(token).To(BeEmpty())
-		})
-
-		It("should skip authentication if token key not found in secret (optional auth)", func() {
-			secret.Data = map[string][]byte{} // Empty secret
-			client := fakeClient.
-				WithObjects(secret).
-				Build()
-
-			config := PodScrapingSourceConfig{
-				ServiceName:             "test-pool-epp",
-				ServiceNamespace:        "test-ns",
-				MetricsPort:             9090,
-				MetricsReaderSecretName: "inference-gateway-sa-metrics-reader-secret",
-			}
-			source, err := NewPodScrapingSource(ctx, client, config)
-			Expect(err).NotTo(HaveOccurred())
-
-			token, useAuth, err := source.getAuthToken(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(useAuth).To(BeFalse())
-			Expect(token).To(BeEmpty())
-		})
-
-		It("should skip authentication if MetricsReaderSecretName is empty", func() {
-			client := fakeClient.Build()
-
-			config := PodScrapingSourceConfig{
-				ServiceName:             "test-pool-epp",
-				ServiceNamespace:        "test-ns",
-				MetricsPort:             9090,
-				MetricsReaderSecretName: "", // Empty - no auth
-			}
-			source, err := NewPodScrapingSource(ctx, client, config)
-			Expect(err).NotTo(HaveOccurred())
-
-			token, useAuth, err := source.getAuthToken(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			token, useAuth := source.getAuthToken()
 			Expect(useAuth).To(BeFalse())
 			Expect(token).To(BeEmpty())
 		})
@@ -516,7 +439,6 @@ vllm_num_requests_waiting{namespace="test-ns"} 5
 	Describe("Refresh", func() {
 		var (
 			service     *corev1.Service
-			secret      *corev1.Secret
 			readyPod1   *corev1.Pod
 			readyPod2   *corev1.Pod
 			mockServer1 *httptest.Server
@@ -538,16 +460,6 @@ vllm_num_requests_waiting{namespace="test-ns"} 5
 					Selector: map[string]string{
 						"inferencepool": "test-pool-epp",
 					},
-				},
-			}
-
-			secret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "inference-gateway-sa-metrics-reader-secret",
-					Namespace: "test-ns",
-				},
-				Data: map[string][]byte{
-					"token": []byte("test-token"),
 				},
 			}
 
@@ -664,18 +576,18 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 			// Create separate sources for each pod (since they use different ports)
 			// In real scenario, all pods use same port but different IPs
 			client1 := fakeClient.
-				WithObjects(service, secret, readyPod1).
+				WithObjects(service, readyPod1).
 				Build()
 
 			config1 := PodScrapingSourceConfig{
-				ServiceName:             "test-pool-epp",
-				ServiceNamespace:        "test-ns",
-				MetricsPort:             port1,
-				MetricsPath:             "/metrics",
-				MetricsScheme:           "http",
-				ScrapeTimeout:           5 * time.Second,
-				MaxConcurrentScrapes:    10,
-				MetricsReaderSecretName: "inference-gateway-sa-metrics-reader-secret",
+				ServiceName:          "test-pool-epp",
+				ServiceNamespace:     "test-ns",
+				MetricsPort:          port1,
+				MetricsPath:          "/metrics",
+				MetricsScheme:        "http",
+				ScrapeTimeout:        5 * time.Second,
+				MaxConcurrentScrapes: 10,
+				BearerToken:          "test-token",
 			}
 			source1, err := NewPodScrapingSource(ctx, client1, config1)
 			Expect(err).NotTo(HaveOccurred())
@@ -726,7 +638,7 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 			}
 
 			client := fakeClient.
-				WithObjects(service, secret, unreachablePod).
+				WithObjects(service, unreachablePod).
 				Build()
 
 			config := PodScrapingSourceConfig{
@@ -782,27 +694,16 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 				},
 			}
 
-			// Use wrong token
-			wrongSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "inference-gateway-sa-metrics-reader-secret",
-					Namespace: "test-ns",
-				},
-				Data: map[string][]byte{
-					"token": []byte("wrong-token"),
-				},
-			}
-
 			client := fakeClient.
-				WithObjects(service, wrongSecret, authPod).
+				WithObjects(service, authPod).
 				Build()
 
 			config := PodScrapingSourceConfig{
-				ServiceName:             "test-pool-epp",
-				ServiceNamespace:        "test-ns",
-				MetricsPort:             port,
-				ScrapeTimeout:           1 * time.Second,
-				MetricsReaderSecretName: "inference-gateway-sa-metrics-reader-secret",
+				ServiceName:      "test-pool-epp",
+				ServiceNamespace: "test-ns",
+				MetricsPort:      port,
+				ScrapeTimeout:    1 * time.Second,
+				BearerToken:      "wrong-token",
 			}
 			source, err := NewPodScrapingSource(ctx, client, config)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -22,7 +22,6 @@ package controller
 // Core resources read during optimization and metrics collection.
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // Note: Namespace watch permission is required for label-based namespace opt-in for namespace-local ConfigMaps.
 

--- a/test/e2e/pod_scraping_test.go
+++ b/test/e2e/pod_scraping_test.go
@@ -19,12 +19,11 @@ import (
 //
 // Note: On Kind clusters, pod IPs are not routable from outside the cluster, so direct
 // scraping tests are skipped. In-cluster scraping tests still run to verify functionality.
-var _ = Describe("PodScrapingSource", Label("full"), Label("flaky"), Ordered, func() {
+var _ = Describe("PodScrapingSource", Label("full"), Ordered, func() {
 	var (
-		poolName          = "pod-scraping-pool"
-		modelServiceName  = "pod-scraping-ms"
-		eppServiceName    string
-		metricsSecretName string
+		poolName         = "pod-scraping-pool"
+		modelServiceName = "pod-scraping-ms"
+		eppServiceName   string
 	)
 
 	BeforeAll(func() {
@@ -100,12 +99,6 @@ var _ = Describe("PodScrapingSource", Label("full"), Label("flaky"), Ordered, fu
 				"Should have at least one Ready EPP pod")
 		}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSlowSec)*time.Second).Should(Succeed())
 
-		By("Discovering or creating metrics reader secret")
-		var discoverErr error
-		metricsSecretName, discoverErr = utils.DiscoverMetricsReaderSecret(ctx, k8sClient,
-			crClient, cfg.LLMDNamespace, eppServiceName)
-		Expect(discoverErr).NotTo(HaveOccurred(), "Should be able to discover or create metrics secret")
-		GinkgoWriter.Printf("Using metrics secret: %s\n", metricsSecretName)
 	})
 
 	AfterAll(func() {
@@ -134,17 +127,15 @@ var _ = Describe("PodScrapingSource", Label("full"), Label("flaky"), Ordered, fu
 	// Use shared PodScrapingSource tests with environment-agnostic configuration
 	utils.DescribePodScrapingSourceTests(func() utils.PodScrapingTestConfig {
 		return utils.PodScrapingTestConfig{
-			Environment:             cfg.Environment,
-			ServiceName:             eppServiceName,
-			ServiceNamespace:        cfg.LLMDNamespace,
-			MetricsPort:             9090,
-			MetricsPath:             "/metrics",
-			MetricsScheme:           "http",
-			MetricsReaderSecretName: metricsSecretName,
-			MetricsReaderSecretKey:  "token",
-			K8sClient:               k8sClient,
-			CRClient:                crClient,
-			Ctx:                     ctx,
+			Environment:      cfg.Environment,
+			ServiceName:      eppServiceName,
+			ServiceNamespace: cfg.LLMDNamespace,
+			MetricsPort:      9090,
+			MetricsPath:      "/metrics",
+			MetricsScheme:    "http",
+			K8sClient:        k8sClient,
+			CRClient:         crClient,
+			Ctx:              ctx,
 		}
 	})
 })

--- a/test/utils/pod_scraping_test_helpers.go
+++ b/test/utils/pod_scraping_test_helpers.go
@@ -353,24 +353,25 @@ func TestInClusterScraping(ctx context.Context, config PodScrapingTestConfig, g 
 	}
 	g.Expect(testPod).NotTo(gom.BeNil(), "Should have at least one ready pod with IP")
 
-	// Create a test Job that runs inside the cluster and verifies scraping works
+	// Run the Job in the controller namespace where the epp-metrics-token secret is
+	// deployed, so it can be mounted the same way the controller mounts it.
+	const jobNS = "workload-variant-autoscaler-system"
 	jobName := fmt.Sprintf("pod-scraping-test-%d", time.Now().Unix())
 	_, err = CreateInClusterScrapingTestJob(
 		ctx,
 		config.K8sClient,
-		config.ServiceNamespace,
+		jobNS,
 		jobName,
 		testPod.Status.PodIP,
 		config.MetricsPort,
 		config.MetricsPath,
 		config.MetricsScheme,
-		"",
 	)
 	g.Expect(err).NotTo(gom.HaveOccurred(), "Should be able to create test job")
 
 	// Cleanup job after test
 	defer func() {
-		_ = config.K8sClient.BatchV1().Jobs(config.ServiceNamespace).Delete(ctx, jobName, metav1.DeleteOptions{
+		_ = config.K8sClient.BatchV1().Jobs(jobNS).Delete(ctx, jobName, metav1.DeleteOptions{
 			PropagationPolicy: func() *metav1.DeletionPropagation {
 				p := metav1.DeletePropagationForeground
 				return &p
@@ -378,30 +379,27 @@ func TestInClusterScraping(ctx context.Context, config PodScrapingTestConfig, g 
 		})
 	}()
 
-	// Wait for job to complete
-	// Timeout must account for image pull time (curlimages/curl may need to be pulled from Docker Hub,
-	// which can be slow in CI due to rate limiting on shared GitHub Actions runner IPs)
 	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Waiting for in-cluster scraping test job to complete...\n")
 	gom.Eventually(func(g gom.Gomega) {
-		currentJob, err := config.K8sClient.BatchV1().Jobs(config.ServiceNamespace).Get(ctx, jobName, metav1.GetOptions{})
+		currentJob, err := config.K8sClient.BatchV1().Jobs(jobNS).Get(ctx, jobName, metav1.GetOptions{})
 		g.Expect(err).NotTo(gom.HaveOccurred(), "Should be able to get job")
 		g.Expect(currentJob.Status.Succeeded+currentJob.Status.Failed).To(gom.BeNumerically(">", 0), "Job should complete")
 	}, 5*time.Minute, 5*time.Second).Should(gom.Succeed())
 
 	// Verify job succeeded
-	finalJob, err := config.K8sClient.BatchV1().Jobs(config.ServiceNamespace).Get(ctx, jobName, metav1.GetOptions{})
+	finalJob, err := config.K8sClient.BatchV1().Jobs(jobNS).Get(ctx, jobName, metav1.GetOptions{})
 	g.Expect(err).NotTo(gom.HaveOccurred(), "Should be able to get final job status")
 	g.Expect(finalJob.Status.Succeeded).To(gom.BeNumerically(">=", 1), "Job should succeed")
 
 	// Get job logs to verify scraping worked
-	podList, err := config.K8sClient.CoreV1().Pods(config.ServiceNamespace).List(ctx, metav1.ListOptions{
+	podList, err := config.K8sClient.CoreV1().Pods(jobNS).List(ctx, metav1.ListOptions{
 		LabelSelector: "job-name=" + jobName,
 	})
 	g.Expect(err).NotTo(gom.HaveOccurred(), "Should be able to list job pods")
 	g.Expect(podList.Items).NotTo(gom.BeEmpty(), "Should have job pod")
 
 	testPodName := podList.Items[0].Name
-	logsReq := config.K8sClient.CoreV1().Pods(config.ServiceNamespace).GetLogs(testPodName, &corev1.PodLogOptions{
+	logsReq := config.K8sClient.CoreV1().Pods(jobNS).GetLogs(testPodName, &corev1.PodLogOptions{
 		Container: "scraper",
 	})
 	logBytes, err := logsReq.DoRaw(ctx)
@@ -418,28 +416,20 @@ func TestInClusterScraping(ctx context.Context, config PodScrapingTestConfig, g 
 // CreateInClusterScrapingTestJob creates a Job that runs inside the cluster and verifies
 // that PodScrapingSource can successfully scrape metrics from EPP pods.
 //
-// This test verifies end-to-end scraping functionality by:
-// 1. Creating a Job pod that runs inside the cluster (can access pod IPs)
-// 2. Using curl to verify the metrics endpoint is accessible
-// 3. Validating that the response contains valid Prometheus-format metrics
-//
-// TODO: Consider migrating to a ConfigMap-based approach where the test script is stored in a ConfigMap
-// and mounted as a volume. This would avoid embedding scripts as command-line arguments and improve
-// maintainability. The current approach embeds the script as a string for simplicity.
+// The Job mounts the epp-metrics-token secret at the same path the controller uses
+// (/var/run/secrets/epp-metrics), so the test script reads the bearer token from a file
+// rather than requiring the caller to look it up via the K8s API.
 func CreateInClusterScrapingTestJob(
 	ctx context.Context,
 	k8sClient *kubernetes.Clientset,
 	namespace, jobName, podIP string,
 	metricsPort int32,
-	metricsPath, metricsScheme, bearerToken string,
+	metricsPath, metricsScheme string,
 ) (*batchv1.Job, error) {
 	url := fmt.Sprintf("%s://%s:%d%s", metricsScheme, podIP, metricsPort, metricsPath)
 
-	// Use the embedded test script with URL and token as environment variables
-	// The script is read from test/utils/scripts/in_cluster_pod_scraping_test.sh at compile time
-	// via the //go:embed directive
-
-	backoffLimit := int32(0) // Don't retry on failure
+	backoffLimit := int32(0)
+	defaultMode := int32(420)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -453,19 +443,33 @@ func CreateInClusterScrapingTestJob(
 					Containers: []corev1.Container{
 						{
 							Name:  "scraper",
-							Image: "curlimages/curl:8.11.1", // Lightweight curl image
+							Image: "curlimages/curl:8.11.1",
 							Env: []corev1.EnvVar{
 								{
 									Name:  "TARGET_URL",
 									Value: url,
 								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:  "BEARER_TOKEN",
-									Value: bearerToken,
+									Name:      "epp-metrics-token",
+									MountPath: "/var/run/secrets/epp-metrics",
+									ReadOnly:  true,
 								},
 							},
 							Command: []string{"/bin/sh", "-c"},
 							Args:    []string{inClusterPodScrapingTestScript},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "epp-metrics-token",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName:  "wva-epp-metrics-token",
+									DefaultMode: &defaultMode,
+								},
+							},
 						},
 					},
 				},

--- a/test/utils/pod_scraping_test_helpers.go
+++ b/test/utils/pod_scraping_test_helpers.go
@@ -118,16 +118,14 @@ func CreatePodScrapingSource(config PodScrapingTestConfig) (*pod.PodScrapingSour
 	}
 
 	podConfig := pod.PodScrapingSourceConfig{
-		ServiceName:             config.ServiceName,
-		ServiceNamespace:        config.ServiceNamespace,
-		MetricsPort:             config.MetricsPort,
-		MetricsPath:             config.MetricsPath,
-		MetricsScheme:           config.MetricsScheme,
-		MetricsReaderSecretName: config.MetricsReaderSecretName,
-		MetricsReaderSecretKey:  config.MetricsReaderSecretKey,
-		ScrapeTimeout:           5 * time.Second,
-		MaxConcurrentScrapes:    10,
-		DefaultTTL:              30 * time.Second,
+		ServiceName:          config.ServiceName,
+		ServiceNamespace:     config.ServiceNamespace,
+		MetricsPort:          config.MetricsPort,
+		MetricsPath:          config.MetricsPath,
+		MetricsScheme:        config.MetricsScheme,
+		ScrapeTimeout:        5 * time.Second,
+		MaxConcurrentScrapes: 10,
+		DefaultTTL:           30 * time.Second,
 	}
 
 	return pod.NewPodScrapingSource(ctx, config.CRClient, podConfig)

--- a/test/utils/pod_scraping_test_helpers.go
+++ b/test/utils/pod_scraping_test_helpers.go
@@ -66,10 +66,8 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/pod"
 	"github.com/onsi/ginkgo/v2"
 	gom "github.com/onsi/gomega"
-	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,10 +94,6 @@ type PodScrapingTestConfig struct {
 	MetricsPort   int32
 	MetricsPath   string
 	MetricsScheme string
-
-	// Authentication
-	MetricsReaderSecretName string
-	MetricsReaderSecretKey  string
 
 	// Kubernetes clients
 	K8sClient *kubernetes.Clientset
@@ -244,136 +238,6 @@ func TestPodScrapingMetricsCollection(ctx context.Context, config PodScrapingTes
 	}
 }
 
-// DiscoverMetricsReaderSecret discovers the metrics reader secret name for an EPP.
-// It tries multiple strategies:
-// 1. From ServiceMonitor bearerTokenSecret reference
-// 2. From EPP service account token secret
-// 3. Common naming patterns
-// 4. Creates a test secret if none found (for e2e testing only)
-func DiscoverMetricsReaderSecret(ctx context.Context, k8sClient *kubernetes.Clientset, crClient client.Client, namespace, eppServiceName string) (string, error) {
-	// Strategy 1: Check ServiceMonitor for authorization credentials
-	// Supports both deprecated BearerTokenSecret and new Authorization.Credentials
-	serviceMonitorList := &promoperator.ServiceMonitorList{}
-	err := crClient.List(ctx, serviceMonitorList, client.InNamespace(namespace))
-	if err == nil {
-		for _, sm := range serviceMonitorList.Items {
-			// Check if this ServiceMonitor targets the EPP service
-			// ServiceMonitor selector should match the EPP service labels
-			for _, endpoint := range sm.Spec.Endpoints {
-				// Check new Authorization API first (preferred)
-				if endpoint.Authorization != nil && endpoint.Authorization.Credentials != nil {
-					secretName := endpoint.Authorization.Credentials.Name
-					// Verify secret exists
-					_, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
-					if err == nil {
-						_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Discovered metrics secret from ServiceMonitor Authorization: %s\n", secretName)
-						return secretName, nil
-					}
-				}
-				// Fallback to deprecated BearerTokenSecret (for backward compatibility)
-				//nolint:staticcheck // SA1019: BearerTokenSecret is deprecated but still used in some deployments
-				if endpoint.BearerTokenSecret != nil {
-					secretName := endpoint.BearerTokenSecret.Name
-					// Verify secret exists
-					_, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
-					if err == nil {
-						_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Discovered metrics secret from ServiceMonitor BearerTokenSecret: %s\n", secretName)
-						return secretName, nil
-					}
-				}
-			}
-		}
-	}
-
-	// Strategy 2: Try to find secret from EPP service account
-	svc, err := k8sClient.CoreV1().Services(namespace).Get(ctx, eppServiceName, metav1.GetOptions{})
-	if err == nil && svc.Spec.Selector != nil {
-		// Get pods for this service
-		podList, err := k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-			LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{
-				MatchLabels: svc.Spec.Selector,
-			}),
-		})
-		if err == nil && len(podList.Items) > 0 {
-			// Get service account from first pod
-			saName := podList.Items[0].Spec.ServiceAccountName
-			if saName != "" {
-				// Try common service account token secret patterns
-				secretPatterns := []string{
-					saName + "-token",
-					saName + "-metrics-reader-secret",
-					"inference-gateway-sa-metrics-reader-secret",
-				}
-				for _, pattern := range secretPatterns {
-					_, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, pattern, metav1.GetOptions{})
-					if err == nil {
-						_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Discovered metrics secret from service account pattern: %s\n", pattern)
-						return pattern, nil
-					}
-				}
-			}
-		}
-	}
-
-	// Strategy 3: Try common naming patterns
-	commonNames := []string{
-		"inference-gateway-sa-metrics-reader-secret",
-		eppServiceName + "-metrics-reader-secret",
-		eppServiceName + "-epp-metrics-reader-secret",
-	}
-	for _, name := range commonNames {
-		_, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err == nil {
-			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Discovered metrics secret from common pattern: %s\n", name)
-			return name, nil
-		}
-	}
-
-	// Strategy 4: Create a test secret for e2e testing (if none found)
-	// This is acceptable for e2e tests where the secret might not exist in CI
-	testSecretName := "inference-gateway-sa-metrics-reader-secret"
-	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "No metrics secret found, creating test secret for e2e: %s\n", testSecretName)
-
-	// Generate a dummy token for testing
-	testToken := fmt.Sprintf("test-token-%d", time.Now().Unix())
-	testSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testSecretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/component":  "e2e-test",
-				"app.kubernetes.io/managed-by": "workload-variant-autoscaler-test",
-			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			"token": []byte(testToken),
-		},
-	}
-
-	// Try to create, ignore if already exists
-	_, err = k8sClient.CoreV1().Secrets(namespace).Create(ctx, testSecret, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return "", fmt.Errorf("failed to create test secret: %w", err)
-	}
-
-	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Created test metrics secret: %s (for e2e testing only)\n", testSecretName)
-	return testSecretName, nil
-}
-
-// TestPodScrapingAuthentication tests that PodScrapingSource can read authentication token
-func TestPodScrapingAuthentication(ctx context.Context, config PodScrapingTestConfig, g gom.Gomega) {
-	// Verify secret exists
-	secret, err := config.K8sClient.CoreV1().Secrets(config.ServiceNamespace).Get(
-		ctx,
-		config.MetricsReaderSecretName,
-		metav1.GetOptions{},
-	)
-	g.Expect(err).NotTo(gom.HaveOccurred(), "Metrics reader secret should exist")
-	g.Expect(secret.Data).To(gom.HaveKey(config.MetricsReaderSecretKey), "Secret should have token key")
-	g.Expect(secret.Data[config.MetricsReaderSecretKey]).NotTo(gom.BeEmpty(), "Token should not be empty")
-}
-
 // TestPodScrapingCaching tests that PodScrapingSource caches results
 func TestPodScrapingCaching(ctx context.Context, config PodScrapingTestConfig, g gom.Gomega) {
 	if config.Environment == envKindVal || config.Environment == envKindEmulatorVal {
@@ -450,16 +314,6 @@ func TestPodScrapingFromController(ctx context.Context, config PodScrapingTestCo
 	}
 	g.Expect(testPod).NotTo(gom.BeNil(), "Should have at least one ready pod with IP")
 
-	// Get the Bearer token from the secret
-	secret, err := config.K8sClient.CoreV1().Secrets(config.ServiceNamespace).Get(
-		ctx,
-		config.MetricsReaderSecretName,
-		metav1.GetOptions{},
-	)
-	g.Expect(err).NotTo(gom.HaveOccurred(), "Should be able to get metrics secret")
-	token := string(secret.Data[config.MetricsReaderSecretKey])
-	g.Expect(token).NotTo(gom.BeEmpty(), "Token should not be empty")
-
 	controllerPods, err := config.K8sClient.CoreV1().Pods("workload-variant-autoscaler-system").List(ctx, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=workload-variant-autoscaler",
 	})
@@ -499,16 +353,6 @@ func TestInClusterScraping(ctx context.Context, config PodScrapingTestConfig, g 
 	}
 	g.Expect(testPod).NotTo(gom.BeNil(), "Should have at least one ready pod with IP")
 
-	// Get the Bearer token from the secret
-	secret, err := config.K8sClient.CoreV1().Secrets(config.ServiceNamespace).Get(
-		ctx,
-		config.MetricsReaderSecretName,
-		metav1.GetOptions{},
-	)
-	g.Expect(err).NotTo(gom.HaveOccurred(), "Should be able to get metrics secret")
-	token := string(secret.Data[config.MetricsReaderSecretKey])
-	g.Expect(token).NotTo(gom.BeEmpty(), "Token should not be empty")
-
 	// Create a test Job that runs inside the cluster and verifies scraping works
 	jobName := fmt.Sprintf("pod-scraping-test-%d", time.Now().Unix())
 	_, err = CreateInClusterScrapingTestJob(
@@ -520,7 +364,7 @@ func TestInClusterScraping(ctx context.Context, config PodScrapingTestConfig, g 
 		config.MetricsPort,
 		config.MetricsPath,
 		config.MetricsScheme,
-		token,
+		"",
 	)
 	g.Expect(err).NotTo(gom.HaveOccurred(), "Should be able to create test job")
 
@@ -729,15 +573,6 @@ func DescribePodScrapingSourceTests(configFn func() PodScrapingTestConfig) {
 				testCtx = context.Background()
 			}
 			TestPodScrapingPodDiscovery(testCtx, config, gom.NewWithT(ginkgo.GinkgoT()))
-		})
-
-		ginkgo.It("should authenticate with Bearer token", func() {
-			config := configFn()
-			testCtx := config.Ctx
-			if testCtx == nil {
-				testCtx = context.Background()
-			}
-			TestPodScrapingAuthentication(testCtx, config, gom.NewWithT(ginkgo.GinkgoT()))
 		})
 
 		ginkgo.It("should scrape metrics from pods", func() {

--- a/test/utils/scripts/in_cluster_pod_scraping_test.sh
+++ b/test/utils/scripts/in_cluster_pod_scraping_test.sh
@@ -7,8 +7,11 @@
 # This is used by TestInClusterScraping to verify end-to-end scraping functionality
 # when running inside the Kubernetes cluster (where pod IPs are accessible).
 #
-# This script expects TARGET_URL as a required environment variable.
-# BEARER_TOKEN is optional; if set, it is sent as an Authorization header.
+# Environment:
+#   TARGET_URL (required) - the metrics endpoint URL to scrape
+#
+# The bearer token is read from the mounted epp-metrics-token secret at
+# /var/run/secrets/epp-metrics/token, mirroring the production controller path.
 
 set -e
 
@@ -17,8 +20,15 @@ if [ -z "$TARGET_URL" ]; then
   exit 1
 fi
 
+TOKEN_PATH="/var/run/secrets/epp-metrics/token"
+BEARER_TOKEN=""
+if [ -f "$TOKEN_PATH" ]; then
+  BEARER_TOKEN=$(cat "$TOKEN_PATH")
+fi
+
 echo "Testing metrics scraping from inside cluster..."
 echo "Target URL: ${TARGET_URL}"
+echo "Auth: $([ -n "$BEARER_TOKEN" ] && echo "bearer token loaded" || echo "no token")"
 echo ""
 
 # Test 1: Verify endpoint is accessible

--- a/test/utils/scripts/in_cluster_pod_scraping_test.sh
+++ b/test/utils/scripts/in_cluster_pod_scraping_test.sh
@@ -2,22 +2,18 @@
 #
 # This script is embedded in the test Job (via //go:embed) and verifies that:
 # 1. The EPP pod metrics endpoint is accessible (HTTP 200)
-# 2. Bearer token authentication works correctly
-# 3. The response contains valid Prometheus-format metrics
+# 2. The response contains valid Prometheus-format metrics
 #
 # This is used by TestInClusterScraping to verify end-to-end scraping functionality
 # when running inside the Kubernetes cluster (where pod IPs are accessible).
 #
-# TODO: Consider migrating to a ConfigMap-based approach for better maintainability
-# and to avoid embedding scripts as command-line arguments.
-#
-# This script expects TARGET_URL and BEARER_TOKEN as environment variables.
+# This script expects TARGET_URL as a required environment variable.
+# BEARER_TOKEN is optional; if set, it is sent as an Authorization header.
 
 set -e
 
-if [ -z "$TARGET_URL" ] || [ -z "$BEARER_TOKEN" ]; then
-  echo "ERROR: Missing required environment variables"
-  echo "Expected: TARGET_URL and BEARER_TOKEN"
+if [ -z "$TARGET_URL" ]; then
+  echo "ERROR: Missing required environment variable TARGET_URL"
   exit 1
 fi
 
@@ -27,9 +23,14 @@ echo ""
 
 # Test 1: Verify endpoint is accessible
 echo "Test 1: Checking if metrics endpoint is accessible..."
-HTTP_CODE=$(curl -s -o /tmp/metrics.txt -w "%{http_code}" --max-time 10 \
-  -H "Authorization: Bearer ${BEARER_TOKEN}" \
-  "${TARGET_URL}" || echo "000")
+if [ -n "$BEARER_TOKEN" ]; then
+  HTTP_CODE=$(curl -s -o /tmp/metrics.txt -w "%{http_code}" --max-time 10 \
+    -H "Authorization: Bearer ${BEARER_TOKEN}" \
+    "${TARGET_URL}" || echo "000")
+else
+  HTTP_CODE=$(curl -s -o /tmp/metrics.txt -w "%{http_code}" --max-time 10 \
+    "${TARGET_URL}" || echo "000")
+fi
 
 if [ "$HTTP_CODE" != "200" ]; then
   echo "ERROR: Metrics endpoint returned HTTP $HTTP_CODE"


### PR DESCRIPTION
Fixes #

## The issue
This issue was flagged by a security scan in downstream to reduce privileges on secret to minimum required by WVA manager.

Currently WVA manager has clusterwide `get,list,watch` on `secrets` as defined in manager-role ClusterRole. It can get,list,watch any secrets in any namespace !

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
WVA manager doesn't need this RBAC:
- By design, it should not read any secrets. The secret `wva-epp-metrics-token` in `workload-variant-autoscaler-system` namespace is already mounted and WVA reads it as a file so it doesn't need to (and shoud not) make API call to read secrets. 
- The main change for this PR is to remove the RBAC. The rest of the changes is for removal of code that reads secrets from any namespace.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [N/A] **E2E tests** for any new behavior
- [N/A] **Docs PR** for any user-facing impact
- [N/A] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
N/A
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
N/A