### PR TITLE
feat(saturation)!: default to V2 (token/capacity-based) saturation analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,40 @@ spec:
 
 More examples in [config/samples/hpa/](config/samples/hpa/) and [config/samples/keda/](config/samples/keda/).
 
+## Upgrading
+
+### Upgrading to v0.9.0 — V2 saturation analyzer is now the default
+
+**Behavioral change.** The default saturation analyzer changes from **V1**
+(percentage/spare-capacity-based) to **V2** (token/capacity-based). The shipped
+`default` entry in the saturation ConfigMap now includes an `analyzers:` section,
+which selects V2. No code change or image rebuild is involved — analyzer selection
+is driven entirely by config.
+
+V2 may produce different scaling decisions than V1 for the same workload. Review
+your dashboards and alert thresholds after upgrading.
+
+**Staying on V1 (opt-out).** Remove the `analyzers:` section (and the V2-only
+`scaleUpThreshold` / `scaleDownBoundary` fields) from the `default` entry of your
+saturation ConfigMap. The remaining `kvCacheThreshold`, `queueLengthThreshold`,
+`kvSpareTrigger`, and `queueSpareTrigger` fields drive V1:
+
+```yaml
+data:
+  default: |
+    kvCacheThreshold: 0.80
+    queueLengthThreshold: 5
+    kvSpareTrigger: 0.1
+    queueSpareTrigger: 3
+```
+
+Apply with `kubectl apply -f deploy/configmap-saturation-scaling.yaml`; the change
+takes effect immediately (the controller watches the ConfigMap).
+
+> V1 is deprecated and scheduled for removal in a future release. See the
+> [saturation scaling configuration guide](docs/developer-guide/saturation-scaling-config.md#analyzer-selection-v1-vs-v2)
+> for threshold ownership (which fields each analyzer reads) and migration details.
+
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/config/base/manager/saturation-scaling-configmap.yaml
+++ b/config/base/manager/saturation-scaling-configmap.yaml
@@ -15,10 +15,23 @@ metadata:
     # are never picked up at runtime.
     app.kubernetes.io/name: workload-variant-autoscaler
 data:
-  # Global defaults applied to all variants unless overridden
+  # Global defaults applied to all variants unless overridden.
+  #
+  # The `analyzers` section selects the V2 (token/capacity-based) saturation
+  # analyzer — the default since v0.9.0. Remove the `analyzers` section (and the
+  # V2-only thresholds) to opt out to the legacy V1 (percentage-based) analyzer.
+  # See docs/developer-guide/saturation-scaling-config.md.
   default: |
+    analyzers:
+      - name: saturation
+        score: 1.0
+    # V2-only thresholds:
+    scaleUpThreshold: 0.85
+    scaleDownBoundary: 0.70
+    # Shared by V1 and V2:
     kvCacheThreshold: 0.80
     queueLengthThreshold: 5
+    # V1-only (ignored by V2):
     kvSpareTrigger: 0.1
     queueSpareTrigger: 3
     # Enable GPU limiter to constrain scaling based on available cluster resources

--- a/deploy/ci-e2e-openshift/deploy-infrastructure.sh
+++ b/deploy/ci-e2e-openshift/deploy-infrastructure.sh
@@ -34,6 +34,12 @@ SKIP_CLUSTER_CRDS=true \
 ./deploy/install-epp.sh
 
 # Tune saturation thresholds for CI simulator mode.
+# NOTE (v0.9.0): this patch overwrites the `default` entry with only the V1-only
+# spare-trigger fields, which drops the shipped `analyzers:` section and therefore
+# pins this CI run to the legacy V1 (percentage-based) analyzer. This is deliberate
+# for now — V1's spare-trigger tuning gives deterministic scale-up in simulator mode.
+# TODO(v2): reconfigure this e2e path for the V2 (token/capacity-based) analyzer by
+# patching an `analyzers:` list + scaleUpThreshold/scaleDownBoundary instead.
 kubectl patch configmap wva-saturation-scaling-config \
   -n "$WVA_NAMESPACE" --type=merge \
   -p "$(printf '{"data":{"default":"kvSpareTrigger: %s\\nqueueSpareTrigger: %s\\n"}}' \

--- a/deploy/configmap-saturation-scaling.yaml
+++ b/deploy/configmap-saturation-scaling.yaml
@@ -21,15 +21,34 @@ metadata:
     app.kubernetes.io/name: workload-variant-autoscaler
     app.kubernetes.io/managed-by: kustomize
 data:
-  # Global defaults applied to all variants unless overridden
+  # Global defaults applied to all variants unless overridden.
+  #
+  # The `analyzers` section selects the V2 (token/capacity-based) saturation
+  # analyzer — the default since v0.9.0. Remove the `analyzers` section (and the
+  # V2-only thresholds) to opt out to the legacy V1 (percentage-based) analyzer.
+  # See docs/developer-guide/saturation-scaling-config.md.
   default: |
+    analyzers:
+      - name: saturation
+        score: 1.0
+    # V2-only thresholds:
+    scaleUpThreshold: 0.85
+    scaleDownBoundary: 0.70
+    # Shared by V1 and V2:
     kvCacheThreshold: 0.80
     queueLengthThreshold: 5
+    # V1-only (ignored by V2):
     kvSpareTrigger: 0.1
     queueSpareTrigger: 3
     # Enable GPU limiter to constrain scaling based on available cluster resources
     # When true, scale-up decisions are limited by available GPU capacity
     enableLimiter: false
+
+  # Per-model overrides inherit the default's analyzer selection (V2) via
+  # field-level merge, so they only need the thresholds they change. Under V2,
+  # kvCacheThreshold/queueLengthThreshold apply; kvSpareTrigger/queueSpareTrigger
+  # are V1-only and are ignored (they take effect only if the default is opted
+  # back to V1 by removing its `analyzers:` section).
 
   # Example per-model override for granite model in lab namespace
   # Uncomment and customize as needed
@@ -38,8 +57,6 @@ data:
   #   namespace: lab-namespace
   #   kvCacheThreshold: 0.75
   #   queueLengthThreshold: 10
-  #   kvSpareTrigger: 0.15
-  #   queueSpareTrigger: 5
 
   # Example per-model override for llama model in production namespace
   # Shows partial override (only some fields specified, rest inherit from default)
@@ -47,4 +64,3 @@ data:
   #   model_id: meta/llama-70b
   #   namespace: production
   #   kvCacheThreshold: 0.85
-  #   kvSpareTrigger: 0.15

--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -11,6 +11,51 @@ The Workload Variant Autoscaler supports saturation-based scaling using KV cache
 - ✅ **Thread-safe** concurrent access with RWMutex
 - ✅ Graceful degradation if ConfigMap missing (V2 has hardcoded defaults; V1 requires ConfigMap — see [Default Configuration](#default-configuration))
 
+## Analyzer Selection (V1 vs V2)
+
+There are two saturation analyzers:
+
+- **V2** (token/capacity-based) — **the default since v0.9.0**. Selected whenever
+  the config carries a non-empty `analyzers:` list (or `analyzerName: "saturation"`).
+- **V1** (percentage/spare-capacity-based) — legacy. Selected when no analyzer is
+  specified (empty `analyzers:` **and** empty `analyzerName`).
+
+The shipped `default` entry (`deploy/configmap-saturation-scaling.yaml` and
+`config/base/manager/saturation-scaling-configmap.yaml`) includes an `analyzers:`
+section, so a fresh install runs V2. **To opt out to V1, remove the `analyzers:`
+section** (and the V2-only thresholds) from the `default` entry. No code change or
+image rebuild is required — selection is driven entirely by config.
+
+> This is a behavioral change introduced in v0.9.0. See the repository README
+> "Upgrading to v0.9.0" note for migration guidance.
+
+> **Analyzer selection is global; thresholds are per-model/namespace.** Selection
+> is resolved once from the **global** `default` entry, while thresholds are
+> resolved from the per-model override and namespace-local ConfigMap when present.
+> Because these can disagree, the engine defaults the V2-only `scaleUpThreshold` /
+> `scaleDownBoundary` on the **final resolved config** (after merging the override
+> onto the base), so a per-model override or namespace-local entry written V1-style
+> (no `analyzers:`) still runs **calibrated** when the global selection routes it to
+> V2. Defaulting happens post-merge — not on the stored entries — so a V1-style
+> override does not clobber a tuned global threshold. To use non-default V2
+> thresholds for a specific model or namespace, set `scaleUpThreshold` /
+> `scaleDownBoundary` explicitly in that entry; the explicit value is honored
+> regardless of whether the entry carries an `analyzers:` section.
+
+### Threshold ownership
+
+Not every threshold applies to both analyzers. When switching between V1 and V2,
+keep the fields that the target analyzer actually reads:
+
+| Threshold | V1 | V2 | Notes |
+|-----------|----|----|-------|
+| `kvCacheThreshold` | ✅ | ✅ | Shared — replica saturated when KV cache ≥ threshold |
+| `queueLengthThreshold` | ✅ | ✅ | Shared — replica saturated when queue length ≥ threshold |
+| `kvSpareTrigger` | ✅ | — | **V1-only** — ignored by V2 |
+| `queueSpareTrigger` | ✅ | — | **V1-only** — ignored by V2 |
+| `scaleUpThreshold` | — | ✅ | **V2-only** — engine post-step (default 0.85) |
+| `scaleDownBoundary` | — | ✅ | **V2-only** — engine post-step (default 0.70) |
+
 ## Configuration
 
 ### ConfigMap Structure
@@ -36,7 +81,7 @@ These parameters apply when `analyzerName: "saturation"` is set or when the `ana
 
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `analyzerName` | string | Selects the V2 token-based analyzer: set to `"saturation"`. Empty string uses V1. | `""` |
+| `analyzerName` | string | Legacy selector for the V2 token-based analyzer: set to `"saturation"`. Empty string uses V1. Prefer the `analyzers:` list, which the shipped default uses. | `""` |
 | `priority` | float64 | Multiplier for this model's scaling urgency in fair-share GPU allocation | 1.0 |
 | `analyzers` | list | Multi-analyzer pipeline registration — see [Multi-Analyzer Registration](#multi-analyzer-registration) | `[{name: "saturation", score: 1.0}]` |
 
@@ -44,7 +89,26 @@ These parameters apply when `analyzerName: "saturation"` is set or when the `ana
 
 ### Default Configuration
 
-The recommended values for the V1 (percentage-based) saturation analyzer are:
+Since v0.9.0 the shipped `default` entry selects **V2** (token/capacity-based) via
+the `analyzers:` list:
+
+```yaml
+analyzers:
+  - name: saturation
+    score: 1.0
+# V2-only thresholds:
+scaleUpThreshold: 0.85
+scaleDownBoundary: 0.70
+# Shared by V1 and V2:
+kvCacheThreshold: 0.80
+queueLengthThreshold: 5
+# V1-only (ignored by V2):
+kvSpareTrigger: 0.1
+queueSpareTrigger: 3
+```
+
+To opt out to the legacy **V1** (percentage-based) analyzer, remove the `analyzers:`
+section (and the V2-only thresholds); the remaining shared + V1-only thresholds drive V1:
 
 ```yaml
 kvCacheThreshold: 0.80
@@ -53,14 +117,21 @@ kvSpareTrigger: 0.1
 queueSpareTrigger: 3
 ```
 
-> **Important:** These V1 threshold values are **not hardcoded** in the analyzer code.
-> If the ConfigMap is missing or has no `default` entry, all V1 thresholds default to zero,
-> which will cause every replica to appear saturated and trigger continuous scale-up.
-> Always deploy the ConfigMap with a `default` entry containing valid thresholds.
+> **Important:** The V1 threshold values are **not hardcoded** in the analyzer code.
+> If you opt out to V1 and the ConfigMap is missing or has no `default` entry, all V1
+> thresholds default to zero, which will cause every replica to appear saturated and
+> trigger continuous scale-up. Always deploy the ConfigMap with a `default` entry
+> containing valid thresholds. (V2 has hardcoded fallbacks for its own thresholds.)
 
 ### How Scale-Up Triggers Work
 
-The saturation analyzer uses a **spare capacity model** to determine when to scale up. Instead of waiting for replicas to become fully saturated, WVA proactively scales when the average spare capacity across non-saturated replicas falls below configured thresholds.
+> **Applies to V1 only.** The spare-capacity / `kvSpareTrigger` / `queueSpareTrigger`
+> model described here is the legacy **V1** analyzer's logic. The default **V2**
+> analyzer uses a token/capacity model driven by `scaleUpThreshold` /
+> `scaleDownBoundary` and ignores the spare triggers (see
+> [Analyzer Selection](#analyzer-selection-v1-vs-v2)).
+
+The V1 saturation analyzer uses a **spare capacity model** to determine when to scale up. Instead of waiting for replicas to become fully saturated, WVA proactively scales when the average spare capacity across non-saturated replicas falls below configured thresholds.
 
 **Scale-up logic:**
 
@@ -145,7 +216,10 @@ analyzers:
     score: 1.0
 ```
 
-When `analyzers:` is omitted, it defaults to `[{name: "saturation", score: 1.0}]`.
+When `analyzers:` is omitted **and** `analyzerName: "saturation"` is set, the list
+defaults to `[{name: "saturation", score: 1.0}]`. When both are omitted, no analyzer
+is selected and the engine falls back to V1 (see
+[Analyzer Selection](#analyzer-selection-v1-vs-v2)).
 
 ### AnalyzerScoreConfig Fields
 
@@ -296,10 +370,13 @@ metadata:
   namespace: <workload-variant-autoscaler-namespace>
 data:
   default: |
+    analyzers:                    # selects V2 (default since v0.9.0)
+      - name: saturation
+        score: 1.0
     kvCacheThreshold: 0.80        # Should match EPP kvCacheUtilThreshold
     queueLengthThreshold: 5       # Should match EPP queueDepthThreshold
-    kvSpareTrigger: 0.10          # WVA-specific (scale-up trigger)
-    queueSpareTrigger: 3          # WVA-specific (scale-up trigger)
+    kvSpareTrigger: 0.10          # WVA-specific scale-up trigger (V1-only, ignored by V2)
+    queueSpareTrigger: 3          # WVA-specific scale-up trigger (V1-only, ignored by V2)
 ```
 
 #### EPP Saturation Detector Configuration
@@ -439,7 +516,9 @@ WARN Saturation scaling ConfigMap not found
 
 ### 2. Customizing Global Defaults
 
-Edit `deploy/configmap-saturation-scaling.yaml`:
+Edit `deploy/configmap-saturation-scaling.yaml`. Keep the `analyzers:` section to
+stay on the default **V2** analyzer — a `default` entry **without** it selects the
+legacy V1 analyzer (see [Analyzer Selection](#analyzer-selection-v1-vs-v2)):
 
 ```yaml
 apiVersion: v1
@@ -449,10 +528,15 @@ metadata:
   namespace: <workload-variant-autoscaler-namespace>
 data:
   default: |
-    kvCacheThreshold: 0.75
-    queueLengthThreshold: 10
-    kvSpareTrigger: 0.15
-    queueSpareTrigger: 5
+    analyzers:
+      - name: saturation
+        score: 1.0
+    scaleUpThreshold: 0.85      # V2-only
+    scaleDownBoundary: 0.70     # V2-only
+    kvCacheThreshold: 0.75      # shared by V1 and V2
+    queueLengthThreshold: 10    # shared by V1 and V2
+    kvSpareTrigger: 0.15        # V1-only (ignored by V2)
+    queueSpareTrigger: 5        # V1-only (ignored by V2)
 ```
 
 Apply the ConfigMap:
@@ -482,13 +566,19 @@ metadata:
   namespace: <workload-variant-autoscaler-namespace>
 data:
   default: |
+    analyzers:              # selects V2 (default since v0.9.0)
+      - name: saturation
+        score: 1.0
+    scaleUpThreshold: 0.85
+    scaleDownBoundary: 0.70
     kvCacheThreshold: 0.80
     queueLengthThreshold: 5
     kvSpareTrigger: 0.1
     queueSpareTrigger: 3
 
-  # Override for granite model in production namespace
-  # Only fields specified here are overridden; the rest inherit from `default`
+  # Override for granite model in production namespace. Overrides inherit the
+  # default's analyzer selection (V2) via field-level merge, so they only list the
+  # thresholds they change.
   "ibm/granite-13b#production": |
     kvCacheThreshold: 0.85
     kvSpareTrigger: 0.15
@@ -638,10 +728,16 @@ WARN Invalid saturation scaling config entry, skipping key=my-config error=...
 WARN No 'default' entry in saturation scaling ConfigMap, using hardcoded defaults
 ```
 
-**Solution:** Add a `default` entry to the ConfigMap:
+**Solution:** Add a `default` entry to the ConfigMap (keep the `analyzers:` section
+to stay on the default V2 analyzer; omitting it selects legacy V1):
 ```yaml
 data:
   default: |
+    analyzers:
+      - name: saturation
+        score: 1.0
+    scaleUpThreshold: 0.85
+    scaleDownBoundary: 0.70
     kvCacheThreshold: 0.80
     queueLengthThreshold: 5
     kvSpareTrigger: 0.1
@@ -722,14 +818,21 @@ metadata:
   name: wva-saturation-scaling-config
   namespace: <workload-variant-autoscaler-namespace>
 data:
-  # Conservative defaults for most workloads
+  # Conservative defaults for most workloads (V2 analyzer — the default since v0.9.0)
   default: |
+    analyzers:
+      - name: saturation
+        score: 1.0
+    scaleUpThreshold: 0.85
+    scaleDownBoundary: 0.70
     kvCacheThreshold: 0.80
     queueLengthThreshold: 5
     kvSpareTrigger: 0.1
     queueSpareTrigger: 3
 
-  # High-priority production workload - scale aggressively
+  # High-priority production workload - scale aggressively.
+  # Per-model overrides inherit the default's analyzer selection (V2 here) via
+  # field-level merge, so they need only the thresholds they change.
   "ibm/granite-13b#production": |
     kvCacheThreshold: 0.70
     queueLengthThreshold: 3

--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -124,8 +124,13 @@ const (
 
 // ApplyDefaults fills in zero-valued fields with their defaults.
 // V1 thresholds (KvCacheThreshold, QueueLengthThreshold, KvSpareTrigger, QueueSpareTrigger)
-// are always defaulted when zero. V2 thresholds are only defaulted when the config is V2.
-// Must be called before Validate() to handle omitempty zero-values correctly.
+// are always defaulted when zero. V2 thresholds (ScaleUpThreshold, ScaleDownBoundary) and
+// the Analyzers list are defaulted only for V2 configs, so that a V1-style entry keeps its
+// V2 thresholds zero — this is deliberate: entries are ApplyDefaults()'d individually at
+// parse time, and defaulting V2 thresholds on a V1-style override would clobber a tuned
+// global value during Merge(). The final resolved config is instead calibrated post-merge
+// via ApplyV2ThresholdDefaults(). Must be called before Validate() to handle omitempty
+// zero-values correctly.
 func (c *SaturationScalingConfig) ApplyDefaults() {
 	if c.Priority == 0 {
 		c.Priority = DefaultPriority
@@ -167,6 +172,22 @@ func (c *SaturationScalingConfig) ApplyDefaults() {
 				c.Analyzers[i].Enabled = &enabled
 			}
 		}
+	}
+}
+
+// ApplyV2ThresholdDefaults fills zero-valued V2 thresholds (ScaleUpThreshold,
+// ScaleDownBoundary) with their defaults regardless of IsV2(). Call this only on a
+// FINAL resolved config (after base + override Merge), never on an individual stored
+// entry: analyzer selection is global, so a V1-style per-model/namespace entry may run
+// on the V2 path and must be calibrated — but defaulting these fields on the stored
+// entry would clobber a tuned global threshold during Merge(). Inert on the V1 path,
+// which never reads these fields.
+func (c *SaturationScalingConfig) ApplyV2ThresholdDefaults() {
+	if c.ScaleUpThreshold == 0 {
+		c.ScaleUpThreshold = DefaultScaleUpThreshold
+	}
+	if c.ScaleDownBoundary == 0 {
+		c.ScaleDownBoundary = DefaultScaleDownBoundary
 	}
 }
 
@@ -238,17 +259,34 @@ func (c *SaturationScalingConfig) Validate() error {
 			c.KvCacheThreshold, c.KvSpareTrigger)
 	}
 
-	// V2 analyzer threshold validation (global defaults)
+	// V2 threshold range/consistency checks apply whenever the fields are set,
+	// regardless of IsV2(): analyzer selection is global, so a V1-style per-model or
+	// namespace entry's explicit scaleUpThreshold/scaleDownBoundary can still be
+	// merged onto the V2 default and consumed on the V2 path. Zero means "unset"
+	// (defaulted elsewhere), so it is skipped here.
+	if c.ScaleUpThreshold != 0 && (c.ScaleUpThreshold < 0 || c.ScaleUpThreshold > 1) {
+		return fmt.Errorf("scaleUpThreshold must be in (0, 1], got %.2f", c.ScaleUpThreshold)
+	}
+	if c.ScaleDownBoundary != 0 && (c.ScaleDownBoundary < 0 || c.ScaleDownBoundary > 1) {
+		return fmt.Errorf("scaleDownBoundary must be in (0, 1], got %.2f", c.ScaleDownBoundary)
+	}
+	if c.ScaleUpThreshold != 0 && c.ScaleDownBoundary != 0 && c.ScaleUpThreshold <= c.ScaleDownBoundary {
+		return fmt.Errorf("scaleUpThreshold (%.2f) must be > scaleDownBoundary (%.2f)", c.ScaleUpThreshold, c.ScaleDownBoundary)
+	}
+
+	// V2 analyzer per-analyzer overrides (only meaningful for a V2 config).
 	if c.IsV2() {
-		if c.ScaleUpThreshold <= 0 || c.ScaleUpThreshold > 1 {
+		// A V2 config must have its thresholds set — ApplyDefaults fills them, so a
+		// zero here means the caller skipped ApplyDefaults, which is invalid. (The
+		// upper-bound and relational checks are handled by the non-zero global checks
+		// above; V1-style entries are only range-checked there when non-zero.)
+		if c.ScaleUpThreshold <= 0 {
 			return fmt.Errorf("scaleUpThreshold must be in (0, 1], got %.2f", c.ScaleUpThreshold)
 		}
-		if c.ScaleDownBoundary <= 0 || c.ScaleDownBoundary > 1 {
+		if c.ScaleDownBoundary <= 0 {
 			return fmt.Errorf("scaleDownBoundary must be in (0, 1], got %.2f", c.ScaleDownBoundary)
 		}
-		if c.ScaleUpThreshold <= c.ScaleDownBoundary {
-			return fmt.Errorf("scaleUpThreshold (%.2f) must be > scaleDownBoundary (%.2f)", c.ScaleUpThreshold, c.ScaleDownBoundary)
-		}
+
 		// Per-analyzer threshold overrides
 		for _, a := range c.Analyzers {
 			if a.ScaleUpThreshold != nil {

--- a/internal/config/saturation_scaling_test.go
+++ b/internal/config/saturation_scaling_test.go
@@ -133,6 +133,35 @@ var _ = Describe("SaturationScalingConfig", func() {
 				ScaleUpThreshold:     0,
 				ScaleDownBoundary:    0,
 			}, false),
+			// A V1-style entry's explicit V2 thresholds can still reach the V2 path via
+			// Merge (selection is global), so out-of-range/inverted values are rejected
+			// even though the entry itself is not V2.
+			Entry("V1-style entry with out-of-range explicit scaleUpThreshold is rejected", SaturationScalingConfig{
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+				AnalyzerName:         "",
+				ScaleUpThreshold:     1.5,
+			}, true),
+			Entry("V1-style entry with inverted explicit V2 thresholds is rejected", SaturationScalingConfig{
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+				AnalyzerName:         "",
+				ScaleUpThreshold:     0.60,
+				ScaleDownBoundary:    0.70,
+			}, true),
+			Entry("V1-style entry with valid explicit V2 thresholds is accepted", SaturationScalingConfig{
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+				AnalyzerName:         "",
+				ScaleUpThreshold:     0.90,
+				ScaleDownBoundary:    0.60,
+			}, false),
 			Entry("valid priority", SaturationScalingConfig{
 				KvCacheThreshold:     0.80,
 				QueueLengthThreshold: 5,
@@ -215,7 +244,7 @@ var _ = Describe("SaturationScalingConfig", func() {
 			Expect(config.ScaleDownBoundary).To(Equal(0.60))
 		})
 
-		It("should apply V1 defaults when not V2", func() {
+		It("should keep V2 thresholds zero on ApplyDefaults when not V2, then calibrate via ApplyV2ThresholdDefaults", func() {
 			config := SaturationScalingConfig{
 				AnalyzerName: "",
 			}
@@ -224,9 +253,29 @@ var _ = Describe("SaturationScalingConfig", func() {
 			Expect(config.QueueLengthThreshold).To(Equal(DefaultQueueLengthThreshold))
 			Expect(config.KvSpareTrigger).To(Equal(DefaultKvSpareTrigger))
 			Expect(config.QueueSpareTrigger).To(Equal(DefaultQueueSpareTrigger))
+			// V2 thresholds stay zero for a V1-style entry: defaulting them on the stored
+			// entry would let a V1-style override clobber a tuned global during Merge.
 			Expect(config.ScaleUpThreshold).To(Equal(0.0))
 			Expect(config.ScaleDownBoundary).To(Equal(0.0))
+			// The analyzer list is NOT seeded, so selection stays V1 (IsV2 false).
 			Expect(config.Analyzers).To(BeEmpty())
+			Expect(config.IsV2()).To(BeFalse())
+			// The final resolved config is calibrated post-merge, independent of IsV2().
+			config.ApplyV2ThresholdDefaults()
+			Expect(config.ScaleUpThreshold).To(Equal(DefaultScaleUpThreshold))
+			Expect(config.ScaleDownBoundary).To(Equal(DefaultScaleDownBoundary))
+		})
+
+		It("ApplyV2ThresholdDefaults should not overwrite already-set (tuned) V2 thresholds", func() {
+			// The whole point of applying this post-merge instead of in ApplyDefaults:
+			// an inherited/tuned value must survive, so it must be a no-op when non-zero.
+			config := SaturationScalingConfig{
+				ScaleUpThreshold:  0.95,
+				ScaleDownBoundary: 0.55,
+			}
+			config.ApplyV2ThresholdDefaults()
+			Expect(config.ScaleUpThreshold).To(Equal(0.95))
+			Expect(config.ScaleDownBoundary).To(Equal(0.55))
 		})
 
 		It("should not overwrite explicit V1 values", func() {

--- a/internal/config/shipped_configmap_test.go
+++ b/internal/config/shipped_configmap_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+// The shipped saturation ConfigMaps must select the V2 (token/capacity-based)
+// analyzer by default as of v0.9.0. Every e2e suite overwrites the `default`
+// entry with its own config, so without this test a YAML typo, an indentation
+// slip, or an ApplyDefaults()/IsV2() regression could silently revert the
+// shipped default back to V1 with no signal. This reads the actual files.
+var _ = Describe("shipped saturation ConfigMap default entry", func() {
+	DescribeTable("selects the V2 analyzer and validates",
+		func(path string) {
+			raw, err := os.ReadFile(path)
+			Expect(err).NotTo(HaveOccurred(), "reading %s", path)
+
+			var cm struct {
+				Data map[string]string `yaml:"data"`
+			}
+			Expect(yaml.Unmarshal(raw, &cm)).To(Succeed(), "parsing ConfigMap %s", path)
+
+			defaultEntry, ok := cm.Data["default"]
+			Expect(ok).To(BeTrue(), "%s must have a data.default entry", path)
+
+			var cfg SaturationScalingConfig
+			Expect(yaml.Unmarshal([]byte(defaultEntry), &cfg)).To(Succeed(), "parsing default entry of %s", path)
+
+			cfg.ApplyDefaults()
+			Expect(cfg.Validate()).To(Succeed(), "%s default entry must validate", path)
+			Expect(cfg.IsV2()).To(BeTrue(), "%s default entry must select the V2 analyzer", path)
+			Expect(cfg.GetAnalyzerName()).To(Equal("saturation"), "%s default entry must resolve to the saturation (V2) analyzer", path)
+		},
+		// Paths are relative to this package directory (internal/config).
+		Entry("kustomize base", "../../config/base/manager/saturation-scaling-configmap.yaml"),
+		Entry("deploy overlay", "../../deploy/configmap-saturation-scaling.yaml"),
+	)
+})

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -96,7 +96,9 @@ type safetyNetEmitter func(
 // Starts from the "default" entry (or zero-value), then merges the model-specific
 // override "{modelID}#{namespace}" on top (if present). This allows per-model
 // overrides to specify only the fields they want to change.
-// ApplyDefaults is called last to fill any remaining zero-valued fields.
+// After merging, ApplyDefaults fills remaining zero-valued fields, then
+// ApplyV2ThresholdDefaults calibrates the V2 thresholds on the final config and an
+// inconsistent (inverted) threshold pair is reset to the defaults.
 func resolveSaturationConfig(
 	configMap map[string]config.SaturationScalingConfig,
 	modelID, namespace string,
@@ -111,6 +113,19 @@ func resolveSaturationConfig(
 		base.Merge(override)
 	}
 	base.ApplyDefaults()
+	// Calibrate V2 thresholds on the final merged config. Analyzer selection is
+	// global, so this entry may run on the V2 path even when written V1-style;
+	// applied here (post-merge) rather than in ApplyDefaults so a V1-style override
+	// cannot clobber a tuned global threshold during Merge.
+	base.ApplyV2ThresholdDefaults()
+	// Per-entry V2 thresholds are range-validated at load, but a merge can still
+	// produce an inconsistent pair across entries (e.g. an override raises
+	// scaleDownBoundary above the base scaleUpThreshold). Rather than feed the
+	// optimizer an inverted pair, fall back to the defaults for both.
+	if base.ScaleUpThreshold <= base.ScaleDownBoundary {
+		base.ScaleUpThreshold = config.DefaultScaleUpThreshold
+		base.ScaleDownBoundary = config.DefaultScaleDownBoundary
+	}
 	return base
 }
 

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -277,6 +277,79 @@ var _ = Describe("resolveSaturationConfig", func() {
 		Expect(cfg.QueueLengthThreshold).To(Equal(5.0))
 		Expect(cfg.KvSpareTrigger).To(Equal(0.10))
 		Expect(cfg.QueueSpareTrigger).To(Equal(3.0))
+		// A V1-style entry stays V1 (selection is decided globally, not here), but the
+		// RESOLVED config is calibrated post-merge so that if the global default routes
+		// this model to the V2 path it runs with valid thresholds rather than zeros
+		// (which would disable the scale-up/scale-down post-step).
+		Expect(cfg.IsV2()).To(BeFalse())
+		Expect(cfg.ScaleUpThreshold).To(Equal(config.DefaultScaleUpThreshold))
+		Expect(cfg.ScaleDownBoundary).To(Equal(config.DefaultScaleDownBoundary))
+	})
+
+	It("should not let a V1-style override clobber a tuned global V2 threshold (production parse order)", func() {
+		// Regression guard: entries are ApplyDefaults()'d individually at parse time
+		// before storage (see parseSaturationConfig). Build the map that way, then
+		// resolve. A V1-style override that omits scaleUpThreshold must INHERIT the
+		// operator-tuned global 0.95, not silently revert to the 0.85 default.
+		def := config.SaturationScalingConfig{
+			Analyzers:        []config.AnalyzerScoreConfig{{Name: "saturation"}},
+			ScaleUpThreshold: 0.95, // operator tuned away from the 0.85 default
+			KvCacheThreshold: 0.80,
+		}
+		def.ApplyDefaults()
+		override := config.SaturationScalingConfig{KvCacheThreshold: 0.90} // V1-style, no V2 thresholds
+		override.ApplyDefaults()
+		configMap := map[string]config.SaturationScalingConfig{
+			"default":                   def,
+			"meta/llama-70b#production": override,
+		}
+		cfg := resolveSaturationConfig(configMap, "meta/llama-70b", "production")
+		Expect(cfg.KvCacheThreshold).To(Equal(0.90))
+		Expect(cfg.ScaleUpThreshold).To(Equal(0.95), "tuned global scaleUpThreshold must survive a V1-style override")
+		Expect(cfg.ScaleDownBoundary).To(Equal(config.DefaultScaleDownBoundary))
+	})
+
+	It("should default the sibling V2 threshold post-merge for a fully V1-style namespace map", func() {
+		// Namespace-local map that is V1-style end-to-end (no analyzers anywhere), as
+		// when a tenant ships their own saturation ConfigMap. Global selection routes
+		// these models to V2. The override sets ONLY scaleUpThreshold; the merged
+		// config's IsV2() stays false, so ApplyV2ThresholdDefaults() is the ONLY thing
+		// that fills the missing scaleDownBoundary — this test fails if that post-merge
+		// call is removed (the explicit ApplyDefaults V2-branch never runs here).
+		def := config.SaturationScalingConfig{KvCacheThreshold: 0.80} // V1-style, no analyzers
+		def.ApplyDefaults()
+		override := config.SaturationScalingConfig{ScaleUpThreshold: 0.90} // only scaleUp set
+		override.ApplyDefaults()
+		configMap := map[string]config.SaturationScalingConfig{
+			"default":      def,
+			"model-1#ns-1": override,
+		}
+		cfg := resolveSaturationConfig(configMap, "model-1", "ns-1")
+		Expect(cfg.IsV2()).To(BeFalse())
+		Expect(cfg.ScaleUpThreshold).To(Equal(0.90), "explicit override must win")
+		Expect(cfg.ScaleDownBoundary).To(Equal(config.DefaultScaleDownBoundary), "missing sibling must be defaulted post-merge")
+	})
+
+	It("should reset an inverted V2 threshold pair produced by a cross-entry merge", func() {
+		// Base scaleUpThreshold 0.85; a V1-style override raises scaleDownBoundary above
+		// it. Each entry is valid on its own (so load-time validation passes), but the
+		// merged pair is inverted — resolveSaturationConfig must fall back to defaults
+		// rather than feed the optimizer scaleUp <= scaleDown.
+		def := config.SaturationScalingConfig{
+			Analyzers:        []config.AnalyzerScoreConfig{{Name: "saturation"}},
+			KvCacheThreshold: 0.80,
+		}
+		def.ApplyDefaults() // scaleUp=0.85, scaleDown=0.70
+		override := config.SaturationScalingConfig{ScaleDownBoundary: 0.95}
+		override.ApplyDefaults()
+		configMap := map[string]config.SaturationScalingConfig{
+			"default":      def,
+			"model-1#ns-1": override,
+		}
+		cfg := resolveSaturationConfig(configMap, "model-1", "ns-1")
+		Expect(cfg.ScaleUpThreshold).To(Equal(config.DefaultScaleUpThreshold))
+		Expect(cfg.ScaleDownBoundary).To(Equal(config.DefaultScaleDownBoundary))
+		Expect(cfg.ScaleUpThreshold).To(BeNumerically(">", cfg.ScaleDownBoundary))
 	})
 })
 

--- a/test/e2e/saturation_analyzer_path_test.go
+++ b/test/e2e/saturation_analyzer_path_test.go
@@ -22,6 +22,13 @@ import (
 // TODO(cleanup): Unify analyzer-path configuration across algorithms
 // (saturation config fields vs queueing-model config presence), then simplify
 // this spec to a single explicit analyzer selector contract.
+//
+// NOTE (v0.9.0): V2 is the default analyzer since v0.9.0. This suite is
+// self-guarded — it snapshots the base ConfigMap and writes its own explicit
+// config for each arc (V1 cases set analyzerName:"" to select the legacy V1
+// path), so the default flip does not affect it. The V1 arcs below deliberately
+// exercise the still-selectable legacy analyzer.
+// TODO(v1-removal): drop the V1 arcs (analyzerName:"") when V1 is removed.
 
 // V1 saturation calibration via the simulator's --fake-metrics flag.
 //

--- a/test/e2e/sglang_backend_test.go
+++ b/test/e2e/sglang_backend_test.go
@@ -6,6 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
@@ -41,12 +43,44 @@ var _ = Describe("SGLang backend", Label("full"), Ordered, func() {
 		ctx      = context.Background()
 		appLabel = baseName + decodeSuffix
 		modelID  = "e2ewva/sglang-model"
+
+		// Saturation ConfigMap snapshot for the V1 guard (see BeforeAll).
+		cmName          string
+		cmNamespace     string
+		cmOriginal      *corev1.ConfigMap
+		cmExistedBefore bool
 	)
 
 	BeforeAll(func() {
 		if !cfg.UseSimulator {
 			Skip("SGLang e2e uses a CPU-only metrics emitter; it runs in the kind-emulator environment (UseSimulator=true)")
 		}
+
+		// V1 guard (v0.9.0 V2-default flip): this suite relies on the shipped
+		// saturation ConfigMap, and its scale-up assertion is calibrated to the V1
+		// (percentage-based) analyzer. The fixture emits a fixed operating point
+		// (token_usage=0.85, num_queue_reqs=3) that deterministically saturates V1's
+		// default thresholds, but sits exactly at V2's scaleUpThreshold=0.85 (V2 must
+		// *exceed* it) — so under the new V2 default the scale-up is no longer
+		// deterministic. Pin this suite to V1 by overwriting the `default` entry with
+		// a V1 config, and restore the original in AfterAll. Analyzer selection is
+		// re-resolved from the watched ConfigMap each cycle, so no controller restart
+		// is needed.
+		// TODO(v2): recalibrate the SGLang fixture metrics + assertion for the V2
+		// (token/capacity-based) analyzer and drop this guard.
+		cmNamespace = cfg.WVANamespace
+		cmName = saturationConfigMapName()
+		cm, err := k8sClient.CoreV1().ConfigMaps(cmNamespace).Get(ctx, cmName, metav1.GetOptions{})
+		if err == nil {
+			cmExistedBefore = true
+			cmOriginal = cm.DeepCopy()
+		} else if !errors.IsNotFound(err) {
+			// Fail fast on a real API error: a false "did not exist" here would make
+			// AfterAll delete the shared ConfigMap without recreating it.
+			Expect(err).NotTo(HaveOccurred(), "reading existing saturation configmap")
+		}
+		By("Pinning the saturation analyzer to V1 for this suite (V2 is the default since v0.9.0)")
+		Expect(upsertSaturationConfigEntry(ctx, cmNamespace, cmName, defaultConfigKey, buildSaturationConfigYAML(""))).To(Succeed())
 
 		By("Deploying the synthetic SGLang model server")
 		Expect(fixtures.CreateSGLangEmulator(ctx, k8sClient, cfg.LLMDNamespace, baseName, modelID, variantName)).To(Succeed())
@@ -62,6 +96,11 @@ var _ = Describe("SGLang backend", Label("full"), Ordered, func() {
 		Expect(fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, baseName, appLabel, variantName, 1, 10, cfg.MonitoringNS,
 			fixtures.WithScaledObjectWVAAnnotations(modelID, "30.0"))).To(Succeed())
 		DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, baseName) })
+	})
+
+	AfterAll(func() {
+		By("Restoring the saturation ConfigMap (V1 guard teardown)")
+		restoreSaturationConfigMap(ctx, cmNamespace, cmName, cmOriginal, cmExistedBefore)
 	})
 
 	It("detects SGLang and emits wva_desired_replicas from sglang:* metrics", func() {


### PR DESCRIPTION
## Fixes

Implements the **v0.9.0 milestone** of the V1-analyzer deprecation timeline (see https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1441)
*V2 default, V1 still selectable*. (Part of the V1-deprecation tracking issue;
link the issue number here.)

## Proposed Changes

Makes the **V2 (token/capacity-based)** saturation analyzer the default. Selection
uses the existing mechanism — the shipped saturation ConfigMap `default` entry now
carries an `analyzers:` section, which `SaturationScalingConfig.GetAnalyzerName()`
resolves to the V2 path. Operators opt back out to the legacy **V1
(percentage-based)** analyzer by removing the `analyzers:` section.

**Config / docs**

- **ConfigMaps** (`config/base/manager/saturation-scaling-configmap.yaml`,
  `deploy/configmap-saturation-scaling.yaml`): add `analyzers:` +
  `scaleUpThreshold`/`scaleDownBoundary` to the `default` entry. Comments label
  each threshold's ownership:
  - Shared (V1 + V2): `kvCacheThreshold`, `queueLengthThreshold`
  - V1-only (ignored by V2): `kvSpareTrigger`, `queueSpareTrigger`
  - V2-only: `scaleUpThreshold` (0.85), `scaleDownBoundary` (0.70)
- **README**: new "Upgrading to v0.9.0" section — behavioral-change notice + V1
  opt-out steps (breaking-change requirement per `release-process.md`).
- **docs/developer-guide/saturation-scaling-config.md**: new "Analyzer Selection
  (V1 vs V2)" section with a threshold-ownership table; every example `default`
  entry carries `analyzers:` so a copy-paste keeps V2; corrected the stale
  "V1 is the default" framing.
- **deploy/ci-e2e-openshift/deploy-infrastructure.sh**: its threshold patch pins
  the run to V1; marked `TODO(v2)`.

**Per-model / namespace threshold calibration** (`internal/config/saturation_scaling.go`,
`internal/engines/saturation/engine.go`)

Analyzer selection is resolved once from the **global** `default` entry, but
thresholds are resolved per-model/namespace. A per-model override or namespace-local
entry written V1-style (no `analyzers:`) can therefore run on the V2 path. Because
entries are `ApplyDefaults()`'d individually at parse time, the V2 thresholds are
defaulted on the **final resolved config** via the new `ApplyV2ThresholdDefaults()`
(post-merge) rather than in `ApplyDefaults()` — this calibrates such entries without
letting a V1-style override clobber a tuned global during `Merge`.
`resolveSaturationConfig` also resets an inverted threshold pair produced by a
cross-entry merge back to the defaults. `Validate()` now range/consistency-checks the
V2 thresholds whenever they are set, regardless of `IsV2()`, so an invalid explicit
value on a V1-style entry can no longer reach the V2 path unchecked.

**E2E tests** — V1-specific tests guarded and marked for V2 reconfiguration:

- `sglang_backend_test.go`: pins to V1 by snapshotting/restoring the saturation
  ConfigMap in `BeforeAll`/`AfterAll` (its scale-up assertion is calibrated to V1
  thresholds; the fixture's `token_usage=0.85` sits exactly at V2's
  `scaleUpThreshold=0.85`, non-deterministic under V2). Marked `TODO(v2)`.
- `saturation_analyzer_path_test.go`: already self-guards both paths — added a note
  plus `TODO(v1-removal)`.
- `saturation_v2_test.go` / `throughput_analyzer_test.go` already write their own
  analyzer config — unaffected.

**Unit tests**

- `internal/config/shipped_configmap_test.go` (new): asserts both shipped ConfigMaps'
  `default` resolves to V2 — guards against a YAML typo silently reverting to V1.
- `resolveSaturationConfig` tests model production parse order and cover tuned-global
  inheritance, fully-V1-style calibration, and inverted-pair reset;
  `ApplyV2ThresholdDefaults` and the new `Validate` rules have direct unit tests.
  (Guard strength verified empirically: the fix-dependent specs fail when the
  post-merge calibration is removed.)

## Pre-review Checklist

- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat(saturation)!:` + `BREAKING CHANGE:` footer)
- [x] Docs updated (developer guide + README upgrade note)
- [x] Unit tests added/updated; `go vet` clean; changed Go files `gofmt`-clean
- [x] `internal/config`, `internal/engines/saturation` (envtest), and `internal/controller` (envtest) suites pass
- [x] E2E smoke run on the V2 default (reviewer / CI)

## Release Note

```release-note
BREAKING CHANGE: The default saturation analyzer is now V2 (token/capacity-based)
instead of V1 (percentage-based). V2 may produce different scaling decisions for
the same workload; review dashboards and alert thresholds after upgrading. To stay
on V1, remove the `analyzers:` section (and the V2-only scaleUpThreshold/
scaleDownBoundary fields) from the `default` entry of the saturation ConfigMap.
```