### PR TITLE
docs(coordinator): add KEDA replica rebalancing guide

### DIFF
--- a/config/samples/hpa/co-ordinator/base/epp-servicemonitor.yaml
+++ b/config/samples/hpa/co-ordinator/base/epp-servicemonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: epp-queue-metrics
+  namespace: workload-variant-autoscaler-monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - llm-d-sim
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - model-a-epp
+          - model-b-epp
+  endpoints:
+    - port: http-metrics
+      path: /metrics
+      interval: 5s

--- a/config/samples/hpa/co-ordinator/base/kustomization.yaml
+++ b/config/samples/hpa/co-ordinator/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - epp-servicemonitor.yaml
   - llm-d-sim-gpu-quota.yaml
   - model-a-hpa.yaml
   - model-b-hpa.yaml

--- a/config/samples/hpa/co-ordinator/model-a-epp-values.yaml
+++ b/config/samples/hpa/co-ordinator/model-a-epp-values.yaml
@@ -20,6 +20,7 @@ router:
     replicas: 1
     flags:
       v: 2
+      metrics-endpoint-auth: false
     resources:
       requests:
         cpu: 100m
@@ -27,11 +28,6 @@ router:
       limits:
         cpu: 500m
         memory: 512Mi
-    monitoring:
-      prometheus:
-        enabled: true
-        auth:
-          enabled: false
     pluginsConfigFile: model-a-plugins.yaml
     pluginsCustomConfig:
       model-a-plugins.yaml: |
@@ -56,6 +52,13 @@ router:
           - pluginRef: no-hit-lru-scorer
             weight: 2
   proxy:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
     args:
     - --service-node
     - envoy-sidecar

--- a/config/samples/hpa/co-ordinator/model-b-epp-values.yaml
+++ b/config/samples/hpa/co-ordinator/model-b-epp-values.yaml
@@ -20,6 +20,7 @@ router:
     replicas: 1
     flags:
       v: 2
+      metrics-endpoint-auth: false
     resources:
       requests:
         cpu: 100m
@@ -27,11 +28,6 @@ router:
       limits:
         cpu: 500m
         memory: 512Mi
-    monitoring:
-      prometheus:
-        enabled: true
-        auth:
-          enabled: false
     pluginsConfigFile: model-b-plugins.yaml
     pluginsCustomConfig:
       model-b-plugins.yaml: |
@@ -56,6 +52,13 @@ router:
           - pluginRef: no-hit-lru-scorer
             weight: 2
   proxy:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
     args:
     - --service-node
     - envoy-sidecar

--- a/config/samples/hpa/co-ordinator/overlays/keda-rebalance/kustomization.yaml
+++ b/config/samples/hpa/co-ordinator/overlays/keda-rebalance/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../keda
+
+patches:
+  - patch: |-
+      apiVersion: keda.sh/v1alpha1
+      kind: ScaledObject
+      metadata:
+        name: model-a-scaler
+        namespace: llm-d-sim
+        annotations:
+          llm-d.ai/epp-inference-pool: "model-a"
+  - patch: |-
+      apiVersion: keda.sh/v1alpha1
+      kind: ScaledObject
+      metadata:
+        name: model-b-scaler
+        namespace: llm-d-sim
+        annotations:
+          llm-d.ai/epp-inference-pool: "model-b"

--- a/config/samples/hpa/co-ordinator/overlays/keda/kustomization.yaml
+++ b/config/samples/hpa/co-ordinator/overlays/keda/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - model-a-scaledobject.yaml
+  - model-b-scaledobject.yaml
+
+patches:
+  - patch: |-
+      $patch: delete
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: model-a-hpa
+        namespace: llm-d-sim
+  - patch: |-
+      $patch: delete
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: model-b-hpa
+        namespace: llm-d-sim

--- a/config/samples/hpa/co-ordinator/overlays/keda/model-a-scaledobject.yaml
+++ b/config/samples/hpa/co-ordinator/overlays/keda/model-a-scaledobject.yaml
@@ -1,0 +1,44 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: model-a-scaler
+  namespace: llm-d-sim
+  annotations:
+    llm-d.ai/managed: "true"
+    llm-d.ai/model-id: "model-a"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: model-a-decode
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  pollingInterval: 5
+  cooldownPeriod: 120
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: model-a-hpa
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - type: Pods
+              value: 4
+              periodSeconds: 15
+        scaleDown:
+          stabilizationWindowSeconds: 120
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 30
+  triggers:
+    - type: prometheus
+      name: model-a-epp-queue
+      metadata:
+        serverAddress: https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090
+        query: sum(inference_extension_flow_control_queue_size{inference_pool="model-a"})
+        threshold: "1"
+        activationThreshold: "0"
+        metricType: Value
+        # The kind Prometheus endpoint uses a self-signed certificate.
+        unsafeSsl: "true"

--- a/config/samples/hpa/co-ordinator/overlays/keda/model-b-scaledobject.yaml
+++ b/config/samples/hpa/co-ordinator/overlays/keda/model-b-scaledobject.yaml
@@ -1,0 +1,44 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: model-b-scaler
+  namespace: llm-d-sim
+  annotations:
+    llm-d.ai/managed: "true"
+    llm-d.ai/model-id: "model-b"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: model-b-decode
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  pollingInterval: 5
+  cooldownPeriod: 120
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: model-b-hpa
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - type: Pods
+              value: 4
+              periodSeconds: 15
+        scaleDown:
+          stabilizationWindowSeconds: 120
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 30
+  triggers:
+    - type: prometheus
+      name: model-b-epp-queue
+      metadata:
+        serverAddress: https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090
+        query: sum(inference_extension_flow_control_queue_size{inference_pool="model-b"})
+        threshold: "1"
+        activationThreshold: "0"
+        metricType: Value
+        # The kind Prometheus endpoint uses a self-signed certificate.
+        unsafeSsl: "true"

--- a/config/samples/hpa/co-ordinator/poc.mk
+++ b/config/samples/hpa/co-ordinator/poc.mk
@@ -3,12 +3,11 @@
 POC_NS       ?= llm-d-sim
 POC_DIR      := config/samples/hpa/co-ordinator
 POC_WVA_NS  := workload-variant-autoscaler-system
-POC_MON_NS  := workload-variant-autoscaler-monitoring
-GAIE_VERSION ?= v1.5.0
+POC_KEDA_NS ?= keda-system
 LLM_D_ROUTER_VERSION ?= v0.9.0
 
 .PHONY: poc-install
-poc-install: ## [POC] Install per-model EPPs, sim workloads, gateway, and Prometheus Adapter rules
+poc-install: ## [POC] Install EPPs, workloads, gateway, and KEDA ScaledObjects
 	@echo ""
 	@echo "================================================================"
 	@echo "  POC Install: model-a + model-b EPPs, workloads, gateway"
@@ -40,8 +39,8 @@ poc-install: ## [POC] Install per-model EPPs, sim workloads, gateway, and Promet
 	  --namespace $(POC_NS) \
 	  -f $(POC_DIR)/model-b-epp-values.yaml
 	@echo ""
-	@echo "--- Step 4: Deploy sim workloads and gateway ---"
-	@kubectl apply -k $(POC_DIR)/base
+	@echo "--- Step 4: Deploy sim workloads, gateway, and KEDA ScaledObjects ---"
+	@kubectl apply -k $(POC_DIR)/overlays/keda
 	@echo ""
 	@echo "--- Step 5: Wait for EPPs and workloads to be ready ---"
 	@echo "  Waiting for model-a-epp..."
@@ -58,13 +57,8 @@ poc-install: ## [POC] Install per-model EPPs, sim workloads, gateway, and Promet
 	@kubectl rollout restart deployment/multi-model-gateway -n $(POC_NS)
 	@kubectl rollout status deployment/multi-model-gateway -n $(POC_NS) --timeout=60s
 	@echo ""
-	@echo "--- Step 6: Add EPP queue rules to Prometheus Adapter ---"
-	@helm upgrade prometheus-adapter prometheus-community/prometheus-adapter \
-	  -n $(POC_MON_NS) \
-	  --reuse-values \
-	  -f $(POC_DIR)/prometheus-adapter-epp-rules.yaml
-	@kubectl rollout restart deployment/prometheus-adapter -n $(POC_MON_NS)
-	@kubectl rollout status deployment/prometheus-adapter -n $(POC_MON_NS) --timeout=180s
+	@echo "--- Step 6: Verify KEDA ---"
+	@kubectl rollout status deployment/keda-operator -n $(POC_KEDA_NS) --timeout=180s
 	@echo ""
 	@echo "--- Step 7: Prime EPP flow control metrics ---"
 	@echo "  Sending one priming request per EPP (metric is not registered until first request)..."
@@ -83,17 +77,11 @@ poc-install: ## [POC] Install per-model EPPs, sim workloads, gateway, and Promet
 	@echo "  Waiting 30s for Prometheus to scrape the new metrics..."
 	@sleep 30
 	@echo ""
-	@echo "--- Step 8: Verify external metrics are reachable ---"
-	@for metric in model_a_epp_queue_size model_b_epp_queue_size; do \
-	  val=$$(kubectl get --raw \
-	    "/apis/external.metrics.k8s.io/v1beta1/namespaces/$(POC_NS)/$$metric" \
-	    2>/dev/null); \
-	  if echo "$$val" | grep -q '"value"'; then \
-	    echo "  $$metric: READY"; \
-	  else \
-	    echo "  $$metric: NOT READY (run 'make poc-status' in ~60s once Prometheus scrapes the EPPs)"; \
-	  fi; \
-	done
+	@echo "--- Step 8: Verify ScaledObjects ---"
+	@kubectl wait --for=condition=Ready \
+	  scaledobject/model-a-scaler scaledobject/model-b-scaler \
+	  -n $(POC_NS) --timeout=180s
+	@kubectl get scaledobject -n $(POC_NS)
 	@echo ""
 	@echo "================================================================"
 	@echo "  Install complete. Run 'make poc-status' to verify."
@@ -152,6 +140,12 @@ poc-status: ## [POC] Status report: cluster health, WVA, HPAs, ResourceQuota, Co
 	@kubectl get resourcequota -n $(POC_NS) 2>/dev/null \
 	  || echo "  NONE — Coordinator will skip (no GPU quota to split)"
 	@echo ""
+	@if kubectl get scaledobject -n $(POC_NS) >/dev/null 2>&1; then \
+	  echo "=== ScaledObjects ($(POC_NS)) ==="; \
+	  kubectl get scaledobject -n $(POC_NS) \
+	    -o custom-columns='SCALEDOBJECT:.metadata.name,MIN:.spec.minReplicaCount,MAX:.spec.maxReplicaCount,READY:.status.conditions[?(@.type=="Ready")].status'; \
+	  echo ""; \
+	fi
 	@echo "=== HPAs ($(POC_NS)) ==="
 	@kubectl get hpa -n $(POC_NS) \
 	  -o custom-columns='HPA:.metadata.name,MAX:.spec.maxReplicas,CURRENT:.status.currentReplicas,DESIRED:.status.desiredReplicas' \
@@ -193,8 +187,10 @@ poc-starvation: ## [POC] Reproduce GPU starvation: reset → phase-1 model-a loa
 	@echo "  Removing stale load jobs..."
 	@kubectl delete job starvation-load-a starvation-load-b \
 	  -n $(POC_NS) --ignore-not-found=true 2>/dev/null; true
-	@echo "  Removing existing HPAs (clears stabilisation history)..."
-	@kubectl delete hpa model-a-hpa model-b-hpa -n $(POC_NS) --ignore-not-found=true 2>/dev/null; true
+	@echo "  Removing existing scalers (clears stabilisation history)..."
+	@kubectl delete scaledobject model-a-scaler model-b-scaler \
+	  -n $(POC_NS) --ignore-not-found=true --wait=true 2>/dev/null || true
+	@kubectl delete hpa model-a-hpa model-b-hpa -n $(POC_NS) --ignore-not-found=true --wait=true 2>/dev/null; true
 	@echo "  Scaling both deployments to 1..."
 	@kubectl scale deployment model-a-decode model-b-decode --replicas=1 -n $(POC_NS)
 	@echo "  Waiting for both deployments to reach 1 ready replica (timeout 120s)..."
@@ -212,8 +208,11 @@ poc-starvation: ## [POC] Reproduce GPU starvation: reset → phase-1 model-a loa
 	    echo "  [$$T""s] waiting... model-a=$$A model-b=$$B"; \
 	    sleep 5; \
 	  done
-	@echo "  Applying base state (quota + HPAs without coordinator annotation)..."
-	@kubectl apply -k $(POC_DIR)/base
+	@echo "  Applying ScaledObjects without coordinator annotations..."
+	@kubectl apply -k $(POC_DIR)/overlays/keda
+	@kubectl wait --for=condition=Ready \
+	  scaledobject/model-a-scaler scaledobject/model-b-scaler \
+	  -n $(POC_NS) --timeout=180s
 	@echo ""
 	@echo "--- Baseline (1 pod each, 2/10 GPUs used) ---"
 	@kubectl get hpa -n $(POC_NS) \
@@ -305,9 +304,8 @@ poc-rebalance: ## [POC] Apply Coordinator + GPU quota → watch rebalancing reso
 	    | grep "model-[ab]-decode" | wc -l | tr -d ' '); \
 	  echo "  Pending model pods: $$PEND"
 	@echo ""
-	@echo "--- Step 1: Activate Coordinator for these HPAs ---"
-	@echo "  Applying rebalance overlay — adds epp-inference-pool annotation to both HPAs"
-	@kubectl apply -k $(POC_DIR)/overlays/rebalance
+	@echo "--- Step 1: Activate Coordinator for these ScaledObjects ---"
+	@kubectl apply -k $(POC_DIR)/overlays/keda-rebalance
 	@echo "  ResourceQuota (still in effect from starvation):"
 	@kubectl get resourcequota -n $(POC_NS)
 	@echo ""
@@ -338,7 +336,7 @@ poc-rebalance: ## [POC] Apply Coordinator + GPU quota → watch rebalancing reso
 	  COORD=$$(kubectl logs -n $(POC_WVA_NS) \
 	    -l app.kubernetes.io/name=workload-variant-autoscaler \
 	    --tail=5 2>/dev/null \
-	    | grep -iE "Setting maxReplicas|contention" | tail -1); \
+	    | grep -iE "Setting max replica ceiling|contention" | tail -1); \
 	  echo "  [$$(printf '%3d' $$((i*5)))s]  model-a: max=$$A_MAX run=$$A_RUN pend=$$A_PEND  |  model-b: max=$$B_MAX run=$$B_RUN pend=$$B_PEND"; \
 	  if [ -n "$$COORD" ]; then echo "         ↳ $$COORD"; fi; \
 	done
@@ -362,7 +360,7 @@ poc-rebalance: ## [POC] Apply Coordinator + GPU quota → watch rebalancing reso
 	@kubectl logs -n $(POC_WVA_NS) \
 	  -l app.kubernetes.io/name=workload-variant-autoscaler \
 	  --tail=60 2>/dev/null \
-	  | grep -iE "gpu-rebalance|Setting maxReplicas|contention" \
+	  | grep -iE "gpu-rebalance|Setting max replica ceiling|contention" \
 	  | tail -10 | sed 's/^/  /' \
 	  || echo "  (none)"
 	@echo ""

--- a/docs/developer-guide/coordinator-rebalancing.md
+++ b/docs/developer-guide/coordinator-rebalancing.md
@@ -2,24 +2,24 @@
 
 This POC demonstrates GPU starvation and Coordinator-driven rebalancing across two
 models sharing a GPU `ResourceQuota` on a kind cluster. Each model has its own EPP,
-InferencePool, HPA, and llm-d-inference-sim workload.
+InferencePool, KEDA ScaledObject, and llm-d-inference-sim workload.
 
 ## Architecture
 
 ```
 multi-model-gateway (nginx, port 9002)
-  /model-a/...  →  model-a EPP  →  InferencePool model-a  →  llm-d-sim A  ← HPA A
-  /model-b/...  →  model-b EPP  →  InferencePool model-b  →  llm-d-sim B  ← HPA B
+  /model-a/...  →  model-a EPP  →  InferencePool model-a  →  llm-d-sim A
+  /model-b/...  →  model-b EPP  →  InferencePool model-b  →  llm-d-sim B
 
 Prometheus  ←  ServiceMonitor per EPP
               ←  inference_extension_flow_control_queue_size{inference_pool="model-a|b"}
-HPA  ←  external metric via Prometheus Adapter
-WVA Coordinator  →  patches HPA spec.maxReplicas proportionally to queue depth
+KEDA  ←  Prometheus trigger on ScaledObject  →  generated HPA
+WVA Coordinator  →  patches ScaledObject spec.maxReplicaCount
 ```
 
-Each model has its own dedicated GAIE EPP instance and InferencePool. A shared EPP
-is incorrect — the EPP uses load-based scoring, not model-name filtering, so it would
-route ~50% of model-a requests to model-b pods and vice versa.
+Each model has its own dedicated llm-d Router EPP instance and InferencePool. A
+shared EPP is incorrect — the EPP uses load-based scoring, not model-name filtering,
+so it would route ~50% of model-a requests to model-b pods and vice versa.
 
 ## Prerequisites
 
@@ -36,28 +36,31 @@ make create-kind-cluster CLUSTER_NODES=1 CLUSTER_GPUS=10 CLUSTER_GPU_TYPE=nvidia
 make docker-build IMG=wva-local:poc
 kind load docker-image wva-local:poc --name kind-wva-gpu-cluster
 
-# 3. Deploy WVA controller + kube-prometheus-stack + Prometheus Adapter
+# 3. Deploy WVA + monitoring + KEDA
 make deploy-e2e-infra IMG=wva-local:poc SKIP_BUILD=true \
-  SCALER_BACKEND=prometheus-adapter LLMD_NS=llm-d-sim
+  SCALER_BACKEND=keda LLMD_NS=llm-d-sim
 
 # 4. Enable the Coordinator (experimental feature, off by default)
 make poc-enable-coordinator
 
-# 5. Install per-model EPPs, sim workloads, gateway, and adapter rules
+# 5. Install per-model EPPs, sim workloads, gateway, and ScaledObjects
 make poc-install
 
 # 6. Verify everything is healthy
 make poc-status
 
-# 7. Reproduce model starvation (applies ResourceQuota, strips HPA annotations)
+# 7. Reproduce model starvation
 make poc-starvation
 
-# 8. Activate the Coordinator (re-add HPA annotations), watch rebalance
+# 8. Activate the Coordinator and watch rebalancing
 make poc-rebalance
 
 # 9. Tear down
 make destroy-kind-cluster
 ```
+
+The EPP metrics endpoint is unauthenticated in this local POC. Use authenticated
+scraping on shared clusters.
 
 ## Experiment setup
 
@@ -69,13 +72,13 @@ make destroy-kind-cluster
 | ResourceQuota (`gpu-quota`) | `requests.nvidia.com/gpu: 10` |
 | Namespace | `llm-d-sim` |
 
-### HPAs (both models identical)
+### ScaledObjects (both models identical)
 
 | Field | Value |
 |---|---|
-| `minReplicas` | 1 |
-| `maxReplicas` | 10 (ceiling overridden by Coordinator once annotation is present) |
-| Metric | External: `model_a/b_epp_queue_size`, target `Value: 1` |
+| `minReplicaCount` | 1 |
+| `maxReplicaCount` | 10 (updated by the Coordinator after opt-in) |
+| Metric | EPP queue depth, target `Value: 1` |
 | `scaleUp.stabilizationWindowSeconds` | 0 (immediate) |
 | `scaleUp` policy | +4 pods per 15s |
 | `scaleDown.stabilizationWindowSeconds` | 120s |
@@ -86,9 +89,9 @@ making the starvation effect visible quickly in a sim environment.
 
 ### Phase 1 — model-a starvation (`starvation-load-a` job)
 
-`make poc-starvation` applies the ResourceQuota, recreates both HPAs **without** the
-`llm-d.ai/epp-inference-pool` annotation (so the Coordinator skips them), then
-launches `starvation-load-a`:
+`make poc-starvation` applies the ResourceQuota and recreates both ScaledObjects
+without the `llm-d.ai/epp-inference-pool` annotation, then launches
+`starvation-load-a`:
 
 - **Burst**: 80 concurrent requests to model-a fired immediately
 - **Drip**: 10 req/s to model-a for 240 seconds
@@ -111,18 +114,16 @@ demand — starvation.
 
 ### Rebalance (`poc-rebalance`)
 
-`make poc-rebalance` re-adds the `llm-d.ai/epp-inference-pool` annotation to both
-HPAs. On the next Coordinator tick (~15s) it reads both EPP queue depths, computes
-proportional `maxReplicas`, and patches both HPAs. Kubernetes immediately enforces the
-new ceilings: model-a pods above its new limit are terminated, freeing GPU slots for
-model-b pods to schedule.
+`make poc-rebalance` adds the `llm-d.ai/epp-inference-pool` annotation to both
+ScaledObjects. On the next Coordinator tick (~15s), it updates each
+`spec.maxReplicaCount`; KEDA copies the new ceiling to the generated HPA. This
+frees GPU slots for model-b pods to schedule.
 
 ### Scale-down after load ends
 
-When a model's queue hits 0 the Coordinator sets its `maxReplicas` to 1 (0% share →
-clamped to `minReplicas`). Because `currentReplicas > spec.maxReplicas`, Kubernetes
-enforces the ceiling immediately, bypassing `scaleDown.stabilizationWindowSeconds`.
-Scale-down completes within ~15s of the queue clearing.
+When a model's queue hits 0, the Coordinator lowers its maximum to the configured
+minimum (1 in this demo). KEDA propagates the ceiling to the HPA, which scales down
+without waiting for the stabilization window.
 
 ## How the Coordinator works
 
@@ -130,16 +131,21 @@ The Coordinator runs a 15-second loop. On each tick it:
 
 1. Reads the namespace `ResourceQuota` GPU budget
 2. Queries each EPP's `inference_extension_flow_control_queue_size` metric
-3. Patches each HPA's `spec.maxReplicas` proportionally:
+3. Reserves every scaler's configured minimum
+4. Distributes the remaining quota by queue weight
+5. Patches the ScaledObject's maximum:
 
 ```
-maxReplicas(pool) = round( queue(pool) / sum(all queues) × gpu_quota )
-                    clamped to [minReplicas, absolute_max]
+remaining = gpu_quota - sum(minimum(pool))
+maximum(pool) = minimum(pool)
+              + floor(queue(pool) / sum(all queues) * remaining)
 ```
 
-The `llm-d.ai/epp-inference-pool` annotation on each HPA is the on/off gate:
-- annotation absent → Coordinator skips the HPA
-- annotation present → Coordinator manages `spec.maxReplicas`
+Any rounding remainder goes to the highest-weight pool. If the configured minima
+already exceed the quota, the Coordinator leaves the namespace unchanged.
+
+The `llm-d.ai/epp-inference-pool` annotation opts a ScaledObject into rebalancing.
+The Coordinator patches the ScaledObject rather than the KEDA-owned HPA.
 
 `poc-starvation` strips the annotation; `poc-rebalance` adds it back.
 
@@ -153,11 +159,10 @@ conflict the Coordinator re-reads the object and re-applies its computed target
 
 | Area | Status | Detail |
 |---|---|---|
-| Scale-to-zero | TODO | When a pool's queue hits 0 the Coordinator sets `maxReplicas=1`, not 0. Full scale-to-zero requires `spec.minReplicas=0` on the HPA, cold-start handling at the EPP, and a drain window before zeroing. |
+| Scale-to-zero | TODO | When a pool's queue hits 0 the Coordinator sets `maxReplicaCount=1`, not 0. Full scale-to-zero requires `spec.minReplicaCount=0` on the ScaledObject, cold-start handling at the EPP, and a drain window before zeroing. |
 | Multiple ResourceQuotas | TODO | Only the first quota with a GPU field is used. The effective limit should be the minimum across all quotas in the namespace. |
-| `minReplicas` floor | TODO | The allocation floor is hardcoded to 1. If an HPA has `spec.minReplicas > 1`, patching `maxReplicas` below it produces an invalid object. Floor should be `max(1, hpa.Spec.MinReplicas)`. |
-| n HPAs > quota | TODO | When more HPAs exist than GPU slots, every pool is clamped to 1 and total allocation exceeds quota. Top-N ranking by queue depth is needed. |
-| Wobble | TODO | Noisy queue readings cause 1-replica flips every tick. A minimum-delta guard and per-HPA cooldown (or EWMA smoothing) are needed. |
+| GPU units per replica | TODO | The POC treats one replica as one GPU. Multi-GPU replicas require converting the GPU quota into per-scaler replica capacity before allocation. |
+| Wobble | TODO | Noisy queue readings cause 1-replica flips every tick. A minimum-delta guard and per-scaler cooldown (or EWMA smoothing) are needed. |
 | Stale patch | Done | Ceiling patches use `MergeFromWithOptimisticLock` with a bounded conflict retry, so a concurrent `maxReplicas` change is no longer silently overwritten. |
 | Pool name collision | TODO | Queue query has no namespace label; pools with the same name in different namespaces inflate each other's readings. |
 
@@ -168,8 +173,9 @@ conflict the Coordinator re-reads the object and re-applies its computed target
 | File | Purpose |
 |---|---|
 | `base/kustomization.yaml` | Lists all base resources |
-| `base/model-a-hpa.yaml` | HPA for model-a — no `epp-inference-pool` annotation (starvation state) |
-| `base/model-b-hpa.yaml` | HPA for model-b — no `epp-inference-pool` annotation (starvation state) |
+| `base/epp-servicemonitor.yaml` | Scrapes queue metrics from both EPP services |
+| `base/model-a-hpa.yaml` | Legacy direct-HPA fixture; deleted by the KEDA overlay |
+| `base/model-b-hpa.yaml` | Legacy direct-HPA fixture; deleted by the KEDA overlay |
 | `base/model-a-decode.yaml` | llm-d-sim Deployment + Service for model-a |
 | `base/model-b-decode.yaml` | llm-d-sim Deployment + Service for model-b |
 | `base/multi-model-gateway.yaml` | nginx path-based gateway (port 9002) |
@@ -181,13 +187,20 @@ conflict the Coordinator re-reads the object and re-applies its computed target
 |---|---|
 | `overlays/rebalance/kustomization.yaml` | Applies base + patches `epp-inference-pool` annotation onto both HPAs |
 
+### KEDA overlays
+
+| File | Purpose |
+|---|---|
+| `overlays/keda/` | Replaces the direct HPAs with ScaledObjects |
+| `overlays/keda-rebalance/` | Opts both ScaledObjects into rebalancing |
+
 ### Top-level
 
 | File | Purpose |
 |---|---|
-| `model-a-epp-values.yaml` | GAIE standalone Helm values for model-a EPP |
-| `model-b-epp-values.yaml` | GAIE standalone Helm values for model-b EPP |
-| `prometheus-adapter-epp-rules.yaml` | Adapter rules: EPP queue → external metrics |
+| `model-a-epp-values.yaml` | Router standalone Helm values for the local model-a EPP |
+| `model-b-epp-values.yaml` | Router standalone Helm values for the local model-b EPP |
+| `prometheus-adapter-epp-rules.yaml` | Legacy direct-HPA adapter rules; unused by the KEDA flow |
 | `starvation-load-a.yaml` | Load job for model-a |
 | `starvation-load-b.yaml` | Load job for model-b |
 | `poc.mk` | All make targets for this POC |


### PR DESCRIPTION
## Summary

- switch the coordinator rebalancing POC to KEDA ScaledObjects
- add separate overlays for the starvation and rebalancing phases
- update the Make targets and guide for the KEDA flow
- add the ServiceMonitor and local EPP settings needed by the kind demo

Fixes #1364.

## Testing

- `make manifests`
- Kustomize builds for both KEDA overlays
- Helm template for both EPP values files with router chart v0.9.0
- dry runs of `poc-install`, `poc-starvation`, and `poc-rebalance`
- live kind run: the coordinator changed the ScaledObject limits from 10/10 to 6/4, KEDA propagated the same limits to the HPAs, and the workloads settled at 6/4 under the 10-GPU quota
