### PR TITLE
fix(coordinator): respect HPA spec.minReplicas in GPU rebalance floor

### DIFF
--- a/internal/coordinator/plugins/gpurebalance/plugin.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin.go
@@ -117,34 +117,37 @@ func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns str
 		}
 	}
 
-	// TODO: the minimum target is hardcoded to 1 but an HPA may have spec.minReplicas
-	// set higher (e.g. 2 or 3). Setting maxReplicas below minReplicas produces an
-	// invalid HPA and Kubernetes will reject the patch. The floor should be
-	// max(1, hpa.Spec.MinReplicas) so the computed target is always a valid value.
-
-	// TODO: when len(entries) > quota the minimum-1 clamp causes every HPA to
-	// receive maxReplicas=1 and allocated exceeds quota (e.g. 100 HPAs, quota=10
-	// → allocated=100). The ResourceQuota becomes the only enforcement and the
-	// first 10 pods to be scheduled win while the other 90 are stuck pending.
-	// Fix: rank HPAs by queue depth, assign maxReplicas=1 only to the top-quota
-	// pools, and park the rest at minReplicas so the budget is not over-committed.
+	// TODO: when len(entries) > quota the minimum-minReplicas clamp can still
+	// cause allocated to exceed quota (e.g. 100 HPAs each with minReplicas=1,
+	// quota=10 → allocated=100). The ResourceQuota becomes the only enforcement
+	// and the first 10 pods to be scheduled win while the other 90 are stuck
+	// pending. Fix: rank HPAs by queue depth, assign minReplicas only to the
+	// top-quota pools, and park the rest at minReplicas so the budget is not
+	// over-committed.
 
 	// TODO: scale-to-zero is not supported. When a pool's queue is 0 its weight is
-	// 0% and the ideal target is 0 replicas, but the floor clamp below forces it to 1.
-	// Supporting scale-to-zero requires: (a) the HPA has spec.minReplicas=0 (opt-in),
-	// and (b) the Coordinator avoids setting maxReplicas=0 while in-flight requests are
-	// still being drained (check active connection count or use a brief drain window
-	// before zeroing). Until those conditions are met the floor is kept at 1 to prevent
+	// 0% and the ideal target is 0 replicas, but the floor clamp below forces it to
+	// minReplicas (minimum 1). Supporting scale-to-zero requires: (a) the HPA has
+	// spec.minReplicas=0 (opt-in), and (b) the Coordinator avoids setting
+	// maxReplicas=0 while in-flight requests are still being drained (check active
+	// connection count or use a brief drain window before zeroing). Until those
+	// conditions are met the floor is kept at max(1, minReplicas) to prevent
 	// accidental full scale-down.
 
-	// Targets: floor(quota * weight), minimum 1, remainder to highest-weight pool.
+	// Targets: floor(quota * weight), floored at max(1, hpa.Spec.MinReplicas) so
+	// that maxReplicas is never patched below the HPA's own minimum. The remainder
+	// after floor-division goes to the highest-weight pool.
 	targets := make([]int32, len(entries))
 	allocated := int64(0)
 	maxWeightIdx := 0
 	for i := range entries {
+		minReplicas := int32(1)
+		if v := entries[i].hpa.Spec.MinReplicas; v != nil && *v > minReplicas {
+			minReplicas = *v
+		}
 		t := int32(math.Floor(float64(quota) * weights[i]))
-		if t < 1 {
-			t = 1
+		if t < minReplicas {
+			t = minReplicas
 		}
 		targets[i] = t
 		allocated += int64(t)

--- a/internal/coordinator/plugins/gpurebalance/plugin_test.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin_test.go
@@ -51,6 +51,10 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 }
 
 func makeHPA(name, ns, pool string, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
+	return makeHPAWithMin(name, ns, pool, maxReplicas, nil)
+}
+
+func makeHPAWithMin(name, ns, pool string, maxReplicas int32, minReplicas *int32) *autoscalingv2.HorizontalPodAutoscaler {
 	ann := map[string]string{}
 	if pool != "" {
 		ann[AnnotationInferencePool] = pool
@@ -62,6 +66,7 @@ func makeHPA(name, ns, pool string, maxReplicas int32) *autoscalingv2.Horizontal
 			Annotations: ann,
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			MinReplicas: minReplicas,
 			MaxReplicas: maxReplicas,
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
@@ -341,5 +346,57 @@ func TestRebalance_MultiNamespace(t *testing.T) {
 		if got := getMaxReplicas(t, c, tc.name, tc.ns); got != tc.want {
 			t.Errorf("%s/%s maxReplicas = %d, want %d", tc.ns, tc.name, got, tc.want)
 		}
+	}
+}
+
+// TestRebalance_RespectsHPAMinReplicas verifies that maxReplicas is never
+// patched below an HPA's spec.minReplicas even when the proportional
+// allocation would compute a lower value.
+func TestRebalance_RespectsHPAMinReplicas(t *testing.T) {
+	// quota=10, model-a=80% queue → floor(8)=8
+	// model-b=20% queue → floor(2)=2; but minReplicas=3, so floor is 3.
+	// allocated=8+3=11 > quota=10; remainder is negative so no bonus added.
+	// model-a still gets 8, model-b gets 3 (clamped up from 2).
+	minReplicas := int32(3)
+	hpaA := makeHPA("model-a", "ns", "model-a", 1)
+	hpaB := makeHPAWithMin("model-b", "ns", "model-b", 1, &minReplicas)
+	p, c := newPlugin(t,
+		map[string]float64{"model-a": 80, "model-b": 20},
+		nil,
+		hpaA, hpaB, makeGPUQuota("q", "ns", 10),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 8 {
+		t.Errorf("model-a maxReplicas = %d, want 8", got)
+	}
+	// Must be clamped up to minReplicas=3, not the proportional value of 2.
+	if got := getMaxReplicas(t, c, "model-b", "ns"); got != 3 {
+		t.Errorf("model-b maxReplicas = %d, want 3 (clamped to minReplicas)", got)
+	}
+}
+
+// TestRebalance_NoMinReplicasDefaultsToOne verifies that when spec.minReplicas
+// is nil (Kubernetes default of 1) the existing floor-of-1 behaviour is preserved.
+func TestRebalance_NoMinReplicasDefaultsToOne(t *testing.T) {
+	// quota=10, model-a=90%, model-b=10% → floor(9)=9, floor(1)=1; total=10.
+	hpaA := makeHPA("model-a", "ns", "model-a", 1)
+	hpaB := makeHPA("model-b", "ns", "model-b", 1) // MinReplicas nil → default 1
+	p, c := newPlugin(t,
+		map[string]float64{"model-a": 90, "model-b": 10},
+		nil,
+		hpaA, hpaB, makeGPUQuota("q", "ns", 10),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getMaxReplicas(t, c, "model-a", "ns"); got != 9 {
+		t.Errorf("model-a maxReplicas = %d, want 9", got)
+	}
+	if got := getMaxReplicas(t, c, "model-b", "ns"); got != 1 {
+		t.Errorf("model-b maxReplicas = %d, want 1 (nil minReplicas defaults to 1)", got)
 	}
 }


### PR DESCRIPTION
Fixes #1406

## Proposed Changes

The GPU rebalance plugin's proportional allocation algorithm clamped every computed `maxReplicas` target to a minimum of `1`, ignoring the HPA's `spec.minReplicas`. Setting `maxReplicas` below `minReplicas` produces an invalid HPA spec that Kubernetes rejects with a `422 Unprocessable Entity` error. A concrete example: an HPA with `spec.minReplicas = 3` could receive `maxReplicas = 2` from the rebalancer when its queue share was less than 20% on a quota-10 pool.

- :bug: Replace the hardcoded floor of `1` with `max(1, hpa.Spec.MinReplicas)` so the patched `maxReplicas` is always a value Kubernetes will accept
- :broom: Add `makeHPAWithMin` test helper alongside the existing `makeHPA`
- :broom: Add `TestRebalance_RespectsHPAMinReplicas` — verifies `maxReplicas` is clamped up when proportional allocation would go below `minReplicas`
- :broom: Add `TestRebalance_NoMinReplicasDefaultsToOne` — verifies the nil `minReplicas` (Kubernetes default of 1) behaviour is preserved

### Pre-review Checklist

- [x] **E2E tests** for any new behavior — unit tests added for both branches
- [ ] **Docs PR** for any user-facing impact — n/a
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — n/a (bug fix)

**Release Note**
```release-note
[BUG] GPU rebalance coordinator now uses max(1, hpa.Spec.MinReplicas) as the minimum target, preventing invalid HPA patches when spec.minReplicas is greater than 1.
```