### PR TITLE
chore: rename internal/interfaces to internal/domain

### DIFF
--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -157,7 +157,7 @@ result slice, so it cannot veto scale-down decisions.
 
 ## Analyzer implementor guide
 
-Implement `interfaces.Analyzer` (`internal/interfaces/analyzer.go`):
+Implement `domain.Analyzer` (`internal/domain/analyzer.go`):
 
 ```go
 type Analyzer interface {

--- a/docs/developer-guide/slo-queuemodel.md
+++ b/docs/developer-guide/slo-queuemodel.md
@@ -319,7 +319,7 @@ Prometheus / vLLM metrics per pod
 | Tuner environment     | `internal/engines/analyzers/queueingmodel/tuner/environment.go`  |
 | QueueAnalyzer         | `pkg/analyzer/queueanalyzer.go`                                  |
 | Engine integration    | `internal/engines/saturation/engine_queueing_model.go`           |
-| ConfigMap interface   | `internal/interfaces/queueing_model_scaling.go`                  |
+| ConfigMap interface   | `internal/domain/queueing_model_scaling.go`                      |
 | ConfigMap YAML        | `deploy/configmap-queueing-model.yaml`                           |
 
 ---

--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -6,7 +6,7 @@ import (
 
 	llmdOptv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -97,7 +97,7 @@ func (a *Actuator) EmitMetrics(ctx context.Context, variantAutoscaling *llmdOptv
 // RecordSaturationMetrics records saturation analysis and KV cache capacity
 // metrics from a decision. The controller does not actively push metrics —
 // Prometheus scrapes them — so the verb is "Record", not "Emit".
-func (a *Actuator) RecordSaturationMetrics(ctx context.Context, decision interfaces.VariantDecision) {
+func (a *Actuator) RecordSaturationMetrics(ctx context.Context, decision domain.VariantDecision) {
 	a.MetricsEmitter.RecordSaturationMetrics(
 		ctx,
 		decision.VariantName,

--- a/internal/actuator/actuator_test.go
+++ b/internal/actuator/actuator_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	ctrlutils "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
@@ -488,7 +488,7 @@ var _ = Describe("Actuator", func() {
 
 		It("should verify that metrics emitter can emit scaling metrics", func() {
 			fmt.Printf("Emitting scaling metrics for variantAutoscaling - name: %s\n numReplicas: %s\n", va.Name, fmtNumReplicas(va.Status.DesiredOptimizedAlloc.NumReplicas))
-			err := actuator.MetricsEmitter.EmitReplicaScalingMetrics(ctx, va, interfaces.ActionScaleUp, interfaces.DecisionReasonV2)
+			err := actuator.MetricsEmitter.EmitReplicaScalingMetrics(ctx, va, domain.ActionScaleUp, domain.DecisionReasonV2)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -505,7 +505,7 @@ var _ = Describe("Actuator", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Additional scaling metrics
-			err = actuator.MetricsEmitter.EmitReplicaScalingMetrics(ctx, va, interfaces.ActionScaleUp, interfaces.DecisionReasonV2)
+			err = actuator.MetricsEmitter.EmitReplicaScalingMetrics(ctx, va, domain.ActionScaleUp, domain.DecisionReasonV2)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -2,7 +2,7 @@
 //
 // The collector package provides a pluggable metrics collection system with support for
 // multiple backends (Prometheus, EPP). Use factory.NewMetricsCollector() to create collector
-// instances, and the MetricsCollector interface from internal/interfaces to interact with them.
+// instances, and the MetricsCollector interface from internal/domain to interact with them.
 //
 // Note: Some legacy functions in this package (ValidateMetricsAvailability, AddMetricsToOptStatus)
 // are deprecated. See individual function documentation for details.

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -14,7 +14,7 @@ import (
 //
 // Only three queries are registered here — those that are genuinely new and not
 // provided by other analyzer registrations. The remaining TA inputs are already
-// collected and exposed via interfaces.ReplicaMetrics; the TA reads those fields
+// collected and exposed via domain.ReplicaMetrics; the TA reads those fields
 // directly instead of re-registering duplicate PromQL templates.
 //
 // TA notation → ReplicaMetrics field (query / registration):
@@ -77,7 +77,7 @@ const (
 //   - QueryKvUsageInstant      — k*: instantaneous KV cache utilization per pod
 //   - QueryRequestRate     — fallback λ_req: completion rate per pod when EPP absent
 //
-// Additional TA inputs are read from interfaces.ReplicaMetrics fields populated by
+// Additional TA inputs are read from domain.ReplicaMetrics fields populated by
 // RegisterSaturationQueries (TotalKvCapacityTokens, AvgOutputTokens, AvgInputTokens,
 // PrefixCacheHitRate) and RegisterQueueingModelQueries (AvgITL, ArrivalRate).
 // See the package-level constant block for the full TA notation → field mapping.

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -58,9 +58,9 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	saturation_v2 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/saturation_v2"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
@@ -162,7 +162,7 @@ func (c *ReplicaMetricsCollector) recordMetricsUnavailableEvent(
 //   - variantCosts: Map of VariantAutoscaling namespace/name to cost value
 //
 // Returns:
-//   - []interfaces.ReplicaMetrics: Per-pod metrics for saturation and queueing model analysis
+//   - []domain.ReplicaMetrics: Per-pod metrics for saturation and queueing model analysis
 //   - error: Any error that occurred during collection
 func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	ctx context.Context,
@@ -172,7 +172,7 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	vaEventTracker map[string]bool,
 	variantCosts map[string]float64,
-) ([]interfaces.ReplicaMetrics, error) {
+) ([]domain.ReplicaMetrics, error) {
 	replicaMetrics, err := c.collectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, variantCosts)
 
 	// Determine if metrics are available in this cycle
@@ -319,7 +319,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	variantCosts map[string]float64,
-) ([]interfaces.ReplicaMetrics, error) {
+) ([]domain.ReplicaMetrics, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	params := map[string]string{
@@ -849,7 +849,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	vaMetricsFreshnessStatus := make(map[string]map[string]int)
 
 	// Build replica metrics from pod data
-	replicaMetrics := make([]interfaces.ReplicaMetrics, 0, len(podData))
+	replicaMetrics := make([]domain.ReplicaMetrics, 0, len(podData))
 	collectedAt := time.Now()
 
 	for instanceKey, data := range podData {
@@ -974,7 +974,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 
 		// Track freshness for metrics in this pod
 		trackMetricFreshness(vaName, data, collectedAt, vaMetricsFreshnessStatus)
-		metric := interfaces.ReplicaMetrics{
+		metric := domain.ReplicaMetrics{
 			PodName:               podName,
 			ModelID:               modelID,
 			Namespace:             namespace,
@@ -997,7 +997,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			GenerationTokenRate:   data.generationTokenRate,
 			KvUsageInstant:        data.kvUsageInstant,
 			RequestRate:           data.requestRate,
-			Metadata: &interfaces.ReplicaMetricsMetadata{
+			Metadata: &domain.ReplicaMetricsMetadata{
 				CollectedAt:     collectedAt,
 				Age:             0, // Fresh
 				FreshnessStatus: "fresh",
@@ -1031,7 +1031,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 func (c *ReplicaMetricsCollector) CollectSchedulerQueueMetrics(
 	ctx context.Context,
 	modelID string,
-) *interfaces.SchedulerQueueMetrics {
+) *domain.SchedulerQueueMetrics {
 	logger := ctrl.LoggerFrom(ctx)
 
 	params := map[string]string{
@@ -1083,7 +1083,7 @@ func (c *ReplicaMetricsCollector) CollectSchedulerQueueMetrics(
 		"queueSize", queueSize,
 		"queueBytes", queueBytes)
 
-	return &interfaces.SchedulerQueueMetrics{
+	return &domain.SchedulerQueueMetrics{
 		QueueSize:  queueSize,
 		QueueBytes: queueBytes,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // Config is the unified configuration structure for the WVA controller.
@@ -123,7 +123,7 @@ type SaturationScalingConfigPerModel map[string]SaturationScalingConfig
 
 // QMAnalyzerConfigPerModel represents queueing model scaling configuration
 // for all models. Maps model ID (or "default" key) to its configuration.
-type QMAnalyzerConfigPerModel map[string]interfaces.QueueingModelScalingConfig
+type QMAnalyzerConfigPerModel map[string]domain.QueueingModelScalingConfig
 
 // saturationConfig holds saturation scaling configuration (namespace-aware)
 type saturationConfig struct {
@@ -550,7 +550,7 @@ func (c *Config) UpdateScaleToZeroConfigForNamespace(namespace string, config Sc
 // QMAnalyzerConfig returns the current global queueing model scaling configuration.
 // Thread-safe. Returns a copy to prevent external modifications.
 // For namespace-aware lookups, use QMAnalyzerConfigForNamespace instead.
-func (c *Config) QMAnalyzerConfig() map[string]interfaces.QueueingModelScalingConfig {
+func (c *Config) QMAnalyzerConfig() map[string]domain.QueueingModelScalingConfig {
 	return c.QMAnalyzerConfigForNamespace("")
 }
 
@@ -558,7 +558,7 @@ func (c *Config) QMAnalyzerConfig() map[string]interfaces.QueueingModelScalingCo
 // Resolution order: namespace-local > global
 // Thread-safe. Returns a copy to prevent external modifications.
 // If namespace is empty, returns global config.
-func (c *Config) QMAnalyzerConfigForNamespace(namespace string) map[string]interfaces.QueueingModelScalingConfig {
+func (c *Config) QMAnalyzerConfigForNamespace(namespace string) map[string]domain.QueueingModelScalingConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	sourceConfig := c.resolveQMAnalyzerConfig(namespace)
@@ -567,7 +567,7 @@ func (c *Config) QMAnalyzerConfigForNamespace(namespace string) map[string]inter
 
 // resolveQMAnalyzerConfig resolves queueing model config for a namespace (namespace-local > global).
 // Must be called while holding at least a read lock.
-func (c *Config) resolveQMAnalyzerConfig(namespace string) map[string]interfaces.QueueingModelScalingConfig {
+func (c *Config) resolveQMAnalyzerConfig(namespace string) map[string]domain.QueueingModelScalingConfig {
 	// Check namespace-local first (if namespace is provided)
 	if namespace != "" {
 		if nsConfig, exists := c.qmAnalyzer.namespaceConfigs[namespace]; exists {
@@ -586,11 +586,11 @@ func (c *Config) resolveQMAnalyzerConfig(namespace string) map[string]interfaces
 }
 
 // copyQMAnalyzerConfig creates a deep copy of the queueing model config map.
-func copyQMAnalyzerConfig(src map[string]interfaces.QueueingModelScalingConfig) map[string]interfaces.QueueingModelScalingConfig {
+func copyQMAnalyzerConfig(src map[string]domain.QueueingModelScalingConfig) map[string]domain.QueueingModelScalingConfig {
 	if src == nil {
-		return make(map[string]interfaces.QueueingModelScalingConfig)
+		return make(map[string]domain.QueueingModelScalingConfig)
 	}
-	result := make(map[string]interfaces.QueueingModelScalingConfig, len(src))
+	result := make(map[string]domain.QueueingModelScalingConfig, len(src))
 	for k, v := range src {
 		result[k] = v
 	}
@@ -600,19 +600,19 @@ func copyQMAnalyzerConfig(src map[string]interfaces.QueueingModelScalingConfig) 
 // UpdateQMAnalyzerConfig updates the global queueing model scaling configuration.
 // Thread-safe. Takes a copy of the provided map to prevent external modifications.
 // For namespace-local updates, use UpdateQMAnalyzerConfigForNamespace instead.
-func (c *Config) UpdateQMAnalyzerConfig(config map[string]interfaces.QueueingModelScalingConfig) {
+func (c *Config) UpdateQMAnalyzerConfig(config map[string]domain.QueueingModelScalingConfig) {
 	c.UpdateQMAnalyzerConfigForNamespace("", config)
 }
 
 // UpdateQMAnalyzerConfigForNamespace updates the queueing model scaling configuration for the given namespace.
 // If namespace is empty, updates global config.
 // Thread-safe. Takes a copy of the provided map to prevent external modifications.
-func (c *Config) UpdateQMAnalyzerConfigForNamespace(namespace string, config map[string]interfaces.QueueingModelScalingConfig) {
+func (c *Config) UpdateQMAnalyzerConfigForNamespace(namespace string, config map[string]domain.QueueingModelScalingConfig) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	// Make a copy to prevent external modifications
-	newConfig := make(map[string]interfaces.QueueingModelScalingConfig, len(config))
+	newConfig := make(map[string]domain.QueueingModelScalingConfig, len(config))
 	maps.Copy(newConfig, config)
 
 	var oldCount int

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // TestConfig_ThreadSafeUpdates tests that concurrent reads and writes to DynamicConfig
@@ -503,7 +503,7 @@ func TestQMAnalyzerConfig_GlobalGetSet(t *testing.T) {
 
 	// Set global config
 	cfg.UpdateQMAnalyzerConfig(QMAnalyzerConfigPerModel{
-		"default": interfaces.QueueingModelScalingConfig{SLOMultiplier: 3.0},
+		"default": domain.QueueingModelScalingConfig{SLOMultiplier: 3.0},
 	})
 
 	qmCfg = cfg.QMAnalyzerConfig()
@@ -519,11 +519,11 @@ func TestQMAnalyzerConfig_NamespaceOverride(t *testing.T) {
 	cfg := NewTestConfig()
 
 	cfg.UpdateQMAnalyzerConfig(QMAnalyzerConfigPerModel{
-		"default": interfaces.QueueingModelScalingConfig{SLOMultiplier: 3.0},
+		"default": domain.QueueingModelScalingConfig{SLOMultiplier: 3.0},
 	})
 
 	cfg.UpdateQMAnalyzerConfigForNamespace("prod", QMAnalyzerConfigPerModel{
-		"default": interfaces.QueueingModelScalingConfig{SLOMultiplier: 5.0},
+		"default": domain.QueueingModelScalingConfig{SLOMultiplier: 5.0},
 	})
 
 	global := cfg.QMAnalyzerConfig()
@@ -545,11 +545,11 @@ func TestQMAnalyzerConfig_NamespaceOverride(t *testing.T) {
 func TestQMAnalyzerConfig_ReturnsCopy(t *testing.T) {
 	cfg := NewTestConfig()
 	cfg.UpdateQMAnalyzerConfig(QMAnalyzerConfigPerModel{
-		"default": interfaces.QueueingModelScalingConfig{SLOMultiplier: 3.0},
+		"default": domain.QueueingModelScalingConfig{SLOMultiplier: 3.0},
 	})
 
 	copy1 := cfg.QMAnalyzerConfig()
-	copy1["default"] = interfaces.QueueingModelScalingConfig{SLOMultiplier: 99.0}
+	copy1["default"] = domain.QueueingModelScalingConfig{SLOMultiplier: 99.0}
 
 	copy2 := cfg.QMAnalyzerConfig()
 	if copy2["default"].SLOMultiplier != 3.0 {

--- a/internal/controller/allocation.go
+++ b/internal/controller/allocation.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
@@ -10,10 +10,10 @@ import (
 // BuildAllocationFromMetrics assembles an Allocation struct from raw optimizer metrics
 // and Kubernetes resources. This delegates to utils.BuildAllocationFromMetrics.
 func BuildAllocationFromMetrics(
-	metrics interfaces.OptimizerMetrics,
+	metrics domain.OptimizerMetrics,
 	va *variant.VariantAutoscaling,
 	scaleTarget scaletarget.ScaleTargetAccessor,
 	acceleratorCost float64,
-) (interfaces.Allocation, error) {
+) (domain.Allocation, error) {
 	return utils.BuildAllocationFromMetrics(metrics, va, scaleTarget, acceleratorCost)
 }

--- a/internal/controller/configmap_helpers.go
+++ b/internal/controller/configmap_helpers.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 )
 
@@ -64,7 +64,7 @@ func parseQMAnalyzerConfig(cmData map[string]string, logger logr.Logger) (config
 	configs := make(config.QMAnalyzerConfigPerModel)
 	count := 0
 	for key, yamlStr := range cmData {
-		var qmConfig interfaces.QueueingModelScalingConfig
+		var qmConfig domain.QueueingModelScalingConfig
 		if err := yaml.Unmarshal([]byte(yamlStr), &qmConfig); err != nil {
 			errorType := "Failed to parse queueing model config entry"
 			logger.Error(err, errorType, "key", key)

--- a/internal/domain/allocation.go
+++ b/internal/domain/allocation.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 // Allocation describes the current resource allocation for a model variant.
 type Allocation struct {

--- a/internal/domain/analyzer.go
+++ b/internal/domain/analyzer.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 import (
 	"context"

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 import (
 	"context"

--- a/internal/domain/metrics_collector.go
+++ b/internal/domain/metrics_collector.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 // MetricsValidationResult contains the result of metrics availability check
 type MetricsValidationResult struct {

--- a/internal/domain/queueing_model_scaling.go
+++ b/internal/domain/queueing_model_scaling.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 import "fmt"
 

--- a/internal/domain/queueing_model_scaling_test.go
+++ b/internal/domain/queueing_model_scaling_test.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 import (
 	"testing"

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 import (
 	"context"

--- a/internal/domain/saturation_analyzer_test.go
+++ b/internal/domain/saturation_analyzer_test.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 import (
 	"testing"

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -1,4 +1,4 @@
-package interfaces
+package domain
 
 type ServiceClassEntry struct {
 	Model   string `yaml:"model"`

--- a/internal/engines/aggregation/aggregation.go
+++ b/internal/engines/aggregation/aggregation.go
@@ -26,7 +26,7 @@ limitations under the License.
 //	r.RoleCapacities[role].* == same sums filtered by vc.Role == role
 package aggregation
 
-import "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+import "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 
 // ScopeTotals holds the three model-level (or per-role) aggregates that the
 // engine's universal threshold post-step reads to compute RC and SC.
@@ -37,7 +37,7 @@ type ScopeTotals struct {
 }
 
 // SumTotalSupply returns Σ_v vc.ReplicaCount × vc.PerReplicaCapacity.
-func SumTotalSupply(vcs []interfaces.VariantCapacity) float64 {
+func SumTotalSupply(vcs []domain.VariantCapacity) float64 {
 	var total float64
 	for _, vc := range vcs {
 		total += float64(vc.ReplicaCount) * vc.PerReplicaCapacity
@@ -49,7 +49,7 @@ func SumTotalSupply(vcs []interfaces.VariantCapacity) float64 {
 // Σ_v (vc.ReplicaCount + vc.PendingReplicas) × vc.PerReplicaCapacity.
 // Pending replicas count toward anticipated supply so an in-flight scale-up
 // reduces the computed RC and prevents double-scaling.
-func SumTotalAnticipatedSupply(vcs []interfaces.VariantCapacity) float64 {
+func SumTotalAnticipatedSupply(vcs []domain.VariantCapacity) float64 {
 	var total float64
 	for _, vc := range vcs {
 		total += float64(vc.ReplicaCount+vc.PendingReplicas) * vc.PerReplicaCapacity
@@ -58,7 +58,7 @@ func SumTotalAnticipatedSupply(vcs []interfaces.VariantCapacity) float64 {
 }
 
 // SumTotalDemand returns Σ_v vc.TotalDemand.
-func SumTotalDemand(vcs []interfaces.VariantCapacity) float64 {
+func SumTotalDemand(vcs []domain.VariantCapacity) float64 {
 	var total float64
 	for _, vc := range vcs {
 		total += vc.TotalDemand
@@ -67,14 +67,14 @@ func SumTotalDemand(vcs []interfaces.VariantCapacity) float64 {
 }
 
 // AggregateByRole groups vcs by role and computes ScopeTotals for each group.
-// An empty or blank role string is canonicalized to interfaces.RoleBoth,
+// An empty or blank role string is canonicalized to domain.RoleBoth,
 // consistent with saturation_v2's role normalization.
-func AggregateByRole(vcs []interfaces.VariantCapacity) map[string]ScopeTotals {
+func AggregateByRole(vcs []domain.VariantCapacity) map[string]ScopeTotals {
 	result := make(map[string]ScopeTotals)
 	for _, vc := range vcs {
 		role := vc.Role
 		if role == "" {
-			role = interfaces.RoleBoth
+			role = domain.RoleBoth
 		}
 		t := result[role]
 		t.TotalSupply += float64(vc.ReplicaCount) * vc.PerReplicaCapacity

--- a/internal/engines/aggregation/aggregation_test.go
+++ b/internal/engines/aggregation/aggregation_test.go
@@ -22,8 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/aggregation"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
 func TestAggregation(t *testing.T) {
@@ -36,11 +36,11 @@ var _ = Describe("aggregation helpers", func() {
 	Describe("SumTotalSupply", func() {
 		It("returns 0 for empty input", func() {
 			Expect(aggregation.SumTotalSupply(nil)).To(BeZero())
-			Expect(aggregation.SumTotalSupply([]interfaces.VariantCapacity{})).To(BeZero())
+			Expect(aggregation.SumTotalSupply([]domain.VariantCapacity{})).To(BeZero())
 		})
 
 		It("sums ReplicaCount × PerReplicaCapacity across variants", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{VariantName: "v1", ReplicaCount: 2, PendingReplicas: 1, PerReplicaCapacity: 5000},
 				{VariantName: "v2", ReplicaCount: 3, PendingReplicas: 0, PerReplicaCapacity: 8000},
 			}
@@ -49,14 +49,14 @@ var _ = Describe("aggregation helpers", func() {
 		})
 
 		It("ignores pending replicas", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{ReplicaCount: 1, PendingReplicas: 99, PerReplicaCapacity: 1000},
 			}
 			Expect(aggregation.SumTotalSupply(vcs)).To(Equal(1000.0))
 		})
 
 		It("handles zero PRC", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{ReplicaCount: 5, PerReplicaCapacity: 0},
 			}
 			Expect(aggregation.SumTotalSupply(vcs)).To(BeZero())
@@ -69,7 +69,7 @@ var _ = Describe("aggregation helpers", func() {
 		})
 
 		It("sums (ReplicaCount + PendingReplicas) × PRC across variants", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{ReplicaCount: 2, PendingReplicas: 1, PerReplicaCapacity: 5000},
 				{ReplicaCount: 3, PendingReplicas: 0, PerReplicaCapacity: 8000},
 			}
@@ -78,7 +78,7 @@ var _ = Describe("aggregation helpers", func() {
 		})
 
 		It("equals SumTotalSupply when no variants have pending replicas", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{ReplicaCount: 3, PendingReplicas: 0, PerReplicaCapacity: 10000},
 			}
 			Expect(aggregation.SumTotalAnticipatedSupply(vcs)).To(Equal(aggregation.SumTotalSupply(vcs)))
@@ -91,7 +91,7 @@ var _ = Describe("aggregation helpers", func() {
 		})
 
 		It("sums TotalDemand across variants", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{TotalDemand: 3000},
 				{TotalDemand: 7000},
 			}
@@ -105,16 +105,16 @@ var _ = Describe("aggregation helpers", func() {
 		})
 
 		It("canonicalizes empty role to RoleBoth", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{Role: "", ReplicaCount: 1, PerReplicaCapacity: 1000, TotalDemand: 500},
 			}
 			result := aggregation.AggregateByRole(vcs)
-			Expect(result).To(HaveKey(interfaces.RoleBoth))
+			Expect(result).To(HaveKey(domain.RoleBoth))
 			Expect(result).NotTo(HaveKey(""))
 		})
 
 		It("groups variants by role and computes ScopeTotals for each", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{Role: "prefill", ReplicaCount: 2, PendingReplicas: 1, PerReplicaCapacity: 5000, TotalDemand: 8000},
 				{Role: "decode", ReplicaCount: 3, PendingReplicas: 0, PerReplicaCapacity: 8000, TotalDemand: 9000},
 				{Role: "decode", ReplicaCount: 1, PendingReplicas: 0, PerReplicaCapacity: 4000, TotalDemand: 2000},
@@ -135,18 +135,18 @@ var _ = Describe("aggregation helpers", func() {
 		})
 
 		It("handles a single non-disaggregated variant (empty role → RoleBoth)", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{Role: "", ReplicaCount: 2, PendingReplicas: 0, PerReplicaCapacity: 10000, TotalDemand: 15000},
 			}
 			result := aggregation.AggregateByRole(vcs)
-			both := result[interfaces.RoleBoth]
+			both := result[domain.RoleBoth]
 			Expect(both.TotalSupply).To(Equal(20000.0))
 			Expect(both.TotalAnticipatedSupply).To(Equal(20000.0))
 			Expect(both.TotalDemand).To(Equal(15000.0))
 		})
 
 		It("handles zero ReplicaCount", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{Role: "prefill", ReplicaCount: 0, PendingReplicas: 0, PerReplicaCapacity: 5000, TotalDemand: 0},
 			}
 			result := aggregation.AggregateByRole(vcs)

--- a/internal/engines/analyzers/queueingmodel/analyzer.go
+++ b/internal/engines/analyzers/queueingmodel/analyzer.go
@@ -7,13 +7,13 @@ import (
 	"math"
 	"time"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel/tuner"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/pkg/analyzer"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// QueueingModelAnalyzer implements interfaces.Analyzer.
+// QueueingModelAnalyzer implements domain.Analyzer.
 // It performs SLO-driven capacity analysis by:
 //  1. Learning model parameters (alpha, beta, gamma) online via Kalman filter
 //  2. Using queueing model to predict max request rate that meets TTFT/ITL SLOs
@@ -31,9 +31,9 @@ func NewQueueingModelAnalyzer() *QueueingModelAnalyzer {
 	}
 }
 
-// Name implements interfaces.Analyzer.
+// Name implements domain.Analyzer.
 func (a *QueueingModelAnalyzer) Name() string {
-	return interfaces.QueueingModelAnalyzerName
+	return domain.QueueingModelAnalyzerName
 }
 
 // Update deletes non-existing models from paramStore[models]
@@ -79,7 +79,7 @@ func (a *QueueingModelAnalyzer) setParams(modelID, namespace, variantName string
 	pStore.Set(namespace, variantName, params)
 }
 
-// Analyze implements interfaces.Analyzer.
+// Analyze implements domain.Analyzer.
 // Called for each model.
 //
 // If we fail to analyze a model (bad config, no learned parameters, no
@@ -91,8 +91,8 @@ func (a *QueueingModelAnalyzer) setParams(modelID, namespace, variantName string
 // without an SLO but the situation is not necessarily erroneous.
 func (a *QueueingModelAnalyzer) Analyze(
 	ctx context.Context,
-	input interfaces.AnalyzerInput,
-) (*interfaces.AnalyzerResult, error) {
+	input domain.AnalyzerInput,
+) (*domain.AnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	modelID := input.ModelID
 	namespace := input.Namespace
@@ -135,7 +135,7 @@ func (a *QueueingModelAnalyzer) Analyze(
 		utilization = totalDemand / totalSupply
 	}
 
-	return &interfaces.AnalyzerResult{
+	return &domain.AnalyzerResult{
 		AnalyzerName:      a.Name(),
 		ModelID:           modelID,
 		Namespace:         namespace,
@@ -155,7 +155,7 @@ func (a *QueueingModelAnalyzer) updateVariantParameters(
 	namespace string,
 	modelID string,
 	variantNames []string,
-	variantMetrics map[string][]interfaces.ReplicaMetrics,
+	variantMetrics map[string][]domain.ReplicaMetrics,
 	config *QMConfig,
 ) {
 	logger := ctrl.LoggerFrom(ctx)
@@ -244,7 +244,7 @@ func (a *QueueingModelAnalyzer) getSLOTarget(
 	modelID string,
 	config *QMConfig,
 	variantNames []string,
-	modelReplicaMetrics []interfaces.ReplicaMetrics,
+	modelReplicaMetrics []domain.ReplicaMetrics,
 ) *SLOTarget {
 	// First try explicit config
 	if slo := config.GetSLOForModel(namespace, modelID); slo != nil {
@@ -259,10 +259,10 @@ func (a *QueueingModelAnalyzer) computeAllVariantCapacities(
 	ctx context.Context,
 	namespace string,
 	modelID string,
-	variantMetrics map[string][]interfaces.ReplicaMetrics,
-	variantStates []interfaces.VariantReplicaState,
+	variantMetrics map[string][]domain.ReplicaMetrics,
+	variantStates []domain.VariantReplicaState,
 	sloTarget *SLOTarget,
-) []interfaces.VariantCapacity {
+) []domain.VariantCapacity {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Build cost and accelerator lookup from input metrics
@@ -275,13 +275,13 @@ func (a *QueueingModelAnalyzer) computeAllVariantCapacities(
 		}
 	}
 
-	variantCapacities := make([]interfaces.VariantCapacity, 0, len(variantStates))
+	variantCapacities := make([]domain.VariantCapacity, 0, len(variantStates))
 	for _, variantState := range variantStates {
 		variantName := variantState.VariantName
 		readyCount := max(variantState.CurrentReplicas-variantState.PendingReplicas, 0)
 
 		// variant capacity in case of error
-		errorVariantCapacity := interfaces.VariantCapacity{
+		errorVariantCapacity := domain.VariantCapacity{
 			VariantName:     variantName,
 			AcceleratorName: variantAccel[variantName],
 			Cost:            variantCost[variantName],
@@ -382,7 +382,7 @@ func (a *QueueingModelAnalyzer) computeAllVariantCapacities(
 		}
 		arrivalRatePerReplica := totalArrivalRate / desiredNumReplicas
 
-		variantCapacity := interfaces.VariantCapacity{
+		variantCapacity := domain.VariantCapacity{
 			VariantName:     variantName,
 			AcceleratorName: variantAccel[variantName],
 			Cost:            variantCost[variantName], // TODO: multiply by numReplicas?
@@ -497,7 +497,7 @@ func (a *QueueingModelAnalyzer) guessSLOFromMetrics(
 	modelID string,
 	config *QMConfig,
 	variantNames []string,
-	modelReplicaMetrics []interfaces.ReplicaMetrics,
+	modelReplicaMetrics []domain.ReplicaMetrics,
 ) *SLOTarget {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -623,7 +623,7 @@ func (a *QueueingModelAnalyzer) storeParametersFromResults(
 // Returns error if required metrics are unavailable.
 func buildEnvironmentsFromMetrics(
 	variantName string,
-	variantReplicaMetrics []interfaces.ReplicaMetrics,
+	variantReplicaMetrics []domain.ReplicaMetrics,
 ) ([]*tuner.Environment, error) {
 	if len(variantReplicaMetrics) == 0 {
 		return nil, fmt.Errorf("no replica metrics for variant %s", variantName)
@@ -771,7 +771,7 @@ func guessInitState(env *tuner.Environment) ([]float64, error) {
 }
 
 // aggregateCapacities calculates the sum of supply and demand over all variants
-func aggregateCapacities(capacities []interfaces.VariantCapacity) (supply, demand float64) {
+func aggregateCapacities(capacities []domain.VariantCapacity) (supply, demand float64) {
 	for _, c := range capacities {
 		supply += c.TotalCapacity
 		demand += c.TotalDemand
@@ -780,8 +780,8 @@ func aggregateCapacities(capacities []interfaces.VariantCapacity) (supply, deman
 }
 
 // groupMetricsByVariant groups replica metrics by variant name.
-func groupMetricsByVariant(modelReplicaMetrics []interfaces.ReplicaMetrics) map[string][]interfaces.ReplicaMetrics {
-	grouped := make(map[string][]interfaces.ReplicaMetrics)
+func groupMetricsByVariant(modelReplicaMetrics []domain.ReplicaMetrics) map[string][]domain.ReplicaMetrics {
+	grouped := make(map[string][]domain.ReplicaMetrics)
 	for _, replicaMetric := range modelReplicaMetrics {
 		grouped[replicaMetric.VariantName] = append(grouped[replicaMetric.VariantName], replicaMetric)
 	}
@@ -790,7 +790,7 @@ func groupMetricsByVariant(modelReplicaMetrics []interfaces.ReplicaMetrics) map[
 
 // getVariantNames returns the variant names, derived from replicaMetrics,
 // in the order they appear in the slice
-func getVariantNames(replicaMetrics []interfaces.ReplicaMetrics) []string {
+func getVariantNames(replicaMetrics []domain.ReplicaMetrics) []string {
 	names := []string{}
 	namesMap := make(map[string]bool)
 	for _, replicaMetric := range replicaMetrics {
@@ -815,7 +815,7 @@ type workloadMetrics struct {
 
 // aggregateWorkloadMetrics averages token sizes and latencies across replicas
 // that have active traffic. Returns zero metrics if no replicas have traffic.
-func aggregateWorkloadMetrics(replicaMetrics []interfaces.ReplicaMetrics) *workloadMetrics {
+func aggregateWorkloadMetrics(replicaMetrics []domain.ReplicaMetrics) *workloadMetrics {
 	var totalArrivalRate float64
 	var totalInputToks, totalOutputToks float64
 	var totalTTFT, totalITL float64

--- a/internal/engines/analyzers/queueingmodel/config.go
+++ b/internal/engines/analyzers/queueingmodel/config.go
@@ -1,11 +1,11 @@
 package queueingmodel
 
 import (
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel/tuner"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
-// QMConfig implements interfaces.AnalyzerConfig
+// QMConfig implements domain.AnalyzerConfig
 type QMConfig struct {
 	// SLOTargets maps (modelID, namespace) to SLO targets
 	// Key format: "namespace/modelID"
@@ -36,9 +36,9 @@ type SLOTarget struct {
 	TargetITL  float32 // Target inter-token latency (ms)
 }
 
-// GetAnalyzerName implements interfaces.AnalyzerConfig
+// GetAnalyzerName implements domain.AnalyzerConfig
 func (c *QMConfig) GetAnalyzerName() string {
-	return interfaces.QueueingModelAnalyzerName
+	return domain.QueueingModelAnalyzerName
 }
 
 // GetSLOForModel retrieves SLO targets for a model in a namespace

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/aggregation"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
-// SaturationAnalyzer implements the interfaces.Analyzer interface using a
+// SaturationAnalyzer implements the domain.Analyzer interface using a
 // token-based capacity model with memory-bound (k1) and compute-bound (k2)
 // constraints. It replaces the V1 percentage-based analyzer when
 // analyzerName is set to "saturation".
@@ -59,7 +59,7 @@ func (a *SaturationAnalyzer) EvictStaleHistory(timeout time.Duration) int {
 }
 
 // Analyze computes capacity signals for a model across all its variants.
-func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.AnalyzerInput) (*interfaces.AnalyzerResult, error) {
+func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerInput) (*domain.AnalyzerResult, error) {
 	satConfig, ok := input.Config.(*config.SaturationScalingConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected *SaturationScalingConfig, got %T", input.Config)
@@ -99,7 +99,7 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.Analy
 	for _, vc := range variantCapacities {
 		role := vc.Role
 		if role == "" {
-			role = interfaces.RoleBoth
+			role = domain.RoleBoth
 		}
 		activeRoles[role] = true
 	}
@@ -121,7 +121,7 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.Analy
 	// Phase 5: Build result. RequiredCapacity and SpareCapacity left zero;
 	// the engine post-step overwrites them using TotalDemand, TotalSupply,
 	// and TotalAnticipatedSupply with the resolved thresholds.
-	result := &interfaces.AnalyzerResult{
+	result := &domain.AnalyzerResult{
 		AnalyzerName:           a.Name(),
 		ModelID:                input.ModelID,
 		Namespace:              input.Namespace,
@@ -140,7 +140,7 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.Analy
 // computeReplicaCapacity computes the capacity breakdown for a single replica.
 // Returns nil if the replica has no V2 capacity data (TotalKvCapacityTokens == 0).
 func (a *SaturationAnalyzer) computeReplicaCapacity(
-	rm interfaces.ReplicaMetrics,
+	rm domain.ReplicaMetrics,
 	config *config.SaturationScalingConfig,
 	modelID, namespace string,
 	gpuCount int,
@@ -223,7 +223,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 // This allows V2 to work with model servers that don't emit cache_config_info
 // (e.g., the llm-d-inference-sim).
 func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
-	rm interfaces.ReplicaMetrics,
+	rm domain.ReplicaMetrics,
 	cfg *config.SaturationScalingConfig,
 	modelID, namespace string,
 ) *ReplicaCapacity {
@@ -324,11 +324,11 @@ func (a *SaturationAnalyzer) computeK2(
 // per-variant capacity metrics.
 func (a *SaturationAnalyzer) aggregateByVariant(
 	replicaCapacities []ReplicaCapacity,
-	inputMetrics []interfaces.ReplicaMetrics,
-	variantStates []interfaces.VariantReplicaState,
+	inputMetrics []domain.ReplicaMetrics,
+	variantStates []domain.VariantReplicaState,
 	modelID, namespace string,
 	kvCacheThreshold float64,
-) []interfaces.VariantCapacity {
+) []domain.VariantCapacity {
 	// Group replicas by variant
 	byVariant := make(map[string][]ReplicaCapacity)
 	for _, rc := range replicaCapacities {
@@ -349,7 +349,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 	// Used for capacity estimation of zero-replica variants with deployment-derived params.
 	modelAvgInput, modelAvgOutput, _ := computeModelWorkloadAverages(inputMetrics)
 
-	result := make([]interfaces.VariantCapacity, 0, len(variantStates))
+	result := make([]domain.VariantCapacity, 0, len(variantStates))
 	for _, vs := range variantStates {
 		replicas := byVariant[vs.VariantName]
 
@@ -396,7 +396,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			utilization = totalDemand / totalCapacity
 		}
 
-		result = append(result, interfaces.VariantCapacity{
+		result = append(result, domain.VariantCapacity{
 			VariantName:        vs.VariantName,
 			AcceleratorName:    accelerator,
 			Cost:               cost,
@@ -423,13 +423,13 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 // RequiredCapacity and SpareCapacity are left zero — the engine post-step
 // writes them after Analyze() returns using the universal threshold formula.
 func (a *SaturationAnalyzer) aggregateByRole(
-	variantCapacities []interfaces.VariantCapacity,
+	variantCapacities []domain.VariantCapacity,
 	queueDemandByRole map[string]float64,
-) map[string]interfaces.RoleCapacity {
+) map[string]domain.RoleCapacity {
 	// Check if any variant has a non-"both" role.
 	hasDisaggregation := false
 	for _, vc := range variantCapacities {
-		if vc.Role != "" && vc.Role != interfaces.RoleBoth {
+		if vc.Role != "" && vc.Role != domain.RoleBoth {
 			hasDisaggregation = true
 			break
 		}
@@ -449,9 +449,9 @@ func (a *SaturationAnalyzer) aggregateByRole(
 		}
 	}
 
-	result := make(map[string]interfaces.RoleCapacity, len(totals))
+	result := make(map[string]domain.RoleCapacity, len(totals))
 	for role, t := range totals {
-		result[role] = interfaces.RoleCapacity{
+		result[role] = domain.RoleCapacity{
 			Role:                   role,
 			TotalSupply:            t.TotalSupply,
 			TotalDemand:            t.TotalDemand,
@@ -553,7 +553,7 @@ func estimateCapacityFromParams(params *EngineParams, avgInput, avgOutput float6
 // output tokens, and prefix cache hit rate from replica metrics across all
 // variants. These averages enable capacity estimation for zero-replica variants
 // using the k2 derivation formula, and scheduler queue demand estimation.
-func computeModelWorkloadAverages(replicaMetrics []interfaces.ReplicaMetrics) (avgInput, avgOutput, avgHitRate float64) {
+func computeModelWorkloadAverages(replicaMetrics []domain.ReplicaMetrics) (avgInput, avgOutput, avgHitRate float64) {
 	var count int
 	for _, rm := range replicaMetrics {
 		if rm.AvgInputTokens > 0 || rm.AvgOutputTokens > 0 {
@@ -601,8 +601,8 @@ type schedulerQueueDemand struct {
 // (vllm:num_requests_waiting / sglang:num_queue_reqs) because those requests
 // have not yet had prefix cache lookup performed.
 func estimateSchedulerQueueDemand(
-	sq *interfaces.SchedulerQueueMetrics,
-	replicaMetrics []interfaces.ReplicaMetrics,
+	sq *domain.SchedulerQueueMetrics,
+	replicaMetrics []domain.ReplicaMetrics,
 	activeRoles map[string]bool,
 ) schedulerQueueDemand {
 	if sq == nil || (sq.QueueSize == 0 && sq.QueueBytes == 0) {

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 var _ = Describe("SaturationAnalyzer", func() {
@@ -32,11 +32,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 	Describe("k1/k2 interaction", func() {
 		It("should use k1 (memory-bound) when k2 is unknown", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						5000, 16000, 0, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -50,12 +50,12 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should use k2 (compute-bound) when queue is saturated", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					// Queue >= threshold (5), tokensInUse = 8000
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						8000, 16000, 6, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -69,12 +69,12 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should detect compute-bound when k2 < k1 with high queue and low KV", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					// Low KV usage but saturated queue
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						4000, 16000, 10, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -89,11 +89,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 	Describe("k2 history", func() {
 		It("should store k2 observation in rolling average", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						8000, 16000, 6, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -111,11 +111,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 		It("should use historical k2 when queue drops below threshold", func() {
 			// First call: queue saturated → observes k2
 			input1 := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						8000, 16000, 6, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -124,11 +124,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			// Second call: queue below threshold → uses historical k2
 			input2 := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						6000, 16000, 2, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -143,11 +143,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 		It("should use different k2 history buckets for different output lengths", func() {
 			// Short output workload: k2 observation
 			input1 := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						8000, 16000, 6, 100, 50), // avgOutput=50 → "short"
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -155,11 +155,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			// Long output workload: no history yet
 			input2 := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						6000, 16000, 2, 100, 600), // avgOutput=600 → "long"
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -185,12 +185,12 @@ var _ = Describe("SaturationAnalyzer", func() {
 			})
 
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					// Queue below threshold, no history → uses derived k2
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						5000, 16000, 2, 500, 100), // I=500, O=100
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -208,11 +208,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should fall back to k1 when no batch/queue/history data exists", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						5000, 16000, 0, 0, 0), // no avg tokens
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -227,11 +227,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 	Describe("Pending replicas", func() {
 		It("should include pending replicas in anticipated supply for scale-up", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						10000, 16000, 0, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 2, PendingReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -246,11 +246,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should NOT include pending replicas in scale-down calculation", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						1000, 16000, 0, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 3, PendingReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -274,8 +274,8 @@ var _ = Describe("SaturationAnalyzer", func() {
 			})
 
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{}, // no pods
-				[]interfaces.VariantReplicaState{
+				[]domain.ReplicaMetrics{}, // no pods
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 0, GPUsPerReplica: 1},
 				},
 			)
@@ -302,11 +302,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			// Another variant has live pods providing workload data
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						5000, 16000, 0, 500, 100), // I=500, O=100
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 					{VariantName: "variant-b", CurrentReplicas: 0, GPUsPerReplica: 1},
 				},
@@ -356,11 +356,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			// variant-a provides workload data
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						5000, 50000, 0, 500, 100), // I=500, O=100
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 					{VariantName: "variant-b", CurrentReplicas: 0, GPUsPerReplica: 1},
 				},
@@ -393,11 +393,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			// Another variant provides workload data (different accelerator, won't be compatible)
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-x", "L40S", 5.0,
 						5000, 16000, 0, 500, 100),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-x", CurrentReplicas: 1, GPUsPerReplica: 1},
 					{VariantName: "variant-a", CurrentReplicas: 0, GPUsPerReplica: 1},
 				},
@@ -429,8 +429,8 @@ var _ = Describe("SaturationAnalyzer", func() {
 			})
 
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{}, // no live pods at all
-				[]interfaces.VariantReplicaState{
+				[]domain.ReplicaMetrics{}, // no live pods at all
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 0, GPUsPerReplica: 1},
 				},
 			)
@@ -482,11 +482,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 	Describe("Scaling signals", func() {
 		It("should signal scale-up when demand exceeds threshold", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						11000, 16000, 3, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -501,13 +501,13 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should signal scale-down when utilization is below boundary", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						1000, 16000, 0, 100, 50),
 					makeReplicaMetrics("pod-2", "variant-a", "H100", 10.0,
 						1000, 16000, 0, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 2, GPUsPerReplica: 1},
 				},
 			)
@@ -524,11 +524,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 		It("should signal steady state when utilization is between thresholds", func() {
 			// Supply ~ demand / 0.77 (between 0.70 boundary and 0.85 threshold)
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						10000, 16000, 0, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -544,15 +544,15 @@ var _ = Describe("SaturationAnalyzer", func() {
 	Describe("Scheduler queue demand", func() {
 		It("should add scheduler queue demand to total demand", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						5000, 16000, 0, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
-			input.SchedulerQueue = &interfaces.SchedulerQueueMetrics{
+			input.SchedulerQueue = &domain.SchedulerQueueMetrics{
 				QueueSize:  10,
 				QueueBytes: 8000,
 			}
@@ -572,11 +572,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should not add demand when scheduler queue is nil", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						5000, 16000, 0, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
@@ -589,7 +589,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should reduce input tokens by prefix cache hit rate", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					{
 						PodName: "pod-1", VariantName: "variant-a",
 						AcceleratorName: "H100", Cost: 10.0,
@@ -599,11 +599,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 						PrefixCacheHitRate: 0.5, // 50% cache hit rate
 					},
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
-			input.SchedulerQueue = &interfaces.SchedulerQueueMetrics{
+			input.SchedulerQueue = &domain.SchedulerQueueMetrics{
 				QueueSize:  10,
 				QueueBytes: 4000, // 4000/4 = 1000 tokens from bytes
 			}
@@ -624,15 +624,15 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 		It("should use max of bytes and count estimates for input tokens", func() {
 			input := makeAnalyzerInput(
-				[]interfaces.ReplicaMetrics{
+				[]domain.ReplicaMetrics{
 					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 						5000, 16000, 0, 100, 50),
 				},
-				[]interfaces.VariantReplicaState{
+				[]domain.VariantReplicaState{
 					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
 			)
-			input.SchedulerQueue = &interfaces.SchedulerQueueMetrics{
+			input.SchedulerQueue = &domain.SchedulerQueueMetrics{
 				QueueSize:  10,
 				QueueBytes: 20000, // 20000/4 = 5000 >> 10*100=1000
 			}
@@ -651,12 +651,12 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 	Describe("Scheduler queue demand role attribution", func() {
 		It("should attribute inputTokens to prefill and inputTokens+outputTokens to decode", func() {
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 					5000, 16000, 0, 100, 50),
 			}
 			activeRoles := map[string]bool{"prefill": true, "decode": true}
-			sq := &interfaces.SchedulerQueueMetrics{
+			sq := &domain.SchedulerQueueMetrics{
 				QueueSize:  10,
 				QueueBytes: 0, // use count-based estimation only
 			}
@@ -675,12 +675,12 @@ var _ = Describe("SaturationAnalyzer", func() {
 		})
 
 		It("should attribute full demand to 'both' role", func() {
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 					5000, 16000, 0, 100, 50),
 			}
 			activeRoles := map[string]bool{"both": true}
-			sq := &interfaces.SchedulerQueueMetrics{
+			sq := &domain.SchedulerQueueMetrics{
 				QueueSize:  10,
 				QueueBytes: 0,
 			}
@@ -692,11 +692,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 		})
 
 		It("should return empty byRole when nil activeRoles", func() {
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 					5000, 16000, 0, 100, 50),
 			}
-			sq := &interfaces.SchedulerQueueMetrics{
+			sq := &domain.SchedulerQueueMetrics{
 				QueueSize:  10,
 				QueueBytes: 0,
 			}
@@ -708,7 +708,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 		})
 
 		It("should return zero for nil scheduler queue", func() {
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
 					5000, 16000, 0, 100, 50),
 			}
@@ -721,7 +721,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 		})
 
 		It("should apply prefix cache hit rate to per-role input tokens", func() {
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				{
 					PodName: "pod-1", VariantName: "variant-a",
 					AcceleratorName: "H100", Cost: 10.0,
@@ -732,7 +732,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				},
 			}
 			activeRoles := map[string]bool{"prefill": true, "decode": true}
-			sq := &interfaces.SchedulerQueueMetrics{
+			sq := &domain.SchedulerQueueMetrics{
 				QueueSize:  10,
 				QueueBytes: 0,
 			}
@@ -751,10 +751,10 @@ var _ = Describe("SaturationAnalyzer", func() {
 		})
 
 		It("should add queue demand to role capacities in end-to-end analysis", func() {
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:   "test-model",
 				Namespace: "test-ns",
-				ReplicaMetrics: []interfaces.ReplicaMetrics{
+				ReplicaMetrics: []domain.ReplicaMetrics{
 					{
 						PodName: "prefill-pod", VariantName: "prefill-v",
 						AcceleratorName: "H100", Cost: 10.0,
@@ -772,7 +772,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 						ModelID: "test-model", Namespace: "test-ns",
 					},
 				},
-				VariantStates: []interfaces.VariantReplicaState{
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 1, Role: "prefill"},
 					{VariantName: "decode-v", CurrentReplicas: 1, GPUsPerReplica: 1, Role: "decode"},
 				},
@@ -783,7 +783,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 					ScaleUpThreshold:     0.85,
 					ScaleDownBoundary:    0.70,
 				},
-				SchedulerQueue: &interfaces.SchedulerQueueMetrics{
+				SchedulerQueue: &domain.SchedulerQueueMetrics{
 					QueueSize:  10,
 					QueueBytes: 0,
 				},
@@ -836,9 +836,9 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 // makeAnalyzerInput creates a standard AnalyzerInput with default config.
 func makeAnalyzerInput(
-	metrics []interfaces.ReplicaMetrics,
-	states []interfaces.VariantReplicaState,
-) interfaces.AnalyzerInput {
+	metrics []domain.ReplicaMetrics,
+	states []domain.VariantReplicaState,
+) domain.AnalyzerInput {
 	config := &config.SaturationScalingConfig{
 		KvCacheThreshold:     0.8,
 		QueueLengthThreshold: 5,
@@ -848,7 +848,7 @@ func makeAnalyzerInput(
 		ScaleUpThreshold:     0.85,
 		ScaleDownBoundary:    0.70,
 	}
-	return interfaces.AnalyzerInput{
+	return domain.AnalyzerInput{
 		ModelID:        "test-model",
 		Namespace:      "test-ns",
 		ReplicaMetrics: metrics,
@@ -864,7 +864,7 @@ func makeReplicaMetrics(
 	tokensInUse, totalCapacity int64,
 	queueLen int,
 	avgInput, avgOutput float64,
-) interfaces.ReplicaMetrics {
+) domain.ReplicaMetrics {
 	var kvUsage float64
 	if totalCapacity > 0 {
 		kvUsage = float64(tokensInUse) / float64(totalCapacity)
@@ -872,7 +872,7 @@ func makeReplicaMetrics(
 	blockSize := int64(16)
 	numBlocks := totalCapacity / blockSize
 
-	return interfaces.ReplicaMetrics{
+	return domain.ReplicaMetrics{
 		PodName:               podName,
 		VariantName:           variantName,
 		AcceleratorName:       accelerator,
@@ -899,7 +899,7 @@ var _ = Describe("aggregateByRole", func() {
 	})
 
 	It("should return nil when all variants are role 'both'", func() {
-		vcs := []interfaces.VariantCapacity{
+		vcs := []domain.VariantCapacity{
 			{VariantName: "v1", Role: "both", TotalCapacity: 10000, TotalDemand: 5000, ReplicaCount: 1, PerReplicaCapacity: 10000},
 			{VariantName: "v2", Role: "", TotalCapacity: 20000, TotalDemand: 10000, ReplicaCount: 1, PerReplicaCapacity: 20000},
 		}
@@ -908,7 +908,7 @@ var _ = Describe("aggregateByRole", func() {
 	})
 
 	It("should compute per-role capacities for P/D disaggregated model", func() {
-		vcs := []interfaces.VariantCapacity{
+		vcs := []domain.VariantCapacity{
 			{VariantName: "prefill-v1", Role: "prefill", TotalCapacity: 10000, TotalDemand: 9000, ReplicaCount: 1, PendingReplicas: 0, PerReplicaCapacity: 10000},
 			{VariantName: "decode-v1", Role: "decode", TotalCapacity: 20000, TotalDemand: 5000, ReplicaCount: 2, PendingReplicas: 0, PerReplicaCapacity: 10000},
 		}
@@ -936,7 +936,7 @@ var _ = Describe("aggregateByRole", func() {
 	})
 
 	It("should handle mixed roles including 'both'", func() {
-		vcs := []interfaces.VariantCapacity{
+		vcs := []domain.VariantCapacity{
 			{VariantName: "prefill-v1", Role: "prefill", TotalCapacity: 10000, TotalDemand: 9000, ReplicaCount: 1, PerReplicaCapacity: 10000},
 			{VariantName: "both-v1", Role: "both", TotalCapacity: 10000, TotalDemand: 5000, ReplicaCount: 1, PerReplicaCapacity: 10000},
 		}
@@ -948,7 +948,7 @@ var _ = Describe("aggregateByRole", func() {
 	})
 
 	It("should add scheduler queue demand to per-role totals", func() {
-		vcs := []interfaces.VariantCapacity{
+		vcs := []domain.VariantCapacity{
 			{VariantName: "prefill-v1", Role: "prefill", TotalCapacity: 10000, TotalDemand: 2000, ReplicaCount: 1, PendingReplicas: 0, PerReplicaCapacity: 10000},
 			{VariantName: "decode-v1", Role: "decode", TotalCapacity: 20000, TotalDemand: 3000, ReplicaCount: 2, PendingReplicas: 0, PerReplicaCapacity: 10000},
 		}
@@ -969,7 +969,7 @@ var _ = Describe("aggregateByRole", func() {
 	})
 
 	It("should skip queue demand for roles with no variants", func() {
-		vcs := []interfaces.VariantCapacity{
+		vcs := []domain.VariantCapacity{
 			{VariantName: "prefill-v1", Role: "prefill", TotalCapacity: 10000, TotalDemand: 5000, ReplicaCount: 1, PendingReplicas: 0, PerReplicaCapacity: 10000},
 		}
 		// Queue demand for decode, but no decode variants exist
@@ -1007,7 +1007,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 	})
 
 	It("should return nil when capacity store has no record", func() {
-		rm := interfaces.ReplicaMetrics{
+		rm := domain.ReplicaMetrics{
 			PodName:               "pod-1",
 			VariantName:           "variant-a",
 			AcceleratorName:       "H100",
@@ -1025,7 +1025,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			LearnedFrom:       "deployment",
 		})
 
-		rm := interfaces.ReplicaMetrics{
+		rm := domain.ReplicaMetrics{
 			PodName:      "pod-1",
 			VariantName:  "variant-a",
 			KvCacheUsage: 0.5,
@@ -1043,7 +1043,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			LearnedFrom:       "deployment",
 		})
 
-		rm := interfaces.ReplicaMetrics{
+		rm := domain.ReplicaMetrics{
 			PodName:               "pod-1",
 			VariantName:           "variant-a",
 			AcceleratorName:       "H100",
@@ -1067,7 +1067,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			LearnedFrom:       "deployment",
 		})
 
-		rm := interfaces.ReplicaMetrics{
+		rm := domain.ReplicaMetrics{
 			PodName:               "pod-1",
 			VariantName:           "variant-a",
 			AcceleratorName:       "H100",
@@ -1092,7 +1092,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			LearnedFrom:       "deployment",
 		})
 
-		rm := interfaces.ReplicaMetrics{
+		rm := domain.ReplicaMetrics{
 			PodName:               "pod-1",
 			VariantName:           "variant-a",
 			AcceleratorName:       "H100",
@@ -1119,7 +1119,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			LearnedFrom:       "deployment",
 		})
 
-		rm := interfaces.ReplicaMetrics{
+		rm := domain.ReplicaMetrics{
 			PodName:               "pod-1",
 			VariantName:           "variant-a",
 			AcceleratorName:       "H100",
@@ -1144,7 +1144,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			LearnedFrom:       "deployment",
 		})
 
-		rm := interfaces.ReplicaMetrics{
+		rm := domain.ReplicaMetrics{
 			PodName:               "pod-1",
 			VariantName:           "variant-a",
 			AcceleratorName:       "H100",
@@ -1168,7 +1168,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			LearnedFrom:       "deployment",
 		})
 
-		rm := interfaces.ReplicaMetrics{
+		rm := domain.ReplicaMetrics{
 			PodName:               "pod-1",
 			VariantName:           "variant-a",
 			AcceleratorName:       "H100",
@@ -1213,10 +1213,10 @@ var _ = Describe("Analyze with fallback (no cache_config_info)", func() {
 			LearnedFrom:       "deployment",
 		})
 
-		input := interfaces.AnalyzerInput{
+		input := domain.AnalyzerInput{
 			ModelID:   "test-model",
 			Namespace: "test-ns",
-			ReplicaMetrics: []interfaces.ReplicaMetrics{
+			ReplicaMetrics: []domain.ReplicaMetrics{
 				{
 					PodName:               "pod-1",
 					VariantName:           "variant-a",
@@ -1232,7 +1232,7 @@ var _ = Describe("Analyze with fallback (no cache_config_info)", func() {
 					AvgOutputTokens:       50,
 				},
 			},
-			VariantStates: []interfaces.VariantReplicaState{
+			VariantStates: []domain.VariantReplicaState{
 				{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 			},
 			Config: &config.SaturationScalingConfig{
@@ -1262,10 +1262,10 @@ var _ = Describe("Analyze with fallback (no cache_config_info)", func() {
 	})
 
 	It("should skip replicas with no store data and no cache_config_info", func() {
-		input := interfaces.AnalyzerInput{
+		input := domain.AnalyzerInput{
 			ModelID:   "test-model",
 			Namespace: "test-ns",
-			ReplicaMetrics: []interfaces.ReplicaMetrics{
+			ReplicaMetrics: []domain.ReplicaMetrics{
 				{
 					PodName:               "pod-1",
 					VariantName:           "variant-a",
@@ -1277,7 +1277,7 @@ var _ = Describe("Analyze with fallback (no cache_config_info)", func() {
 					TotalKvCapacityTokens: 0,
 				},
 			},
-			VariantStates: []interfaces.VariantReplicaState{
+			VariantStates: []domain.VariantReplicaState{
 				{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
 			},
 			Config: &config.SaturationScalingConfig{
@@ -1371,12 +1371,12 @@ var _ = Describe("aggregateByVariant capacity Reason", func() {
 		})
 		a := NewSaturationAnalyzer(store)
 
-		input := interfaces.AnalyzerInput{
+		input := domain.AnalyzerInput{
 			ModelID:   "m",
 			Namespace: "ns",
 			// No ReplicaMetrics — store path will fire.
 			ReplicaMetrics: nil,
-			VariantStates: []interfaces.VariantReplicaState{
+			VariantStates: []domain.VariantReplicaState{
 				{VariantName: "v1", CurrentReplicas: 0, PendingReplicas: 0},
 			},
 			Config: &config.SaturationScalingConfig{KvCacheThreshold: 0.9, KvSpareTrigger: 0.2, QueueLengthThreshold: 5},
@@ -1391,11 +1391,11 @@ var _ = Describe("aggregateByVariant capacity Reason", func() {
 		store := NewCapacityKnowledgeStore()
 		a := NewSaturationAnalyzer(store)
 
-		input := interfaces.AnalyzerInput{
+		input := domain.AnalyzerInput{
 			ModelID:        "m",
 			Namespace:      "ns",
 			ReplicaMetrics: nil,
-			VariantStates: []interfaces.VariantReplicaState{
+			VariantStates: []domain.VariantReplicaState{
 				{VariantName: "v1", CurrentReplicas: 0, PendingReplicas: 0},
 			},
 			Config: &config.SaturationScalingConfig{KvCacheThreshold: 0.9, KvSpareTrigger: 0.2, QueueLengthThreshold: 5},

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -8,14 +8,14 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/aggregation"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
 // ThroughputAnalyzer accumulates per-variant workload shape and ITL observations
 // across reconcile cycles and computes a μ_dec supply vs λ_dec demand scaling signal.
-// It implements interfaces.Analyzer.
+// It implements domain.Analyzer.
 //
 // State is tracked per variant (keyed by "namespace|modelID|variantName") because
 // different variants may run on different hardware with different ITL coefficients,
@@ -78,7 +78,7 @@ func (a *ThroughputAnalyzer) Observe(
 	ctx context.Context,
 	now time.Time,
 	modelID, namespace string,
-	metrics []interfaces.ReplicaMetrics,
+	metrics []domain.ReplicaMetrics,
 ) map[string]SanityReport {
 	if err := ctx.Err(); err != nil {
 		return nil
@@ -165,7 +165,7 @@ func (a *ThroughputAnalyzer) Observe(
 	return reports
 }
 
-// Analyze implements interfaces.Analyzer. It calls Observe to update internal
+// Analyze implements domain.Analyzer. It calls Observe to update internal
 // state, then computes a supply vs demand scaling signal for each variant using
 // a two-tier ITL model resolution strategy:
 //
@@ -194,8 +194,8 @@ func (a *ThroughputAnalyzer) Observe(
 // the OL guard in computeLocalDemand.
 func (a *ThroughputAnalyzer) Analyze(
 	ctx context.Context,
-	input interfaces.AnalyzerInput,
-) (*interfaces.AnalyzerResult, error) {
+	input domain.AnalyzerInput,
+) (*domain.AnalyzerResult, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (a *ThroughputAnalyzer) Analyze(
 		totalDecodeITLSat      float64
 		nDecodeVariants        int
 	)
-	variantCapacities := make([]interfaces.VariantCapacity, 0, len(byVariant))
+	variantCapacities := make([]domain.VariantCapacity, 0, len(byVariant))
 
 	for variantName, variantMetrics := range byVariant {
 		key := variantKey(input.Namespace, input.ModelID, variantName)
@@ -296,7 +296,7 @@ func (a *ThroughputAnalyzer) Analyze(
 			anyEPP = true
 		}
 		// Track ITL(k_sat) across non-prefill variants for queue demand estimation.
-		if state.role != interfaces.RolePrefill {
+		if state.role != domain.RolePrefill {
 			totalDecodeITLSat += itlSat
 			nDecodeVariants++
 		}
@@ -328,7 +328,7 @@ func (a *ThroughputAnalyzer) Analyze(
 		// TotalCapacity is the product ReplicaCount × PerReplicaCapacity (the VariantCapacity
 		// contract, and what aggregation.SumTotalSupply recomputes); equals supply for nKV ≥ 1.
 		totalCapacity := float64(nKV) * perReplicaSupply
-		variantCapacities = append(variantCapacities, interfaces.VariantCapacity{
+		variantCapacities = append(variantCapacities, domain.VariantCapacity{
 			VariantName:        variantName,
 			Role:               state.role,
 			ReplicaCount:       nKV,
@@ -372,7 +372,7 @@ func (a *ThroughputAnalyzer) Analyze(
 	_ = anyEPP
 	_ = anyGPSMismatch
 
-	return &interfaces.AnalyzerResult{
+	return &domain.AnalyzerResult{
 		AnalyzerName:           AnalyzerName,
 		ModelID:                input.ModelID,
 		Namespace:              input.Namespace,
@@ -461,7 +461,7 @@ func (a *ThroughputAnalyzer) getOrCreateVariantState(key string) *variantState {
 // is extended to iterate variants with state but no current replica metrics.
 //
 // Must be called with a.mu held.
-func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variantState, metrics []interfaces.ReplicaMetrics, namespace, modelID, variantName string) (ITLModel, string, bool) {
+func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variantState, metrics []domain.ReplicaMetrics, namespace, modelID, variantName string) (ITLModel, string, bool) {
 	// Tier 1: OLS fit.
 	if state.observationWindow.Ready() {
 		obs := state.observationWindow.Observations()
@@ -527,7 +527,7 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 // AvgOutputTokens == 0), the function falls through to the engine request-rate proxy
 // so the caller can use computeLocalDemand when both paths yield zero. isEPP still
 // reflects "EPP present" so the anyEPP tracking in Analyze is unaffected.
-func computeDemand(metrics []interfaces.ReplicaMetrics) (float64, bool) {
+func computeDemand(metrics []domain.ReplicaMetrics) (float64, bool) {
 	var lambdaDec float64
 	var isEPP bool
 	for _, m := range metrics {
@@ -564,7 +564,7 @@ func computeDemand(metrics []interfaces.ReplicaMetrics) (float64, bool) {
 // KV_max = 0 are excluded (no meaningful signal at idle).
 // This path is scale-up only: k*-based demand may undercount arriving load
 // without EPP. The engine post-step determines SC from the published totals.
-func computeLocalDemand(metrics []interfaces.ReplicaMetrics, shape WorkloadShape, model ITLModel) float64 {
+func computeLocalDemand(metrics []domain.ReplicaMetrics, shape WorkloadShape, model ITLModel) float64 {
 	if shape.KVreq <= 0 || shape.AvgOutputTokens <= DefaultMinDecodeOLForLocalDemand {
 		return 0
 	}
@@ -591,7 +591,7 @@ func computeLocalDemand(metrics []interfaces.ReplicaMetrics, shape WorkloadShape
 //
 // ITL(k_sat) is used as the reference latency so that admitted queue demand
 // bounds per-request queueing time to ≤ QueueDrainFactor × ITL(k_sat) × avgOL.
-func estimateQueueDemand(sq *interfaces.SchedulerQueueMetrics, itlSat, drainFactor float64) float64 {
+func estimateQueueDemand(sq *domain.SchedulerQueueMetrics, itlSat, drainFactor float64) float64 {
 	if sq == nil || sq.QueueSize <= 0 || itlSat <= 0 || drainFactor <= 0 {
 		return 0
 	}
@@ -603,7 +603,7 @@ func estimateQueueDemand(sq *interfaces.SchedulerQueueMetrics, itlSat, drainFact
 // Per replica: N_dec_sat = DefaultKSat × KV_max / KVreq; μ_dec_sat = N_dec_sat / itlSat.
 // Returns (totalSupply Σμ_dec_sat, perReplicaSupply mean(μ_dec_sat), nKV count of
 // KV-capable replicas). All are zero when no replica has KV capacity data.
-func computeVariantSupply(metrics []interfaces.ReplicaMetrics, shape WorkloadShape, itlSat float64) (total, perReplica float64, nKV int) {
+func computeVariantSupply(metrics []domain.ReplicaMetrics, shape WorkloadShape, itlSat float64) (total, perReplica float64, nKV int) {
 	var sum float64
 	var n int
 	for _, m := range metrics {
@@ -622,8 +622,8 @@ func computeVariantSupply(metrics []interfaces.ReplicaMetrics, shape WorkloadSha
 }
 
 // groupByVariant partitions a slice of ReplicaMetrics by VariantName.
-func groupByVariant(metrics []interfaces.ReplicaMetrics) map[string][]interfaces.ReplicaMetrics {
-	groups := make(map[string][]interfaces.ReplicaMetrics)
+func groupByVariant(metrics []domain.ReplicaMetrics) map[string][]domain.ReplicaMetrics {
+	groups := make(map[string][]domain.ReplicaMetrics)
 	for _, m := range metrics {
 		groups[m.VariantName] = append(groups[m.VariantName], m)
 	}
@@ -634,7 +634,7 @@ func groupByVariant(metrics []interfaces.ReplicaMetrics) map[string][]interfaces
 // prefix hit rate across a slice of replica metrics. Replicas with zero or
 // negative IL or OL are excluded. When all eligible replicas have zero
 // RequestRate, falls back to an unweighted mean.
-func averageShapeMetrics(metrics []interfaces.ReplicaMetrics) (il, ol, hitRate float64) {
+func averageShapeMetrics(metrics []domain.ReplicaMetrics) (il, ol, hitRate float64) {
 	var sumIL, sumOL, sumHitRate float64 // weighted accumulators
 	var sumILu, sumOLu, sumHRu float64   // unweighted fallback
 	var totalWeight, count float64
@@ -665,8 +665,8 @@ func averageShapeMetrics(metrics []interfaces.ReplicaMetrics) (il, ol, hitRate f
 // filterHealthyForShape returns only the replicas that pass all per-replica
 // sanity checks. Replicas with cold-start (ITL=0), stale metrics, or missing
 // KV capacity are excluded so a single bad pod cannot block the variant.
-func filterHealthyForShape(metrics []interfaces.ReplicaMetrics) []interfaces.ReplicaMetrics {
-	healthy := make([]interfaces.ReplicaMetrics, 0, len(metrics))
+func filterHealthyForShape(metrics []domain.ReplicaMetrics) []domain.ReplicaMetrics {
+	healthy := make([]domain.ReplicaMetrics, 0, len(metrics))
 	for _, m := range metrics {
 		if len(checkReplicaMetrics(m)) == 0 {
 			healthy = append(healthy, m)
@@ -695,7 +695,7 @@ func safeDivide(num, denom float64) float64 {
 //     suggesting IL, OL, or prefix-hit-rate parameters are wrong.
 func checkVariantGPSMismatch(
 	ctx context.Context,
-	metrics []interfaces.ReplicaMetrics,
+	metrics []domain.ReplicaMetrics,
 	shape WorkloadShape,
 	model ITLModel,
 	namespace, modelID, variantName string,
@@ -778,7 +778,7 @@ func checkVariantGPSMismatch(
 // distributeQueueDemandByRole splits queueDemand evenly across active non-prefill
 // roles derived from vcs. Queue demand is decode-rate-denominated so prefill roles
 // are excluded. Returns nil when queueDemand is zero or no non-prefill roles exist.
-func distributeQueueDemandByRole(queueDemand float64, vcs []interfaces.VariantCapacity) map[string]float64 {
+func distributeQueueDemandByRole(queueDemand float64, vcs []domain.VariantCapacity) map[string]float64 {
 	if queueDemand == 0 {
 		return nil
 	}
@@ -786,9 +786,9 @@ func distributeQueueDemandByRole(queueDemand float64, vcs []interfaces.VariantCa
 	for _, vc := range vcs {
 		role := vc.Role
 		if role == "" {
-			role = interfaces.RoleBoth
+			role = domain.RoleBoth
 		}
-		if role != interfaces.RolePrefill {
+		if role != domain.RolePrefill {
 			roles[role] = struct{}{}
 		}
 	}
@@ -808,16 +808,16 @@ func distributeQueueDemandByRole(queueDemand float64, vcs []interfaces.VariantCa
 // TotalDemand (nil is safe — treated as zero). Returns nil for non-disaggregated
 // models (all variants role "" or "both"). RequiredCapacity and SpareCapacity are
 // left zero — the engine's universal threshold post-step writes them.
-func aggregateRoleCapacities(vcs []interfaces.VariantCapacity, queueDemandByRole map[string]float64) map[string]interfaces.RoleCapacity {
+func aggregateRoleCapacities(vcs []domain.VariantCapacity, queueDemandByRole map[string]float64) map[string]domain.RoleCapacity {
 	byRole := aggregation.AggregateByRole(vcs)
 	// Non-disaggregated: only a "both" bucket (or nothing) — no per-role breakdown.
-	if _, hasBoth := byRole[interfaces.RoleBoth]; len(byRole) == 0 || (len(byRole) == 1 && hasBoth) {
+	if _, hasBoth := byRole[domain.RoleBoth]; len(byRole) == 0 || (len(byRole) == 1 && hasBoth) {
 		return nil
 	}
 
-	result := make(map[string]interfaces.RoleCapacity, len(byRole))
+	result := make(map[string]domain.RoleCapacity, len(byRole))
 	for role, t := range byRole {
-		result[role] = interfaces.RoleCapacity{
+		result[role] = domain.RoleCapacity{
 			Role:                   role,
 			TotalSupply:            t.TotalSupply,
 			TotalAnticipatedSupply: t.TotalAnticipatedSupply,

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -9,17 +9,17 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/aggregation"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
 // makeMetrics builds a slice of healthy ReplicaMetrics for a single variant,
 // each with a distinct KvCacheUsage/KvUsageInstant to provide k-spread.
-func makeMetrics(variant string, count int, baseK float64, kStep float64) []interfaces.ReplicaMetrics {
-	metrics := make([]interfaces.ReplicaMetrics, count)
+func makeMetrics(variant string, count int, baseK float64, kStep float64) []domain.ReplicaMetrics {
+	metrics := make([]domain.ReplicaMetrics, count)
 	for i := range metrics {
 		k := baseK + float64(i)*kStep
-		metrics[i] = interfaces.ReplicaMetrics{
+		metrics[i] = domain.ReplicaMetrics{
 			PodName:               "pod-" + variant + "-" + string(rune('0'+i)),
 			VariantName:           variant,
 			KvCacheUsage:          k,
@@ -41,7 +41,7 @@ func injectWindowObs(a *ThroughputAnalyzer, ctx context.Context, modelID, namesp
 	il, ol, prefixRate float64, kvMax int64, b float64, kValues []float64) {
 	const A = 0.073
 	for _, k := range kValues {
-		m := interfaces.ReplicaMetrics{
+		m := domain.ReplicaMetrics{
 			VariantName:           variant,
 			KvCacheUsage:          k,
 			KvUsageInstant:        k,
@@ -51,7 +51,7 @@ func injectWindowObs(a *ThroughputAnalyzer, ctx context.Context, modelID, namesp
 			PrefixCacheHitRate:    prefixRate,
 			TotalKvCapacityTokens: kvMax,
 		}
-		a.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{m})
+		a.Observe(ctx, time.Now(), modelID, namespace, []domain.ReplicaMetrics{m})
 	}
 }
 
@@ -202,7 +202,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 	Describe("Analyze — basic behaviour", func() {
 		It("returns an AnalyzerResult with the correct identifiers", func() {
 			metrics := makeMetrics("v1", 3, 0.20, 0.10)
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: metrics,
@@ -217,7 +217,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("returns zero signal when demand is zero (no ArrivalRate or RequestRate set)", func() {
 			metrics := makeMetrics("v1", 3, 0.20, 0.10)
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: metrics,
@@ -229,7 +229,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("updates internal state on each Analyze call", func() {
 			for i := range 4 {
-				input := interfaces.AnalyzerInput{
+				input := domain.AnalyzerInput{
 					ModelID:        modelID,
 					Namespace:      namespace,
 					ReplicaMetrics: makeMetrics("v1", 3, 0.20+float64(i)*0.10, 0.05),
@@ -244,7 +244,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("sets AnalyzedAt to a recent timestamp", func() {
 			before := time.Now()
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: makeMetrics("v1", 3, 0.20, 0.10),
@@ -276,10 +276,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		kValues := []float64{0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65}
 
 		// baseReplica is a healthy replica for the signal-test variant.
-		baseReplica := func(arrivalRate float64) interfaces.ReplicaMetrics {
+		baseReplica := func(arrivalRate float64) domain.ReplicaMetrics {
 			const A = 0.073
 			const k = 0.50
-			return interfaces.ReplicaMetrics{
+			return domain.ReplicaMetrics{
 				VariantName:           "v1",
 				KvCacheUsage:          k,
 				KvUsageInstant:        k,
@@ -303,10 +303,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			buildReadyWindow()
 
 			// ArrivalRate=15 req/s, OL=200 → λ_dec = 3000 tok/s > μ_sat ≈ 2782 tok/s
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica(15)},
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica(15)},
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -321,10 +321,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			buildReadyWindow()
 
 			// ArrivalRate=5 req/s, OL=200 → λ_dec = 1000 tok/s < μ_sat ≈ 2782 tok/s
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica(5)},
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica(5)},
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -340,10 +340,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 			// ArrivalRate=0, RequestRate=0 → isEPP=false → no scale-down signal
 			replica := baseReplica(0)
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replica},
+				ReplicaMetrics: []domain.ReplicaMetrics{replica},
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -353,10 +353,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("populates VariantCapacities and TotalSupply/TotalDemand", func() {
 			buildReadyWindow()
 
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica(5)},
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica(5)},
 			}
 			result, _ := analyzer.Analyze(ctx, input)
 			Expect(result.VariantCapacities).To(HaveLen(1))
@@ -379,12 +379,12 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			booting.KvCacheUsage = 0
 			booting.KvUsageInstant = 0
 
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{ready, booting},
+				ReplicaMetrics: []domain.ReplicaMetrics{ready, booting},
 				// The booting pod is a not-ready replica (currentReplicas − readyReplicas = 1).
-				VariantStates: []interfaces.VariantReplicaState{
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "v1", CurrentReplicas: 2, PendingReplicas: 1},
 				},
 			}
@@ -407,10 +407,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("exposes ITLModel and supply/demand in VariantState after Analyze", func() {
 			buildReadyWindow()
 
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica(5)},
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica(5)},
 			}
 			analyzer.Analyze(ctx, input) //nolint:errcheck
 
@@ -425,10 +425,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("sets Reason to T1-ols when tier-1 OLS fit succeeds", func() {
 			buildReadyWindow()
 
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica(5)},
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica(5)},
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -444,8 +444,8 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		//   A_est  = (0.06075 - 0.006) / 0.75 = 0.073
 		//   ITL_sat ≈ 0.068  →  μ_sat ≈ 2782 tok/s (same scenario as tier-1)
 
-		tier2Replica := func(k, arrivalRate float64) interfaces.ReplicaMetrics { //nolint:unparam
-			return interfaces.ReplicaMetrics{
+		tier2Replica := func(k, arrivalRate float64) domain.ReplicaMetrics { //nolint:unparam
+			return domain.ReplicaMetrics{
 				VariantName:           "v1",
 				KvCacheUsage:          k,
 				KvUsageInstant:        k,
@@ -460,16 +460,16 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("resolves a supply signal without OLS window using tier-2 estimation", func() {
 			// Single Observe cycle → only 1 observation → window NOT ready.
-			analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{tier2Replica(0.75, 0)})
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, []domain.ReplicaMetrics{tier2Replica(0.75, 0)})
 
 			state, _ := analyzer.VariantState(modelID, namespace, "v1")
 			Expect(state.ObservationReady).To(BeFalse())
 
 			// Analyze with ArrivalRate=15 → λ_dec=3000 tok/s; tier-2 model → scale up.
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{tier2Replica(0.75, 15)},
+				ReplicaMetrics: []domain.ReplicaMetrics{tier2Replica(0.75, 15)},
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -481,12 +481,12 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("sets Reason to T2-default when no prior tier-1 fit exists", func() {
 			// Single observation → window not ready; no prior fit → T2-default.
-			analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{tier2Replica(0.75, 0)})
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, []domain.ReplicaMetrics{tier2Replica(0.75, 0)})
 
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{tier2Replica(0.75, 5)},
+				ReplicaMetrics: []domain.ReplicaMetrics{tier2Replica(0.75, 5)},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.VariantCapacities).To(HaveLen(1))
@@ -498,15 +498,15 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			const trueA, trueB = 0.073, 0.006
 			t1kValues := []float64{0.20, 0.30, 0.40, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80}
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", 5000, 200, 0.1, 1024000, trueB, t1kValues)
-			onLine := interfaces.ReplicaMetrics{
+			onLine := domain.ReplicaMetrics{
 				VariantName: "v1", KvUsageInstant: 0.75, KvCacheUsage: 0.75,
 				AvgITL: trueA*0.75 + trueB, AvgInputTokens: 5000, AvgOutputTokens: 200,
 				PrefixCacheHitRate: 0.1, TotalKvCapacityTokens: 1024000, ArrivalRate: 5,
 			}
-			_, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			_, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{onLine},
+				ReplicaMetrics: []domain.ReplicaMetrics{onLine},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			st, _ := analyzer.VariantState(modelID, namespace, "v1")
@@ -519,10 +519,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			}
 			analyzer.mu.Unlock()
 
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{tier2Replica(0.75, 5)},
+				ReplicaMetrics: []domain.ReplicaMetrics{tier2Replica(0.75, 5)},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.VariantCapacities).To(HaveLen(1))
@@ -532,12 +532,12 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("resolveITLModel returns T2-failed when all replicas are idle (KvUsageInstant == 0)", func() {
 			// Single Observe with idle metrics to create variant state, then Analyze
 			// with idle replicas so both tiers fail — tier-2 needs KvUsageInstant > 0.
-			idleMetrics := interfaces.ReplicaMetrics{
+			idleMetrics := domain.ReplicaMetrics{
 				VariantName: "v1", KvUsageInstant: 0, KvCacheUsage: 0,
 				AvgITL: 0.006, AvgInputTokens: 5000, AvgOutputTokens: 200,
 				PrefixCacheHitRate: 0.1, TotalKvCapacityTokens: 1024000,
 			}
-			analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{idleMetrics})
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, []domain.ReplicaMetrics{idleMetrics})
 
 			_, reason, ok := analyzer.resolveITLModel(ctx,
 				func() *variantState {
@@ -545,7 +545,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					defer analyzer.mu.Unlock()
 					return analyzer.variantStates[variantKey(namespace, modelID, "v1")]
 				}(),
-				[]interfaces.ReplicaMetrics{idleMetrics},
+				[]domain.ReplicaMetrics{idleMetrics},
 				namespace, modelID, "v1",
 			)
 			Expect(ok).To(BeFalse())
@@ -558,7 +558,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// Idle replicas (k*=0) cannot contribute to tier-1 (filtered by ObservationWindow)
 			// or tier-2 (KvUsageInstant > 0 guard). The knowledge store must NOT be consulted
 			// while replicas are running — a stale model could trigger incorrect scaling.
-			idleReplica := interfaces.ReplicaMetrics{
+			idleReplica := domain.ReplicaMetrics{
 				VariantName:           "v1",
 				KvCacheUsage:          0.0,
 				KvUsageInstant:        0.0,
@@ -569,10 +569,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				TotalKvCapacityTokens: 1024000,
 				ArrivalRate:           15, // demand present, but no supply estimate possible
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{idleReplica},
+				ReplicaMetrics: []domain.ReplicaMetrics{idleReplica},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequiredCapacity).To(Equal(0.0))
@@ -588,7 +588,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(state.ObservationReady).To(BeTrue())
 
 			// Trigger a shape change (+50% IL) to clear the OLS window.
-			analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{{
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, []domain.ReplicaMetrics{{
 				VariantName:           "v1",
 				KvCacheUsage:          0.50,
 				KvUsageInstant:        0.50,
@@ -602,10 +602,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(stateAfter.ObservationReady).To(BeFalse())
 
 			// Variant goes idle with cleared window — neither tier-1 nor tier-2 can resolve.
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:   modelID,
 				Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{{
+				ReplicaMetrics: []domain.ReplicaMetrics{{
 					VariantName:           "v1",
 					KvCacheUsage:          0.0,
 					KvUsageInstant:        0.0,
@@ -625,7 +625,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 	Describe("Analyze — empty metrics list", func() {
 		It("handles an empty metrics slice gracefully", func() {
-			reports := analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{})
+			reports := analyzer.Observe(ctx, time.Now(), modelID, namespace, []domain.ReplicaMetrics{})
 			Expect(reports).To(BeEmpty())
 		})
 	})
@@ -661,7 +661,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			cancelled, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: makeMetrics("v1", 3, 0.20, 0.10),
@@ -689,7 +689,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("suppresses RequiredCapacity when pending replicas cover anticipated demand", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 
-			replica := interfaces.ReplicaMetrics{
+			replica := domain.ReplicaMetrics{
 				VariantName:           "v1",
 				KvCacheUsage:          0.50,
 				KvUsageInstant:        0.50,
@@ -700,11 +700,11 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				TotalKvCapacityTokens: kvMax,
 				ArrivalRate:           15, // λ_dec = 3000 tok/s > 1 × μ_sat
 			}
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replica},
-				VariantStates: []interfaces.VariantReplicaState{
+				ReplicaMetrics: []domain.ReplicaMetrics{replica},
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "v1", CurrentReplicas: 1, PendingReplicas: 1},
 				},
 			}
@@ -719,7 +719,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 			// 3 replicas running, ArrivalRate=15 each → λ_dec = 3×3000 = 9000 tok/s
 			// μ_sat ≈ 2782 tok/s per replica; anticipated = 3 × 2782 ≈ 8346 < 9000
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50, AvgITL: A*0.50 + B,
 					AvgInputTokens: il, AvgOutputTokens: ol, PrefixCacheHitRate: prefix,
 					TotalKvCapacityTokens: kvMax, ArrivalRate: 15},
@@ -730,7 +730,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					AvgInputTokens: il, AvgOutputTokens: ol, PrefixCacheHitRate: prefix,
 					TotalKvCapacityTokens: kvMax, ArrivalRate: 15},
 			}
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: replicas,
@@ -766,10 +766,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, variant, il, ol, prefix, kvMax, B, kValues)
 		}
 
-		baseReplica := func(variant string, arrivalRate float64) interfaces.ReplicaMetrics {
+		baseReplica := func(variant string, arrivalRate float64) domain.ReplicaMetrics {
 			const A = 0.073
 			const k = 0.50
-			return interfaces.ReplicaMetrics{
+			return domain.ReplicaMetrics{
 				VariantName:           variant,
 				KvCacheUsage:          k,
 				KvUsageInstant:        k,
@@ -786,14 +786,14 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			buildVariantWindow("v-decode")
 			buildVariantWindow("v-prefill")
 
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:   modelID,
 				Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{
+				ReplicaMetrics: []domain.ReplicaMetrics{
 					baseReplica("v-decode", 5),
 					baseReplica("v-prefill", 5),
 				},
-				VariantStates: []interfaces.VariantReplicaState{
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "v-decode", Role: "decode"},
 					{VariantName: "v-prefill", Role: "prefill"},
 				},
@@ -810,14 +810,14 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			buildVariantWindow("v-prefill")
 
 			// ArrivalRate=15 → λ_dec=3000 > μ_sat≈2782: scale-up signal for decode.
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:   modelID,
 				Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{
+				ReplicaMetrics: []domain.ReplicaMetrics{
 					baseReplica("v-decode", 15),
 					baseReplica("v-prefill", 15),
 				},
-				VariantStates: []interfaces.VariantReplicaState{
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "v-decode", Role: "decode"},
 					{VariantName: "v-prefill", Role: "prefill"},
 				},
@@ -840,10 +840,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("returns nil RoleCapacities when all variants are non-disaggregated", func() {
 			buildVariantWindow("v1")
 
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica("v1", 5)},
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica("v1", 5)},
 				// No VariantStates → role is "" for all variants
 			}
 			result, err := analyzer.Analyze(ctx, input)
@@ -854,11 +854,11 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("sets Role on VariantCapacity and ThroughputVariantState", func() {
 			buildVariantWindow("v-decode")
 
-			input := interfaces.AnalyzerInput{
+			input := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica("v-decode", 5)},
-				VariantStates: []interfaces.VariantReplicaState{
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica("v-decode", 5)},
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "v-decode", Role: "decode"},
 				},
 			}
@@ -891,7 +891,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("emits RequiredCapacity from k* when EPP is absent", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v1", KvCacheUsage: 0.95, KvUsageInstant: 0.95,
 					AvgITL: A*0.95 + B, AvgInputTokens: il, AvgOutputTokens: ol,
 					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
@@ -902,7 +902,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
 				},
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -918,14 +918,14 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 
 			// Low k* → λ_local << μ_sat, but no EPP → no scale-down.
-			replica := interfaces.ReplicaMetrics{
+			replica := domain.ReplicaMetrics{
 				VariantName: "v1", KvCacheUsage: 0.20, KvUsageInstant: 0.20,
 				AvgITL: A*0.20 + B, AvgInputTokens: il, AvgOutputTokens: ol,
 				PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replica},
+				ReplicaMetrics: []domain.ReplicaMetrics{replica},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.SpareCapacity).To(Equal(0.0))
@@ -938,7 +938,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			const lowOL = 5.0
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, lowOL, prefix, kvMax, B, kValues)
 
-			replica := interfaces.ReplicaMetrics{
+			replica := domain.ReplicaMetrics{
 				VariantName:           "v1",
 				KvCacheUsage:          0.95,
 				KvUsageInstant:        0.95,
@@ -949,9 +949,9 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				TotalKvCapacityTokens: kvMax,
 				// ArrivalRate=0, RequestRate=0
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replica},
+				ReplicaMetrics: []domain.ReplicaMetrics{replica},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequiredCapacity).To(Equal(0.0))
@@ -980,7 +980,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 			// Replica with EPP ArrivalRate>0 but AvgOutputTokens==0 (no completions yet).
 			// k*=0.85 is near saturation → local demand is high.
-			replica := interfaces.ReplicaMetrics{
+			replica := domain.ReplicaMetrics{
 				VariantName:           "v1",
 				KvCacheUsage:          0.85,
 				KvUsageInstant:        0.85,
@@ -991,9 +991,9 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				TotalKvCapacityTokens: kvMaxW,
 				ArrivalRate:           5.0, // EPP present
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replica},
+				ReplicaMetrics: []domain.ReplicaMetrics{replica},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Local demand must be > 0 (k*=0.85 is busy) so Utilization > 0 and
@@ -1009,7 +1009,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				ilW, olW, prefixW, kvMaxW, BW, kValuesW)
 
 			// Normal operation: EPP present with usable demand.
-			replica := interfaces.ReplicaMetrics{
+			replica := domain.ReplicaMetrics{
 				VariantName:           "v1",
 				KvCacheUsage:          0.50,
 				KvUsageInstant:        0.50,
@@ -1020,9 +1020,9 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				TotalKvCapacityTokens: kvMaxW,
 				ArrivalRate:           10.0, // 10 req/s × 200 ol = 2000 tok/s
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replica},
+				ReplicaMetrics: []domain.ReplicaMetrics{replica},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// EPP demand = 10×200 = 2000 tok/s; TotalDemand must reflect that.
@@ -1048,7 +1048,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		)
 		kValues := []float64{0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65}
 
-		baseReplica := interfaces.ReplicaMetrics{
+		baseReplica := domain.ReplicaMetrics{
 			VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
 			AvgITL: A*0.50 + B, AvgInputTokens: il, AvgOutputTokens: ol,
 			PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
@@ -1058,10 +1058,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("adds queue demand and emits RequiredCapacity when queue is large", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 
-			withQueue := interfaces.AnalyzerInput{
+			withQueue := domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica},
-				SchedulerQueue: &interfaces.SchedulerQueueMetrics{QueueSize: 200},
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica},
+				SchedulerQueue: &domain.SchedulerQueueMetrics{QueueSize: 200},
 			}
 			result, err := analyzer.Analyze(ctx, withQueue)
 			Expect(err).NotTo(HaveOccurred())
@@ -1074,9 +1074,9 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("emits no RequiredCapacity when SchedulerQueue is nil", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 
-			noQueue := interfaces.AnalyzerInput{
+			noQueue := domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{baseReplica},
+				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica},
 				// SchedulerQueue: nil
 			}
 			result, err := analyzer.Analyze(ctx, noQueue)
@@ -1105,7 +1105,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v2", il, ol, prefix, kvMax, B, kValues)
 
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
 					AvgITL: A*0.50 + B, AvgInputTokens: il, AvgOutputTokens: ol,
 					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
@@ -1115,7 +1115,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
 					ArrivalRate: 1}, // λ = 200 << μ_sat per-variant
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1133,7 +1133,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v2", il, ol, prefix, kvMax, B, kValues)
 
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
 					AvgITL: A*0.50 + B, AvgInputTokens: il, AvgOutputTokens: ol,
 					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
@@ -1143,7 +1143,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
 					ArrivalRate: 15},
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1172,7 +1172,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("TotalSupply equals aggregation.SumTotalSupply(VariantCapacities)", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v2", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
 					AvgITL: aA*0.50 + bA, AvgInputTokens: ilA, AvgOutputTokens: olA,
 					PrefixCacheHitRate: prefixA, TotalKvCapacityTokens: kvMaxA, ArrivalRate: 5},
@@ -1180,7 +1180,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					AvgITL: aA*0.40 + bA, AvgInputTokens: ilA, AvgOutputTokens: olA,
 					PrefixCacheHitRate: prefixA, TotalKvCapacityTokens: kvMaxA, ArrivalRate: 3},
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1190,17 +1190,17 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("TotalAnticipatedSupply equals aggregation.SumTotalAnticipatedSupply(VariantCapacities)", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
 					AvgITL: aA*0.50 + bA, AvgInputTokens: ilA, AvgOutputTokens: olA,
 					PrefixCacheHitRate: prefixA, TotalKvCapacityTokens: kvMaxA, ArrivalRate: 5},
 			}
 			// 1 pending replica — TotalAnticipatedSupply should count it.
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: replicas,
-				VariantStates: []interfaces.VariantReplicaState{
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "v1", PendingReplicas: 1},
 				},
 			})
@@ -1211,17 +1211,17 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("TotalDemand equals aggregation.SumTotalDemand(VariantCapacities) plus queue demand", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
 					AvgITL: aA*0.50 + bA, AvgInputTokens: ilA, AvgOutputTokens: olA,
 					PrefixCacheHitRate: prefixA, TotalKvCapacityTokens: kvMaxA, ArrivalRate: 5},
 			}
 			const queueSize = int64(10)
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: replicas,
-				SchedulerQueue: &interfaces.SchedulerQueueMetrics{QueueSize: queueSize},
+				SchedulerQueue: &domain.SchedulerQueueMetrics{QueueSize: queueSize},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			variantDemand := aggregation.SumTotalDemand(result.VariantCapacities)
@@ -1234,7 +1234,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("RoleCapacities[role].TotalAnticipatedSupply matches per-role aggregation", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v-decode", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v-prefill", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v-decode", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
 					AvgITL: aA*0.50 + bA, AvgInputTokens: ilA, AvgOutputTokens: olA,
 					PrefixCacheHitRate: prefixA, TotalKvCapacityTokens: kvMaxA, ArrivalRate: 5},
@@ -1242,11 +1242,11 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					AvgITL: aA*0.50 + bA, AvgInputTokens: ilA, AvgOutputTokens: olA,
 					PrefixCacheHitRate: prefixA, TotalKvCapacityTokens: kvMaxA, ArrivalRate: 1},
 			}
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: replicas,
-				VariantStates: []interfaces.VariantReplicaState{
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "v-decode", Role: "decode"},
 					{VariantName: "v-prefill", Role: "prefill"},
 				},
@@ -1264,7 +1264,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("RoleCapacities[decode].TotalDemand includes the queue-demand share", func() {
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v-decode", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v-prefill", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
-			replicas := []interfaces.ReplicaMetrics{
+			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v-decode", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
 					AvgITL: aA*0.50 + bA, AvgInputTokens: ilA, AvgOutputTokens: olA,
 					PrefixCacheHitRate: prefixA, TotalKvCapacityTokens: kvMaxA, ArrivalRate: 5},
@@ -1274,17 +1274,17 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			}
 			// With queue: decode role should receive the queue-demand share.
 			// Without queue: decode TotalDemand == variant-level demand only.
-			inputNoQ := interfaces.AnalyzerInput{
+			inputNoQ := domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: replicas,
-				VariantStates: []interfaces.VariantReplicaState{
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "v-decode", Role: "decode"},
 					{VariantName: "v-prefill", Role: "prefill"},
 				},
 			}
 			inputWithQ := inputNoQ
-			inputWithQ.SchedulerQueue = &interfaces.SchedulerQueueMetrics{QueueSize: 20}
+			inputWithQ.SchedulerQueue = &domain.SchedulerQueueMetrics{QueueSize: 20}
 
 			resultNoQ, errNoQ := analyzer.Analyze(ctx, inputNoQ)
 			Expect(errNoQ).NotTo(HaveOccurred())
@@ -1309,7 +1309,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// r1: rate=1, IL=1000, OL=200, hr=0.1
 			// r2: rate=3, IL=3000, OL=600, hr=0.5
 			// Weighted: IL=(1*1000+3*3000)/4=2500, OL=(1*200+3*600)/4=500, hr=(1*0.1+3*0.5)/4=0.4
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, RequestRate: 1},
 				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, RequestRate: 3},
 			}
@@ -1320,7 +1320,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		})
 
 		It("falls back to unweighted mean when all RequestRates are zero", func() {
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, RequestRate: 0},
 				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, RequestRate: 0},
 			}
@@ -1333,7 +1333,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("excludes zero-rate replicas from weighted sum when mixed rates are present", func() {
 			// r1 has rate=0: contributes only to unweighted fallback
 			// r2 has rate=2: drives the weighted result entirely
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				{AvgInputTokens: 1000, AvgOutputTokens: 200, PrefixCacheHitRate: 0.1, RequestRate: 0},
 				{AvgInputTokens: 3000, AvgOutputTokens: 600, PrefixCacheHitRate: 0.5, RequestRate: 2},
 			}
@@ -1353,7 +1353,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			const wantA = 0.073
 			const wantB = 0.006
 			// Fresh analyzer: no OLS window → tier-2 fires.
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				{
 					VariantName: "v1", KvUsageInstant: 0.20, KvCacheUsage: 0.20,
 					AvgITL: wantA*0.20 + wantB, AvgInputTokens: 5000, AvgOutputTokens: 200,
@@ -1368,7 +1368,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// Seed the shape tracker with one prior Observe so shape is known.
 			analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
 
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: metrics,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1393,8 +1393,8 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		// onLineMetrics returns two replicas whose (k*, ITL) lie exactly on y = trueA*k + trueB.
 		// IL/OL/shape matches the buildTier1Window observations so no shape change fires.
-		onLineMetrics := func() []interfaces.ReplicaMetrics {
-			return []interfaces.ReplicaMetrics{
+		onLineMetrics := func() []domain.ReplicaMetrics {
+			return []domain.ReplicaMetrics{
 				{
 					VariantName: "v1", KvUsageInstant: 0.30, KvCacheUsage: 0.30,
 					AvgITL: trueA*0.30 + trueB, AvgInputTokens: 1024, AvgOutputTokens: 256,
@@ -1418,7 +1418,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("saves lastFittedB after a successful Tier-1 OLS fit", func() {
 			buildTier1Window()
 			// Analyze-internal Observe must also add on-line points so OLS recovers trueB exactly.
-			_, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			_, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: onLineMetrics(),
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1432,12 +1432,12 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("retains lastFittedB after a shape change clears the observation window", func() {
 			buildTier1Window()
-			_, _ = analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			_, _ = analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: onLineMetrics(),
 			})
 
 			// Trigger a shape change: shift OL by >20%.
-			shapeShiftMetrics := []interfaces.ReplicaMetrics{
+			shapeShiftMetrics := []domain.ReplicaMetrics{
 				{
 					VariantName: "v1", KvUsageInstant: 0.40, KvCacheUsage: 0.40,
 					AvgITL: trueA*0.40 + trueB, AvgInputTokens: 1024, AvgOutputTokens: 800,
@@ -1455,12 +1455,12 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("uses lastFittedB as the pinned B in tier-2 after a shape reset", func() {
 			buildTier1Window()
-			_, _ = analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			_, _ = analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: onLineMetrics(),
 			})
 
 			// Shape change → window cleared → tier-2 will fire next.
-			shapeShiftMetrics := []interfaces.ReplicaMetrics{
+			shapeShiftMetrics := []domain.ReplicaMetrics{
 				{
 					VariantName: "v1", KvUsageInstant: 0.40, KvCacheUsage: 0.40,
 					AvgITL: trueA*0.40 + trueB, AvgInputTokens: 1024, AvgOutputTokens: 800,
@@ -1469,7 +1469,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			}
 			analyzer.Observe(ctx, time.Now(), modelID, namespace, shapeShiftMetrics)
 
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: shapeShiftMetrics,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1484,7 +1484,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("uses DefaultBaselineITLSec in tier-2 when no Tier-1 fit has occurred", func() {
 			// Fresh analyzer, never reached tier-1 — hasFittedB is false.
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				{
 					VariantName: "v1", KvUsageInstant: 0.40, KvCacheUsage: 0.40,
 					AvgITL: trueA*0.40 + DefaultBaselineITLSec, AvgInputTokens: 1024, AvgOutputTokens: 256,
@@ -1493,7 +1493,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			}
 			analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
 
-			_, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			_, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: metrics,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1535,8 +1535,8 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(state.ObservationReady).To(BeTrue())
 		}
 
-		replicaG := func(k, arrivalRate, gps float64) interfaces.ReplicaMetrics {
-			return interfaces.ReplicaMetrics{
+		replicaG := func(k, arrivalRate, gps float64) domain.ReplicaMetrics {
+			return domain.ReplicaMetrics{
 				VariantName:           "gv1",
 				KvCacheUsage:          k,
 				KvUsageInstant:        k,
@@ -1561,10 +1561,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			buildWindowG()
 			// GPS equals model value → 0% error, well within threshold.
 			gps := muDecG()
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replicaG(kStar, 2, gps)},
+				ReplicaMetrics: []domain.ReplicaMetrics{replicaG(kStar, 2, gps)},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// GPS gate is dropped — TA always leaves SC=0; engine post-step computes it.
@@ -1577,10 +1577,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			buildWindowG()
 			// GPS is 50% of model → gpsErrPct = |1 - 0.5| / 0.5 × 100 = 100% >> 15%.
 			gps := muDecG() * 0.5
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replicaG(kStar, 2, gps)},
+				ReplicaMetrics: []domain.ReplicaMetrics{replicaG(kStar, 2, gps)},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.SpareCapacity).To(Equal(0.0))
@@ -1590,10 +1590,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			buildWindowG()
 			// k*=0.20 < DefaultGPSMinKForVerification(0.30); GPS check is skipped.
 			gps := muDecG() * 0.1 // enormous mismatch, but k* too low to trust
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replicaG(0.20, 2, gps)},
+				ReplicaMetrics: []domain.ReplicaMetrics{replicaG(0.20, 2, gps)},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// GPS gate is dropped — TA always leaves SC=0; engine post-step computes it.
@@ -1605,10 +1605,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		It("GenerationTokenRate is zero (metric absent) — fixture for future SC pass-through", func() {
 			buildWindowG()
 			// GPS=0 → check is skipped entirely.
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replicaG(kStar, 2, 0)},
+				ReplicaMetrics: []domain.ReplicaMetrics{replicaG(kStar, 2, 0)},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// GPS gate is dropped — TA always leaves SC=0; engine post-step computes it.
@@ -1622,10 +1622,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// High ArrivalRate drives demand > supply (RC > 0).
 			// GPS gate is dropped — TA always leaves SC=0; SC=0 is now unconditional.
 			gps := muDecG() * 0.1
-			result, err := analyzer.Analyze(ctx, interfaces.AnalyzerInput{
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{replicaG(kStar, 20, gps)},
+				ReplicaMetrics: []domain.ReplicaMetrics{replicaG(kStar, 20, gps)},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.SpareCapacity).To(Equal(0.0))
@@ -1663,11 +1663,11 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			return nDec / (aW*k + bW)
 		}
 
-		mismatchInput := func() interfaces.AnalyzerInput {
-			return interfaces.AnalyzerInput{
+		mismatchInput := func() domain.AnalyzerInput {
+			return domain.AnalyzerInput{
 				ModelID:   modelID,
 				Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{{
+				ReplicaMetrics: []domain.ReplicaMetrics{{
 					VariantName:           "wv1",
 					KvCacheUsage:          kStarW,
 					KvUsageInstant:        kStarW,
@@ -1682,11 +1682,11 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			}
 		}
 
-		cleanInput := func() interfaces.AnalyzerInput {
-			return interfaces.AnalyzerInput{
+		cleanInput := func() domain.AnalyzerInput {
+			return domain.AnalyzerInput{
 				ModelID:   modelID,
 				Namespace: namespace,
-				ReplicaMetrics: []interfaces.ReplicaMetrics{{
+				ReplicaMetrics: []domain.ReplicaMetrics{{
 					VariantName:           "wv1",
 					KvCacheUsage:          kStarW,
 					KvUsageInstant:        kStarW,
@@ -1780,19 +1780,19 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(estimateQueueDemand(nil, 0.05, 2.0)).To(Equal(0.0))
 		})
 		It("returns 0 when QueueSize is zero", func() {
-			sq := &interfaces.SchedulerQueueMetrics{QueueSize: 0}
+			sq := &domain.SchedulerQueueMetrics{QueueSize: 0}
 			Expect(estimateQueueDemand(sq, 0.05, 2.0)).To(Equal(0.0))
 		})
 		It("returns 0 when itlSat is zero", func() {
-			sq := &interfaces.SchedulerQueueMetrics{QueueSize: 10}
+			sq := &domain.SchedulerQueueMetrics{QueueSize: 10}
 			Expect(estimateQueueDemand(sq, 0, 2.0)).To(Equal(0.0))
 		})
 		It("returns 0 when drainFactor is zero", func() {
-			sq := &interfaces.SchedulerQueueMetrics{QueueSize: 10}
+			sq := &domain.SchedulerQueueMetrics{QueueSize: 10}
 			Expect(estimateQueueDemand(sq, 0.05, 0)).To(Equal(0.0))
 		})
 		It("returns QueueSize / (drainFactor * itlSat) for valid inputs", func() {
-			sq := &interfaces.SchedulerQueueMetrics{QueueSize: 100}
+			sq := &domain.SchedulerQueueMetrics{QueueSize: 100}
 			// 100 / (2.0 × 0.05) = 1000
 			Expect(estimateQueueDemand(sq, 0.05, 2.0)).To(BeNumerically("~", 1000.0, 1e-9))
 		})
@@ -1810,7 +1810,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		)
 
 		It("still observes shape and window entries when one pod has ITL=0 (cold start)", func() {
-			healthy := interfaces.ReplicaMetrics{
+			healthy := domain.ReplicaMetrics{
 				PodName:               "pod-healthy",
 				VariantName:           "v1",
 				KvCacheUsage:          0.50,
@@ -1820,7 +1820,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				AvgOutputTokens:       olS,
 				TotalKvCapacityTokens: kvMaxS,
 			}
-			cold := interfaces.ReplicaMetrics{
+			cold := domain.ReplicaMetrics{
 				PodName:               "pod-cold",
 				VariantName:           "v1",
 				KvCacheUsage:          0.0,
@@ -1830,7 +1830,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				AvgOutputTokens:       olS,
 				TotalKvCapacityTokens: kvMaxS,
 			}
-			analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{healthy, cold})
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, []domain.ReplicaMetrics{healthy, cold})
 
 			state, ok := analyzer.VariantState(modelID, namespace, "v1")
 			Expect(ok).To(BeTrue())

--- a/internal/engines/analyzers/throughput/sanity.go
+++ b/internal/engines/analyzers/throughput/sanity.go
@@ -3,7 +3,7 @@ package throughput
 import (
 	"math"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // CheckModelMetrics validates the replica metrics for a set of replicas belonging
@@ -15,7 +15,7 @@ import (
 //
 // Issues are deduplicated: the same SanityIssue type appears at most once in
 // the report even if multiple pods trigger it.
-func CheckModelMetrics(metrics []interfaces.ReplicaMetrics) SanityReport {
+func CheckModelMetrics(metrics []domain.ReplicaMetrics) SanityReport {
 	if len(metrics) == 0 {
 		return SanityReport{Issues: []SanityIssue{SanityIssueNoReplicas}}
 	}
@@ -46,7 +46,7 @@ func CheckModelMetrics(metrics []interfaces.ReplicaMetrics) SanityReport {
 
 // checkReplicaMetrics validates a single replica's metrics and returns the
 // list of issues found. An empty slice means the replica is healthy.
-func checkReplicaMetrics(m interfaces.ReplicaMetrics) []SanityIssue {
+func checkReplicaMetrics(m domain.ReplicaMetrics) []SanityIssue {
 	var issues []SanityIssue
 
 	// Stale metrics: FreshnessStatus == "stale" means the scrape is behind.

--- a/internal/engines/analyzers/throughput/sanity_test.go
+++ b/internal/engines/analyzers/throughput/sanity_test.go
@@ -4,12 +4,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // healthyReplica returns a ReplicaMetrics with all fields valid.
-func healthyReplica(podName string) interfaces.ReplicaMetrics {
-	return interfaces.ReplicaMetrics{
+func healthyReplica(podName string) domain.ReplicaMetrics {
+	return domain.ReplicaMetrics{
 		PodName:               podName,
 		VariantName:           "v1",
 		KvUsageInstant:        0.50,
@@ -30,7 +30,7 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("returns SanityIssueNoReplicas for empty slice", func() {
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{})
 			Expect(report.OK()).To(BeFalse())
 			Expect(report.Has(SanityIssueNoReplicas)).To(BeTrue())
 		})
@@ -38,7 +38,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("healthy metrics", func() {
 		It("returns OK for a single healthy replica", func() {
-			metrics := []interfaces.ReplicaMetrics{healthyReplica("pod-0")}
+			metrics := []domain.ReplicaMetrics{healthyReplica("pod-0")}
 			report := CheckModelMetrics(metrics)
 			Expect(report.OK()).To(BeTrue())
 			Expect(report.Issues).To(BeEmpty())
@@ -46,7 +46,7 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("returns OK for multiple healthy replicas", func() {
-			metrics := []interfaces.ReplicaMetrics{
+			metrics := []domain.ReplicaMetrics{
 				healthyReplica("pod-0"),
 				healthyReplica("pod-1"),
 				healthyReplica("pod-2"),
@@ -59,23 +59,23 @@ var _ = Describe("CheckModelMetrics", func() {
 	Describe("stale metrics", func() {
 		It("flags SanityIssueStaleMetrics when FreshnessStatus is stale", func() {
 			m := healthyReplica("pod-0")
-			m.Metadata = &interfaces.ReplicaMetricsMetadata{FreshnessStatus: "stale"}
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			m.Metadata = &domain.ReplicaMetricsMetadata{FreshnessStatus: "stale"}
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueStaleMetrics)).To(BeTrue())
 			Expect(report.AffectedPods).To(ContainElement("pod-0"))
 		})
 
 		It("does not flag stale when FreshnessStatus is fresh", func() {
 			m := healthyReplica("pod-0")
-			m.Metadata = &interfaces.ReplicaMetricsMetadata{FreshnessStatus: "fresh"}
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			m.Metadata = &domain.ReplicaMetricsMetadata{FreshnessStatus: "fresh"}
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueStaleMetrics)).To(BeFalse())
 		})
 
 		It("does not flag stale when Metadata is nil", func() {
 			m := healthyReplica("pod-0")
 			// Metadata is nil by default in healthyReplica
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueStaleMetrics)).To(BeFalse())
 		})
 	})
@@ -84,7 +84,7 @@ var _ = Describe("CheckModelMetrics", func() {
 		It("flags SanityIssueMissingKV when TotalKvCapacityTokens is zero", func() {
 			m := healthyReplica("pod-0")
 			m.TotalKvCapacityTokens = 0
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingKV)).To(BeTrue())
 			Expect(report.AffectedPods).To(ContainElement("pod-0"))
 		})
@@ -92,7 +92,7 @@ var _ = Describe("CheckModelMetrics", func() {
 		It("flags SanityIssueMissingKV when TotalKvCapacityTokens is negative", func() {
 			m := healthyReplica("pod-0")
 			m.TotalKvCapacityTokens = -1
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingKV)).To(BeTrue())
 		})
 	})
@@ -101,7 +101,7 @@ var _ = Describe("CheckModelMetrics", func() {
 		It("flags SanityIssueKVOutOfRange when KvUsageInstant (k*) is negative", func() {
 			m := healthyReplica("pod-0")
 			m.KvUsageInstant = -0.01
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
 			Expect(report.AffectedPods).To(ContainElement("pod-0"))
 		})
@@ -109,14 +109,14 @@ var _ = Describe("CheckModelMetrics", func() {
 		It("flags SanityIssueKVOutOfRange when KvUsageInstant (k*) exceeds 1.0", func() {
 			m := healthyReplica("pod-0")
 			m.KvUsageInstant = 1.01
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
 		})
 
 		It("flags SanityIssueKVOutOfRange for NaN KvUsageInstant (k*)", func() {
 			m := healthyReplica("pod-0")
 			m.KvUsageInstant = float64NaN()
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
 		})
 
@@ -125,8 +125,8 @@ var _ = Describe("CheckModelMetrics", func() {
 			m0.KvUsageInstant = 0.0
 			m1 := healthyReplica("pod-1")
 			m1.KvUsageInstant = 1.0
-			Expect(CheckModelMetrics([]interfaces.ReplicaMetrics{m0}).Has(SanityIssueKVOutOfRange)).To(BeFalse())
-			Expect(CheckModelMetrics([]interfaces.ReplicaMetrics{m1}).Has(SanityIssueKVOutOfRange)).To(BeFalse())
+			Expect(CheckModelMetrics([]domain.ReplicaMetrics{m0}).Has(SanityIssueKVOutOfRange)).To(BeFalse())
+			Expect(CheckModelMetrics([]domain.ReplicaMetrics{m1}).Has(SanityIssueKVOutOfRange)).To(BeFalse())
 		})
 	})
 
@@ -134,7 +134,7 @@ var _ = Describe("CheckModelMetrics", func() {
 		It("flags SanityIssueITLNonPositive when AvgITL is zero", func() {
 			m := healthyReplica("pod-0")
 			m.AvgITL = 0
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
 			Expect(report.AffectedPods).To(ContainElement("pod-0"))
 		})
@@ -142,14 +142,14 @@ var _ = Describe("CheckModelMetrics", func() {
 		It("flags SanityIssueITLNonPositive when AvgITL is negative", func() {
 			m := healthyReplica("pod-0")
 			m.AvgITL = -0.001
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
 		})
 
 		It("flags SanityIssueITLNonPositive when AvgITL is NaN", func() {
 			m := healthyReplica("pod-0")
 			m.AvgITL = float64NaN()
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
 		})
 	})
@@ -158,7 +158,7 @@ var _ = Describe("CheckModelMetrics", func() {
 		It("flags SanityIssueMissingShape when AvgOutputTokens is at threshold", func() {
 			m := healthyReplica("pod-0")
 			m.AvgOutputTokens = DefaultMinTokensPerRequest
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
 			Expect(report.AffectedPods).To(ContainElement("pod-0"))
 		})
@@ -166,21 +166,21 @@ var _ = Describe("CheckModelMetrics", func() {
 		It("flags SanityIssueMissingShape when AvgOutputTokens is zero", func() {
 			m := healthyReplica("pod-0")
 			m.AvgOutputTokens = 0
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
 		})
 
 		It("flags SanityIssueMissingShape when AvgInputTokens is at threshold", func() {
 			m := healthyReplica("pod-0")
 			m.AvgInputTokens = DefaultMinTokensPerRequest
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
 		})
 
 		It("flags SanityIssueMissingShape when AvgInputTokens is NaN", func() {
 			m := healthyReplica("pod-0")
 			m.AvgInputTokens = float64NaN()
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
 		})
 	})
@@ -192,7 +192,7 @@ var _ = Describe("CheckModelMetrics", func() {
 			m1 := healthyReplica("pod-1")
 			m1.AvgITL = 0
 
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m0, m1})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m0, m1})
 			count := 0
 			for _, issue := range report.Issues {
 				if issue == SanityIssueITLNonPositive {
@@ -209,7 +209,7 @@ var _ = Describe("CheckModelMetrics", func() {
 			m1 := healthyReplica("pod-1")
 			m1.TotalKvCapacityTokens = 0 // KV issue
 
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m0, m1})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{m0, m1})
 			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
 			Expect(report.Has(SanityIssueMissingKV)).To(BeTrue())
 			Expect(report.AffectedPods).To(ConsistOf("pod-0", "pod-1"))
@@ -220,7 +220,7 @@ var _ = Describe("CheckModelMetrics", func() {
 			bad := healthyReplica("pod-bad")
 			bad.AvgITL = 0
 
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{good, bad})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{good, bad})
 			Expect(report.AffectedPods).To(ConsistOf("pod-bad"))
 			Expect(report.AffectedPods).NotTo(ContainElement("pod-good"))
 		})
@@ -228,7 +228,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("SanityReport helpers", func() {
 		It("Has returns false for an issue not in the report", func() {
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{healthyReplica("pod-0")})
+			report := CheckModelMetrics([]domain.ReplicaMetrics{healthyReplica("pod-0")})
 			Expect(report.Has(SanityIssueNoReplicas)).To(BeFalse())
 		})
 	})

--- a/internal/engines/common/cache.go
+++ b/internal/engines/common/cache.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	interfaces "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
@@ -13,7 +13,7 @@ import (
 // This is used to pass decisions from the Engine to the Controller without API server interaction.
 type InternalDecisionCache struct {
 	sync.RWMutex
-	items map[string]interfaces.VariantDecision
+	items map[string]domain.VariantDecision
 }
 
 // Key format: namespace/name
@@ -21,14 +21,14 @@ func cacheKey(name, namespace string) string {
 	return namespace + "/" + name
 }
 
-func (c *InternalDecisionCache) Set(name, namespace string, d interfaces.VariantDecision) {
+func (c *InternalDecisionCache) Set(name, namespace string, d domain.VariantDecision) {
 	c.Lock()
 	defer c.Unlock()
 	key := cacheKey(name, namespace)
 	c.items[key] = d
 }
 
-func (c *InternalDecisionCache) Get(name, namespace string) (interfaces.VariantDecision, bool) {
+func (c *InternalDecisionCache) Get(name, namespace string) (domain.VariantDecision, bool) {
 	c.RLock()
 	defer c.RUnlock()
 	key := cacheKey(name, namespace)
@@ -38,7 +38,7 @@ func (c *InternalDecisionCache) Get(name, namespace string) (interfaces.VariantD
 
 // Global cache instance
 var DecisionCache = &InternalDecisionCache{
-	items: make(map[string]interfaces.VariantDecision),
+	items: make(map[string]domain.VariantDecision),
 }
 
 // DecisionTrigger is a channel to trigger reconciliation for VAs.
@@ -46,7 +46,7 @@ var DecisionCache = &InternalDecisionCache{
 var DecisionTrigger = make(chan event.GenericEvent, 1000)
 
 // DecisionToOptimizedAlloc converts a VariantDecision to OptimizedAlloc status fields.
-func DecisionToOptimizedAlloc(d interfaces.VariantDecision) (*int32, string, metav1.Time) {
+func DecisionToOptimizedAlloc(d domain.VariantDecision) (*int32, string, metav1.Time) {
 	// If LastRunTime is adding to VariantDecision, use it, else Now
 	// For now we assume the consumer sets LastRunTime or uses Now
 	numReplicas := int32(d.TargetReplicas)

--- a/internal/engines/common/cache_test.go
+++ b/internal/engines/common/cache_test.go
@@ -4,21 +4,21 @@ import (
 	"sync"
 	"testing"
 
-	interfaces "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 func TestInternalDecisionCache(t *testing.T) {
 	cache := &InternalDecisionCache{
-		items: make(map[string]interfaces.VariantDecision),
+		items: make(map[string]domain.VariantDecision),
 	}
 
 	// Test Set and Get
-	decision := interfaces.VariantDecision{
+	decision := domain.VariantDecision{
 		VariantName:     "test-variant",
 		Namespace:       "test-ns",
 		TargetReplicas:  5,
 		AcceleratorName: "A100",
-		Action:          interfaces.ActionScaleUp,
+		Action:          domain.ActionScaleUp,
 	}
 
 	cache.Set("test-variant", "test-ns", decision)
@@ -53,7 +53,7 @@ func TestInternalDecisionCache(t *testing.T) {
 // from internal/config package. Config functionality is now tested in internal/config/loader_test.go
 
 func TestDecisionToOptimizedAlloc(t *testing.T) {
-	d := interfaces.VariantDecision{
+	d := domain.VariantDecision{
 		TargetReplicas:  3,
 		AcceleratorName: "H100",
 	}

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -7,7 +7,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
@@ -37,9 +37,9 @@ func applyAllocation(s []NamedAnalyzerResult, v string, n int) {
 // The saturation entry is the keeper of per-variant metadata (Cost, AcceleratorName, Role,
 // replica counts) that the optimizer uses for variant selection and GPU accounting.
 // TODO: remove the sat_v2 special role once all analyzers populate variant metadata.
-func saturationEntry(s []NamedAnalyzerResult) *interfaces.AnalyzerResult {
+func saturationEntry(s []NamedAnalyzerResult) *domain.AnalyzerResult {
 	for _, e := range s {
-		if e.Name == interfaces.SaturationAnalyzerName {
+		if e.Name == domain.SaturationAnalyzerName {
 			return e.Result
 		}
 	}
@@ -48,7 +48,7 @@ func saturationEntry(s []NamedAnalyzerResult) *interfaces.AnalyzerResult {
 
 // prcForVariant returns the PerReplicaCapacity for variant v in result r.
 // Returns 0 if the variant is not present.
-func prcForVariant(r *interfaces.AnalyzerResult, v string) float64 {
+func prcForVariant(r *domain.AnalyzerResult, v string) float64 {
 	for _, vc := range r.VariantCapacities {
 		if vc.VariantName == v {
 			return vc.PerReplicaCapacity
@@ -94,12 +94,12 @@ func initRoleState(s []NamedAnalyzerResult) (roles []string, pickerState RolePai
 			}
 		} else {
 			// Non-disaggregated: synthesize a single "both" role from model-level scalars.
-			pickerState[i][interfaces.RoleBoth] = e.Remaining
+			pickerState[i][domain.RoleBoth] = e.Remaining
 			if s[i].RoleSpare == nil {
 				s[i].RoleSpare = make(map[string]float64, 1)
 			}
-			s[i].RoleSpare[interfaces.RoleBoth] = e.Spare
-			roleSet[interfaces.RoleBoth] = struct{}{}
+			s[i].RoleSpare[domain.RoleBoth] = e.Spare
+			roleSet[domain.RoleBoth] = struct{}{}
 		}
 	}
 
@@ -171,13 +171,13 @@ func anyRoleNeedsScaleUp(state RolePairedState, roles []string) bool {
 }
 
 // variantsForRole returns the capacities whose role matches role exactly,
-// canonicalizing an empty Role to interfaces.RoleBoth.
-func variantsForRole(vcs []interfaces.VariantCapacity, role string) []interfaces.VariantCapacity {
-	out := make([]interfaces.VariantCapacity, 0, len(vcs))
+// canonicalizing an empty Role to domain.RoleBoth.
+func variantsForRole(vcs []domain.VariantCapacity, role string) []domain.VariantCapacity {
+	out := make([]domain.VariantCapacity, 0, len(vcs))
 	for _, vc := range vcs {
 		r := vc.Role
 		if r == "" {
-			r = interfaces.RoleBoth
+			r = domain.RoleBoth
 		}
 		if r == role {
 			out = append(out, vc)
@@ -256,8 +256,8 @@ func needsScaleDownForRole(s []NamedAnalyzerResult, role string) bool {
 type RolePickFn func(
 	role string,
 	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
+	variants []domain.VariantCapacity,
+	stateMap map[string]domain.VariantReplicaState,
 	available map[string]int,
 	targets map[string]int,
 ) (variant string, capN int)
@@ -270,8 +270,8 @@ type RolePickFn func(
 func allocateForModelPaired(
 	ctx context.Context,
 	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
+	variants []domain.VariantCapacity,
+	stateMap map[string]domain.VariantReplicaState,
 	available map[string]int,
 	targets map[string]int,
 	pick RolePickFn,
@@ -356,7 +356,7 @@ func allocateForModelPaired(
 		// Update model-level Remaining via the P-anchor role so fairShareValue
 		// reflects committed capacity. For "both" (non-disaggregated) use the
 		// single role; for P/D prefer "prefill".
-		for _, anchor := range []string{"prefill", interfaces.RoleBoth} {
+		for _, anchor := range []string{"prefill", domain.RoleBoth} {
 			if v, ok := variantByRole[anchor]; ok {
 				applyAllocation(s, v, kByRole[anchor])
 				break

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -4,24 +4,24 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // makeNamed builds a NamedAnalyzerResult with the given RC, SC, and per-variant
 // (variantName, perReplicaCapacity) pairs.
 func makeNamed(name string, rc, sc float64, vcs ...any) NamedAnalyzerResult {
-	var caps []interfaces.VariantCapacity
+	var caps []domain.VariantCapacity
 	for i := 0; i+1 < len(vcs); i += 2 {
 		vName := vcs[i].(string)
 		prc := vcs[i+1].(float64)
-		caps = append(caps, interfaces.VariantCapacity{
+		caps = append(caps, domain.VariantCapacity{
 			VariantName:        vName,
 			PerReplicaCapacity: prc,
 		})
 	}
 	return NamedAnalyzerResult{
 		Name: name,
-		Result: &interfaces.AnalyzerResult{
+		Result: &domain.AnalyzerResult{
 			RequiredCapacity:  rc,
 			SpareCapacity:     sc,
 			VariantCapacities: caps,
@@ -62,9 +62,9 @@ var _ = Describe("analyzer helpers", func() {
 
 	Describe("saturationEntry", func() {
 		It("returns the saturation result from the slice", func() {
-			satResult := &interfaces.AnalyzerResult{RequiredCapacity: 42}
+			satResult := &domain.AnalyzerResult{RequiredCapacity: 42}
 			s := []NamedAnalyzerResult{
-				{Name: interfaces.SaturationAnalyzerName, Result: satResult},
+				{Name: domain.SaturationAnalyzerName, Result: satResult},
 				makeNamed("ta", 10, 0),
 			}
 			Expect(saturationEntry(s)).To(BeIdenticalTo(satResult))
@@ -82,12 +82,12 @@ var _ = Describe("analyzer helpers", func() {
 func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float64, vPPRC float64, vDPRC float64) NamedAnalyzerResult {
 	return NamedAnalyzerResult{
 		Name: name,
-		Result: &interfaces.AnalyzerResult{
-			VariantCapacities: []interfaces.VariantCapacity{
+		Result: &domain.AnalyzerResult{
+			VariantCapacities: []domain.VariantCapacity{
 				{VariantName: "pf", Role: "prefill", PerReplicaCapacity: vPPRC},
 				{VariantName: "dc", Role: "decode", PerReplicaCapacity: vDPRC},
 			},
-			RoleCapacities: map[string]interfaces.RoleCapacity{
+			RoleCapacities: map[string]domain.RoleCapacity{
 				"prefill": {Role: "prefill", RequiredCapacity: pRC, SpareCapacity: pSC, TotalDemand: pDemand},
 				"decode":  {Role: "decode", RequiredCapacity: dRC, SpareCapacity: dSC, TotalDemand: dDemand},
 			},
@@ -113,9 +113,9 @@ var _ = Describe("paired helpers", func() {
 		It("non-disaggregated: synthetic 'both' role using model-level Remaining/Spare", func() {
 			s := []NamedAnalyzerResult{makeNamed("sat", 20000, 5000, "v", 10.0)}
 			roles, ps := initRoleState(s)
-			Expect(roles).To(ConsistOf(interfaces.RoleBoth))
-			Expect(ps[0][interfaces.RoleBoth]).To(BeNumerically("~", 20000.0, 1e-9))
-			Expect(s[0].RoleSpare[interfaces.RoleBoth]).To(BeNumerically("~", 5000.0, 1e-9))
+			Expect(roles).To(ConsistOf(domain.RoleBoth))
+			Expect(ps[0][domain.RoleBoth]).To(BeNumerically("~", 20000.0, 1e-9))
+			Expect(s[0].RoleSpare[domain.RoleBoth]).To(BeNumerically("~", 5000.0, 1e-9))
 		})
 	})
 
@@ -200,7 +200,7 @@ var _ = Describe("paired helpers", func() {
 
 	Describe("variantsForRole", func() {
 		It("filters variants by exact role match", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{VariantName: "pf", Role: "prefill"},
 				{VariantName: "dc", Role: "decode"},
 				{VariantName: "both", Role: "both"},
@@ -211,7 +211,7 @@ var _ = Describe("paired helpers", func() {
 		})
 
 		It("matches 'both' query against both explicit 'both' and empty-role variants", func() {
-			vcs := []interfaces.VariantCapacity{
+			vcs := []domain.VariantCapacity{
 				{VariantName: "pf", Role: "prefill"},
 				{VariantName: "dc", Role: "decode"},
 				{VariantName: "all", Role: "both"},

--- a/internal/engines/pipeline/composite_limiter.go
+++ b/internal/engines/pipeline/composite_limiter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // CompositeLimiter runs a slice of Limiter instances sequentially against the
@@ -73,7 +73,7 @@ func (c *CompositeLimiter) Constituents() []Limiter {
 // against the already-capped TargetReplicas that earlier constituents mutated in
 // place — so the most-restrictive cap wins as each successive constituent sees a
 // lower target.
-func (c *CompositeLimiter) Limit(ctx context.Context, decisions []*interfaces.VariantDecision) error {
+func (c *CompositeLimiter) Limit(ctx context.Context, decisions []*domain.VariantDecision) error {
 	if len(decisions) == 0 || len(c.limiters) == 0 {
 		return nil
 	}

--- a/internal/engines/pipeline/composite_limiter_test.go
+++ b/internal/engines/pipeline/composite_limiter_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // recordingLimiter is a test double that records each invocation and can
@@ -20,7 +20,7 @@ type recordingLimiter struct {
 }
 
 func (r *recordingLimiter) Name() string { return r.name }
-func (r *recordingLimiter) Limit(_ context.Context, decisions []*interfaces.VariantDecision) error {
+func (r *recordingLimiter) Limit(_ context.Context, decisions []*domain.VariantDecision) error {
 	r.invocations++
 	if r.err != nil {
 		return r.err
@@ -61,7 +61,7 @@ var _ = Describe("CompositeLimiter", func() {
 
 	It("is a no-op when given no constituents", func() {
 		c := NewCompositeLimiter("composite", nil)
-		decisions := []*interfaces.VariantDecision{{TargetReplicas: 5}}
+		decisions := []*domain.VariantDecision{{TargetReplicas: 5}}
 		Expect(c.Limit(ctx, decisions)).To(Succeed())
 		Expect(decisions[0].TargetReplicas).To(Equal(5))
 	})
@@ -72,7 +72,7 @@ var _ = Describe("CompositeLimiter", func() {
 		c := &recordingLimiter{name: "c"}
 		comp := NewCompositeLimiter("composite", []Limiter{a, b, c})
 
-		decisions := []*interfaces.VariantDecision{{TargetReplicas: 10}}
+		decisions := []*domain.VariantDecision{{TargetReplicas: 10}}
 		Expect(comp.Limit(ctx, decisions)).To(Succeed())
 
 		Expect(a.invocations).To(Equal(1))
@@ -88,7 +88,7 @@ var _ = Describe("CompositeLimiter", func() {
 		b := &recordingLimiter{name: "namespace-quota", cap: 2}
 		comp := NewCompositeLimiter("composite", []Limiter{a, b})
 
-		decisions := []*interfaces.VariantDecision{{TargetReplicas: 10}}
+		decisions := []*domain.VariantDecision{{TargetReplicas: 10}}
 		Expect(comp.Limit(ctx, decisions)).To(Succeed())
 		Expect(decisions[0].TargetReplicas).To(Equal(2))
 		Expect(decisions[0].WasLimited).To(BeTrue())
@@ -100,7 +100,7 @@ var _ = Describe("CompositeLimiter", func() {
 		c := &recordingLimiter{name: "c"}
 		comp := NewCompositeLimiter("composite", []Limiter{a, b, c})
 
-		err := comp.Limit(ctx, []*interfaces.VariantDecision{{TargetReplicas: 1}})
+		err := comp.Limit(ctx, []*domain.VariantDecision{{TargetReplicas: 1}})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(`constituent[1] ("b")`))
 		Expect(err.Error()).To(ContainSubstring("boom"))
@@ -116,7 +116,7 @@ var _ = Describe("CompositeLimiter", func() {
 		b := &recordingLimiter{name: "b", err: errors.New("boom")}
 		comp := NewCompositeLimiter("composite", []Limiter{a, b})
 
-		decisions := []*interfaces.VariantDecision{{TargetReplicas: 10}}
+		decisions := []*domain.VariantDecision{{TargetReplicas: 10}}
 		err := comp.Limit(ctx, decisions)
 		Expect(err).To(HaveOccurred())
 

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -8,7 +8,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
@@ -40,9 +40,9 @@ func (o *CostAwareOptimizer) Optimize(
 	ctx context.Context,
 	requests []ModelScalingRequest,
 	constraints []*ResourceConstraints,
-) []interfaces.VariantDecision {
+) []domain.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx).WithName(o.Name())
-	var allDecisions []interfaces.VariantDecision
+	var allDecisions []domain.VariantDecision
 
 	for _, req := range requests {
 		satEntry := saturationEntry(req.AnalyzerResults)
@@ -81,8 +81,8 @@ func (o *CostAwareOptimizer) Optimize(
 func costGreedyRolePick(
 	role string,
 	_ []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
+	variants []domain.VariantCapacity,
+	stateMap map[string]domain.VariantReplicaState,
 	_ map[string]int,
 	targets map[string]int,
 ) (string, int) {
@@ -110,11 +110,11 @@ func costGreedyRolePick(
 // onRemove is invoked after committing n so the caller can update its spare bookkeeping.
 func scaleDownVariantSet(
 	ctx context.Context,
-	sortedVariants []interfaces.VariantCapacity,
+	sortedVariants []domain.VariantCapacity,
 	targets map[string]int,
-	states map[string]interfaces.VariantReplicaState,
-	maxRemovable func(vc interfaces.VariantCapacity) int,
-	onRemove func(vc interfaces.VariantCapacity, n int),
+	states map[string]domain.VariantReplicaState,
+	maxRemovable func(vc domain.VariantCapacity) int,
+	onRemove func(vc domain.VariantCapacity, n int),
 ) {
 	logger := ctrl.LoggerFrom(ctx)
 	for i, vc := range sortedVariants {
@@ -158,7 +158,7 @@ func scaleDownVariantSet(
 //
 // With a single analyzer (Score=1) this reduces to Cost-desc then PRC-asc, i.e.
 // #1237's existing tie-break.
-func sortVariantsForScaleDown(s []NamedAnalyzerResult, roleVCs []interfaces.VariantCapacity) []interfaces.VariantCapacity {
+func sortVariantsForScaleDown(s []NamedAnalyzerResult, roleVCs []domain.VariantCapacity) []domain.VariantCapacity {
 	weighted := func(name string) float64 {
 		sum := 0.0
 		for _, e := range s {
@@ -169,7 +169,7 @@ func sortVariantsForScaleDown(s []NamedAnalyzerResult, roleVCs []interfaces.Vari
 		}
 		return sum
 	}
-	out := append([]interfaces.VariantCapacity(nil), roleVCs...)
+	out := append([]domain.VariantCapacity(nil), roleVCs...)
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Cost != out[j].Cost {
 			return out[i].Cost > out[j].Cost
@@ -184,7 +184,7 @@ func sortVariantsForScaleDown(s []NamedAnalyzerResult, roleVCs []interfaces.Vari
 }
 
 // anyHasReplicas reports whether any of the given variants has a positive target.
-func anyHasReplicas(variants []interfaces.VariantCapacity, targets map[string]int) bool {
+func anyHasReplicas(variants []domain.VariantCapacity, targets map[string]int) bool {
 	for _, vc := range variants {
 		if targets[vc.VariantName] > 0 {
 			return true
@@ -194,8 +194,8 @@ func anyHasReplicas(variants []interfaces.VariantCapacity, targets map[string]in
 }
 
 // buildStateMap creates a lookup map from variant name to VariantReplicaState.
-func buildStateMap(states []interfaces.VariantReplicaState) map[string]interfaces.VariantReplicaState {
-	m := make(map[string]interfaces.VariantReplicaState, len(states))
+func buildStateMap(states []domain.VariantReplicaState) map[string]domain.VariantReplicaState {
+	m := make(map[string]domain.VariantReplicaState, len(states))
 	for _, s := range states {
 		m[s.VariantName] = s
 	}
@@ -203,8 +203,8 @@ func buildStateMap(states []interfaces.VariantReplicaState) map[string]interface
 }
 
 // buildCapacityMap creates a lookup map from variant name to VariantCapacity.
-func buildCapacityMap(capacities []interfaces.VariantCapacity) map[string]interfaces.VariantCapacity {
-	m := make(map[string]interfaces.VariantCapacity, len(capacities))
+func buildCapacityMap(capacities []domain.VariantCapacity) map[string]domain.VariantCapacity {
+	m := make(map[string]domain.VariantCapacity, len(capacities))
 	for _, vc := range capacities {
 		m[vc.VariantName] = vc
 	}
@@ -212,7 +212,7 @@ func buildCapacityMap(capacities []interfaces.VariantCapacity) map[string]interf
 }
 
 // initTargets creates initial targets from current replica counts.
-func initTargets(states []interfaces.VariantReplicaState) map[string]int {
+func initTargets(states []domain.VariantReplicaState) map[string]int {
 	targets := make(map[string]int, len(states))
 	for _, s := range states {
 		targets[s.VariantName] = s.CurrentReplicas
@@ -221,8 +221,8 @@ func initTargets(states []interfaces.VariantReplicaState) map[string]int {
 }
 
 // sortByCostEfficiencyAsc returns variants sorted by cost/perReplicaCapacity ascending.
-func sortByCostEfficiencyAsc(capacities []interfaces.VariantCapacity) []interfaces.VariantCapacity {
-	sorted := make([]interfaces.VariantCapacity, len(capacities))
+func sortByCostEfficiencyAsc(capacities []domain.VariantCapacity) []domain.VariantCapacity {
+	sorted := make([]domain.VariantCapacity, len(capacities))
 	copy(sorted, capacities)
 	sort.Slice(sorted, func(i, j int) bool {
 		return costEfficiency(sorted[i]) < costEfficiency(sorted[j])
@@ -231,7 +231,7 @@ func sortByCostEfficiencyAsc(capacities []interfaces.VariantCapacity) []interfac
 }
 
 // costEfficiency returns the cost per unit of capacity.
-func costEfficiency(vc interfaces.VariantCapacity) float64 {
+func costEfficiency(vc domain.VariantCapacity) float64 {
 	if vc.PerReplicaCapacity <= 0 {
 		return math.MaxFloat64
 	}
@@ -242,12 +242,12 @@ func costEfficiency(vc interfaces.VariantCapacity) float64 {
 // optimizerName is included in reason strings for observability.
 func buildDecisionsWithOptimizer(
 	req ModelScalingRequest,
-	stateMap map[string]interfaces.VariantReplicaState,
-	vcMap map[string]interfaces.VariantCapacity,
+	stateMap map[string]domain.VariantReplicaState,
+	vcMap map[string]domain.VariantCapacity,
 	targets map[string]int,
 	optimizerName string,
-) []interfaces.VariantDecision {
-	decisions := make([]interfaces.VariantDecision, 0, len(targets))
+) []domain.VariantDecision {
+	decisions := make([]domain.VariantDecision, 0, len(targets))
 	// satEntry carries the model-level RequiredCapacity/SpareCapacity computed by
 	// applyUniversalThreshold; per-variant Utilization is on each VariantCapacity.
 	// These feed the saturation gauges (utilization/required/spare). SpareCapacity is
@@ -258,25 +258,25 @@ func buildDecisionsWithOptimizer(
 		state := stateMap[name]
 		vc := vcMap[name]
 
-		var action interfaces.SaturationAction
-		var decisionReason interfaces.DecisionReason
+		var action domain.SaturationAction
+		var decisionReason domain.DecisionReason
 		var detailedReason string
 		switch {
 		case target > state.CurrentReplicas:
-			action = interfaces.ActionScaleUp
-			decisionReason = interfaces.DecisionReasonV2
+			action = domain.ActionScaleUp
+			decisionReason = domain.DecisionReasonV2
 			detailedReason = fmt.Sprintf("%s (optimizer: %s)", string(decisionReason), optimizerName)
 		case target < state.CurrentReplicas:
-			action = interfaces.ActionScaleDown
-			decisionReason = interfaces.DecisionReasonV2
+			action = domain.ActionScaleDown
+			decisionReason = domain.DecisionReasonV2
 			detailedReason = fmt.Sprintf("%s (optimizer: %s)", string(decisionReason), optimizerName)
 		default:
-			action = interfaces.ActionNoChange
-			decisionReason = interfaces.DecisionReasonV2
+			action = domain.ActionNoChange
+			decisionReason = domain.DecisionReasonV2
 			detailedReason = string(decisionReason)
 		}
 
-		decision := interfaces.VariantDecision{
+		decision := domain.VariantDecision{
 			VariantName:     name,
 			ModelID:         req.ModelID,
 			Namespace:       req.Namespace,
@@ -304,7 +304,7 @@ func buildDecisionsWithOptimizer(
 			reqCap, spareCap := satEntry.RequiredCapacity, satEntry.SpareCapacity
 			role := state.Role
 			if role == "" {
-				role = interfaces.RoleBoth
+				role = domain.RoleBoth
 			}
 			if rc, ok := satEntry.RoleCapacities[role]; ok {
 				reqCap, spareCap = rc.RequiredCapacity, rc.SpareCapacity
@@ -421,11 +421,11 @@ func tighterBudget(a, b int) int {
 func scaleDownRoleIterated(
 	ctx context.Context,
 	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
+	variants []domain.VariantCapacity,
 	targets map[string]int,
-	stateMap ...map[string]interfaces.VariantReplicaState,
+	stateMap ...map[string]domain.VariantReplicaState,
 ) {
-	var states map[string]interfaces.VariantReplicaState
+	var states map[string]domain.VariantReplicaState
 	if len(stateMap) > 0 {
 		states = stateMap[0]
 	}
@@ -433,7 +433,7 @@ func scaleDownRoleIterated(
 	for _, vc := range variants {
 		role := vc.Role
 		if role == "" {
-			role = interfaces.RoleBoth
+			role = domain.RoleBoth
 		}
 		rolesSet[role] = struct{}{}
 	}
@@ -453,10 +453,10 @@ func scaleDownRoleIterated(
 		}
 		sorted := sortVariantsForScaleDown(s, roleVCs)
 		scaleDownVariantSet(ctx, sorted, targets, states,
-			func(vc interfaces.VariantCapacity) int {
+			func(vc domain.VariantCapacity) int {
 				return safeRemovalReplicasForRole(s, vc.VariantName, role)
 			},
-			func(vc interfaces.VariantCapacity, n int) {
+			func(vc domain.VariantCapacity, n int) {
 				applyDeallocationForRole(s, vc.VariantName, role, n)
 			},
 		)

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -8,15 +8,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // withSatEntry adds a single-saturation AnalyzerResults to req, initialised from r.
 // Used by test fixtures so CostAwareOptimizer can find the saturation entry.
-func withSatEntry(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
+func withSatEntry(r *domain.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
 	if r != nil {
 		req.AnalyzerResults = []NamedAnalyzerResult{{
-			Name:      interfaces.SaturationAnalyzerName,
+			Name:      domain.SaturationAnalyzerName,
 			Result:    r,
 			Remaining: r.RequiredCapacity,
 			Spare:     r.SpareCapacity,
@@ -44,12 +44,12 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Scale-Up", func() {
 
 		It("should add replicas to most cost-efficient variant", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				AnalyzedAt:       time.Now(),
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 					{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
@@ -58,7 +58,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 2},
 						{VariantName: "expensive", CurrentReplicas: 1},
 					},
@@ -77,12 +77,12 @@ var _ = Describe("CostAwareOptimizer", func() {
 		It("populates decision observability fields (utilization/required/spare) from the analyzer result", func() {
 			// Regression: these three feed wva_saturation_utilization / wva_required_capacity /
 			// wva_spare_capacity. If buildDecisionsWithOptimizer stops copying them, the gauges read 0.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				RequiredCapacity: 5000,
 				SpareCapacity:    1200,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.42},
 				},
 			}
@@ -90,7 +90,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2},
 					},
 				}),
@@ -103,16 +103,16 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("uses per-role required/spare capacity for P/D-disaggregated models", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				RequiredCapacity: 9999, // model-level; must NOT be used for role-scoped variants
 				SpareCapacity:    8888,
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {Role: "prefill", RequiredCapacity: 100, SpareCapacity: 10},
 					"decode":  {Role: "decode", RequiredCapacity: 200, SpareCapacity: 20},
 				},
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "p", Role: "prefill", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.3},
 					{VariantName: "d", Role: "decode", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.6},
 				},
@@ -121,7 +121,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "p", Role: "prefill", CurrentReplicas: 1},
 						{VariantName: "d", Role: "decode", CurrentReplicas: 1},
 					},
@@ -138,15 +138,15 @@ var _ = Describe("CostAwareOptimizer", func() {
 		It("maps an empty-role variant to the \"both\" RoleCapacities entry", func() {
 			// Role "" normalizes to RoleBoth, so the "both" entry (not the model-level
 			// totals) must be used. Model-level 9999/8888 are decoys.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				RequiredCapacity: 9999,
 				SpareCapacity:    8888,
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"both": {Role: "both", RequiredCapacity: 300, SpareCapacity: 30},
 				},
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v", Role: "", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.5},
 				},
 			}
@@ -154,7 +154,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v", Role: "", CurrentReplicas: 1},
 					},
 				}),
@@ -166,9 +166,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should not skip variants with pending replicas", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 					{VariantName: "mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
 				},
@@ -177,7 +177,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 2, PendingReplicas: 1},
 						{VariantName: "mid", CurrentReplicas: 1},
 					},
@@ -194,9 +194,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should skip variants with zero capacity", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "zero-cap", Cost: 1.0, ReplicaCount: 0, PerReplicaCapacity: 0},
 					{VariantName: "normal", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
@@ -205,7 +205,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "zero-cap", CurrentReplicas: 0},
 						{VariantName: "normal", CurrentReplicas: 1},
 					},
@@ -220,9 +220,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should spread across multiple variants when needed", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 25000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
 				},
@@ -231,7 +231,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 1},
 						{VariantName: "mid", CurrentReplicas: 1},
 					},
@@ -250,9 +250,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Scale-Down", func() {
 
 		It("should remove from most expensive variant first", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 15000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
 				},
@@ -261,7 +261,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 3},
 						{VariantName: "expensive", CurrentReplicas: 2},
 					},
@@ -278,9 +278,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should protect cheapest variant at 1 replica", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 30000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
@@ -289,7 +289,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 1},
 						{VariantName: "cheap", CurrentReplicas: 1},
 					},
@@ -306,9 +306,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should remove cheap variant when expensive replica capacity exceeds spare", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 15000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
@@ -317,7 +317,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 1},
 						{VariantName: "cheap", CurrentReplicas: 1},
 					},
@@ -334,9 +334,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should cascade scale-down across variants", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
 					{VariantName: "mid", Cost: 10.0, ReplicaCount: 2, PerReplicaCapacity: 15000},
 					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
@@ -346,7 +346,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 2},
 						{VariantName: "mid", CurrentReplicas: 2},
 						{VariantName: "cheap", CurrentReplicas: 2},
@@ -371,13 +371,13 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// decode has spare. Model-level SpareCapacity aggregates both roles, so a
 			// role-blind scale-down would trim the expensive prefill. Role-aware
 			// scale-down must leave the saturated prefill untouched and shed decode.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 20000, // aggregate (decode's spare) — gates scale-down
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill", Role: "prefill", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 					{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {Role: "prefill", SpareCapacity: 0},
 					"decode":  {Role: "decode", SpareCapacity: 20000},
 				},
@@ -386,7 +386,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 2},
 						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
 					},
@@ -398,22 +398,22 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 			// Prefill (saturated role) is never trimmed despite being most expensive.
 			Expect(dm["prefill"].TargetReplicas).To(Equal(2))
-			Expect(dm["prefill"].Action).To(Equal(interfaces.ActionNoChange))
+			Expect(dm["prefill"].Action).To(Equal(domain.ActionNoChange))
 			// Decode sheds its own spare: floor(20000/10000)=2 → 3 - 2 = 1.
 			Expect(dm["decode"].TargetReplicas).To(Equal(1))
-			Expect(dm["decode"].Action).To(Equal(interfaces.ActionScaleDown))
+			Expect(dm["decode"].Action).To(Equal(domain.ActionScaleDown))
 		})
 
 		It("should shed each role by its own spare when both have slack", func() {
 			// Both roles have spare, but different amounts. Each role must shed by
 			// its own per-role spare, not the aggregate.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 30000, // aggregate — gates scale-down
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill", Role: "prefill", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 					{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {Role: "prefill", SpareCapacity: 10000}, // 1 replica
 					"decode":  {Role: "decode", SpareCapacity: 20000},  // 2 replicas
 				},
@@ -422,7 +422,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 3},
 						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
 					},
@@ -442,13 +442,13 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// Only decode has a RoleCapacities entry (e.g. a prefill data-collection
 			// gap). The one-iteration path must shed decode against its own spare and
 			// keep the cheapest decode variant at one replica.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "decode-exp", Role: "decode", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "decode-cheap", Role: "decode", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"decode": {Role: "decode", SpareCapacity: 20000}, // 2 replicas
 				},
 			}
@@ -456,7 +456,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "decode-exp", Role: "decode", CurrentReplicas: 1},
 						{VariantName: "decode-cheap", Role: "decode", CurrentReplicas: 1},
 					},
@@ -477,14 +477,14 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// prefill/decode RoleCapacities map — so the per-role sheds never include it.
 			// The design assumes one role per variant; this pins the defensive behavior
 			// if that assumption is violated: the orphan is left as-is.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill", Role: "prefill", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 					{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 					{VariantName: "orphan", Role: "", Cost: 20.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {Role: "prefill", SpareCapacity: 0},
 					"decode":  {Role: "decode", SpareCapacity: 20000},
 				},
@@ -493,7 +493,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 2},
 						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
 						{VariantName: "orphan", Role: "", CurrentReplicas: 2},
@@ -507,7 +507,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// orphan (role "") matches no per-role set → never trimmed, despite being
 			// the most expensive variant.
 			Expect(dm["orphan"].TargetReplicas).To(Equal(2))
-			Expect(dm["orphan"].Action).To(Equal(interfaces.ActionNoChange))
+			Expect(dm["orphan"].Action).To(Equal(domain.ActionNoChange))
 			// prefill saturated → untouched; decode sheds its own spare → 3 - 2 = 1.
 			Expect(dm["prefill"].TargetReplicas).To(Equal(2))
 			Expect(dm["decode"].TargetReplicas).To(Equal(1))
@@ -517,10 +517,10 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Steady State", func() {
 
 		It("should return no-change when no scaling signal", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 0,
 				SpareCapacity:    0,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 				},
 			}
@@ -528,7 +528,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2},
 					},
 				}),
@@ -537,7 +537,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 			decisions := optimizer.Optimize(ctx, requests, nil)
 
 			Expect(decisions).To(HaveLen(1))
-			Expect(decisions[0].Action).To(Equal(interfaces.ActionNoChange))
+			Expect(decisions[0].Action).To(Equal(domain.ActionNoChange))
 			Expect(decisions[0].TargetReplicas).To(Equal(2))
 		})
 
@@ -554,15 +554,15 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Multi-Model", func() {
 
 		It("should process models independently", func() {
-			r1 := &interfaces.AnalyzerResult{
+			r1 := &domain.AnalyzerResult{
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "m1-v1", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			r2 := &interfaces.AnalyzerResult{
+			r2 := &domain.AnalyzerResult{
 				SpareCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "m2-v1", Cost: 10.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 				},
 			}
@@ -570,14 +570,14 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r1, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "m1-v1", CurrentReplicas: 1},
 					},
 				}),
 				withSatEntry(r2, ModelScalingRequest{
 					ModelID:   "model-2",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "m2-v1", CurrentReplicas: 2},
 					},
 				}),
@@ -586,9 +586,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 			decisions := optimizer.Optimize(ctx, requests, nil)
 			dm := decisionMap(decisions)
 
-			Expect(dm["m1-v1"].Action).To(Equal(interfaces.ActionScaleUp))
+			Expect(dm["m1-v1"].Action).To(Equal(domain.ActionScaleUp))
 			Expect(dm["m1-v1"].TargetReplicas).To(Equal(2))
-			Expect(dm["m2-v1"].Action).To(Equal(interfaces.ActionScaleDown))
+			Expect(dm["m2-v1"].Action).To(Equal(domain.ActionScaleDown))
 			Expect(dm["m2-v1"].TargetReplicas).To(Equal(1))
 		})
 	})
@@ -596,9 +596,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Decision Metadata", func() {
 
 		It("should set model ID, namespace, and cost on decisions", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -606,7 +606,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "ns-1",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1},
 					},
 				}),
@@ -626,9 +626,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		intPtr := func(n int) *int { return &n }
 
 		It("should respect maxReplicas during scale-up (spillover to next variant)", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 30000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
@@ -637,7 +637,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 1, MaxReplicas: intPtr(3)},
 						{VariantName: "expensive", CurrentReplicas: 1},
 					},
@@ -654,9 +654,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should respect minReplicas during scale-down", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 3, PerReplicaCapacity: 20000},
 					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 				},
@@ -665,7 +665,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 3, MinReplicas: intPtr(2)},
 						{VariantName: "cheap", CurrentReplicas: 3},
 					},
@@ -682,9 +682,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should scale minReplicas=0 variant to zero while keeping minReplicas>0 sibling", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 80000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "keep-alive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
 					{VariantName: "expendable", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 				},
@@ -693,7 +693,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "keep-alive", CurrentReplicas: 2, MinReplicas: intPtr(1)},
 						{VariantName: "expendable", CurrentReplicas: 3, MinReplicas: intPtr(0)},
 					},
@@ -708,10 +708,10 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should propagate MinReplicas/MaxReplicas to VariantDecision", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 0,
 				SpareCapacity:    0,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 				},
 			}
@@ -719,7 +719,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2, MinReplicas: intPtr(1), MaxReplicas: intPtr(10)},
 					},
 				}),
@@ -736,11 +736,11 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Disaggregated (P/D) Scale-Up", func() {
 
 		// withSatEntryPD builds a request with a disaggregated saturation result.
-		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
+		withSatEntryPD := func(r *domain.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
 			if r != nil {
 				req.Disaggregated = true
 				req.AnalyzerResults = []NamedAnalyzerResult{{
-					Name:      interfaces.SaturationAnalyzerName,
+					Name:      domain.SaturationAnalyzerName,
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
@@ -752,13 +752,13 @@ var _ = Describe("CostAwareOptimizer", func() {
 		It("should allocate paired (n_P, n_D) replicas for cheapest prefill + decode pair", func() {
 			// P-Remaining=20000, PRC_P=10000 → n_P=2
 			// D=α×P=20000 (α=1), PRC_D=10000 → n_D=2
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill-v", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "decode-v", Cost: 5.0, Role: "decode", ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {RequiredCapacity: 20000, TotalDemand: 20000},
 					"decode":  {RequiredCapacity: 20000, TotalDemand: 20000},
 				},
@@ -767,7 +767,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntryPD(r, ModelScalingRequest{
 					ModelID:   "model-pd",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1},
 						{VariantName: "decode-v", CurrentReplicas: 1},
 					},
@@ -786,15 +786,15 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// Two prefill variants: cheap-p (cost 5) and expensive-p (cost 15)
 			// Two decode variants: cheap-d (cost 5) and expensive-d (cost 15)
 			// α=1; P-RC=10000, PRC=10000 → n_P=1 on cheap-p; n_D=1 on cheap-d
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap-p", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
 					{VariantName: "expensive-p", Cost: 15.0, Role: "prefill", PerReplicaCapacity: 10000},
 					{VariantName: "cheap-d", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
 					{VariantName: "expensive-d", Cost: 15.0, Role: "decode", PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {RequiredCapacity: 10000, TotalDemand: 10000},
 					"decode":  {RequiredCapacity: 10000, TotalDemand: 10000},
 				},
@@ -803,7 +803,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntryPD(r, ModelScalingRequest{
 					ModelID:   "model-pd",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap-p", CurrentReplicas: 1},
 						{VariantName: "expensive-p", CurrentReplicas: 1},
 						{VariantName: "cheap-d", CurrentReplicas: 1},
@@ -828,11 +828,11 @@ var _ = Describe("CostAwareOptimizer", func() {
 	// (anyRoleNeedsScaleUp) correctly fires on decode demand.
 	Context("Disaggregated (P/D) D-only scale-up", func() {
 
-		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
+		withSatEntryPD := func(r *domain.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
 			if r != nil {
 				req.Disaggregated = true
 				req.AnalyzerResults = []NamedAnalyzerResult{{
-					Name:      interfaces.SaturationAnalyzerName,
+					Name:      domain.SaturationAnalyzerName,
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
@@ -842,13 +842,13 @@ var _ = Describe("CostAwareOptimizer", func() {
 		}
 
 		It("should scale up only decode when only D has demand (RC_P=0, RC_D>0)", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill-v", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
 					{VariantName: "decode-v", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {RequiredCapacity: 0, TotalDemand: 0},
 					"decode":  {RequiredCapacity: 10000, TotalDemand: 10000},
 				},
@@ -857,7 +857,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntryPD(r, ModelScalingRequest{
 					ModelID:   "model-d-only",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 2},
 						{VariantName: "decode-v", CurrentReplicas: 1},
 					},
@@ -876,11 +876,11 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 	Context("Disaggregated (P/D) Scale-Down", func() {
 
-		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
+		withSatEntryPD := func(r *domain.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
 			if r != nil {
 				req.Disaggregated = true
 				req.AnalyzerResults = []NamedAnalyzerResult{{
-					Name:      interfaces.SaturationAnalyzerName,
+					Name:      domain.SaturationAnalyzerName,
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
@@ -891,14 +891,14 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should remove from most expensive prefill and decode variants", func() {
 			// P-Spare=20000, PRC_P=10000 → n_P=2; D-Spare=10000, PRC_D=10000 → n_D=1
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 20000, // model-level (unused in disaggregated path)
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap-p", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
 					{VariantName: "expensive-p", Cost: 15.0, Role: "prefill", PerReplicaCapacity: 10000},
 					{VariantName: "decode-v", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {SpareCapacity: 20000, TotalDemand: 10000},
 					"decode":  {SpareCapacity: 10000, TotalDemand: 10000},
 				},
@@ -907,7 +907,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 				withSatEntryPD(r, ModelScalingRequest{
 					ModelID:   "model-pd",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap-p", CurrentReplicas: 2},
 						{VariantName: "expensive-p", CurrentReplicas: 2},
 						{VariantName: "decode-v", CurrentReplicas: 3},
@@ -929,7 +929,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Helper Functions", func() {
 
 		It("sortByCostEfficiencyAsc should order by cost/capacity", func() {
-			capacities := []interfaces.VariantCapacity{
+			capacities := []domain.VariantCapacity{
 				{VariantName: "expensive", Cost: 15.0, PerReplicaCapacity: 10000},
 				{VariantName: "cheap", Cost: 5.0, PerReplicaCapacity: 10000},
 				{VariantName: "mid", Cost: 10.0, PerReplicaCapacity: 10000},
@@ -987,8 +987,8 @@ var _ = Describe("CostAwareOptimizer", func() {
 	})
 })
 
-func decisionMap(decisions []interfaces.VariantDecision) map[string]interfaces.VariantDecision {
-	m := make(map[string]interfaces.VariantDecision, len(decisions))
+func decisionMap(decisions []domain.VariantDecision) map[string]domain.VariantDecision {
+	m := make(map[string]domain.VariantDecision, len(decisions))
 	for _, d := range decisions {
 		m[d.VariantName] = d
 	}

--- a/internal/engines/pipeline/default_limiter.go
+++ b/internal/engines/pipeline/default_limiter.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 )
 
@@ -45,7 +45,7 @@ func (l *DefaultLimiter) Name() string {
 
 // Limit applies resource constraints to scaling decisions.
 // Modifies decisions in place - may reduce TargetReplicas based on available resources.
-func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*interfaces.VariantDecision) error {
+func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*domain.VariantDecision) error {
 	if len(decisions) == 0 {
 		return nil
 	}
@@ -112,7 +112,7 @@ func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*interfaces.Vari
 // real GPU type when the inventory has exactly one type (homogeneous cluster).
 // This must run before calculateUsedGPUs so existing replicas are counted
 // against the correct pool, and before TryAllocate so new allocations use it.
-func (l *DefaultLimiter) resolveUnknownAccelerators(decisions []*interfaces.VariantDecision) {
+func (l *DefaultLimiter) resolveUnknownAccelerators(decisions []*domain.VariantDecision) {
 	pools := l.inventory.GetResourcePools()
 	if len(pools) != 1 {
 		return // heterogeneous or empty — can't resolve
@@ -130,7 +130,7 @@ func (l *DefaultLimiter) resolveUnknownAccelerators(decisions []*interfaces.Vari
 
 // calculateUsedGPUs computes current GPU usage per accelerator type.
 // Uses CurrentReplicas * GPUsPerReplica for each decision.
-func (l *DefaultLimiter) calculateUsedGPUs(decisions []*interfaces.VariantDecision) map[string]int {
+func (l *DefaultLimiter) calculateUsedGPUs(decisions []*domain.VariantDecision) map[string]int {
 	usedByType := make(map[string]int)
 	for _, d := range decisions {
 		if d.AcceleratorName == "" {
@@ -145,7 +145,7 @@ func (l *DefaultLimiter) calculateUsedGPUs(decisions []*interfaces.VariantDecisi
 // (namespace, accelerator type). Outer key: namespace; inner key: accelerator
 // type. Used to feed NamespaceAwareInventory implementations the per-namespace
 // usage map needed for per-tenant cap enforcement.
-func (l *DefaultLimiter) calculateUsedGPUsByNamespace(decisions []*interfaces.VariantDecision) map[string]map[string]int {
+func (l *DefaultLimiter) calculateUsedGPUsByNamespace(decisions []*domain.VariantDecision) map[string]map[string]int {
 	usedByNS := make(map[string]map[string]int)
 	for _, d := range decisions {
 		if d.AcceleratorName == "" || d.Namespace == "" {
@@ -165,7 +165,7 @@ func (l *DefaultLimiter) calculateUsedGPUsByNamespace(decisions []*interfaces.Va
 // targetBefore are the per-decision WasLimited / TargetReplicas snapshots taken
 // before this limiter's algorithm ran, indexed to match decisions. See Limit for
 // why attribution and the per-step flag use different signals.
-func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantDecision, limitedBefore []bool, targetBefore []int) {
+func (l *DefaultLimiter) updateDecisionMetadata(decisions []*domain.VariantDecision, limitedBefore []bool, targetBefore []int) {
 	for i, d := range decisions {
 		// Attribution: credit the first limiter that newly marks the decision
 		// resource-limited (WasLimited is sticky across composite constituents).
@@ -188,7 +188,7 @@ func (l *DefaultLimiter) updateDecisionMetadata(decisions []*interfaces.VariantD
 // buildStepReason creates a human-readable reason for the decision step. limited
 // reflects whether THIS limiter constrained the decision this pass (matching the
 // step's limited flag), not the sticky WasLimited.
-func (l *DefaultLimiter) buildStepReason(d *interfaces.VariantDecision, limited bool) string {
+func (l *DefaultLimiter) buildStepReason(d *domain.VariantDecision, limited bool) string {
 	replicaChange := d.TargetReplicas - d.CurrentReplicas
 
 	if replicaChange <= 0 {

--- a/internal/engines/pipeline/default_limiter_namespace_test.go
+++ b/internal/engines/pipeline/default_limiter_namespace_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // namespaceAwareMockInventory extends mockInventory with SetUsedByNamespace
@@ -58,7 +58,7 @@ var _ = Describe("DefaultLimiter namespace-aware feature detection", func() {
 		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 100})
 		limiter := NewDefaultLimiter("test", inv, algorithm)
 
-		decisions := []*interfaces.VariantDecision{
+		decisions := []*domain.VariantDecision{
 			{VariantName: "v1", Namespace: "team-a", AcceleratorName: "H100", CurrentReplicas: 2, GPUsPerReplica: 4},
 			{VariantName: "v2", Namespace: "team-a", AcceleratorName: "H100", CurrentReplicas: 1, GPUsPerReplica: 2},
 			{VariantName: "v3", Namespace: "team-b", AcceleratorName: "A100", CurrentReplicas: 3, GPUsPerReplica: 1},
@@ -79,7 +79,7 @@ var _ = Describe("DefaultLimiter namespace-aware feature detection", func() {
 		inv := newNamespaceAwareMockInventory(map[string]int{"H100": 100, "A100": 100})
 		limiter := NewDefaultLimiter("test", inv, algorithm)
 
-		decisions := []*interfaces.VariantDecision{
+		decisions := []*domain.VariantDecision{
 			{Namespace: "team-a", AcceleratorName: "H100", CurrentReplicas: 1, GPUsPerReplica: 1},
 			{Namespace: "", AcceleratorName: "H100", CurrentReplicas: 99, GPUsPerReplica: 99},   // skipped (empty ns)
 			{Namespace: "team-a", AcceleratorName: "", CurrentReplicas: 99, GPUsPerReplica: 99}, // skipped (empty type, unresolvable)
@@ -95,7 +95,7 @@ var _ = Describe("DefaultLimiter namespace-aware feature detection", func() {
 		inv := newMockInventory("plain", map[string]int{"H100": 100})
 		limiter := NewDefaultLimiter("test", inv, algorithm)
 
-		decisions := []*interfaces.VariantDecision{
+		decisions := []*domain.VariantDecision{
 			{Namespace: "team-a", AcceleratorName: "H100", CurrentReplicas: 1, GPUsPerReplica: 1},
 		}
 		Expect(limiter.Limit(ctx, decisions)).To(Succeed())

--- a/internal/engines/pipeline/default_limiter_test.go
+++ b/internal/engines/pipeline/default_limiter_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 )
 
@@ -90,7 +90,7 @@ type mockTypeAllocator struct {
 	availableByType map[string]int
 }
 
-func (m *mockTypeAllocator) TryAllocate(_ context.Context, decision *interfaces.VariantDecision, gpusRequested int) (int, error) {
+func (m *mockTypeAllocator) TryAllocate(_ context.Context, decision *domain.VariantDecision, gpusRequested int) (int, error) {
 	accelType := decision.AcceleratorName
 	if accelType == "" {
 		accelType = "default"
@@ -118,14 +118,14 @@ func (m *mockTypeAllocator) Remaining() int {
 // mockAlgorithm implements AllocationAlgorithm for testing
 type mockAlgorithm struct {
 	name         string
-	allocateFunc func(ctx context.Context, decisions []*interfaces.VariantDecision, allocator ResourceAllocator) error
+	allocateFunc func(ctx context.Context, decisions []*domain.VariantDecision, allocator ResourceAllocator) error
 }
 
 func (m *mockAlgorithm) Name() string {
 	return m.name
 }
 
-func (m *mockAlgorithm) Allocate(ctx context.Context, decisions []*interfaces.VariantDecision, allocator ResourceAllocator) error {
+func (m *mockAlgorithm) Allocate(ctx context.Context, decisions []*domain.VariantDecision, allocator ResourceAllocator) error {
 	if m.allocateFunc != nil {
 		return m.allocateFunc(ctx, decisions, allocator)
 	}
@@ -138,7 +138,7 @@ var _ = Describe("DefaultLimiter", func() {
 		limiter   *DefaultLimiter
 		inventory *mockInventory
 		algorithm *mockAlgorithm
-		decisions []*interfaces.VariantDecision
+		decisions []*domain.VariantDecision
 	)
 
 	BeforeEach(func() {
@@ -162,7 +162,7 @@ var _ = Describe("DefaultLimiter", func() {
 				algorithm = &mockAlgorithm{name: "algo"}
 				limiter = NewDefaultLimiter("limiter", inventory, algorithm)
 
-				err := limiter.Limit(ctx, []*interfaces.VariantDecision{})
+				err := limiter.Limit(ctx, []*domain.VariantDecision{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -172,7 +172,7 @@ var _ = Describe("DefaultLimiter", func() {
 				inventory = newMockInventory("type-inv", map[string]int{"A100": 8})
 				algorithm = &mockAlgorithm{
 					name: "pass-through",
-					allocateFunc: func(ctx context.Context, decisions []*interfaces.VariantDecision, allocator ResourceAllocator) error {
+					allocateFunc: func(ctx context.Context, decisions []*domain.VariantDecision, allocator ResourceAllocator) error {
 						for _, d := range decisions {
 							if d.TargetReplicas > d.CurrentReplicas {
 								gpusNeeded := (d.TargetReplicas - d.CurrentReplicas) * d.GPUsPerReplica
@@ -185,7 +185,7 @@ var _ = Describe("DefaultLimiter", func() {
 				}
 				limiter = NewDefaultLimiter("gpu-limiter", inventory, algorithm)
 
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1",
 						AcceleratorName: "A100",
@@ -228,7 +228,7 @@ var _ = Describe("DefaultLimiter", func() {
 				inventory = newMockInventory("type-inv", map[string]int{"A100": 6})
 				algorithm = &mockAlgorithm{
 					name: "partial-alloc",
-					allocateFunc: func(ctx context.Context, decisions []*interfaces.VariantDecision, allocator ResourceAllocator) error {
+					allocateFunc: func(ctx context.Context, decisions []*domain.VariantDecision, allocator ResourceAllocator) error {
 						for _, d := range decisions {
 							if d.TargetReplicas > d.CurrentReplicas {
 								replicasNeeded := d.TargetReplicas - d.CurrentReplicas
@@ -252,7 +252,7 @@ var _ = Describe("DefaultLimiter", func() {
 				}
 				limiter = NewDefaultLimiter("gpu-limiter", inventory, algorithm)
 
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1",
 						AcceleratorName: "A100",
@@ -289,7 +289,7 @@ var _ = Describe("DefaultLimiter", func() {
 				})
 				algorithm = &mockAlgorithm{
 					name: "multi-type",
-					allocateFunc: func(ctx context.Context, decisions []*interfaces.VariantDecision, allocator ResourceAllocator) error {
+					allocateFunc: func(ctx context.Context, decisions []*domain.VariantDecision, allocator ResourceAllocator) error {
 						for _, d := range decisions {
 							if d.TargetReplicas > d.CurrentReplicas {
 								gpusNeeded := (d.TargetReplicas - d.CurrentReplicas) * d.GPUsPerReplica
@@ -302,7 +302,7 @@ var _ = Describe("DefaultLimiter", func() {
 				}
 				limiter = NewDefaultLimiter("gpu-limiter", inventory, algorithm)
 
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1-a100",
 						AcceleratorName: "A100",
@@ -346,7 +346,7 @@ var _ = Describe("DefaultLimiter", func() {
 			algorithm = &mockAlgorithm{name: "algo"}
 			limiter = NewDefaultLimiter("limiter", inventory, algorithm)
 
-			decisions = []*interfaces.VariantDecision{
+			decisions = []*domain.VariantDecision{
 				{VariantName: "v1", AcceleratorName: ""},
 				{VariantName: "v2", AcceleratorName: "unknown"},
 				{VariantName: "v3", AcceleratorName: "H100"},
@@ -363,7 +363,7 @@ var _ = Describe("DefaultLimiter", func() {
 			algorithm = &mockAlgorithm{name: "algo"}
 			limiter = NewDefaultLimiter("limiter", inventory, algorithm)
 
-			decisions = []*interfaces.VariantDecision{
+			decisions = []*domain.VariantDecision{
 				{VariantName: "v1", AcceleratorName: ""},
 				{VariantName: "v2", AcceleratorName: "unknown"},
 				{VariantName: "v3", AcceleratorName: "A100"},
@@ -380,7 +380,7 @@ var _ = Describe("DefaultLimiter", func() {
 			algorithm = &mockAlgorithm{name: "algo"}
 			limiter = NewDefaultLimiter("limiter", inventory, algorithm)
 
-			decisions = []*interfaces.VariantDecision{
+			decisions = []*domain.VariantDecision{
 				{VariantName: "v1", AcceleratorName: "unknown"},
 			}
 			limiter.resolveUnknownAccelerators(decisions)

--- a/internal/engines/pipeline/enforcer.go
+++ b/internal/engines/pipeline/enforcer.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
@@ -44,7 +44,7 @@ func (e *Enforcer) EnforcePolicyOnDecisions(
 	ctx context.Context,
 	modelID string,
 	namespace string,
-	decisions []interfaces.VariantDecision,
+	decisions []domain.VariantDecision,
 	scaleToZeroConfig config.ScaleToZeroConfigData,
 	optimizerName string,
 ) bool {
@@ -78,7 +78,7 @@ func (e *Enforcer) applyScaleToZeroOnDecisions(
 	ctx context.Context,
 	modelID string,
 	namespace string,
-	decisions []interfaces.VariantDecision,
+	decisions []domain.VariantDecision,
 	scaleToZeroConfig config.ScaleToZeroConfigData,
 	optimizerName string,
 ) bool {
@@ -129,7 +129,7 @@ func (e *Enforcer) ensureMinimumReplicasOnDecisions(
 	ctx context.Context,
 	modelID string,
 	namespace string,
-	decisions []interfaces.VariantDecision,
+	decisions []domain.VariantDecision,
 	optimizerName string,
 ) bool {
 	logger := ctrl.LoggerFrom(ctx)
@@ -181,22 +181,22 @@ func (e *Enforcer) ensureMinimumReplicasOnDecisions(
 // updateDecisionAction recomputes a decision's Action from TargetReplicas vs
 // CurrentReplicas after enforcement and refreshes its reason. SetDecisionReason
 // is the single place that writes d.Action.
-func updateDecisionAction(d *interfaces.VariantDecision, optimizerName, policyType string, metricsEmitter *metrics.MetricsEmitter) {
-	var action interfaces.SaturationAction
+func updateDecisionAction(d *domain.VariantDecision, optimizerName, policyType string, metricsEmitter *metrics.MetricsEmitter) {
+	var action domain.SaturationAction
 	switch {
 	case d.TargetReplicas > d.CurrentReplicas:
-		action = interfaces.ActionScaleUp
+		action = domain.ActionScaleUp
 	case d.TargetReplicas < d.CurrentReplicas:
-		action = interfaces.ActionScaleDown
+		action = domain.ActionScaleDown
 	default:
-		action = interfaces.ActionNoChange
+		action = domain.ActionNoChange
 	}
 	// Preserve the decision's original reason category (e.g. saturation-only on
 	// the V1 path) instead of hardcoding V2, so an enforced decision is not
 	// mis-attributed in the reason metric label. Fall back to V2 if it was unset.
 	category := d.ReasonCategory()
 	if category == "" {
-		category = interfaces.DecisionReasonV2
+		category = domain.DecisionReasonV2
 	}
 	d.SetDecisionReason(action, category, fmt.Sprintf("%s %s (optimizer: %s, enforced)", category, action, optimizerName))
 

--- a/internal/engines/pipeline/enforcer_test.go
+++ b/internal/engines/pipeline/enforcer_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/testutil"
 )
@@ -40,9 +40,9 @@ var _ = Describe("Enforcer", func() {
 					enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 						return 0, nil
 					})
-					decisions := []interfaces.VariantDecision{
-						{VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 2, Action: interfaces.ActionNoChange},
-						{VariantName: "variant-b", ModelID: "test-model", Namespace: "test-ns", Cost: 2.0, CurrentReplicas: 1, TargetReplicas: 3, Action: interfaces.ActionScaleUp},
+					decisions := []domain.VariantDecision{
+						{VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 2, Action: domain.ActionNoChange},
+						{VariantName: "variant-b", ModelID: "test-model", Namespace: "test-ns", Cost: 2.0, CurrentReplicas: 1, TargetReplicas: 3, Action: domain.ActionScaleUp},
 					}
 					scaleToZeroConfig := config.ScaleToZeroConfigData{
 						"test-model": {EnableScaleToZero: boolPtr(true), RetentionPeriod: "10m"},
@@ -52,9 +52,9 @@ var _ = Describe("Enforcer", func() {
 
 					Expect(applied).To(BeTrue())
 					Expect(decisions[0].TargetReplicas).To(Equal(0))
-					Expect(decisions[0].Action).To(Equal(interfaces.ActionScaleDown))
+					Expect(decisions[0].Action).To(Equal(domain.ActionScaleDown))
 					Expect(decisions[1].TargetReplicas).To(Equal(0))
-					Expect(decisions[1].Action).To(Equal(interfaces.ActionScaleDown))
+					Expect(decisions[1].Action).To(Equal(domain.ActionScaleDown))
 				})
 			})
 
@@ -63,11 +63,11 @@ var _ = Describe("Enforcer", func() {
 					enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 						return 10, nil
 					})
-					decision := interfaces.VariantDecision{
-						VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 3, Action: interfaces.ActionScaleUp,
+					decision := domain.VariantDecision{
+						VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 3, Action: domain.ActionScaleUp,
 					}
-					decision.SetDecisionReason(interfaces.ActionScaleUp, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
-					decisions := []interfaces.VariantDecision{decision}
+					decision.SetDecisionReason(domain.ActionScaleUp, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
+					decisions := []domain.VariantDecision{decision}
 					scaleToZeroConfig := config.ScaleToZeroConfigData{
 						"test-model": {EnableScaleToZero: boolPtr(true), RetentionPeriod: "10m"},
 					}
@@ -76,8 +76,8 @@ var _ = Describe("Enforcer", func() {
 
 					Expect(applied).To(BeFalse())
 					Expect(decisions[0].TargetReplicas).To(Equal(3))
-					Expect(decisions[0].Action).To(Equal(interfaces.ActionScaleUp))
-					Expect(decisions[0].Reason()).To(Equal(string(interfaces.DecisionReasonTest)))
+					Expect(decisions[0].Action).To(Equal(domain.ActionScaleUp))
+					Expect(decisions[0].Reason()).To(Equal(string(domain.DecisionReasonTest)))
 				})
 			})
 
@@ -90,7 +90,7 @@ var _ = Describe("Enforcer", func() {
 					enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 						return 0, errors.New("prometheus unavailable")
 					})
-					decisions := []interfaces.VariantDecision{
+					decisions := []domain.VariantDecision{
 						{VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 2},
 					}
 					scaleToZeroConfig := config.ScaleToZeroConfigData{
@@ -116,7 +116,7 @@ var _ = Describe("Enforcer", func() {
 					enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 						return 0, nil
 					})
-					decisions := []interfaces.VariantDecision{
+					decisions := []domain.VariantDecision{
 						{VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 2.0, CurrentReplicas: 0, TargetReplicas: 0},
 						{VariantName: "variant-b", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 0, TargetReplicas: 0},
 					}
@@ -128,7 +128,7 @@ var _ = Describe("Enforcer", func() {
 
 					Expect(decisions[0].TargetReplicas).To(Equal(0)) // expensive
 					Expect(decisions[1].TargetReplicas).To(Equal(1)) // cheapest gets 1
-					Expect(decisions[1].Action).To(Equal(interfaces.ActionScaleUp))
+					Expect(decisions[1].Action).To(Equal(domain.ActionScaleUp))
 				})
 			})
 
@@ -137,11 +137,11 @@ var _ = Describe("Enforcer", func() {
 					enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 						return 0, nil
 					})
-					decision1 := interfaces.VariantDecision{
-						VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 2.0, CurrentReplicas: 2, TargetReplicas: 2, Action: interfaces.ActionNoChange,
+					decision1 := domain.VariantDecision{
+						VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 2.0, CurrentReplicas: 2, TargetReplicas: 2, Action: domain.ActionNoChange,
 					}
-					decision1.SetDecisionReason(interfaces.ActionNoChange, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
-					decisions := []interfaces.VariantDecision{
+					decision1.SetDecisionReason(domain.ActionNoChange, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
+					decisions := []domain.VariantDecision{
 						decision1,
 						{VariantName: "variant-b", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 0, TargetReplicas: 0},
 					}
@@ -152,7 +152,7 @@ var _ = Describe("Enforcer", func() {
 					enforcer.EnforcePolicyOnDecisions(ctx, "test-model", "test-ns", decisions, scaleToZeroConfig, "cost-aware")
 
 					Expect(decisions[0].TargetReplicas).To(Equal(2))
-					Expect(decisions[0].Reason()).To(Equal(string(interfaces.DecisionReasonTest)))
+					Expect(decisions[0].Reason()).To(Equal(string(domain.DecisionReasonTest)))
 					Expect(decisions[1].TargetReplicas).To(Equal(0))
 				})
 			})
@@ -162,7 +162,7 @@ var _ = Describe("Enforcer", func() {
 					enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 						return 0, nil
 					})
-					decisions := []interfaces.VariantDecision{
+					decisions := []domain.VariantDecision{
 						{VariantName: "variant-z", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 0, TargetReplicas: 0},
 						{VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 0, TargetReplicas: 0},
 					}
@@ -184,19 +184,19 @@ var _ = Describe("Enforcer", func() {
 				enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 					return 0, nil
 				})
-				d1 := interfaces.VariantDecision{
-					VariantName: "v1", ModelID: "model-1", Namespace: "ns-1", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 3, Action: interfaces.ActionScaleUp,
+				d1 := domain.VariantDecision{
+					VariantName: "v1", ModelID: "model-1", Namespace: "ns-1", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 3, Action: domain.ActionScaleUp,
 				}
-				d1.SetDecisionReason(interfaces.ActionScaleUp, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
-				d2 := interfaces.VariantDecision{
-					VariantName: "v2", ModelID: "model-2", Namespace: "ns-1", Cost: 1.0, CurrentReplicas: 1, TargetReplicas: 2, Action: interfaces.ActionScaleUp,
+				d1.SetDecisionReason(domain.ActionScaleUp, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
+				d2 := domain.VariantDecision{
+					VariantName: "v2", ModelID: "model-2", Namespace: "ns-1", Cost: 1.0, CurrentReplicas: 1, TargetReplicas: 2, Action: domain.ActionScaleUp,
 				}
-				d2.SetDecisionReason(interfaces.ActionScaleUp, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
-				d3 := interfaces.VariantDecision{
-					VariantName: "v3", ModelID: "model-1", Namespace: "ns-2", Cost: 1.0, CurrentReplicas: 1, TargetReplicas: 1, Action: interfaces.ActionNoChange,
+				d2.SetDecisionReason(domain.ActionScaleUp, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
+				d3 := domain.VariantDecision{
+					VariantName: "v3", ModelID: "model-1", Namespace: "ns-2", Cost: 1.0, CurrentReplicas: 1, TargetReplicas: 1, Action: domain.ActionNoChange,
 				}
-				d3.SetDecisionReason(interfaces.ActionNoChange, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
-				decisions := []interfaces.VariantDecision{d1, d2, d3}
+				d3.SetDecisionReason(domain.ActionNoChange, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
+				decisions := []domain.VariantDecision{d1, d2, d3}
 				scaleToZeroConfig := config.ScaleToZeroConfigData{
 					"model-1": {EnableScaleToZero: boolPtr(true), RetentionPeriod: "10m"},
 				}
@@ -206,15 +206,15 @@ var _ = Describe("Enforcer", func() {
 				Expect(applied).To(BeTrue())
 				// model-1/ns-1 → scaled to zero
 				Expect(decisions[0].TargetReplicas).To(Equal(0))
-				Expect(decisions[0].Action).To(Equal(interfaces.ActionScaleDown))
+				Expect(decisions[0].Action).To(Equal(domain.ActionScaleDown))
 				// model-2/ns-1 → untouched
 				Expect(decisions[1].TargetReplicas).To(Equal(2))
-				Expect(decisions[1].Action).To(Equal(interfaces.ActionScaleUp))
-				Expect(decisions[1].Reason()).To(Equal(string(interfaces.DecisionReasonTest)))
+				Expect(decisions[1].Action).To(Equal(domain.ActionScaleUp))
+				Expect(decisions[1].Reason()).To(Equal(string(domain.DecisionReasonTest)))
 				// model-1/ns-2 → untouched (different namespace)
 				Expect(decisions[2].TargetReplicas).To(Equal(1))
-				Expect(decisions[2].Action).To(Equal(interfaces.ActionNoChange))
-				Expect(decisions[2].Reason()).To(Equal(string(interfaces.DecisionReasonTest)))
+				Expect(decisions[2].Action).To(Equal(domain.ActionNoChange))
+				Expect(decisions[2].Reason()).To(Equal(string(domain.DecisionReasonTest)))
 			})
 		})
 
@@ -224,7 +224,7 @@ var _ = Describe("Enforcer", func() {
 				enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 					return 0, nil
 				})
-				decisions := []interfaces.VariantDecision{
+				decisions := []domain.VariantDecision{
 					{VariantName: "v1", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 2},
 				}
 				scaleToZeroConfig := config.ScaleToZeroConfigData{
@@ -254,7 +254,7 @@ var _ = Describe("Enforcer", func() {
 				enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 					return 0, nil
 				})
-				decisions := []interfaces.VariantDecision{
+				decisions := []domain.VariantDecision{
 					{VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 2},
 				}
 				scaleToZeroConfig := config.ScaleToZeroConfigData{
@@ -292,7 +292,7 @@ var _ = Describe("Enforcer", func() {
 				enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 					return 0, nil
 				})
-				decisions := []interfaces.VariantDecision{
+				decisions := []domain.VariantDecision{
 					{VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 0, TargetReplicas: 0},
 				}
 				scaleToZeroConfig := config.ScaleToZeroConfigData{
@@ -328,7 +328,7 @@ var _ = Describe("Enforcer", func() {
 				enforcer = NewEnforcer(func(ctx context.Context, modelID, namespace string, retentionPeriod time.Duration) (float64, error) {
 					return 10, nil // Has requests
 				})
-				decisions := []interfaces.VariantDecision{
+				decisions := []domain.VariantDecision{
 					{VariantName: "variant-a", ModelID: "test-model", Namespace: "test-ns", Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 3},
 				}
 				scaleToZeroConfig := config.ScaleToZeroConfigData{

--- a/internal/engines/pipeline/greedy_saturation_algorithm.go
+++ b/internal/engines/pipeline/greedy_saturation_algorithm.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // GreedyBySaturation allocates resources to the most saturated variants first.
@@ -33,7 +33,7 @@ func (g *GreedyBySaturation) Name() string {
 // the most saturated variants (lowest spare capacity).
 func (g *GreedyBySaturation) Allocate(
 	ctx context.Context,
-	decisions []*interfaces.VariantDecision,
+	decisions []*domain.VariantDecision,
 	allocator ResourceAllocator,
 ) error {
 	// Filter and sort decisions that need scale-up
@@ -49,8 +49,8 @@ func (g *GreedyBySaturation) Allocate(
 }
 
 // filterScaleUpCandidates returns decisions that want to scale up.
-func (g *GreedyBySaturation) filterScaleUpCandidates(decisions []*interfaces.VariantDecision) []*interfaces.VariantDecision {
-	var candidates []*interfaces.VariantDecision
+func (g *GreedyBySaturation) filterScaleUpCandidates(decisions []*domain.VariantDecision) []*domain.VariantDecision {
+	var candidates []*domain.VariantDecision
 	for _, d := range decisions {
 		if d.TargetReplicas > d.CurrentReplicas {
 			candidates = append(candidates, d)
@@ -62,7 +62,7 @@ func (g *GreedyBySaturation) filterScaleUpCandidates(decisions []*interfaces.Var
 // sortByPriority sorts decisions by:
 //  1. SpareCapacity ascending (most saturated first)
 //  2. Cost ascending (cheaper variants as tie-breaker)
-func (g *GreedyBySaturation) sortByPriority(decisions []*interfaces.VariantDecision) {
+func (g *GreedyBySaturation) sortByPriority(decisions []*domain.VariantDecision) {
 	sort.Slice(decisions, func(i, j int) bool {
 		// Primary: lowest spare capacity first (most saturated)
 		if decisions[i].SpareCapacity != decisions[j].SpareCapacity {
@@ -76,7 +76,7 @@ func (g *GreedyBySaturation) sortByPriority(decisions []*interfaces.VariantDecis
 // allocateForDecision attempts to allocate GPUs for a single decision.
 // If partial allocation, adjusts TargetReplicas accordingly.
 // Respects MaxReplicas (caps scale-up) and MinReplicas (floor even under GPU scarcity).
-func (g *GreedyBySaturation) allocateForDecision(ctx context.Context, d *interfaces.VariantDecision, allocator ResourceAllocator) {
+func (g *GreedyBySaturation) allocateForDecision(ctx context.Context, d *domain.VariantDecision, allocator ResourceAllocator) {
 	replicasNeeded := d.TargetReplicas - d.CurrentReplicas
 	if replicasNeeded <= 0 {
 		return

--- a/internal/engines/pipeline/greedy_saturation_algorithm_test.go
+++ b/internal/engines/pipeline/greedy_saturation_algorithm_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // simpleAllocator implements ResourceAllocator with a single pool
@@ -14,7 +14,7 @@ type simpleAllocator struct {
 	remaining int
 }
 
-func (s *simpleAllocator) TryAllocate(_ context.Context, decision *interfaces.VariantDecision, gpusRequested int) (int, error) {
+func (s *simpleAllocator) TryAllocate(_ context.Context, decision *domain.VariantDecision, gpusRequested int) (int, error) {
 	if gpusRequested <= 0 {
 		return 0, nil
 	}
@@ -36,7 +36,7 @@ var _ = Describe("GreedyBySaturation", func() {
 		ctx       context.Context
 		algorithm *GreedyBySaturation
 		allocator *simpleAllocator
-		decisions []*interfaces.VariantDecision
+		decisions []*domain.VariantDecision
 	)
 
 	BeforeEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("GreedyBySaturation", func() {
 		Context("with single decision that needs scale-up", func() {
 			BeforeEach(func() {
 				allocator = &simpleAllocator{remaining: 10}
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1",
 						CurrentReplicas: 2,
@@ -78,7 +78,7 @@ var _ = Describe("GreedyBySaturation", func() {
 		Context("with multiple decisions prioritized by saturation", func() {
 			BeforeEach(func() {
 				allocator = &simpleAllocator{remaining: 6} // Only enough for 3 replicas at 2 GPUs each
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1-medium",
 						CurrentReplicas: 1,
@@ -115,7 +115,7 @@ var _ = Describe("GreedyBySaturation", func() {
 				// v3-idle (SpareCapacity=0.5) should get allocation third
 				// Only 6 GPUs available, so only first 3 replicas can be allocated
 
-				var v1, v2, v3 *interfaces.VariantDecision
+				var v1, v2, v3 *domain.VariantDecision
 				for _, d := range decisions {
 					switch d.VariantName {
 					case "v1-medium":
@@ -146,7 +146,7 @@ var _ = Describe("GreedyBySaturation", func() {
 		Context("when resources are exhausted", func() {
 			BeforeEach(func() {
 				allocator = &simpleAllocator{remaining: 3} // Not enough for a full replica
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1",
 						CurrentReplicas: 1,
@@ -171,7 +171,7 @@ var _ = Describe("GreedyBySaturation", func() {
 		Context("with decisions that don't need scale-up", func() {
 			BeforeEach(func() {
 				allocator = &simpleAllocator{remaining: 10}
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1-no-change",
 						CurrentReplicas: 2,
@@ -202,7 +202,7 @@ var _ = Describe("GreedyBySaturation", func() {
 		Context("with equal saturation (tie-breaker by cost)", func() {
 			BeforeEach(func() {
 				allocator = &simpleAllocator{remaining: 4} // Only enough for 2 replicas
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1-expensive",
 						CurrentReplicas: 1,
@@ -226,7 +226,7 @@ var _ = Describe("GreedyBySaturation", func() {
 				err := algorithm.Allocate(ctx, decisions, allocator)
 				Expect(err).NotTo(HaveOccurred())
 
-				var expensive, cheap *interfaces.VariantDecision
+				var expensive, cheap *domain.VariantDecision
 				for _, d := range decisions {
 					if d.VariantName == "v1-expensive" {
 						expensive = d
@@ -248,7 +248,7 @@ var _ = Describe("GreedyBySaturation", func() {
 		Context("with zero GPUs per replica", func() {
 			BeforeEach(func() {
 				allocator = &simpleAllocator{remaining: 10}
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1",
 						CurrentReplicas: 1,
@@ -272,7 +272,7 @@ var _ = Describe("GreedyBySaturation", func() {
 		Context("with empty decisions", func() {
 			It("should return without error", func() {
 				allocator = &simpleAllocator{remaining: 10}
-				err := algorithm.Allocate(ctx, []*interfaces.VariantDecision{}, allocator)
+				err := algorithm.Allocate(ctx, []*domain.VariantDecision{}, allocator)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -281,7 +281,7 @@ var _ = Describe("GreedyBySaturation", func() {
 			It("should cap scale-up at maxReplicas even when GPUs are available", func() {
 				maxReplicas := 3
 				allocator = &simpleAllocator{remaining: 100}
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1",
 						CurrentReplicas: 1,
@@ -304,7 +304,7 @@ var _ = Describe("GreedyBySaturation", func() {
 			It("should enforce minReplicas floor even under GPU scarcity", func() {
 				minReplicas := 3
 				allocator = &simpleAllocator{remaining: 0} // no GPUs
-				decisions = []*interfaces.VariantDecision{
+				decisions = []*domain.VariantDecision{
 					{
 						VariantName:     "v1",
 						CurrentReplicas: 1,

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -8,7 +8,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
@@ -37,12 +37,12 @@ func (o *GreedyByScoreOptimizer) Name() string {
 // modelWork tracks per-model allocation state during fair-share iteration.
 type modelWork struct {
 	req       ModelScalingRequest
-	s         []NamedAnalyzerResult      // working slice; Remaining/Spare decremented in place
-	satEntry  *interfaces.AnalyzerResult // variant metadata keeper (Cost, AcceleratorName, Role)
-	ps        RolePairedState            // picker-local per-role demand (from initRoleState)
-	roles     []string                   // active roles for this model
-	remaining float64                    // fair-share priority metric (negative = fully satisfied)
-	targets   map[string]int             // variant name → target replicas (ALL variants)
+	s         []NamedAnalyzerResult  // working slice; Remaining/Spare decremented in place
+	satEntry  *domain.AnalyzerResult // variant metadata keeper (Cost, AcceleratorName, Role)
+	ps        RolePairedState        // picker-local per-role demand (from initRoleState)
+	roles     []string               // active roles for this model
+	remaining float64                // fair-share priority metric (negative = fully satisfied)
+	targets   map[string]int         // variant name → target replicas (ALL variants)
 }
 
 // fairShareValue computes the fair-share priority metric for one model.
@@ -93,7 +93,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 	ctx context.Context,
 	requests []ModelScalingRequest,
 	constraints []*ResourceConstraints,
-) []interfaces.VariantDecision {
+) []domain.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx).WithName(o.Name())
 	available := mergeConstraints(constraints)
 	availableByNS := mergeNamespaceConstraints(constraints)
@@ -122,7 +122,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 
 	o.fairShareScaleUp(ctx, scaleUpWork, available, availableByNS)
 
-	allDecisions := make([]interfaces.VariantDecision, 0, len(scaleUpWork))
+	allDecisions := make([]domain.VariantDecision, 0, len(scaleUpWork))
 
 	for _, w := range scaleUpWork {
 		stateMap := buildStateMap(w.req.VariantStates)
@@ -160,7 +160,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 }
 
 // buildScaleUpWork creates a single work unit for a scale-up request.
-func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest, satEntry *interfaces.AnalyzerResult, s []NamedAnalyzerResult, ps RolePairedState, roles []string, fsv float64) *modelWork {
+func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest, satEntry *domain.AnalyzerResult, s []NamedAnalyzerResult, ps RolePairedState, roles []string, fsv float64) *modelWork {
 	if fsv <= 0 {
 		return nil
 	}
@@ -320,7 +320,7 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	// For "both" (non-disag): use fresh ps so applyAllocation-decremented
 	// s[i].Remaining is read (budget-capped ps is already 0).
 	// For P/D: use local capped ps which correctly reaches 0 when both roles served.
-	if len(w.roles) == 1 && w.roles[0] == interfaces.RoleBoth {
+	if len(w.roles) == 1 && w.roles[0] == domain.RoleBoth {
 		_, freshPs := initRoleState(w.s)
 		w.remaining = fairShareValue(w.req.Priority, w.s, freshPs, w.roles)
 	} else {
@@ -378,8 +378,8 @@ func fairShareRolePick(target float64, s []NamedAnalyzerResult, roles []string) 
 	return func(
 		role string,
 		_ []NamedAnalyzerResult,
-		variants []interfaces.VariantCapacity,
-		stateMap map[string]interfaces.VariantReplicaState,
+		variants []domain.VariantCapacity,
+		stateMap map[string]domain.VariantReplicaState,
 		available map[string]int,
 		targets map[string]int,
 	) (string, int) {
@@ -445,7 +445,7 @@ func sortByRemainingDesc(active []*modelWork) {
 }
 
 // prcFromVCs returns the PerReplicaCapacity for variant v from a slice of VCs.
-func prcFromVCs(vcs []interfaces.VariantCapacity, v string) float64 {
+func prcFromVCs(vcs []domain.VariantCapacity, v string) float64 {
 	for _, vc := range vcs {
 		if vc.VariantName == v {
 			return vc.PerReplicaCapacity
@@ -455,7 +455,7 @@ func prcFromVCs(vcs []interfaces.VariantCapacity, v string) float64 {
 }
 
 // accFromVCs returns the AcceleratorName for variant v from a slice of VCs.
-func accFromVCs(vcs []interfaces.VariantCapacity, v string) string {
+func accFromVCs(vcs []domain.VariantCapacity, v string) string {
 	for _, vc := range vcs {
 		if vc.VariantName == v {
 			return vc.AcceleratorName
@@ -465,7 +465,7 @@ func accFromVCs(vcs []interfaces.VariantCapacity, v string) string {
 }
 
 // gpusPerReplicaFromState returns GPUsPerReplica for variant v, defaulting to 1.
-func gpusPerReplicaFromState(stateMap map[string]interfaces.VariantReplicaState, v string) int {
+func gpusPerReplicaFromState(stateMap map[string]domain.VariantReplicaState, v string) int {
 	if state, ok := stateMap[v]; ok && state.GPUsPerReplica > 0 {
 		return state.GPUsPerReplica
 	}

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 var _ = Describe("GreedyByScoreOptimizer", func() {
@@ -30,12 +30,12 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Single-Model Scale-Up", func() {
 
 		It("should allocate replicas to cheapest variant within GPU budget", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				AnalyzedAt:       time.Now(),
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
@@ -44,7 +44,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 1, GPUsPerReplica: 2},
 						{VariantName: "expensive", CurrentReplicas: 1, GPUsPerReplica: 4},
 					},
@@ -63,7 +63,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// cheap is most cost-efficient (5/10000 vs 15/20000)
 			// ceil(20000/10000) = 2 replicas, needs 4 A100 GPUs (2 per replica)
 			Expect(dm["cheap"].TargetReplicas).To(Equal(3)) // 1 + 2
-			Expect(dm["cheap"].Action).To(Equal(interfaces.ActionScaleUp))
+			Expect(dm["cheap"].Action).To(Equal(domain.ActionScaleUp))
 			Expect(dm["expensive"].TargetReplicas).To(Equal(1)) // unchanged
 		})
 
@@ -71,13 +71,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// Regression guard for the greedy-by-score path, which shares
 			// buildDecisionsWithOptimizer with cost-aware. Without the copy the V2 gauges
 			// (wva_saturation_utilization / wva_required_capacity / wva_spare_capacity) read 0.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				AnalyzedAt:       time.Now(),
 				RequiredCapacity: 5000,
 				SpareCapacity:    1200,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.42},
 				},
 			}
@@ -85,7 +85,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -101,9 +101,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle GPU exhaustion with partial allocation", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -111,7 +111,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -127,22 +127,22 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 			// Only 4 GPUs / 2 per replica = 2 replicas max
 			Expect(dm["v1"].TargetReplicas).To(Equal(3)) // 1 + 2
-			Expect(dm["v1"].Action).To(Equal(interfaces.ActionScaleUp))
+			Expect(dm["v1"].Action).To(Equal(domain.ActionScaleUp))
 		})
 	})
 
 	Context("Multi-Model Fair-Share", func() {
 
 		It("should give GPUs to most starved model first", func() {
-			rA := &interfaces.AnalyzerResult{
+			rA := &domain.AnalyzerResult{
 				RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
 				},
 			}
-			rB := &interfaces.AnalyzerResult{
+			rB := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
 				},
 			}
@@ -150,14 +150,14 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(rA, ModelScalingRequest{
 					ModelID:   "model-A",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
 				withSatEntry(rB, ModelScalingRequest{
 					ModelID:   "model-B",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -177,21 +177,21 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should verify 3-model walkthrough from design doc", func() {
-			rA := &interfaces.AnalyzerResult{
+			rA := &domain.AnalyzerResult{
 				RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
 				},
 			}
-			rB := &interfaces.AnalyzerResult{
+			rB := &domain.AnalyzerResult{
 				RequiredCapacity: 30000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
 				},
 			}
-			rC := &interfaces.AnalyzerResult{
+			rC := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "c-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
 				},
 			}
@@ -199,21 +199,21 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(rA, ModelScalingRequest{
 					ModelID:   "model-A",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
 				withSatEntry(rB, ModelScalingRequest{
 					ModelID:   "model-B",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
 				withSatEntry(rC, ModelScalingRequest{
 					ModelID:   "model-C",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "c-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -233,15 +233,15 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should distribute evenly with equal RequiredCapacity", func() {
-			rX := &interfaces.AnalyzerResult{
+			rX := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "x-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rY := &interfaces.AnalyzerResult{
+			rY := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "y-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -249,14 +249,14 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(rX, ModelScalingRequest{
 					ModelID:   "model-X",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "x-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
 				withSatEntry(rY, ModelScalingRequest{
 					ModelID:   "model-Y",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "y-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -278,15 +278,15 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("GPU Constraints", func() {
 
 		It("should respect per-accelerator-type limits", func() {
-			rH := &interfaces.AnalyzerResult{
+			rH := &domain.AnalyzerResult{
 				RequiredCapacity: 30000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "h100-v", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
 			}
-			rA := &interfaces.AnalyzerResult{
+			rA := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "a100-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -294,14 +294,14 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(rH, ModelScalingRequest{
 					ModelID:   "model-h100",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "h100-v", CurrentReplicas: 1, GPUsPerReplica: 4},
 					},
 				}),
 				withSatEntry(rA, ModelScalingRequest{
 					ModelID:   "model-a100",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "a100-v", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -321,9 +321,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle mixed accelerator types across variants", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 30000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "a100-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "h100-v", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
@@ -332,7 +332,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-mixed",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "a100-v", CurrentReplicas: 1, GPUsPerReplica: 2},
 						{VariantName: "h100-v", CurrentReplicas: 1, GPUsPerReplica: 4},
 					},
@@ -353,9 +353,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should not allocate when zero GPU budget", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -363,7 +363,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -381,9 +381,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should not allocate when nil constraints", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -391,7 +391,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -411,12 +411,12 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// so fairShareRolePick read a 0 budget and denied every scale-up —
 			// inverting -1 = unlimited into a hard deny.
 			newReq := func() []ModelScalingRequest {
-				r := &interfaces.AnalyzerResult{
+				r := &domain.AnalyzerResult{
 					ModelID:          "model-1",
 					Namespace:        "default",
 					AnalyzedAt:       time.Now(),
 					RequiredCapacity: 40000,
-					VariantCapacities: []interfaces.VariantCapacity{
+					VariantCapacities: []domain.VariantCapacity{
 						{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					},
 				}
@@ -424,7 +424,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					withSatEntry(r, ModelScalingRequest{
 						ModelID:   "model-1",
 						Namespace: "default",
-						VariantStates: []interfaces.VariantReplicaState{
+						VariantStates: []domain.VariantReplicaState{
 							{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 						},
 					}),
@@ -438,7 +438,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			abundant := decisionMap(optimizer.Optimize(ctx, newReq(),
 				[]*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 1000}}}}))
 
-			Expect(unlimited["v1"].Action).To(Equal(interfaces.ActionScaleUp), "unlimited cluster quota must not deny scale-up")
+			Expect(unlimited["v1"].Action).To(Equal(domain.ActionScaleUp), "unlimited cluster quota must not deny scale-up")
 			Expect(unlimited["v1"].TargetReplicas).To(BeNumerically(">", 1))
 			Expect(unlimited["v1"].TargetReplicas).To(Equal(abundant["v1"].TargetReplicas),
 				"unlimited behaves like abundant finite capacity")
@@ -450,16 +450,16 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// must stay recognized as unbounded, so the totalGPUs sum cannot wrap
 			// to 0 and starve a model on an unrelated finite type.
 			mk := func(id, variant, accel string) ModelScalingRequest {
-				r := &interfaces.AnalyzerResult{
+				r := &domain.AnalyzerResult{
 					ModelID: id, Namespace: "default", AnalyzedAt: time.Now(),
 					RequiredCapacity: 25000,
-					VariantCapacities: []interfaces.VariantCapacity{
+					VariantCapacities: []domain.VariantCapacity{
 						{VariantName: variant, AcceleratorName: accel, Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					},
 				}
 				return withSatEntry(r, ModelScalingRequest{
 					ModelID: id, Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: variant, CurrentReplicas: 1, GPUsPerReplica: 1},
 					},
 				})
@@ -486,9 +486,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Scale-Down", func() {
 
 		It("should apply role-iterated scale-down for scale-down models", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				SpareCapacity: 15000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
 				},
@@ -497,7 +497,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 3},
 						{VariantName: "expensive", CurrentReplicas: 2},
 					},
@@ -512,15 +512,15 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle mixed scale-up and scale-down models", func() {
-			rUp := &interfaces.AnalyzerResult{
+			rUp := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "up-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rDown := &interfaces.AnalyzerResult{
+			rDown := &domain.AnalyzerResult{
 				SpareCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "down-v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 				},
 			}
@@ -528,14 +528,14 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(rUp, ModelScalingRequest{
 					ModelID:   "model-up",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "up-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
 				withSatEntry(rDown, ModelScalingRequest{
 					ModelID:   "model-down",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "down-v1", CurrentReplicas: 2},
 					},
 				}),
@@ -550,19 +550,19 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			dm := decisionMap(decisions)
 
 			Expect(dm["up-v1"].TargetReplicas).To(Equal(2))
-			Expect(dm["up-v1"].Action).To(Equal(interfaces.ActionScaleUp))
+			Expect(dm["up-v1"].Action).To(Equal(domain.ActionScaleUp))
 
 			Expect(dm["down-v1"].TargetReplicas).To(Equal(1))
-			Expect(dm["down-v1"].Action).To(Equal(interfaces.ActionScaleDown))
+			Expect(dm["down-v1"].Action).To(Equal(domain.ActionScaleDown))
 		})
 	})
 
 	Context("Pending Replicas", func() {
 
 		It("should allocate to most cost-efficient variant regardless of pending replicas", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap-pending", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 					{VariantName: "expensive-ready", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
@@ -571,7 +571,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap-pending", CurrentReplicas: 2, PendingReplicas: 1, GPUsPerReplica: 2},
 						{VariantName: "expensive-ready", CurrentReplicas: 1, PendingReplicas: 0, GPUsPerReplica: 2},
 					},
@@ -603,9 +603,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should skip variants with zero capacity", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "zero-cap", AcceleratorName: "A100", Cost: 1.0, ReplicaCount: 0, PerReplicaCapacity: 0},
 					{VariantName: "normal", AcceleratorName: "A100", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
@@ -614,7 +614,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "zero-cap", CurrentReplicas: 0, GPUsPerReplica: 2},
 						{VariantName: "normal", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
@@ -634,10 +634,10 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle steady state (no scaling needed)", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 0,
 				SpareCapacity:    0,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 				},
 			}
@@ -645,7 +645,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2},
 					},
 				}),
@@ -654,7 +654,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			decisions := optimizer.Optimize(ctx, requests, nil)
 
 			Expect(decisions).To(HaveLen(1))
-			Expect(decisions[0].Action).To(Equal(interfaces.ActionNoChange))
+			Expect(decisions[0].Action).To(Equal(domain.ActionNoChange))
 			Expect(decisions[0].TargetReplicas).To(Equal(2))
 		})
 
@@ -664,9 +664,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should default GPUsPerReplica to 1 when not specified", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -674,7 +674,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 0},
 					},
 				}),
@@ -695,9 +695,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Decision Metadata", func() {
 
 		It("should set correct model ID, namespace, and cost on decisions", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -705,7 +705,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "ns-1",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -726,9 +726,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should contain greedy-by-score in reason strings", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -736,7 +736,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -757,15 +757,15 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Score-Based Priority", func() {
 
 		It("should give GPUs to higher-score model first", func() {
-			rLow := &interfaces.AnalyzerResult{
+			rLow := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "low-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rHigh := &interfaces.AnalyzerResult{
+			rHigh := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "high-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -774,7 +774,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					ModelID:   "low-priority",
 					Namespace: "default",
 					Priority:  1.0,
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "low-v", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -782,7 +782,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					ModelID:   "high-priority",
 					Namespace: "default",
 					Priority:  5.0,
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "high-v", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -814,15 +814,15 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// B (fsv=100000) should always get served first.
 			// Strict assertions require Score to be populated; Score=0 fallback
 			// produces equal fsv and non-deterministic ordering.
-			rA := &interfaces.AnalyzerResult{
+			rA := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rB := &interfaces.AnalyzerResult{
+			rB := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -832,13 +832,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					Namespace: "default",
 					Priority:  1.0,
 					AnalyzerResults: []NamedAnalyzerResult{{
-						Name:      interfaces.SaturationAnalyzerName,
+						Name:      domain.SaturationAnalyzerName,
 						Result:    rA,
 						Score:     1.0, // explicit: mirrors engine-populated value
 						Remaining: rA.RequiredCapacity,
 						Spare:     rA.SpareCapacity,
 					}},
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				},
@@ -847,13 +847,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					Namespace: "default",
 					Priority:  5.0,
 					AnalyzerResults: []NamedAnalyzerResult{{
-						Name:      interfaces.SaturationAnalyzerName,
+						Name:      domain.SaturationAnalyzerName,
 						Result:    rB,
 						Score:     1.0, // explicit: mirrors engine-populated value
 						Remaining: rB.RequiredCapacity,
 						Spare:     rB.SpareCapacity,
 					}},
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				},
@@ -884,15 +884,15 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			//   fsv(B) = 1.0 × (20000×1.0) = 20000
 			// With 4 A100 GPUs (2 GPUs/replica): A (higher fsv) gets both
 			// available replicas; B gets none.
-			rA := &interfaces.AnalyzerResult{
+			rA := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rB := &interfaces.AnalyzerResult{
+			rB := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -913,11 +913,11 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 							Score: 2.0,
 							// throughput shares rA's variant capacity for simplicity;
 							// its RC signal adds to the fair-share weight.
-							Result:    &interfaces.AnalyzerResult{RequiredCapacity: 20000},
+							Result:    &domain.AnalyzerResult{RequiredCapacity: 20000},
 							Remaining: 20000,
 						},
 					},
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				},
@@ -931,7 +931,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						Score:     1.0,
 						Remaining: rB.RequiredCapacity,
 					}},
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				},
@@ -957,13 +957,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// Prefill RequiredCapacity=15000 (75%), Decode RequiredCapacity=5000 (25%)
 			// Total model RequiredCapacity=20000, Score=20000
 			// With 10 A100 GPUs available, each variant uses 2 GPUs/replica
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {Role: "prefill", RequiredCapacity: 15000, TotalDemand: 15000},
 					"decode":  {Role: "decode", RequiredCapacity: 5000, TotalDemand: 5000},
 				},
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 3, PerReplicaCapacity: 10000},
 				},
@@ -974,7 +974,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					Namespace:     "default",
 					Disaggregated: true,
 					Priority:      1.0,
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "prefill"},
 						{VariantName: "decode-v", CurrentReplicas: 3, GPUsPerReplica: 2, Role: "decode"},
 					},
@@ -997,13 +997,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should distribute equally when roles have equal demand", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {Role: "prefill", RequiredCapacity: 10000, TotalDemand: 10000},
 					"decode":  {Role: "decode", RequiredCapacity: 10000, TotalDemand: 10000},
 				},
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
@@ -1014,7 +1014,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					Namespace:     "default",
 					Disaggregated: true,
 					Priority:      1.0,
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "prefill"},
 						{VariantName: "decode-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "decode"},
 					},
@@ -1036,13 +1036,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 		It("should only allocate to the role that needs scale-up", func() {
 			// Only prefill needs scale-up; decode has 0 RequiredCapacity
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {Role: "prefill", RequiredCapacity: 10000, TotalDemand: 10000},
 					"decode":  {Role: "decode", RequiredCapacity: 0, TotalDemand: 0},
 				},
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 3, PerReplicaCapacity: 10000},
 				},
@@ -1053,7 +1053,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					Namespace:     "default",
 					Disaggregated: true,
 					Priority:      1.0,
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "prefill"},
 						{VariantName: "decode-v", CurrentReplicas: 3, GPUsPerReplica: 2, Role: "decode"},
 					},
@@ -1076,13 +1076,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 		It("should handle GPU exhaustion for one role without affecting the other", func() {
 			// Prefill uses H100s (exhausted), decode uses A100s (available)
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 20000,
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {Role: "prefill", RequiredCapacity: 10000, TotalDemand: 10000},
 					"decode":  {Role: "decode", RequiredCapacity: 10000, TotalDemand: 10000},
 				},
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "prefill-v", AcceleratorName: "H100", Cost: 15.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 20000},
 					{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
@@ -1093,7 +1093,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					Namespace:     "default",
 					Disaggregated: true,
 					Priority:      1.0,
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 4, Role: "prefill"},
 						{VariantName: "decode-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "decode"},
 					},
@@ -1116,9 +1116,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle non-disaggregated model with Score", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -1127,7 +1127,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					ModelID:   "model-1",
 					Namespace: "default",
 					Priority:  2.0,
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -1185,12 +1185,12 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				{Pools: map[string]ResourcePool{"A100": {Limit: 20}}},
 			}
 
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				AnalyzedAt:       time.Now(),
 				RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "expensive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
@@ -1199,7 +1199,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 1, GPUsPerReplica: 1, MaxReplicas: intPtr(3)},
 						{VariantName: "expensive", CurrentReplicas: 1, GPUsPerReplica: 1},
 					},
@@ -1217,12 +1217,12 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		It("scale-down should respect minReplicas via scaleDownRoleIterated", func() {
 			intPtr := func(n int) *int { return &n }
 
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:       "model-1",
 				Namespace:     "default",
 				AnalyzedAt:    time.Now(),
 				SpareCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "expensive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 3, PerReplicaCapacity: 20000},
 					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 				},
@@ -1231,7 +1231,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 3, GPUsPerReplica: 1, MinReplicas: intPtr(2)},
 						{VariantName: "cheap", CurrentReplicas: 3, GPUsPerReplica: 1},
 					},
@@ -1248,12 +1248,12 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		It("scale-down should zero minReplicas=0 variant while keeping minReplicas>0 sibling", func() {
 			intPtr := func(n int) *int { return &n }
 
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:       "model-1",
 				Namespace:     "default",
 				AnalyzedAt:    time.Now(),
 				SpareCapacity: 80000, // enough to remove all
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "keep-alive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
 					{VariantName: "expendable", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 				},
@@ -1262,7 +1262,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "keep-alive", CurrentReplicas: 2, GPUsPerReplica: 1, MinReplicas: intPtr(1)},
 						{VariantName: "expendable", CurrentReplicas: 3, GPUsPerReplica: 1, MinReplicas: intPtr(0)},
 					},
@@ -1298,13 +1298,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		It("should scale up only decode when RC_P=0 and RC_D>0", func() {
 			// Pre-Phase-3 the model-level gate (Remaining=0 from P-anchor) would
 			// route the model to scale-down. anyRoleNeedsScaleUp fires on D demand.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 0,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "pf", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
 					{VariantName: "dc", AcceleratorName: "A100", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {RequiredCapacity: 0, TotalDemand: 0},
 					"decode":  {RequiredCapacity: 10000, TotalDemand: 10000},
 				},
@@ -1316,13 +1316,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					Disaggregated: true,
 					Priority:      1.0,
 					AnalyzerResults: []NamedAnalyzerResult{{
-						Name:      interfaces.SaturationAnalyzerName,
+						Name:      domain.SaturationAnalyzerName,
 						Result:    r,
 						Score:     1.0,
 						Remaining: r.RequiredCapacity,
 						Spare:     r.SpareCapacity,
 					}},
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "pf", CurrentReplicas: 2, GPUsPerReplica: 2},
 						{VariantName: "dc", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
@@ -1348,13 +1348,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// n_P=1 (ceil(10000/10000)), n_D=3 (ceil(30000/10000)).
 			// util_P=1.0, util_D=3.0 → Δ_util=1.0 → k_P=1, k_D=3.
 			// Result: prefill+1, decode+3 — same Δ_util=1.0 for both.
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				RequiredCapacity: 10000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "pf", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
 					{VariantName: "dc", AcceleratorName: "A100", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
 				},
-				RoleCapacities: map[string]interfaces.RoleCapacity{
+				RoleCapacities: map[string]domain.RoleCapacity{
 					"prefill": {RequiredCapacity: 10000, TotalDemand: 10000},
 					"decode":  {RequiredCapacity: 30000, TotalDemand: 30000},
 				},
@@ -1366,13 +1366,13 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					Disaggregated: true,
 					Priority:      1.0,
 					AnalyzerResults: []NamedAnalyzerResult{{
-						Name:      interfaces.SaturationAnalyzerName,
+						Name:      domain.SaturationAnalyzerName,
 						Result:    r,
 						Score:     1.0,
 						Remaining: r.RequiredCapacity,
 						Spare:     r.SpareCapacity,
 					}},
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "pf", CurrentReplicas: 1, GPUsPerReplica: 2},
 						{VariantName: "dc", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
@@ -1394,11 +1394,11 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Namespace-Scoped Quota", func() {
 
 		It("caps a model at its namespace budget even when cluster GPUs remain", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "m",
 				Namespace:        "team-a",
 				RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
@@ -1406,7 +1406,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "m",
 					Namespace: "team-a",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				}),
@@ -1429,26 +1429,26 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("enforces independent per-namespace budgets across models", func() {
-			rA := &interfaces.AnalyzerResult{
+			rA := &domain.AnalyzerResult{
 				ModelID: "mA", Namespace: "team-a", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "a", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rB := &interfaces.AnalyzerResult{
+			rB := &domain.AnalyzerResult{
 				ModelID: "mB", Namespace: "team-b", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "b", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			requests := []ModelScalingRequest{
 				withSatEntry(rA, ModelScalingRequest{
 					ModelID: "mA", Namespace: "team-a",
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "a", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "a", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 				withSatEntry(rB, ModelScalingRequest{
 					ModelID: "mB", Namespace: "team-b",
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "b", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "b", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 			}
 			// Cluster is unconstrained relative to the quotas; team-a is capped
@@ -1472,26 +1472,26 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("shares one namespace budget across same-namespace models, higher priority first", func() {
-			rHi := &interfaces.AnalyzerResult{
+			rHi := &domain.AnalyzerResult{
 				ModelID: "hi", Namespace: "team-a", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "hi-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rLo := &interfaces.AnalyzerResult{
+			rLo := &domain.AnalyzerResult{
 				ModelID: "lo", Namespace: "team-a", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "lo-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			requests := []ModelScalingRequest{
 				withSatEntry(rHi, ModelScalingRequest{
 					ModelID: "hi", Namespace: "team-a", Priority: 10,
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "hi-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "hi-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 				withSatEntry(rLo, ModelScalingRequest{
 					ModelID: "lo", Namespace: "team-a", Priority: 1,
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "lo-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "lo-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 			}
 			// Both models are in team-a, which has 4 free GPUs (cap 6 − 2 used) =
@@ -1520,26 +1520,26 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// 2-GPU replica. With a 100x priority gap, the winner is deterministic:
 			// hi takes the single replica, lo gets nothing. A weaker >= assertion
 			// would not catch a priority inversion here.
-			rHi := &interfaces.AnalyzerResult{
+			rHi := &domain.AnalyzerResult{
 				ModelID: "hi", Namespace: "team-a", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "hi-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rLo := &interfaces.AnalyzerResult{
+			rLo := &domain.AnalyzerResult{
 				ModelID: "lo", Namespace: "team-a", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "lo-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			requests := []ModelScalingRequest{
 				withSatEntry(rHi, ModelScalingRequest{
 					ModelID: "hi", Namespace: "team-a", Priority: 100,
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "hi-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "hi-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 				withSatEntry(rLo, ModelScalingRequest{
 					ModelID: "lo", Namespace: "team-a", Priority: 1,
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "lo-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "lo-v", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 			}
 			constraints := []*ResourceConstraints{
@@ -1564,26 +1564,26 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// not in team-a's allowlist) — it must NOT draw on team-b's A100
 			// quota via the cluster aggregate. This is the cross-namespace
 			// isolation breach the closed-allowlist model closes.
-			rA := &interfaces.AnalyzerResult{
+			rA := &domain.AnalyzerResult{
 				ModelID: "mA", Namespace: "team-a", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "a", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
-			rB := &interfaces.AnalyzerResult{
+			rB := &domain.AnalyzerResult{
 				ModelID: "mB", Namespace: "team-b", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "b", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			requests := []ModelScalingRequest{
 				withSatEntry(rA, ModelScalingRequest{
 					ModelID: "mA", Namespace: "team-a",
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "a", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "a", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 				withSatEntry(rB, ModelScalingRequest{
 					ModelID: "mB", Namespace: "team-b",
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "b", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "b", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 			}
 			constraints := []*ResourceConstraints{
@@ -1604,16 +1604,16 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("denies all scale-up for a closed namespace with no listed types (deny-all)", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID: "m", Namespace: "team-x", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			requests := []ModelScalingRequest{
 				withSatEntry(r, ModelScalingRequest{
 					ModelID: "m", Namespace: "team-x",
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 			}
 			// team-x is present (closed) but lists no types — a real deny-all.
@@ -1631,16 +1631,16 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("honors an unlimited (-1) per-namespace cap, bounding only by the cluster budget", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID: "m", Namespace: "team-a", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			requests := []ModelScalingRequest{
 				withSatEntry(r, ModelScalingRequest{
 					ModelID: "m", Namespace: "team-a",
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 			}
 			// team-a holds an unlimited A100 cap (sentinel Limit == -1) from a
@@ -1665,16 +1665,16 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("does not scale a purely-unlimited namespace config with no finite cluster cap (documented V2 limitation)", func() {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID: "m", Namespace: "team-a", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			requests := []ModelScalingRequest{
 				withSatEntry(r, ModelScalingRequest{
 					ModelID: "m", Namespace: "team-a",
-					VariantStates: []interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+					VariantStates: []domain.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
 				}),
 			}
 			// All-unlimited ns config: aggregateNamespacePools yields an empty

--- a/internal/engines/pipeline/limiter_interfaces.go
+++ b/internal/engines/pipeline/limiter_interfaces.go
@@ -50,7 +50,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // Limiter constrains scaling decisions based on resource availability.
@@ -76,7 +76,7 @@ type Limiter interface {
 	// Limit applies resource constraints to scaling decisions.
 	// Modifies decisions in place - may reduce TargetReplicas based on available resources.
 	// Sets GPUsAllocated, WasLimited, LimitedBy fields and appends to DecisionSteps.
-	Limit(ctx context.Context, decisions []*interfaces.VariantDecision) error
+	Limit(ctx context.Context, decisions []*domain.VariantDecision) error
 }
 
 // AllocationAlgorithm defines how to distribute limited resources across decisions.
@@ -112,7 +112,7 @@ type AllocationAlgorithm interface {
 	//   - GPUsAllocated: number of GPUs actually allocated
 	Allocate(
 		ctx context.Context,
-		decisions []*interfaces.VariantDecision,
+		decisions []*domain.VariantDecision,
 		allocator ResourceAllocator,
 	) error
 }
@@ -134,7 +134,7 @@ type ResourceAllocator interface {
 	// ScaleTargetRef) that some allocators need for type-aware or node-aware allocation.
 	// ctx carries the request-scoped logger so per-cycle traces emitted from the
 	// allocator are correlated with the rest of the engine cycle's structured logs.
-	TryAllocate(ctx context.Context, decision *interfaces.VariantDecision, gpusRequested int) (gpusAllocated int, err error)
+	TryAllocate(ctx context.Context, decision *domain.VariantDecision, gpusRequested int) (gpusAllocated int, err error)
 
 	// Remaining returns total remaining allocatable GPUs across all resources.
 	Remaining() int

--- a/internal/engines/pipeline/noop_limiter.go
+++ b/internal/engines/pipeline/noop_limiter.go
@@ -3,7 +3,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // NoOpLimiter is a Limiter whose Limit method returns nil without
@@ -25,7 +25,7 @@ func NewNoOpLimiter(name string) *NoOpLimiter {
 func (l *NoOpLimiter) Name() string { return l.name }
 
 // Limit is a no-op; decisions are returned unchanged.
-func (l *NoOpLimiter) Limit(_ context.Context, _ []*interfaces.VariantDecision) error {
+func (l *NoOpLimiter) Limit(_ context.Context, _ []*domain.VariantDecision) error {
 	return nil
 }
 

--- a/internal/engines/pipeline/optimizer_equivalence_test.go
+++ b/internal/engines/pipeline/optimizer_equivalence_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // These tests answer: does the fair-share optimizer (GreedyByScore) produce the
@@ -41,7 +41,7 @@ var _ = Describe("GreedyByScore vs CostAware when GPUs are unconstrained", func(
 		return []*ResourceConstraints{{Pools: pools}}
 	}
 
-	targets := func(decisions []interfaces.VariantDecision) map[string]int {
+	targets := func(decisions []domain.VariantDecision) map[string]int {
 		m := make(map[string]int, len(decisions))
 		for _, d := range decisions {
 			m[d.VariantName] = d.TargetReplicas
@@ -63,15 +63,15 @@ var _ = Describe("GreedyByScore vs CostAware when GPUs are unconstrained", func(
 
 	It("single model, single variant: identical", func() {
 		build := func() []ModelScalingRequest {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID: "m", Namespace: "ns", RequiredCapacity: 50000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "v", AcceleratorName: "A100", Cost: 5, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			return []ModelScalingRequest{withSatEntry(r, ModelScalingRequest{
 				ModelID: "m", Namespace: "ns", Priority: 1,
-				VariantStates: []interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+				VariantStates: []domain.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
 			})}
 		}
 		ca, gs := run(build, "A100")
@@ -84,16 +84,16 @@ var _ = Describe("GreedyByScore vs CostAware when GPUs are unconstrained", func(
 
 	It("single model, multiple variants (cost-efficiency selection): identical", func() {
 		build := func() []ModelScalingRequest {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID: "m", Namespace: "ns", RequiredCapacity: 25000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5, ReplicaCount: 1, PerReplicaCapacity: 10000},
 					{VariantName: "pricey", AcceleratorName: "H100", Cost: 15, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
 			}
 			return []ModelScalingRequest{withSatEntry(r, ModelScalingRequest{
 				ModelID: "m", Namespace: "ns", Priority: 1,
-				VariantStates: []interfaces.VariantReplicaState{
+				VariantStates: []domain.VariantReplicaState{
 					{VariantName: "cheap", CurrentReplicas: 1, GPUsPerReplica: 1},
 					{VariantName: "pricey", CurrentReplicas: 1, GPUsPerReplica: 1},
 				},
@@ -111,15 +111,15 @@ var _ = Describe("GreedyByScore vs CostAware when GPUs are unconstrained", func(
 
 	It("multiple models scaling up at once: report both", func() {
 		mk := func(id, variant, accel string, req float64, prio float64) ModelScalingRequest {
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID: id, Namespace: "ns", RequiredCapacity: req,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: variant, AcceleratorName: accel, Cost: 5, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
 			}
 			return withSatEntry(r, ModelScalingRequest{
 				ModelID: id, Namespace: "ns", Priority: prio,
-				VariantStates: []interfaces.VariantReplicaState{{VariantName: variant, CurrentReplicas: 1, GPUsPerReplica: 1}},
+				VariantStates: []domain.VariantReplicaState{{VariantName: variant, CurrentReplicas: 1, GPUsPerReplica: 1}},
 			})
 		}
 		build := func() []ModelScalingRequest {

--- a/internal/engines/pipeline/optimizer_interfaces.go
+++ b/internal/engines/pipeline/optimizer_interfaces.go
@@ -3,7 +3,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // NamedAnalyzerResult pairs an analyzer's name with its result and mutable
@@ -20,7 +20,7 @@ import (
 // The original Result values are never mutated.
 type NamedAnalyzerResult struct {
 	Name              string
-	Result            *interfaces.AnalyzerResult
+	Result            *domain.AnalyzerResult
 	Score             float64            // per-analyzer weight from AnalyzerScoreConfig; used for fair-share priority
 	Remaining         float64            // mutable remaining required capacity; P-scope for disaggregated, model-scope otherwise
 	Spare             float64            // mutable remaining spare capacity; model-scope (non-disaggregated only)
@@ -35,7 +35,7 @@ type ModelScalingRequest struct {
 	ModelID         string
 	Namespace       string
 	AnalyzerResults []NamedAnalyzerResult // per-analyzer slice; saturation entry is always first
-	VariantStates   []interfaces.VariantReplicaState
+	VariantStates   []domain.VariantReplicaState
 	Priority        float64 // Model priority (default 1.0)
 	Disaggregated   bool    // true when model has prefill+decode variants
 }
@@ -51,5 +51,5 @@ type ScalingOptimizer interface {
 
 	// Optimize produces VariantDecisions from analyzer results and optional constraints.
 	// constraints may be nil in unlimited mode.
-	Optimize(ctx context.Context, requests []ModelScalingRequest, constraints []*ResourceConstraints) []interfaces.VariantDecision
+	Optimize(ctx context.Context, requests []ModelScalingRequest, constraints []*ResourceConstraints) []domain.VariantDecision
 }

--- a/internal/engines/pipeline/quota_inventory.go
+++ b/internal/engines/pipeline/quota_inventory.go
@@ -9,7 +9,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
@@ -370,7 +370,7 @@ type quotaAllocator struct {
 //     does enforce); exact match → cap; fall-through to `default` → cap;
 //     missing → 0.
 //   - Unlimited (-1) on either scope: pass-through.
-func (a *quotaAllocator) TryAllocate(ctx context.Context, decision *interfaces.VariantDecision, gpusRequested int) (int, error) {
+func (a *quotaAllocator) TryAllocate(ctx context.Context, decision *domain.VariantDecision, gpusRequested int) (int, error) {
 	if gpusRequested <= 0 {
 		return 0, nil
 	}

--- a/internal/engines/pipeline/quota_inventory_test.go
+++ b/internal/engines/pipeline/quota_inventory_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 func newClusterQuotaInv(quotas map[string]int) *QuotaInventory {
@@ -29,8 +29,8 @@ func newNamespaceQuotaInv(quotas map[string]map[string]int, exclude []string) *Q
 	})
 }
 
-func quotaDecisionFor(namespace, accType string) *interfaces.VariantDecision {
-	return &interfaces.VariantDecision{
+func quotaDecisionFor(namespace, accType string) *domain.VariantDecision {
+	return &domain.VariantDecision{
 		Namespace:       namespace,
 		AcceleratorName: accType,
 		VariantName:     "v",

--- a/internal/engines/pipeline/quota_limit_integration_test.go
+++ b/internal/engines/pipeline/quota_limit_integration_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // These specs exercise the V1 Limit() enforcement path end-to-end: a real
@@ -24,8 +24,8 @@ var _ = Describe("Quota limiter V1 enforcement (integration)", func() {
 		ctx = context.Background()
 	})
 
-	newDecision := func() *interfaces.VariantDecision {
-		return &interfaces.VariantDecision{
+	newDecision := func() *domain.VariantDecision {
+		return &domain.VariantDecision{
 			VariantName:     "v1",
 			Namespace:       "team-a",
 			AcceleratorName: "H100",
@@ -53,7 +53,7 @@ var _ = Describe("Quota limiter V1 enforcement (integration)", func() {
 	It("caps TargetReplicas at the cluster quota headroom", func() {
 		d := newDecision()
 		// cap 6, used 4 → 2 free = 1 replica; target lands at 2 + 1 = 3.
-		Expect(clusterLimiter("cluster-quota", 6).Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+		Expect(clusterLimiter("cluster-quota", 6).Limit(ctx, []*domain.VariantDecision{d})).To(Succeed())
 
 		Expect(d.TargetReplicas).To(Equal(3), "capped at cluster quota headroom")
 		Expect(d.WasLimited).To(BeTrue())
@@ -62,7 +62,7 @@ var _ = Describe("Quota limiter V1 enforcement (integration)", func() {
 
 	It("caps TargetReplicas at the namespace quota headroom", func() {
 		d := newDecision()
-		Expect(namespaceLimiter("namespace-quota", 6).Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+		Expect(namespaceLimiter("namespace-quota", 6).Limit(ctx, []*domain.VariantDecision{d})).To(Succeed())
 
 		Expect(d.TargetReplicas).To(Equal(3), "capped at namespace quota headroom")
 		Expect(d.WasLimited).To(BeTrue())
@@ -77,7 +77,7 @@ var _ = Describe("Quota limiter V1 enforcement (integration)", func() {
 			namespaceLimiter("namespace-quota", 6),
 		})
 		d := newDecision()
-		Expect(comp.Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+		Expect(comp.Limit(ctx, []*domain.VariantDecision{d})).To(Succeed())
 
 		Expect(d.TargetReplicas).To(Equal(3), "namespace quota is the binding constraint")
 		Expect(d.WasLimited).To(BeTrue())
@@ -100,7 +100,7 @@ var _ = Describe("Quota limiter V1 enforcement (integration)", func() {
 		minReplicas := 5
 		d := newDecision()
 		d.MinReplicas = &minReplicas
-		Expect(limiter.Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+		Expect(limiter.Limit(ctx, []*domain.VariantDecision{d})).To(Succeed())
 
 		Expect(d.TargetReplicas).To(Equal(5), "MinReplicas floor restores the requested target")
 		Expect(d.WasLimited).To(BeTrue(), "the quota still denied GPUs")
@@ -117,7 +117,7 @@ var _ = Describe("Quota limiter V1 enforcement (integration)", func() {
 			clusterLimiter("cluster-quota", 100),
 		})
 		d := newDecision()
-		Expect(comp.Limit(ctx, []*interfaces.VariantDecision{d})).To(Succeed())
+		Expect(comp.Limit(ctx, []*domain.VariantDecision{d})).To(Succeed())
 
 		Expect(d.TargetReplicas).To(Equal(3))
 		Expect(d.WasLimited).To(BeTrue())

--- a/internal/engines/pipeline/type_inventory.go
+++ b/internal/engines/pipeline/type_inventory.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/discovery"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 )
@@ -290,7 +290,7 @@ type typeAllocator struct {
 // The accelerator type is determined from the decision's AcceleratorName field.
 // Returns the actual GPUs allocated (may be less than requested if the type's
 // pool is exhausted).
-func (a *typeAllocator) TryAllocate(ctx context.Context, decision *interfaces.VariantDecision, gpusRequested int) (int, error) {
+func (a *typeAllocator) TryAllocate(ctx context.Context, decision *domain.VariantDecision, gpusRequested int) (int, error) {
 	if gpusRequested <= 0 {
 		return 0, nil
 	}

--- a/internal/engines/pipeline/type_inventory_test.go
+++ b/internal/engines/pipeline/type_inventory_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/discovery"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // mockDiscovery implements discovery.CapacityDiscovery for testing.
@@ -260,7 +260,7 @@ var _ = Describe("TypeInventory", func() {
 			Expect(allocator.Remaining()).To(Equal(16)) // H100: 16-4=12, A100: 8-4=4
 
 			// Allocate from H100 pool
-			allocated, err := allocator.TryAllocate(ctx, &interfaces.VariantDecision{
+			allocated, err := allocator.TryAllocate(ctx, &domain.VariantDecision{
 				VariantName:     "model-a",
 				Namespace:       "default",
 				AcceleratorName: "H100",
@@ -292,7 +292,7 @@ var _ = Describe("TypeInventory", func() {
 			Expect(allocator.Remaining()).To(Equal(2))
 
 			// Request more than available - should get partial allocation
-			allocated, err := allocator.TryAllocate(ctx, &interfaces.VariantDecision{
+			allocated, err := allocator.TryAllocate(ctx, &domain.VariantDecision{
 				VariantName:     "model-a",
 				Namespace:       "default",
 				AcceleratorName: "H100",
@@ -313,7 +313,7 @@ var _ = Describe("TypeAllocator", func() {
 
 	Describe("TryAllocate", func() {
 		DescribeTable("should allocate GPUs correctly",
-			func(initialByType map[string]int, decision *interfaces.VariantDecision, gpusRequested int, expectedAllocated int, expectedRemaining map[string]int, expectError bool) {
+			func(initialByType map[string]int, decision *domain.VariantDecision, gpusRequested int, expectedAllocated int, expectedRemaining map[string]int, expectError bool) {
 				// Calculate initial total
 				total := 0
 				for _, count := range initialByType {
@@ -341,56 +341,56 @@ var _ = Describe("TypeAllocator", func() {
 			},
 			Entry("allocate from available pool",
 				map[string]int{"H100": 16, "A100": 8},
-				&interfaces.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
+				&domain.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
 				4, 4,
 				map[string]int{"H100": 12, "A100": 8},
 				false,
 			),
 			Entry("allocate entire pool",
 				map[string]int{"H100": 8},
-				&interfaces.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
+				&domain.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
 				8, 8,
 				map[string]int{"H100": 0},
 				false,
 			),
 			Entry("partial allocation when pool exhausted",
 				map[string]int{"H100": 4},
-				&interfaces.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
+				&domain.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
 				8, 4,
 				map[string]int{"H100": 0},
 				false,
 			),
 			Entry("no allocation when type not available",
 				map[string]int{"A100": 8},
-				&interfaces.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
+				&domain.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
 				4, 0,
 				map[string]int{"A100": 8},
 				false,
 			),
 			Entry("resolve empty accelerator in homogeneous cluster",
 				map[string]int{"H100": 8},
-				&interfaces.VariantDecision{VariantName: "model-a", Namespace: "default"},
+				&domain.VariantDecision{VariantName: "model-a", Namespace: "default"},
 				4, 4,
 				map[string]int{"H100": 4},
 				false,
 			),
 			Entry("return zero for empty accelerator in heterogeneous cluster",
 				map[string]int{"H100": 8, "A100": 8},
-				&interfaces.VariantDecision{VariantName: "model-a", Namespace: "default"},
+				&domain.VariantDecision{VariantName: "model-a", Namespace: "default"},
 				4, 0,
 				map[string]int{"H100": 8, "A100": 8},
 				false,
 			),
 			Entry("zero request returns zero",
 				map[string]int{"H100": 8},
-				&interfaces.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
+				&domain.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "H100"},
 				0, 0,
 				map[string]int{"H100": 8},
 				false,
 			),
 			Entry("types are isolated",
 				map[string]int{"H100": 4, "A100": 8},
-				&interfaces.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "A100"},
+				&domain.VariantDecision{VariantName: "model-a", Namespace: "default", AcceleratorName: "A100"},
 				6, 6,
 				map[string]int{"H100": 4, "A100": 2},
 				false,
@@ -408,7 +408,7 @@ var _ = Describe("TypeAllocator", func() {
 			ctx := context.Background()
 
 			// First allocation: 4 H100 GPUs
-			allocated, err := allocator.TryAllocate(ctx, &interfaces.VariantDecision{
+			allocated, err := allocator.TryAllocate(ctx, &domain.VariantDecision{
 				VariantName:     "model-a",
 				Namespace:       "default",
 				AcceleratorName: "H100",
@@ -420,7 +420,7 @@ var _ = Describe("TypeAllocator", func() {
 			Expect(allocator.Remaining()).To(Equal(20))
 
 			// Second allocation: 6 A100 GPUs
-			allocated, err = allocator.TryAllocate(ctx, &interfaces.VariantDecision{
+			allocated, err = allocator.TryAllocate(ctx, &domain.VariantDecision{
 				VariantName:     "model-b",
 				Namespace:       "default",
 				AcceleratorName: "A100",
@@ -432,7 +432,7 @@ var _ = Describe("TypeAllocator", func() {
 			Expect(allocator.Remaining()).To(Equal(14))
 
 			// Third allocation: more H100 than available
-			allocated, err = allocator.TryAllocate(ctx, &interfaces.VariantDecision{
+			allocated, err = allocator.TryAllocate(ctx, &domain.VariantDecision{
 				VariantName:     "model-c",
 				Namespace:       "default",
 				AcceleratorName: "H100",

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -38,12 +38,12 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	queueingmodel "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel"
 	saturation_v2 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/saturation_v2"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/executor"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
@@ -57,7 +57,7 @@ import (
 // deterministically.
 type analyzerEntry struct {
 	name     string
-	analyzer interfaces.Analyzer
+	analyzer domain.Analyzer
 }
 
 // v1Analyzer is the minimal surface of *saturation.Analyzer that optimizeV1
@@ -67,13 +67,13 @@ type v1Analyzer interface {
 	AnalyzeModelSaturation(
 		ctx context.Context,
 		modelID, namespace string,
-		replicaMetrics []interfaces.ReplicaMetrics,
+		replicaMetrics []domain.ReplicaMetrics,
 		config config.SaturationScalingConfig,
-	) (*interfaces.ModelSaturationAnalysis, error)
+	) (*domain.ModelSaturationAnalysis, error)
 	CalculateSaturationTargets(
 		ctx context.Context,
-		saturationAnalysis *interfaces.ModelSaturationAnalysis,
-		variantStates []interfaces.VariantReplicaState,
+		saturationAnalysis *domain.ModelSaturationAnalysis,
+		variantStates []domain.VariantReplicaState,
 	) map[string]int
 }
 
@@ -88,7 +88,7 @@ func defaultV1AnalyzerFactory() v1Analyzer { return saturation.NewAnalyzer() }
 type safetyNetEmitter func(
 	ctx context.Context,
 	roleVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	currentAllocations map[string]*interfaces.Allocation,
+	currentAllocations map[string]*domain.Allocation,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 )
 
@@ -142,9 +142,9 @@ type Engine struct {
 	metricsRegistry *source.SourceRegistry
 
 	// saturationV2Analyzer is the V2 token-based saturation analyzer (initialized once).
-	// Also pre-registered in analyzers under interfaces.SaturationAnalyzerName.
-	// Typed as interfaces.Analyzer to allow injection in tests.
-	saturationV2Analyzer interfaces.Analyzer
+	// Also pre-registered in analyzers under domain.SaturationAnalyzerName.
+	// Typed as domain.Analyzer to allow injection in tests.
+	saturationV2Analyzer domain.Analyzer
 
 	// queueingModelAnalyzer is the queueing model-based analyzer (initialized once).
 	// Selected via analyzerName: "queueing-model" in SaturationScalingConfig.
@@ -236,7 +236,7 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 		metricsEmitter:          metrics.NewMetricsEmitter(),
 		v1AnalyzerFactory:       defaultV1AnalyzerFactory,
 		analyzers: []analyzerEntry{
-			{name: interfaces.SaturationAnalyzerName, analyzer: satV2},
+			{name: domain.SaturationAnalyzerName, analyzer: satV2},
 		},
 	}
 
@@ -271,7 +271,7 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 // registry. Returns an error if called after StartOptimizeLoop or if name
 // is already registered — callers must check the error. The analyzer is
 // appended in registration order.
-func (e *Engine) RegisterAnalyzer(name string, a interfaces.Analyzer) error {
+func (e *Engine) RegisterAnalyzer(name string, a domain.Analyzer) error {
 	if e.started {
 		return errors.New("RegisterAnalyzer: called after StartOptimizeLoop")
 	}
@@ -408,7 +408,7 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 
 	// Create map to store current allocations populated during metrics collection
 	// Keyed by VariantAutoscaling Namespace/Name
-	currentAllocations := make(map[string]*interfaces.Allocation)
+	currentAllocations := make(map[string]*domain.Allocation)
 
 	// Determine which analyzer to use.
 	// Priority: queueing model ConfigMap (presence-based) > saturation config analyzerName.
@@ -429,12 +429,12 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 
 	// Queueing model ConfigMap takes priority over saturation analyzerName.
 	if hasQMAnalyzerConfig {
-		analyzerName = interfaces.QueueingModelAnalyzerName
+		analyzerName = domain.QueueingModelAnalyzerName
 	}
 
 	// Select optimizer based on enableLimiter flag (both are stateless, safe to swap)
 	// Applies to V2 and queueing-model paths which both use the optimizer pipeline.
-	if analyzerName == interfaces.SaturationAnalyzerName || analyzerName == interfaces.QueueingModelAnalyzerName {
+	if analyzerName == domain.SaturationAnalyzerName || analyzerName == domain.QueueingModelAnalyzerName {
 		savedOptimizer := e.optimizer
 		if enableLimiter {
 			e.optimizer = pipeline.NewGreedyByScoreOptimizer()
@@ -447,7 +447,7 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 		logger.V(logging.DEBUG).Info("Optimizer selected", "analyzer", analyzerName, "optimizer", e.optimizer.Name(), "enableLimiter", enableLimiter)
 	}
 
-	var allDecisions []interfaces.VariantDecision
+	var allDecisions []domain.VariantDecision
 
 	// Each analyzer has a separate optimize path because they use fundamentally
 	// different analysis types and target-building flows:
@@ -457,9 +457,9 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	// V1 will be deprecated once V2 is fully validated.
 	// Queueing model is activated by presence of wva-queueing-model-config ConfigMap.
 	switch analyzerName {
-	case interfaces.QueueingModelAnalyzerName:
+	case domain.QueueingModelAnalyzerName:
 		allDecisions = e.optimizeQueueingModel(ctx, modelGroups, currentAllocations)
-	case interfaces.SaturationAnalyzerName:
+	case domain.SaturationAnalyzerName:
 		allDecisions = e.optimizeV2(ctx, modelGroups, currentAllocations)
 	default:
 		allDecisions = e.optimizeV1(ctx, modelGroups, currentAllocations)
@@ -528,7 +528,7 @@ func (e *Engine) recordOptimizationFailedEvent(
 
 func (e *Engine) recordScalingEvent(
 	va *llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	action interfaces.SaturationAction,
+	action domain.SaturationAction,
 	targetReplicas int,
 	reason string,
 ) {
@@ -536,9 +536,9 @@ func (e *Engine) recordScalingEvent(
 		return
 	}
 	switch action {
-	case interfaces.ActionScaleUp:
+	case domain.ActionScaleUp:
 		e.recordEvent(va, corev1.EventTypeNormal, constants.K8SEventScaledUp, reason)
-	case interfaces.ActionScaleDown:
+	case domain.ActionScaleDown:
 		if targetReplicas == 0 {
 			e.recordEvent(va, corev1.EventTypeNormal, constants.K8SEventScaledToZero, reason)
 		} else {
@@ -566,10 +566,10 @@ func (e *Engine) resolveSaturationConfig(
 func (e *Engine) optimizeV1(
 	ctx context.Context,
 	modelGroups map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	currentAllocations map[string]*interfaces.Allocation,
-) []interfaces.VariantDecision {
+	currentAllocations map[string]*domain.Allocation,
+) []domain.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx)
-	var allDecisions []interfaces.VariantDecision
+	var allDecisions []domain.VariantDecision
 
 	for groupKey, modelVAs := range modelGroups {
 		modelID := modelVAs[0].Spec.ModelID
@@ -642,7 +642,7 @@ func (e *Engine) optimizeV1(
 		logger.Info("Applying GPU limiter to scaling decisions",
 			"decisionCount", len(allDecisions))
 
-		decisionPtrs := make([]*interfaces.VariantDecision, len(allDecisions))
+		decisionPtrs := make([]*domain.VariantDecision, len(allDecisions))
 		for i := range allDecisions {
 			decisionPtrs[i] = &allDecisions[i]
 		}
@@ -682,9 +682,9 @@ func (e *Engine) analyzeRoleGroups(
 	saturationConfig config.SaturationScalingConfig,
 	data *modelData,
 	modelVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	currentAllocations map[string]*interfaces.Allocation,
+	currentAllocations map[string]*domain.Allocation,
 	emitSafetyNet safetyNetEmitter,
-) []interfaces.VariantDecision {
+) []domain.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Sub-group variants by role for P/D-aware analysis.
@@ -693,7 +693,7 @@ func (e *Engine) analyzeRoleGroups(
 	roleGroups := groupByRole(data.variantStates)
 	sortedRoles := sortedRoleKeys(roleGroups)
 
-	var modelDecisions []interfaces.VariantDecision
+	var modelDecisions []domain.VariantDecision
 	for _, role := range sortedRoles {
 		roleStates := roleGroups[role]
 		roleMetrics := filterReplicaMetricsByVariants(data.replicaMetrics, roleStates)
@@ -821,14 +821,14 @@ func (e *Engine) selectV2Optimizer(
 func (e *Engine) optimizeV2(
 	ctx context.Context,
 	modelGroups map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	currentAllocations map[string]*interfaces.Allocation,
-) []interfaces.VariantDecision {
+	currentAllocations map[string]*domain.Allocation,
+) []domain.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Stage 1: Collect ModelScalingRequests for all models
 	requests := make([]pipeline.ModelScalingRequest, 0, len(modelGroups))
 	// modelReplicaMetrics collects per-model replica metrics for KV token enrichment
-	modelReplicaMetrics := make(map[string][]interfaces.ReplicaMetrics)
+	modelReplicaMetrics := make(map[string][]domain.ReplicaMetrics)
 	// modelScaleTargets carries each model's scale targets into stage 3, where
 	// applyScaleToZeroEnforcement needs them to gate the enforcer. Captured here
 	// because data.scaleTargets is only in scope during this collection loop.
@@ -919,8 +919,8 @@ func (e *Engine) BuildVariantStates(
 	vas []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	k8sClient client.Client,
-) []interfaces.VariantReplicaState {
-	states := make([]interfaces.VariantReplicaState, 0, len(vas))
+) []domain.VariantReplicaState {
+	states := make([]domain.VariantReplicaState, 0, len(vas))
 
 	for _, va := range vas {
 		// Get current replicas using ScaleTargetRef
@@ -988,7 +988,7 @@ func (e *Engine) BuildVariantStates(
 		if va.Status.DesiredOptimizedAlloc.NumReplicas != nil {
 			desiredReplicas = int(*va.Status.DesiredOptimizedAlloc.NumReplicas)
 		}
-		states = append(states, interfaces.VariantReplicaState{
+		states = append(states, domain.VariantReplicaState{
 			VariantName:     va.Name,
 			CurrentReplicas: currentReplicas,
 			DesiredReplicas: desiredReplicas,
@@ -1007,15 +1007,15 @@ func (e *Engine) BuildVariantStates(
 // Returns "prefill", "decode", or "both" (default when no role label is present).
 func getRoleFromScaleTarget(scaleTarget scaletarget.ScaleTargetAccessor) string {
 	if scaleTarget == nil {
-		return interfaces.RoleBoth
+		return domain.RoleBoth
 	}
 	podTemplateSpec := scaleTarget.GetLeaderPodTemplateSpec()
 	if podTemplateSpec == nil {
-		return interfaces.RoleBoth
+		return domain.RoleBoth
 	}
 	labels := podTemplateSpec.Labels
 	if labels == nil {
-		return interfaces.RoleBoth
+		return domain.RoleBoth
 	}
 	if val, ok := labels["llm-d.ai/role"]; ok {
 		switch val {
@@ -1024,10 +1024,10 @@ func getRoleFromScaleTarget(scaleTarget scaletarget.ScaleTargetAccessor) string 
 		case "decode":
 			return "decode"
 		default:
-			return interfaces.RoleBoth
+			return domain.RoleBoth
 		}
 	}
-	return interfaces.RoleBoth
+	return domain.RoleBoth
 }
 
 // convertSaturationTargetsToDecisions converts saturation-only targets to VariantDecisions.
@@ -1035,21 +1035,21 @@ func getRoleFromScaleTarget(scaleTarget scaletarget.ScaleTargetAccessor) string 
 func (e *Engine) convertSaturationTargetsToDecisions(
 	ctx context.Context,
 	saturationTargets map[string]int,
-	saturationAnalysis *interfaces.ModelSaturationAnalysis,
-	variantStates []interfaces.VariantReplicaState,
-) []interfaces.VariantDecision {
+	saturationAnalysis *domain.ModelSaturationAnalysis,
+	variantStates []domain.VariantReplicaState,
+) []domain.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx)
-	decisions := make([]interfaces.VariantDecision, 0, len(saturationTargets))
+	decisions := make([]domain.VariantDecision, 0, len(saturationTargets))
 
 	// Build variant analysis map for quick lookup
-	vaMap := make(map[string]*interfaces.VariantSaturationAnalysis)
+	vaMap := make(map[string]*domain.VariantSaturationAnalysis)
 	for i := range saturationAnalysis.VariantAnalyses {
 		va := &saturationAnalysis.VariantAnalyses[i]
 		vaMap[va.VariantName] = va
 	}
 
 	// Build state map for quick lookup
-	stateMap := make(map[string]interfaces.VariantReplicaState)
+	stateMap := make(map[string]domain.VariantReplicaState)
 	for _, state := range variantStates {
 		stateMap[state.VariantName] = state
 	}
@@ -1058,14 +1058,14 @@ func (e *Engine) convertSaturationTargetsToDecisions(
 		state := stateMap[variantName]
 		va := vaMap[variantName]
 
-		var action interfaces.SaturationAction
+		var action domain.SaturationAction
 		switch {
 		case targetReplicas > state.CurrentReplicas:
-			action = interfaces.ActionScaleUp
+			action = domain.ActionScaleUp
 		case targetReplicas < state.CurrentReplicas:
-			action = interfaces.ActionScaleDown
+			action = domain.ActionScaleDown
 		default:
-			action = interfaces.ActionNoChange
+			action = domain.ActionNoChange
 		}
 
 		// Use GPUsPerReplica from variant state (extracted from scale target)
@@ -1074,7 +1074,7 @@ func (e *Engine) convertSaturationTargetsToDecisions(
 			gpusPerReplica = 1 // Fallback default
 		}
 
-		decision := interfaces.VariantDecision{
+		decision := domain.VariantDecision{
 			VariantName:            variantName,
 			Namespace:              saturationAnalysis.Namespace,
 			ModelID:                saturationAnalysis.ModelID,
@@ -1091,7 +1091,7 @@ func (e *Engine) convertSaturationTargetsToDecisions(
 			MinReplicas:            state.MinReplicas,
 			MaxReplicas:            state.MaxReplicas,
 		}
-		decision.SetDecisionReason(action, interfaces.DecisionReasonSaturationOnly, fmt.Sprintf("%s: %s", string(interfaces.DecisionReasonSaturationOnly), string(action)))
+		decision.SetDecisionReason(action, domain.DecisionReasonSaturationOnly, fmt.Sprintf("%s: %s", string(domain.DecisionReasonSaturationOnly), string(action)))
 
 		if va != nil {
 			decision.AcceleratorName = va.AcceleratorName
@@ -1118,7 +1118,7 @@ func (e *Engine) convertSaturationTargetsToDecisions(
 //
 // Aggregation is keyed by (modelID, variantName) — not just variantName — because
 // variant names can collide across different models in the same reconcile cycle.
-func enrichDecisionsWithKvTokenData(decisions []interfaces.VariantDecision, modelReplicaMetrics map[string][]interfaces.ReplicaMetrics) {
+func enrichDecisionsWithKvTokenData(decisions []domain.VariantDecision, modelReplicaMetrics map[string][]domain.ReplicaMetrics) {
 	type kvAgg struct {
 		kvUsed  int64
 		kvTotal int64
@@ -1152,7 +1152,7 @@ func enrichDecisionsWithKvTokenData(decisions []interfaces.VariantDecision, mode
 }
 
 // hasMinReplicasAboveZero returns true if any variant in the states has MinReplicas > 0.
-func hasMinReplicasAboveZero(states []interfaces.VariantReplicaState) bool {
+func hasMinReplicasAboveZero(states []domain.VariantReplicaState) bool {
 	for _, state := range states {
 		if state.MinReplicas != nil && *state.MinReplicas > 0 {
 			return true
@@ -1194,9 +1194,9 @@ func scaleToZeroSupportedForEngines(scaleTargets map[string]scaletarget.ScaleTar
 func (e *Engine) applyScaleToZeroEnforcement(
 	ctx context.Context,
 	modelID, namespace, optimizerName string,
-	decisions []interfaces.VariantDecision,
+	decisions []domain.VariantDecision,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
-	variantStates []interfaces.VariantReplicaState,
+	variantStates []domain.VariantReplicaState,
 ) bool {
 	if len(decisions) == 0 {
 		return false
@@ -1230,7 +1230,7 @@ func (e *Engine) applyScaleToZeroEnforcement(
 // deployment carries a role label.
 func normalizeRole(role string) string {
 	if role == "" {
-		return interfaces.RoleBoth
+		return domain.RoleBoth
 	}
 	return role
 }
@@ -1238,8 +1238,8 @@ func normalizeRole(role string) string {
 // groupByRole sub-groups variant states by their P/D role.
 // Returns a map keyed by normalized role ("both", "prefill", "decode").
 // For non-disaggregated models (all "both"/""), the map contains a single entry.
-func groupByRole(states []interfaces.VariantReplicaState) map[string][]interfaces.VariantReplicaState {
-	groups := make(map[string][]interfaces.VariantReplicaState)
+func groupByRole(states []domain.VariantReplicaState) map[string][]domain.VariantReplicaState {
+	groups := make(map[string][]domain.VariantReplicaState)
 	for _, s := range states {
 		key := normalizeRole(s.Role)
 		groups[key] = append(groups[key], s)
@@ -1252,7 +1252,7 @@ func groupByRole(states []interfaces.VariantReplicaState) map[string][]interface
 // easier debugging). The caller is expected to pass a map whose keys were
 // produced by groupByRole, which has already canonicalized empty roles to
 // "both"; the resulting lexicographic order is then "both" < "decode" < "prefill".
-func sortedRoleKeys(groups map[string][]interfaces.VariantReplicaState) []string {
+func sortedRoleKeys(groups map[string][]domain.VariantReplicaState) []string {
 	keys := make([]string, 0, len(groups))
 	for k := range groups {
 		keys = append(keys, k)
@@ -1264,12 +1264,12 @@ func sortedRoleKeys(groups map[string][]interfaces.VariantReplicaState) []string
 // filterReplicaMetricsByVariants returns only the replica metrics whose VariantName
 // appears in the given variant state slice. Used to split per-model metrics into
 // per-role subsets without re-querying Prometheus.
-func filterReplicaMetricsByVariants(metrics []interfaces.ReplicaMetrics, states []interfaces.VariantReplicaState) []interfaces.ReplicaMetrics {
+func filterReplicaMetricsByVariants(metrics []domain.ReplicaMetrics, states []domain.VariantReplicaState) []domain.ReplicaMetrics {
 	allowed := make(map[string]struct{}, len(states))
 	for _, s := range states {
 		allowed[s.VariantName] = struct{}{}
 	}
-	filtered := make([]interfaces.ReplicaMetrics, 0, len(metrics))
+	filtered := make([]domain.ReplicaMetrics, 0, len(metrics))
 	for _, m := range metrics {
 		if _, ok := allowed[m.VariantName]; ok {
 			filtered = append(filtered, m)
@@ -1283,7 +1283,7 @@ func filterReplicaMetricsByVariants(metrics []interfaces.ReplicaMetrics, states 
 // safety-net metric emission.
 func filterVAsByVariantStates(
 	vas []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	states []interfaces.VariantReplicaState,
+	states []domain.VariantReplicaState,
 ) []llmdVariantAutoscalingV1alpha1.VariantAutoscaling {
 	allowed := make(map[string]struct{}, len(states))
 	for _, s := range states {
@@ -1299,7 +1299,7 @@ func filterVAsByVariantStates(
 }
 
 // variantNames returns variant names from states for logging.
-func variantNames(states []interfaces.VariantReplicaState) []string {
+func variantNames(states []domain.VariantReplicaState) []string {
 	names := make([]string, len(states))
 	for i, s := range states {
 		names[i] = s.VariantName
@@ -1311,12 +1311,12 @@ func variantNames(states []interfaces.VariantReplicaState) []string {
 type modelData struct {
 	modelID             string
 	namespace           string
-	replicaMetrics      []interfaces.ReplicaMetrics
+	replicaMetrics      []domain.ReplicaMetrics
 	scaleTargets        map[string]scaletarget.ScaleTargetAccessor
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling
 	variantCosts        map[string]float64
-	variantStates       []interfaces.VariantReplicaState
-	schedulerQueue      *interfaces.SchedulerQueueMetrics
+	variantStates       []domain.VariantReplicaState
+	schedulerQueue      *domain.SchedulerQueueMetrics
 }
 
 // prepareModelData collects metrics and builds lookup maps for a model's VAs.
@@ -1407,14 +1407,14 @@ func (e *Engine) prepareModelData(
 // applySaturationDecisions updates VA status and emits metrics based on Saturation decisions.
 func (e *Engine) applySaturationDecisions(
 	ctx context.Context,
-	decisions []interfaces.VariantDecision,
+	decisions []domain.VariantDecision,
 	vaMap map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	currentAllocations map[string]*interfaces.Allocation,
+	currentAllocations map[string]*domain.Allocation,
 ) {
 	logger := ctrl.LoggerFrom(ctx)
 	// Create a map of decisions for O(1) lookup
 	// Use namespace/variantName as key to match vaMap and avoid collisions
-	decisionMap := make(map[string]interfaces.VariantDecision)
+	decisionMap := make(map[string]domain.VariantDecision)
 	for _, d := range decisions {
 		decisionMap[utils.GetNamespacedKey(d.Namespace, d.VariantName)] = d
 	}
@@ -1641,7 +1641,7 @@ func (e *Engine) applySaturationDecisions(
 		// reconcile trigger is needed.
 
 		if hasDecision {
-			if decision.Action != interfaces.ActionNoChange {
+			if decision.Action != domain.ActionNoChange {
 				if err := e.metricsEmitter.EmitReplicaScalingMetrics(ctx, &updateVa, decision.Action, decision.ReasonCategory()); err != nil {
 					logger.Error(err, "Failed to emit replica scaling metrics")
 				}
@@ -1675,7 +1675,7 @@ func (e *Engine) emitAcceleratorNotResolvedEvent(va *llmdVariantAutoscalingV1alp
 func (e *Engine) emitSafetyNetMetrics(
 	ctx context.Context,
 	modelVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	currentAllocations map[string]*interfaces.Allocation,
+	currentAllocations map[string]*domain.Allocation,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 ) {
 	logger := ctrl.LoggerFrom(ctx)

--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -6,9 +6,9 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	queueingmodel "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
@@ -23,8 +23,8 @@ import (
 func (e *Engine) optimizeQueueingModel(
 	ctx context.Context,
 	modelGroups map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	currentAllocations map[string]*interfaces.Allocation,
-) []interfaces.VariantDecision {
+	currentAllocations map[string]*domain.Allocation,
+) []domain.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// update analyzer given current models
@@ -78,7 +78,7 @@ func (e *Engine) optimizeQueueingModel(
 			ModelID:   modelID,
 			Namespace: namespace,
 			AnalyzerResults: []pipeline.NamedAnalyzerResult{{
-				Name:      interfaces.SaturationAnalyzerName,
+				Name:      domain.SaturationAnalyzerName,
 				Result:    result,
 				Score:     1.0, // QM path: single analyzer, no per-entry score config
 				Remaining: result.RequiredCapacity,
@@ -121,13 +121,13 @@ func (e *Engine) optimizeQueueingModel(
 func (e *Engine) runQueueingModelAnalysis(
 	ctx context.Context,
 	modelID, namespace string,
-	replicaMetrics []interfaces.ReplicaMetrics,
+	replicaMetrics []domain.ReplicaMetrics,
 	config *queueingmodel.QMConfig,
-	variantStates []interfaces.VariantReplicaState,
-) (*interfaces.AnalyzerResult, error) {
+	variantStates []domain.VariantReplicaState,
+) (*domain.AnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	input := interfaces.AnalyzerInput{
+	input := domain.AnalyzerInput{
 		ModelID:        modelID,
 		Namespace:      namespace,
 		ReplicaMetrics: replicaMetrics,
@@ -157,7 +157,7 @@ func (e *Engine) runQueueingModelAnalysis(
 // sloMultiplier, tuningEnabled, and provide explicit SLO targets (targetTTFT/targetITL).
 // Falls back to defaults when fields are zero/nil.
 func buildQMConfig(
-	allConfigs map[string]interfaces.QueueingModelScalingConfig,
+	allConfigs map[string]domain.QueueingModelScalingConfig,
 	namespace, modelID string,
 ) *queueingmodel.QMConfig {
 	cfg := &queueingmodel.QMConfig{

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
-// spyAnalyzer is a minimal interfaces.Analyzer used in registration tests.
+// spyAnalyzer is a minimal domain.Analyzer used in registration tests.
 // Configurable to record calls, return an error, or panic.
 type spyAnalyzer struct {
 	name      string
@@ -43,7 +43,7 @@ type spyAnalyzer struct {
 
 func (s *spyAnalyzer) Name() string { return s.name }
 
-func (s *spyAnalyzer) Analyze(_ context.Context, in interfaces.AnalyzerInput) (*interfaces.AnalyzerResult, error) {
+func (s *spyAnalyzer) Analyze(_ context.Context, in domain.AnalyzerInput) (*domain.AnalyzerResult, error) {
 	s.callCount++
 	if s.panicMsg != "" {
 		panic(s.panicMsg)
@@ -51,7 +51,7 @@ func (s *spyAnalyzer) Analyze(_ context.Context, in interfaces.AnalyzerInput) (*
 	if s.err != nil {
 		return nil, s.err
 	}
-	return &interfaces.AnalyzerResult{AnalyzerName: s.name, ModelID: in.ModelID}, nil
+	return &domain.AnalyzerResult{AnalyzerName: s.name, ModelID: in.ModelID}, nil
 }
 
 var _ = Describe("Engine analyzer registry", func() {
@@ -64,7 +64,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
 
 			Expect(engine.analyzers).To(HaveLen(1))
-			Expect(engine.analyzers[0].name).To(Equal(interfaces.SaturationAnalyzerName))
+			Expect(engine.analyzers[0].name).To(Equal(domain.SaturationAnalyzerName))
 			Expect(engine.analyzers[0].analyzer).To(BeIdenticalTo(engine.saturationV2Analyzer))
 		})
 	})
@@ -73,7 +73,7 @@ var _ = Describe("Engine analyzer registry", func() {
 		It("appends new analyzers in registration order", func() {
 			e := &Engine{
 				analyzers: []analyzerEntry{
-					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+					{name: domain.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: domain.SaturationAnalyzerName}},
 				},
 			}
 
@@ -81,7 +81,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			Expect(e.RegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})).To(Succeed())
 
 			Expect(e.analyzers).To(HaveLen(3))
-			Expect(e.analyzers[0].name).To(Equal(interfaces.SaturationAnalyzerName))
+			Expect(e.analyzers[0].name).To(Equal(domain.SaturationAnalyzerName))
 			Expect(e.analyzers[1].name).To(Equal("throughput"))
 			Expect(e.analyzers[2].name).To(Equal("slo"))
 		})
@@ -89,7 +89,7 @@ var _ = Describe("Engine analyzer registry", func() {
 		It("returns an error when re-registering an existing name", func() {
 			e := &Engine{
 				analyzers: []analyzerEntry{
-					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+					{name: domain.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: domain.SaturationAnalyzerName}},
 					{name: "throughput", analyzer: &spyAnalyzer{name: "throughput"}},
 				},
 			}
@@ -97,14 +97,14 @@ var _ = Describe("Engine analyzer registry", func() {
 			Expect(e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})).
 				To(MatchError(ContainSubstring(`duplicate analyzer name "throughput"`)))
 
-			Expect(e.RegisterAnalyzer(interfaces.SaturationAnalyzerName, &spyAnalyzer{name: "x"})).
+			Expect(e.RegisterAnalyzer(domain.SaturationAnalyzerName, &spyAnalyzer{name: "x"})).
 				To(MatchError(ContainSubstring(`duplicate analyzer name`)))
 		})
 
 		It("returns an error when called after StartOptimizeLoop has frozen the registry", func() {
 			e := &Engine{
 				analyzers: []analyzerEntry{
-					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+					{name: domain.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: domain.SaturationAnalyzerName}},
 				},
 				started: true,
 			}
@@ -201,7 +201,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			spy := &spyAnalyzer{name: "throughput", err: errors.New("boom")}
 			entry := analyzerEntry{name: "throughput", analyzer: spy}
 			result := runRegisteredAnalyzer(testCtx, testLogger, entry, "model-1",
-				interfaces.AnalyzerInput{ModelID: "model-1"})
+				domain.AnalyzerInput{ModelID: "model-1"})
 			Expect(result).To(BeNil())
 			Expect(spy.callCount).To(Equal(1))
 		})
@@ -209,10 +209,10 @@ var _ = Describe("Engine analyzer registry", func() {
 		It("recovers from a panicking analyzer and returns nil", func() {
 			spy := &spyAnalyzer{name: "throughput", panicMsg: "boom"}
 			entry := analyzerEntry{name: "throughput", analyzer: spy}
-			var result *interfaces.AnalyzerResult
+			var result *domain.AnalyzerResult
 			Expect(func() {
 				result = runRegisteredAnalyzer(testCtx, testLogger, entry, "model-1",
-					interfaces.AnalyzerInput{ModelID: "model-1"})
+					domain.AnalyzerInput{ModelID: "model-1"})
 			}).NotTo(Panic())
 			Expect(result).To(BeNil())
 		})

--- a/internal/engines/saturation/engine_scale_to_zero_enforce_test.go
+++ b/internal/engines/saturation/engine_scale_to_zero_enforce_test.go
@@ -11,8 +11,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
@@ -60,8 +60,8 @@ var _ = Describe("applyScaleToZeroEnforcement", func() {
 		}
 	}
 
-	decisions := func() []interfaces.VariantDecision {
-		return []interfaces.VariantDecision{
+	decisions := func() []domain.VariantDecision {
+		return []domain.VariantDecision{
 			{VariantName: "v1", ModelID: modelID, Namespace: namespace, Cost: 1.0, CurrentReplicas: 2, TargetReplicas: 2},
 		}
 	}
@@ -102,7 +102,7 @@ var _ = Describe("applyScaleToZeroEnforcement", func() {
 		min := 1
 		scaledToZero := e.applyScaleToZeroEnforcement(ctx, modelID, namespace, "v1-saturation",
 			d, map[string]scaletarget.ScaleTargetAccessor{"a": target("vllm/vllm-openai:latest")},
-			[]interfaces.VariantReplicaState{{VariantName: "v1", MinReplicas: &min}})
+			[]domain.VariantReplicaState{{VariantName: "v1", MinReplicas: &min}})
 		Expect(scaledToZero).To(BeFalse())
 		Expect(d[0].TargetReplicas).To(Equal(2))
 	})

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -35,8 +35,8 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	interfaces "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	utils "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	testutils "github.com/llm-d/llm-d-workload-variant-autoscaler/test/utils"
@@ -254,10 +254,10 @@ var _ = Describe("Saturation Engine", func() {
 				"variant-c": 2,
 			}
 
-			saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+			saturationAnalysis := &domain.ModelSaturationAnalysis{
 				ModelID:   "test-model",
 				Namespace: "test-ns",
-				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+				VariantAnalyses: []domain.VariantSaturationAnalysis{
 					{VariantName: "variant-a", AcceleratorName: "A100", Cost: 10.0},
 					{VariantName: "variant-b", AcceleratorName: "A100", Cost: 10.0},
 					{VariantName: "variant-c", AcceleratorName: "A100", Cost: 10.0},
@@ -266,7 +266,7 @@ var _ = Describe("Saturation Engine", func() {
 
 			// Populate Role to verify it propagates to VariantDecision in the
 			// P/D-aware path (empty, prefill, decode cover the common cases).
-			variantStates := []interfaces.VariantReplicaState{
+			variantStates := []domain.VariantReplicaState{
 				{VariantName: "variant-a", CurrentReplicas: 3, DesiredReplicas: 3, Role: ""},
 				{VariantName: "variant-b", CurrentReplicas: 3, DesiredReplicas: 3, Role: "prefill"},
 				{VariantName: "variant-c", CurrentReplicas: 2, DesiredReplicas: 2, Role: "decode"},
@@ -285,15 +285,15 @@ var _ = Describe("Saturation Engine", func() {
 			Expect(decisions).To(HaveLen(3), "All 3 variants should have decisions including ActionNoChange")
 
 			By("Verifying ActionNoChange decisions are present")
-			decisionMap := make(map[string]interfaces.VariantDecision)
+			decisionMap := make(map[string]domain.VariantDecision)
 			for _, d := range decisions {
 				decisionMap[d.VariantName] = d
 			}
 
 			Expect(decisionMap).To(HaveKey("variant-a"))
-			Expect(decisionMap["variant-a"].Action).To(Equal(interfaces.ActionNoChange))
-			Expect(decisionMap["variant-b"].Action).To(Equal(interfaces.ActionScaleUp))
-			Expect(decisionMap["variant-c"].Action).To(Equal(interfaces.ActionNoChange))
+			Expect(decisionMap["variant-a"].Action).To(Equal(domain.ActionNoChange))
+			Expect(decisionMap["variant-b"].Action).To(Equal(domain.ActionScaleUp))
+			Expect(decisionMap["variant-c"].Action).To(Equal(domain.ActionNoChange))
 
 			By("Verifying Role propagates from VariantReplicaState to VariantDecision")
 			Expect(decisionMap["variant-a"].Role).To(Equal(""), "empty role must pass through unchanged")
@@ -536,7 +536,7 @@ var _ = Describe("Saturation Engine", func() {
 			testConfig := config.NewTestConfig()
 			testConfig.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{
 				"default": {
-					AnalyzerName:  interfaces.SaturationAnalyzerName, // V2 path
+					AnalyzerName:  domain.SaturationAnalyzerName, // V2 path
 					EnableLimiter: false,
 				},
 			})
@@ -551,7 +551,7 @@ var _ = Describe("Saturation Engine", func() {
 			By("Updating config to EnableLimiter=true")
 			testConfig.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{
 				"default": {
-					AnalyzerName:  interfaces.SaturationAnalyzerName, // V2 path
+					AnalyzerName:  domain.SaturationAnalyzerName, // V2 path
 					EnableLimiter: true,
 				},
 			})
@@ -565,7 +565,7 @@ var _ = Describe("Saturation Engine", func() {
 			By("Updating config back to EnableLimiter=false")
 			testConfig.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{
 				"default": {
-					AnalyzerName:  interfaces.SaturationAnalyzerName, // V2 path
+					AnalyzerName:  domain.SaturationAnalyzerName, // V2 path
 					EnableLimiter: false,
 				},
 			})

--- a/internal/engines/saturation/engine_v1_utilization_test.go
+++ b/internal/engines/saturation/engine_v1_utilization_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
@@ -16,10 +16,10 @@ func TestConvertSaturationTargetsToDecisions_V1Utilization(t *testing.T) {
 	engine := &Engine{}
 	ctx := context.Background()
 
-	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+	saturationAnalysis := &domain.ModelSaturationAnalysis{
 		ModelID:   "test-model",
 		Namespace: "test-ns",
-		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+		VariantAnalyses: []domain.VariantSaturationAnalysis{
 			{
 				VariantName:        "variant-a",
 				AcceleratorName:    "nvidia-a100",
@@ -42,7 +42,7 @@ func TestConvertSaturationTargetsToDecisions_V1Utilization(t *testing.T) {
 		"variant-b": 5,
 	}
 
-	variantStates := []interfaces.VariantReplicaState{
+	variantStates := []domain.VariantReplicaState{
 		{VariantName: "variant-a", CurrentReplicas: 2, DesiredReplicas: 0, GPUsPerReplica: 1},
 		{VariantName: "variant-b", CurrentReplicas: 4, DesiredReplicas: 0, GPUsPerReplica: 2},
 	}
@@ -54,7 +54,7 @@ func TestConvertSaturationTargetsToDecisions_V1Utilization(t *testing.T) {
 	}
 
 	// Find decisions by variant name
-	decisionMap := make(map[string]interfaces.VariantDecision)
+	decisionMap := make(map[string]domain.VariantDecision)
 	for _, d := range decisions {
 		decisionMap[d.VariantName] = d
 	}

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -8,8 +8,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
@@ -22,13 +22,13 @@ import (
 func (e *Engine) runV2AnalysisOnly(
 	ctx context.Context,
 	modelID, namespace string,
-	replicaMetrics []interfaces.ReplicaMetrics,
+	replicaMetrics []domain.ReplicaMetrics,
 	config config.SaturationScalingConfig,
-	variantStates []interfaces.VariantReplicaState,
+	variantStates []domain.VariantReplicaState,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	schedulerQueue *interfaces.SchedulerQueueMetrics,
-) (*interfaces.AnalyzerResult, error) {
+	schedulerQueue *domain.SchedulerQueueMetrics,
+) (*domain.AnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// 1. Pre-populate capacity store with scale target-derived params
@@ -49,7 +49,7 @@ func (e *Engine) runV2AnalysisOnly(
 	}
 
 	// 2. Build AnalyzerInput
-	input := interfaces.AnalyzerInput{
+	input := domain.AnalyzerInput{
 		ModelID:        modelID,
 		Namespace:      namespace,
 		ReplicaMetrics: replicaMetrics,
@@ -84,12 +84,12 @@ func (e *Engine) runV2AnalysisOnly(
 func (e *Engine) runAnalyzersAndScore(
 	ctx context.Context,
 	modelID, namespace string,
-	replicaMetrics []interfaces.ReplicaMetrics,
+	replicaMetrics []domain.ReplicaMetrics,
 	config config.SaturationScalingConfig,
-	variantStates []interfaces.VariantReplicaState,
+	variantStates []domain.VariantReplicaState,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	schedulerQueue *interfaces.SchedulerQueueMetrics,
+	schedulerQueue *domain.SchedulerQueueMetrics,
 ) ([]pipeline.NamedAnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -102,7 +102,7 @@ func (e *Engine) runAnalyzersAndScore(
 
 	// Universal threshold post-step for saturation: recalibrate RC/SC using the
 	// resolved threshold for the saturation entry (per-analyzer override over global).
-	satUp, satDown := resolveThresholds(interfaces.SaturationAnalyzerName, config)
+	satUp, satDown := resolveThresholds(domain.SaturationAnalyzerName, config)
 	applyUniversalThreshold(baseResult, satUp, satDown)
 
 	// Build AnalyzerInput once; shared by all non-saturation analyzers.
@@ -112,7 +112,7 @@ func (e *Engine) runAnalyzersAndScore(
 	// on this branch (their results are discarded), and the clean fix —
 	// engine applies thresholds universally after each analyzer runs —
 	// is tracked on multi-analyzer-threshold (PR #1228).
-	input := interfaces.AnalyzerInput{
+	input := domain.AnalyzerInput{
 		ModelID:        modelID,
 		Namespace:      namespace,
 		ReplicaMetrics: replicaMetrics,
@@ -124,16 +124,16 @@ func (e *Engine) runAnalyzersAndScore(
 	// Collect per-analyzer results. Saturation is first; each non-saturation
 	// analyzer is run, calibrated with its resolved thresholds, and appended.
 	namedResults := []pipeline.NamedAnalyzerResult{{
-		Name:              interfaces.SaturationAnalyzerName,
+		Name:              domain.SaturationAnalyzerName,
 		Result:            baseResult,
-		Score:             scoreForAnalyzer(interfaces.SaturationAnalyzerName, config),
+		Score:             scoreForAnalyzer(domain.SaturationAnalyzerName, config),
 		Remaining:         baseResult.RequiredCapacity,
 		Spare:             baseResult.SpareCapacity,
 		ScaleUpThreshold:  satUp,
 		ScaleDownBoundary: satDown,
 	}}
 	for _, entry := range e.analyzersSnapshot {
-		if entry.name == interfaces.SaturationAnalyzerName {
+		if entry.name == domain.SaturationAnalyzerName {
 			continue
 		}
 		if !effectiveEnabled(entry.name, config) {
@@ -211,8 +211,8 @@ func runRegisteredAnalyzer(
 	logger logr.Logger,
 	entry analyzerEntry,
 	modelID string,
-	input interfaces.AnalyzerInput,
-) (result *interfaces.AnalyzerResult) {
+	input domain.AnalyzerInput,
+) (result *domain.AnalyzerResult) {
 	defer func() {
 		if r := recover(); r != nil {
 			// Plugin failure is non-fatal; log at debug to avoid spamming
@@ -251,7 +251,7 @@ func runRegisteredAnalyzer(
 // scope — model-level and each RoleCapacity entry. There are no per-role
 // threshold overrides. A non-positive scaleUp or scaleDown leaves the
 // corresponding signal unchanged.
-func applyUniversalThreshold(r *interfaces.AnalyzerResult, scaleUp, scaleDown float64) {
+func applyUniversalThreshold(r *domain.AnalyzerResult, scaleUp, scaleDown float64) {
 	if r == nil {
 		return
 	}
@@ -296,9 +296,9 @@ func applyUniversalThreshold(r *interfaces.AnalyzerResult, scaleUp, scaleDown fl
 func computeCurrentGPUUsage(requests []pipeline.ModelScalingRequest) map[string]int {
 	usage := make(map[string]int)
 	for _, req := range requests {
-		var satEntry *interfaces.AnalyzerResult
+		var satEntry *domain.AnalyzerResult
 		for _, e := range req.AnalyzerResults {
-			if e.Name == interfaces.SaturationAnalyzerName {
+			if e.Name == domain.SaturationAnalyzerName {
 				satEntry = e.Result
 				break
 			}
@@ -306,7 +306,7 @@ func computeCurrentGPUUsage(requests []pipeline.ModelScalingRequest) map[string]
 		if satEntry == nil {
 			continue
 		}
-		stateMap := make(map[string]interfaces.VariantReplicaState, len(req.VariantStates))
+		stateMap := make(map[string]domain.VariantReplicaState, len(req.VariantStates))
 		for _, s := range req.VariantStates {
 			stateMap[s.VariantName] = s
 		}
@@ -335,9 +335,9 @@ func computeCurrentGPUUsageByNamespace(requests []pipeline.ModelScalingRequest) 
 			perType = make(map[string]int)
 			usage[req.Namespace] = perType
 		}
-		var satEntry *interfaces.AnalyzerResult
+		var satEntry *domain.AnalyzerResult
 		for _, e := range req.AnalyzerResults {
-			if e.Name == interfaces.SaturationAnalyzerName {
+			if e.Name == domain.SaturationAnalyzerName {
 				satEntry = e.Result
 				break
 			}
@@ -345,7 +345,7 @@ func computeCurrentGPUUsageByNamespace(requests []pipeline.ModelScalingRequest) 
 		if satEntry == nil {
 			continue
 		}
-		stateMap := make(map[string]interfaces.VariantReplicaState, len(req.VariantStates))
+		stateMap := make(map[string]domain.VariantReplicaState, len(req.VariantStates))
 		for _, s := range req.VariantStates {
 			stateMap[s.VariantName] = s
 		}
@@ -388,12 +388,12 @@ func gpuConstraintProviders(l pipeline.Limiter) []pipeline.ConstraintProvider {
 func (e *Engine) collectV2ModelRequest(
 	ctx context.Context,
 	modelID, namespace string,
-	replicaMetrics []interfaces.ReplicaMetrics,
+	replicaMetrics []domain.ReplicaMetrics,
 	config config.SaturationScalingConfig,
-	variantStates []interfaces.VariantReplicaState,
+	variantStates []domain.VariantReplicaState,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	schedulerQueue *interfaces.SchedulerQueueMetrics,
+	schedulerQueue *domain.SchedulerQueueMetrics,
 ) (*pipeline.ModelScalingRequest, error) {
 	namedResults, err := e.runAnalyzersAndScore(ctx, modelID, namespace, replicaMetrics, config,
 		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
@@ -401,10 +401,10 @@ func (e *Engine) collectV2ModelRequest(
 		return nil, fmt.Errorf("collecting V2 model request for %s/%s: %w", namespace, modelID, err)
 	}
 
-	// Detect P/D disaggregation: true when any variant has role != interfaces.RoleBoth
+	// Detect P/D disaggregation: true when any variant has role != domain.RoleBoth
 	disaggregated := false
 	for _, vs := range variantStates {
-		if vs.Role != "" && vs.Role != interfaces.RoleBoth {
+		if vs.Role != "" && vs.Role != domain.RoleBoth {
 			disaggregated = true
 			break
 		}
@@ -463,7 +463,7 @@ func logAnalyzerResult(ctx context.Context, modelID, namespace string, nr pipeli
 func logScalingDecisions(
 	ctx context.Context,
 	modelRequests []pipeline.ModelScalingRequest,
-	decisions []interfaces.VariantDecision,
+	decisions []domain.VariantDecision,
 ) {
 	logger := ctrl.LoggerFrom(ctx)
 

--- a/internal/engines/saturation/engine_v2_log_test.go
+++ b/internal/engines/saturation/engine_v2_log_test.go
@@ -13,8 +13,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
 func zapObserverCtx(t *testing.T) (context.Context, *observer.ObservedLogs) {
@@ -31,13 +31,13 @@ func TestLogAnalyzerResult_EmitsRequiredFields(t *testing.T) {
 		Name:              "saturation",
 		ScaleUpThreshold:  1.2,
 		ScaleDownBoundary: 0.7,
-		Result: &interfaces.AnalyzerResult{
+		Result: &domain.AnalyzerResult{
 			TotalSupply:      100000,
 			TotalDemand:      80000,
 			Utilization:      0.8,
 			RequiredCapacity: 0,
 			SpareCapacity:    20000,
-			VariantCapacities: []interfaces.VariantCapacity{
+			VariantCapacities: []domain.VariantCapacity{
 				{
 					VariantName:        "primary",
 					PerReplicaCapacity: 50000,
@@ -87,11 +87,11 @@ func TestLogAnalyzerResult_EmptyVariants(t *testing.T) {
 
 	nr := pipeline.NamedAnalyzerResult{
 		Name: "throughput",
-		Result: &interfaces.AnalyzerResult{
+		Result: &domain.AnalyzerResult{
 			TotalSupply:       0,
 			TotalDemand:       0,
 			RequiredCapacity:  15000,
-			VariantCapacities: []interfaces.VariantCapacity{},
+			VariantCapacities: []domain.VariantCapacity{},
 		},
 	}
 
@@ -110,10 +110,10 @@ func TestLogScalingDecisions_EmitsPerModel(t *testing.T) {
 		{ModelID: "model-a", Namespace: "ns"},
 		{ModelID: "model-b", Namespace: "ns"},
 	}
-	decisions := []interfaces.VariantDecision{
-		{ModelID: "model-a", Namespace: "ns", VariantName: "v1", CurrentReplicas: 1, TargetReplicas: 2, Action: interfaces.ActionScaleUp},
-		{ModelID: "model-a", Namespace: "ns", VariantName: "v2", CurrentReplicas: 1, TargetReplicas: 1, Action: interfaces.ActionNoChange},
-		{ModelID: "model-b", Namespace: "ns", VariantName: "v1", CurrentReplicas: 2, TargetReplicas: 1, Action: interfaces.ActionScaleDown},
+	decisions := []domain.VariantDecision{
+		{ModelID: "model-a", Namespace: "ns", VariantName: "v1", CurrentReplicas: 1, TargetReplicas: 2, Action: domain.ActionScaleUp},
+		{ModelID: "model-a", Namespace: "ns", VariantName: "v2", CurrentReplicas: 1, TargetReplicas: 1, Action: domain.ActionNoChange},
+		{ModelID: "model-b", Namespace: "ns", VariantName: "v1", CurrentReplicas: 2, TargetReplicas: 1, Action: domain.ActionScaleDown},
 	}
 
 	logScalingDecisions(ctx, requests, decisions)
@@ -137,8 +137,8 @@ func TestLogScalingDecisions_NoDecisionsSkipsModel(t *testing.T) {
 		{ModelID: "model-b", Namespace: "ns"},
 	}
 	// Only model-a has a decision; model-b has none.
-	decisions := []interfaces.VariantDecision{
-		{ModelID: "model-a", Namespace: "ns", VariantName: "v1", Action: interfaces.ActionNoChange},
+	decisions := []domain.VariantDecision{
+		{ModelID: "model-a", Namespace: "ns", VariantName: "v1", Action: domain.ActionNoChange},
 	}
 
 	logScalingDecisions(ctx, requests, decisions)

--- a/internal/engines/saturation/engine_v2_optimizer_select_test.go
+++ b/internal/engines/saturation/engine_v2_optimizer_select_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
 // selectInventory is a minimal pipeline.Inventory whose Refresh result and
@@ -66,7 +66,7 @@ func (s *selectInventory) TotalAvailable() int {
 type selectLimiter struct{}
 
 func (selectLimiter) Name() string { return "select-limiter" }
-func (selectLimiter) Limit(context.Context, []*interfaces.VariantDecision) error {
+func (selectLimiter) Limit(context.Context, []*domain.VariantDecision) error {
 	return nil
 }
 

--- a/internal/engines/saturation/engine_v2_population_test.go
+++ b/internal/engines/saturation/engine_v2_population_test.go
@@ -7,20 +7,20 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
-// fakeAnalyzerWithResult is a minimal interfaces.Analyzer whose Analyze result
+// fakeAnalyzerWithResult is a minimal domain.Analyzer whose Analyze result
 // is set at construction time. Used to inject controlled saturation/spy output
 // into runAnalyzersAndScore without needing a real SaturationAnalyzer.
 type fakeAnalyzerWithResult struct {
 	analyzerName string
-	result       *interfaces.AnalyzerResult
+	result       *domain.AnalyzerResult
 }
 
 func (f *fakeAnalyzerWithResult) Name() string { return f.analyzerName }
-func (f *fakeAnalyzerWithResult) Analyze(_ context.Context, _ interfaces.AnalyzerInput) (*interfaces.AnalyzerResult, error) {
+func (f *fakeAnalyzerWithResult) Analyze(_ context.Context, _ domain.AnalyzerInput) (*domain.AnalyzerResult, error) {
 	return f.result, nil
 }
 
@@ -101,9 +101,9 @@ var _ = Describe("Engine config-population helpers", func() {
 
 		// minEngine builds a minimal Engine suitable for calling runAnalyzersAndScore.
 		// satFake is used as saturationV2Analyzer; spies is the additional snapshot.
-		minEngine := func(satFake interfaces.Analyzer, spies ...analyzerEntry) *Engine {
+		minEngine := func(satFake domain.Analyzer, spies ...analyzerEntry) *Engine {
 			snapshot := append(
-				[]analyzerEntry{{name: interfaces.SaturationAnalyzerName, analyzer: satFake}},
+				[]analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: satFake}},
 				spies...,
 			)
 			return &Engine{
@@ -114,21 +114,21 @@ var _ = Describe("Engine config-population helpers", func() {
 		}
 
 		zeroSat := &fakeAnalyzerWithResult{
-			analyzerName: interfaces.SaturationAnalyzerName,
-			result:       &interfaces.AnalyzerResult{},
+			analyzerName: domain.SaturationAnalyzerName,
+			result:       &domain.AnalyzerResult{},
 		}
 
 		It("populates Score from AnalyzerScoreConfig.Score into the returned slice", func() {
 			spy := &fakeAnalyzerWithResult{
 				analyzerName: "spy",
-				result:       &interfaces.AnalyzerResult{},
+				result:       &domain.AnalyzerResult{},
 			}
 			e := minEngine(zeroSat, analyzerEntry{name: "spy", analyzer: spy})
 			cfg := config.SaturationScalingConfig{
 				ScaleUpThreshold:  0.85,
 				ScaleDownBoundary: 0.70,
 				Analyzers: []config.AnalyzerScoreConfig{
-					{Name: interfaces.SaturationAnalyzerName, Score: 2.0},
+					{Name: domain.SaturationAnalyzerName, Score: 2.0},
 					{Name: "spy", Score: 0.5},
 				},
 			}
@@ -138,14 +138,14 @@ var _ = Describe("Engine config-population helpers", func() {
 			Expect(results).To(HaveLen(2))
 
 			byName := namedByName(results)
-			Expect(byName[interfaces.SaturationAnalyzerName].Score).To(Equal(2.0))
+			Expect(byName[domain.SaturationAnalyzerName].Score).To(Equal(2.0))
 			Expect(byName["spy"].Score).To(Equal(0.5))
 		})
 
 		It("defaults Score to 1.0 when the analyzer has no Analyzers entry", func() {
 			spy := &fakeAnalyzerWithResult{
 				analyzerName: "spy",
-				result:       &interfaces.AnalyzerResult{},
+				result:       &domain.AnalyzerResult{},
 			}
 			e := minEngine(zeroSat, analyzerEntry{name: "spy", analyzer: spy})
 			cfg := config.SaturationScalingConfig{
@@ -159,7 +159,7 @@ var _ = Describe("Engine config-population helpers", func() {
 			Expect(results).To(HaveLen(2))
 
 			byName := namedByName(results)
-			Expect(byName[interfaces.SaturationAnalyzerName].Score).To(Equal(1.0))
+			Expect(byName[domain.SaturationAnalyzerName].Score).To(Equal(1.0))
 			Expect(byName["spy"].Score).To(Equal(1.0))
 		})
 
@@ -167,7 +167,7 @@ var _ = Describe("Engine config-population helpers", func() {
 			// spy returns TotalDemand=100, everything else zero.
 			spy := &fakeAnalyzerWithResult{
 				analyzerName: "spy",
-				result:       &interfaces.AnalyzerResult{TotalDemand: 100},
+				result:       &domain.AnalyzerResult{TotalDemand: 100},
 			}
 			e := minEngine(zeroSat, analyzerEntry{name: "spy", analyzer: spy})
 

--- a/internal/engines/saturation/engine_v2_quota_test.go
+++ b/internal/engines/saturation/engine_v2_quota_test.go
@@ -5,18 +5,18 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
 // satReq builds a ModelScalingRequest with a saturation analyzer entry whose
 // variant capacities and replica states drive computeCurrentGPUUsageByNamespace.
-func satReq(namespace string, vcs []interfaces.VariantCapacity, states []interfaces.VariantReplicaState) pipeline.ModelScalingRequest {
+func satReq(namespace string, vcs []domain.VariantCapacity, states []domain.VariantReplicaState) pipeline.ModelScalingRequest {
 	return pipeline.ModelScalingRequest{
 		Namespace: namespace,
 		AnalyzerResults: []pipeline.NamedAnalyzerResult{{
-			Name:   interfaces.SaturationAnalyzerName,
-			Result: &interfaces.AnalyzerResult{Namespace: namespace, VariantCapacities: vcs},
+			Name:   domain.SaturationAnalyzerName,
+			Result: &domain.AnalyzerResult{Namespace: namespace, VariantCapacities: vcs},
 		}},
 		VariantStates: states,
 	}
@@ -26,11 +26,11 @@ var _ = Describe("computeCurrentGPUUsageByNamespace", func() {
 	It("sums currentReplicas*gpusPerReplica per (namespace, accelerator type)", func() {
 		usage := computeCurrentGPUUsageByNamespace([]pipeline.ModelScalingRequest{
 			satReq("team-a",
-				[]interfaces.VariantCapacity{{VariantName: "v", AcceleratorName: "A100"}},
-				[]interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 2, GPUsPerReplica: 2}}),
+				[]domain.VariantCapacity{{VariantName: "v", AcceleratorName: "A100"}},
+				[]domain.VariantReplicaState{{VariantName: "v", CurrentReplicas: 2, GPUsPerReplica: 2}}),
 			satReq("team-b",
-				[]interfaces.VariantCapacity{{VariantName: "w", AcceleratorName: "H100"}},
-				[]interfaces.VariantReplicaState{{VariantName: "w", CurrentReplicas: 1, GPUsPerReplica: 4}}),
+				[]domain.VariantCapacity{{VariantName: "w", AcceleratorName: "H100"}},
+				[]domain.VariantReplicaState{{VariantName: "w", CurrentReplicas: 1, GPUsPerReplica: 4}}),
 		})
 		Expect(usage["team-a"]).To(HaveKeyWithValue("A100", 4))
 		Expect(usage["team-b"]).To(HaveKeyWithValue("H100", 4))
@@ -39,8 +39,8 @@ var _ = Describe("computeCurrentGPUUsageByNamespace", func() {
 	It("defaults GPUsPerReplica <= 0 to 1", func() {
 		usage := computeCurrentGPUUsageByNamespace([]pipeline.ModelScalingRequest{
 			satReq("team-a",
-				[]interfaces.VariantCapacity{{VariantName: "v", AcceleratorName: "A100"}},
-				[]interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 3, GPUsPerReplica: 0}}),
+				[]domain.VariantCapacity{{VariantName: "v", AcceleratorName: "A100"}},
+				[]domain.VariantReplicaState{{VariantName: "v", CurrentReplicas: 3, GPUsPerReplica: 0}}),
 		})
 		Expect(usage["team-a"]).To(HaveKeyWithValue("A100", 3), "GPUsPerReplica defaulted to 1")
 	})

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -9,17 +9,17 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
 // withSatEntryV2 adds a single-saturation AnalyzerResults to req from r.
 // Mirrors the helper in cost_aware_optimizer_test.go for use in the saturation package.
-func withSatEntryV2(r *interfaces.AnalyzerResult, req pipeline.ModelScalingRequest) pipeline.ModelScalingRequest {
+func withSatEntryV2(r *domain.AnalyzerResult, req pipeline.ModelScalingRequest) pipeline.ModelScalingRequest {
 	if r != nil {
 		req.AnalyzerResults = []pipeline.NamedAnalyzerResult{{
-			Name:      interfaces.SaturationAnalyzerName,
+			Name:      domain.SaturationAnalyzerName,
 			Result:    r,
 			Remaining: r.RequiredCapacity,
 			Spare:     r.SpareCapacity,
@@ -34,11 +34,11 @@ var _ = Describe("V2 Engine Integration", func() {
 
 		It("should scale up cheapest variant by cost-efficiency", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "variant-cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 					{VariantName: "variant-expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 				},
@@ -47,7 +47,7 @@ var _ = Describe("V2 Engine Integration", func() {
 				withSatEntryV2(r, pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "variant-cheap", CurrentReplicas: 2},
 						{VariantName: "variant-expensive", CurrentReplicas: 1},
 					},
@@ -65,11 +65,11 @@ var _ = Describe("V2 Engine Integration", func() {
 
 		It("should scale down most expensive variant", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:       "model-1",
 				Namespace:     "default",
 				SpareCapacity: 25000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
 					{VariantName: "variant-expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
 				},
@@ -78,7 +78,7 @@ var _ = Describe("V2 Engine Integration", func() {
 				withSatEntryV2(r, pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "variant-cheap", CurrentReplicas: 3},
 						{VariantName: "variant-expensive", CurrentReplicas: 2},
 					},
@@ -94,11 +94,11 @@ var _ = Describe("V2 Engine Integration", func() {
 
 		It("should protect cheapest variant at 1 during scale-down", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:       "model-1",
 				Namespace:     "default",
 				SpareCapacity: 30000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "variant-expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
 					{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
 				},
@@ -107,7 +107,7 @@ var _ = Describe("V2 Engine Integration", func() {
 				withSatEntryV2(r, pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "variant-expensive", CurrentReplicas: 1},
 						{VariantName: "variant-cheap", CurrentReplicas: 1},
 					},
@@ -123,11 +123,11 @@ var _ = Describe("V2 Engine Integration", func() {
 
 		It("should not skip variants with pending replicas", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
-			r := &interfaces.AnalyzerResult{
+			r := &domain.AnalyzerResult{
 				ModelID:          "model-1",
 				Namespace:        "default",
 				RequiredCapacity: 5000,
-				VariantCapacities: []interfaces.VariantCapacity{
+				VariantCapacities: []domain.VariantCapacity{
 					{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
 					{VariantName: "variant-mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
 				},
@@ -136,7 +136,7 @@ var _ = Describe("V2 Engine Integration", func() {
 				withSatEntryV2(r, pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					VariantStates: []interfaces.VariantReplicaState{
+					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "variant-cheap", CurrentReplicas: 2, PendingReplicas: 1},
 						{VariantName: "variant-mid", CurrentReplicas: 1},
 					},
@@ -284,15 +284,15 @@ var _ = Describe("runAnalyzersAndScore call ordering", func() {
 
 	It("calls each enabled non-saturation analyzer exactly once in registration order", func() {
 		fakeSat := &fakeAnalyzerWithResult{
-			analyzerName: interfaces.SaturationAnalyzerName,
-			result:       &interfaces.AnalyzerResult{},
+			analyzerName: domain.SaturationAnalyzerName,
+			result:       &domain.AnalyzerResult{},
 		}
 		ta := &spyAnalyzer{name: "throughput"}
 		slo := &spyAnalyzer{name: "slo"}
 		e := &Engine{
 			saturationV2Analyzer: fakeSat,
 			analyzersSnapshot: []analyzerEntry{
-				{name: interfaces.SaturationAnalyzerName, analyzer: fakeSat},
+				{name: domain.SaturationAnalyzerName, analyzer: fakeSat},
 				{name: "throughput", analyzer: ta},
 				{name: "slo", analyzer: slo},
 			},
@@ -311,7 +311,7 @@ var _ = Describe("runAnalyzersAndScore call ordering", func() {
 		Expect(slo.callCount).To(Equal(1))
 		// saturationV2Analyzer is called via runV2AnalysisOnly, not the loop;
 		// the snapshot entry for saturation is skipped by the name guard.
-		Expect(fakeSat.Name()).To(Equal(interfaces.SaturationAnalyzerName)) // sanity
+		Expect(fakeSat.Name()).To(Equal(domain.SaturationAnalyzerName)) // sanity
 	})
 })
 
@@ -319,14 +319,14 @@ var _ = Describe("runAnalyzersAndScore disabled-analyzer gate", func() {
 
 	It("disabled analyzer is not appended and its Analyze is never called", func() {
 		fakeSat := &fakeAnalyzerWithResult{
-			analyzerName: interfaces.SaturationAnalyzerName,
-			result:       &interfaces.AnalyzerResult{SpareCapacity: 1000},
+			analyzerName: domain.SaturationAnalyzerName,
+			result:       &domain.AnalyzerResult{SpareCapacity: 1000},
 		}
 		spy := &spyAnalyzer{name: "spy"}
 		e := &Engine{
 			saturationV2Analyzer: fakeSat,
 			analyzersSnapshot: []analyzerEntry{
-				{name: interfaces.SaturationAnalyzerName, analyzer: fakeSat},
+				{name: domain.SaturationAnalyzerName, analyzer: fakeSat},
 				{name: "spy", analyzer: spy},
 			},
 			started: true,
@@ -343,7 +343,7 @@ var _ = Describe("runAnalyzersAndScore disabled-analyzer gate", func() {
 		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(results).To(HaveLen(1), "only saturation entry — disabled spy must not be appended")
-		Expect(results[0].Name).To(Equal(interfaces.SaturationAnalyzerName))
+		Expect(results[0].Name).To(Equal(domain.SaturationAnalyzerName))
 		Expect(spy.callCount).To(Equal(0), "Analyze must not be called for a disabled analyzer")
 	})
 })
@@ -352,13 +352,13 @@ var _ = Describe("collectV2ModelRequest Disaggregated flag", func() {
 
 	It("sets Disaggregated=true when any variant has a non-both role", func() {
 		fakeSat := &fakeAnalyzerWithResult{
-			analyzerName: interfaces.SaturationAnalyzerName,
-			result:       &interfaces.AnalyzerResult{},
+			analyzerName: domain.SaturationAnalyzerName,
+			result:       &domain.AnalyzerResult{},
 		}
 		e := &Engine{
 			saturationV2Analyzer: fakeSat,
 			analyzersSnapshot: []analyzerEntry{
-				{name: interfaces.SaturationAnalyzerName, analyzer: fakeSat},
+				{name: domain.SaturationAnalyzerName, analyzer: fakeSat},
 			},
 			started: true,
 		}
@@ -366,7 +366,7 @@ var _ = Describe("collectV2ModelRequest Disaggregated flag", func() {
 			ScaleUpThreshold:  0.85,
 			ScaleDownBoundary: 0.70,
 		}
-		variantStates := []interfaces.VariantReplicaState{
+		variantStates := []domain.VariantReplicaState{
 			{VariantName: "prefill-v1", Role: "prefill"},
 			{VariantName: "decode-v1", Role: "decode"},
 		}
@@ -378,13 +378,13 @@ var _ = Describe("collectV2ModelRequest Disaggregated flag", func() {
 
 	It("sets Disaggregated=false when all variants have role 'both' or empty", func() {
 		fakeSat := &fakeAnalyzerWithResult{
-			analyzerName: interfaces.SaturationAnalyzerName,
-			result:       &interfaces.AnalyzerResult{},
+			analyzerName: domain.SaturationAnalyzerName,
+			result:       &domain.AnalyzerResult{},
 		}
 		e := &Engine{
 			saturationV2Analyzer: fakeSat,
 			analyzersSnapshot: []analyzerEntry{
-				{name: interfaces.SaturationAnalyzerName, analyzer: fakeSat},
+				{name: domain.SaturationAnalyzerName, analyzer: fakeSat},
 			},
 			started: true,
 		}
@@ -392,8 +392,8 @@ var _ = Describe("collectV2ModelRequest Disaggregated flag", func() {
 			ScaleUpThreshold:  0.85,
 			ScaleDownBoundary: 0.70,
 		}
-		variantStates := []interfaces.VariantReplicaState{
-			{VariantName: "v1", Role: interfaces.RoleBoth},
+		variantStates := []domain.VariantReplicaState{
+			{VariantName: "v1", Role: domain.RoleBoth},
 			{VariantName: "v2", Role: ""},
 		}
 
@@ -403,8 +403,8 @@ var _ = Describe("collectV2ModelRequest Disaggregated flag", func() {
 	})
 })
 
-func decisionsByVariant(decisions []interfaces.VariantDecision) map[string]interfaces.VariantDecision {
-	m := make(map[string]interfaces.VariantDecision, len(decisions))
+func decisionsByVariant(decisions []domain.VariantDecision) map[string]domain.VariantDecision {
+	m := make(map[string]domain.VariantDecision, len(decisions))
 	for _, d := range decisions {
 		m[d.VariantName] = d
 	}

--- a/internal/engines/saturation/engine_v2_threshold_test.go
+++ b/internal/engines/saturation/engine_v2_threshold_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 var _ = Describe("applyUniversalThreshold", func() {
@@ -31,7 +31,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 
 	It("scales up when demand exceeds the scale-up threshold against anticipated supply", func() {
 		// RC = 10000/0.85 − 10000 = 1764.7...
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            10000,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 10000,
@@ -44,7 +44,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 
 	It("scales down when demand is well below the scale-down boundary", func() {
 		// SC = 10000 − 5000/0.70 = 2857.1
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            5000,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 10000,
@@ -56,7 +56,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 
 	It("yields RC=SC=0 when demand sits in the hysteresis band", func() {
 		// utilization 0.80: above scaleDown 0.70 (no SC) but below scaleUp 0.85 (no RC)
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            8000,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 10000,
@@ -67,7 +67,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 	})
 
 	It("clamps RC and SC to zero exactly at the respective thresholds", func() {
-		rUp := &interfaces.AnalyzerResult{
+		rUp := &domain.AnalyzerResult{
 			TotalDemand:            10000 * scaleUp,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 10000,
@@ -75,7 +75,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 		applyUniversalThreshold(rUp, scaleUp, scaleDown)
 		Expect(rUp.RequiredCapacity).To(BeNumerically("~", 0, 1e-9))
 
-		rDown := &interfaces.AnalyzerResult{
+		rDown := &domain.AnalyzerResult{
 			TotalDemand:            10000 * scaleDown,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 10000,
@@ -87,7 +87,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 	It("uses anticipated supply for RC but steady-state TotalSupply for SC", func() {
 		// Pending replica: anticipated=10000 > steady-state=7000 → RC=0 despite demand>supply.
 		// SC still uses TotalSupply (7000), not anticipated.
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            8000,
 			TotalSupply:            7000,
 			TotalAnticipatedSupply: 10000,
@@ -102,7 +102,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 	It("treats TotalAnticipatedSupply == 0 as a literal value — RC = TotalDemand/scaleUp", func() {
 		// No fallback: zero means zero anticipated supply.
 		// RC = 10000/0.85 − 0 = 11764.7...
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            10000,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 0,
@@ -112,7 +112,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 	})
 
 	It("does not divide by zero when scaleUp or scaleDown is non-positive", func() {
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            5000,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 10000,
@@ -129,7 +129,7 @@ var _ = Describe("applyUniversalThreshold", func() {
 	})
 
 	It("is idempotent on its own output under the same inputs", func() {
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            12000,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 11000,
@@ -149,11 +149,11 @@ var _ = Describe("applyUniversalThreshold", func() {
 		// P/D disaggregated: two roles with distinct demand/anticipated/supply.
 		// prefill: RC = 8000/0.85 − 11000 = 9411.7 − 11000 → 0; SC = 10000 − 8000/0.70 → 0
 		// decode:  RC = 9500/0.85 − 10000 = 11176.4 − 10000 = 1176.4; SC = 10000 − 9500/0.70 → 0
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            17500,
 			TotalSupply:            20000,
 			TotalAnticipatedSupply: 21000,
-			RoleCapacities: map[string]interfaces.RoleCapacity{
+			RoleCapacities: map[string]domain.RoleCapacity{
 				"prefill": {
 					TotalDemand:            8000,
 					TotalSupply:            10000,
@@ -180,11 +180,11 @@ var _ = Describe("applyUniversalThreshold", func() {
 	It("treats per-role TotalAnticipatedSupply == 0 as a literal value — RC = TotalDemand/scaleUp", func() {
 		// No fallback to TotalSupply; zero means zero anticipated supply for that role.
 		// RC = 5000/0.85 − 0 = 5882.3
-		r := &interfaces.AnalyzerResult{
+		r := &domain.AnalyzerResult{
 			TotalDemand:            5000,
 			TotalSupply:            10000,
 			TotalAnticipatedSupply: 10000,
-			RoleCapacities: map[string]interfaces.RoleCapacity{
+			RoleCapacities: map[string]domain.RoleCapacity{
 				"both": {
 					TotalDemand:            5000,
 					TotalSupply:            10000,

--- a/internal/engines/saturation/event_deduplication_test.go
+++ b/internal/engines/saturation/event_deduplication_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 )
 
@@ -55,13 +55,13 @@ func TestEventDeduplication(t *testing.T) {
 	}
 
 	// First scaling event should be recorded
-	engine.recordScalingEvent(va, interfaces.ActionScaleUp, 3, "First scale up")
+	engine.recordScalingEvent(va, domain.ActionScaleUp, 3, "First scale up")
 
 	// Second scaling event should be deduplicated (not recorded)
-	engine.recordScalingEvent(va, interfaces.ActionScaleDown, 2, "Scale down attempt")
+	engine.recordScalingEvent(va, domain.ActionScaleDown, 2, "Scale down attempt")
 
 	// Third scaling event should also be deduplicated (not recorded)
-	engine.recordScalingEvent(va, interfaces.ActionScaleUp, 4, "Second scale up")
+	engine.recordScalingEvent(va, domain.ActionScaleUp, 4, "Second scale up")
 
 	// Count recorded events - should only be 1
 	eventCount := 0
@@ -108,7 +108,7 @@ func TestEventDeduplicationResourceConstrainedException(t *testing.T) {
 	}
 
 	// Record a scaling event first
-	engine.recordScalingEvent(va, interfaces.ActionScaleUp, 3, "Scale up")
+	engine.recordScalingEvent(va, domain.ActionScaleUp, 3, "Scale up")
 
 	// ResourceConstrained event should still be recorded (exception to deduplication)
 	engine.recordEvent(va, corev1.EventTypeWarning, constants.K8SEventResourceConstrained, "Limited by resources")
@@ -167,7 +167,7 @@ func TestEventDeduplicationNilTracker(t *testing.T) {
 
 	// Should not panic with nil tracker
 	assert.NotPanics(t, func() {
-		engine.recordScalingEvent(va, interfaces.ActionScaleUp, 3, "Scale up")
+		engine.recordScalingEvent(va, domain.ActionScaleUp, 3, "Scale up")
 	})
 
 	// Event should still be recorded
@@ -219,16 +219,16 @@ func TestEventDeduplicationMultipleVAs(t *testing.T) {
 	}
 
 	// Record event for first VA
-	engine.recordScalingEvent(va1, interfaces.ActionScaleUp, 3, "VA1 scale up")
+	engine.recordScalingEvent(va1, domain.ActionScaleUp, 3, "VA1 scale up")
 
 	// Record event for second VA (should be recorded - different VA)
-	engine.recordScalingEvent(va2, interfaces.ActionScaleUp, 2, "VA2 scale up")
+	engine.recordScalingEvent(va2, domain.ActionScaleUp, 2, "VA2 scale up")
 
 	// Try to record another event for first VA (should be deduplicated)
-	engine.recordScalingEvent(va1, interfaces.ActionScaleDown, 1, "VA1 scale down")
+	engine.recordScalingEvent(va1, domain.ActionScaleDown, 1, "VA1 scale down")
 
 	// Try to record another event for second VA (should be deduplicated)
-	engine.recordScalingEvent(va2, interfaces.ActionScaleDown, 1, "VA2 scale down")
+	engine.recordScalingEvent(va2, domain.ActionScaleDown, 1, "VA2 scale down")
 
 	// Count recorded events - should be 2 (one for each VA)
 	eventCount := 0

--- a/internal/engines/saturation/event_scaling_test.go
+++ b/internal/engines/saturation/event_scaling_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 )
 
@@ -49,19 +49,19 @@ func TestScaledUpEvent(t *testing.T) {
 		},
 	}
 
-	decision := &interfaces.VariantDecision{
+	decision := &domain.VariantDecision{
 		VariantName:    "test-va",
-		Action:         interfaces.ActionScaleUp,
+		Action:         domain.ActionScaleUp,
 		TargetReplicas: 3,
 	}
-	decision.SetDecisionReason(interfaces.ActionScaleUp, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
+	decision.SetDecisionReason(domain.ActionScaleUp, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
 
 	// Simulate the event recording logic from applySaturationDecisions
 	if fakeRecorder != nil {
 		switch decision.Action {
-		case interfaces.ActionScaleUp:
+		case domain.ActionScaleUp:
 			fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledUp, decision.Reason())
-		case interfaces.ActionScaleDown:
+		case domain.ActionScaleDown:
 			if decision.TargetReplicas == 0 {
 				fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledToZero, decision.Reason())
 			} else {
@@ -103,19 +103,19 @@ func TestScaledDownEvent(t *testing.T) {
 		},
 	}
 
-	decision := &interfaces.VariantDecision{
+	decision := &domain.VariantDecision{
 		VariantName:    "test-va",
-		Action:         interfaces.ActionScaleDown,
+		Action:         domain.ActionScaleDown,
 		TargetReplicas: 2,
 	}
-	decision.SetDecisionReason(interfaces.ActionScaleDown, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
+	decision.SetDecisionReason(domain.ActionScaleDown, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
 
 	// Simulate the event recording logic from applySaturationDecisions
 	if fakeRecorder != nil {
 		switch decision.Action {
-		case interfaces.ActionScaleUp:
+		case domain.ActionScaleUp:
 			fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledUp, decision.Reason())
-		case interfaces.ActionScaleDown:
+		case domain.ActionScaleDown:
 			if decision.TargetReplicas == 0 {
 				fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledToZero, decision.Reason())
 			} else {
@@ -157,19 +157,19 @@ func TestScaledToZeroEvent(t *testing.T) {
 		},
 	}
 
-	decision := &interfaces.VariantDecision{
+	decision := &domain.VariantDecision{
 		VariantName:    "test-va",
-		Action:         interfaces.ActionScaleDown,
+		Action:         domain.ActionScaleDown,
 		TargetReplicas: 0,
 	}
-	decision.SetDecisionReason(interfaces.ActionScaleDown, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
+	decision.SetDecisionReason(domain.ActionScaleDown, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
 
 	// Simulate the event recording logic from applySaturationDecisions
 	if fakeRecorder != nil {
 		switch decision.Action {
-		case interfaces.ActionScaleUp:
+		case domain.ActionScaleUp:
 			fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledUp, decision.Reason())
-		case interfaces.ActionScaleDown:
+		case domain.ActionScaleDown:
 			if decision.TargetReplicas == 0 {
 				fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledToZero, decision.Reason())
 			} else {
@@ -211,20 +211,20 @@ func TestResourceConstrainedEvent(t *testing.T) {
 		},
 	}
 
-	decision := &interfaces.VariantDecision{
+	decision := &domain.VariantDecision{
 		VariantName:    "test-va",
-		Action:         interfaces.ActionScaleUp,
+		Action:         domain.ActionScaleUp,
 		TargetReplicas: 3,
 		WasLimited:     true,
 	}
-	decision.SetDecisionReason(interfaces.ActionScaleUp, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
+	decision.SetDecisionReason(domain.ActionScaleUp, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
 
 	// Simulate the event recording logic from applySaturationDecisions
 	if fakeRecorder != nil {
 		switch decision.Action {
-		case interfaces.ActionScaleUp:
+		case domain.ActionScaleUp:
 			fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledUp, decision.Reason())
-		case interfaces.ActionScaleDown:
+		case domain.ActionScaleDown:
 			if decision.TargetReplicas == 0 {
 				fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledToZero, decision.Reason())
 			} else {
@@ -288,19 +288,19 @@ func TestNoEventForNoDecision(t *testing.T) {
 		},
 	}
 
-	decision := &interfaces.VariantDecision{
+	decision := &domain.VariantDecision{
 		VariantName:    "test-va",
-		Action:         interfaces.ActionNoChange,
+		Action:         domain.ActionNoChange,
 		TargetReplicas: 3,
 	}
-	decision.SetDecisionReason(interfaces.ActionNoChange, interfaces.DecisionReasonTest, string(interfaces.DecisionReasonTest))
+	decision.SetDecisionReason(domain.ActionNoChange, domain.DecisionReasonTest, string(domain.DecisionReasonTest))
 
 	// Simulate the event recording logic from applySaturationDecisions
 	if fakeRecorder != nil {
 		switch decision.Action {
-		case interfaces.ActionScaleUp:
+		case domain.ActionScaleUp:
 			fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledUp, decision.Reason())
-		case interfaces.ActionScaleDown:
+		case domain.ActionScaleDown:
 			if decision.TargetReplicas == 0 {
 				fakeRecorder.Eventf(va, corev1.EventTypeNormal, constants.K8SEventScaledToZero, decision.Reason())
 			} else {

--- a/internal/engines/saturation/role_grouping_loop_test.go
+++ b/internal/engines/saturation/role_grouping_loop_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 )
@@ -40,10 +40,10 @@ import (
 type stubAnalyzer struct {
 	// callMetrics captures the replicaMetrics slice handed to each call so
 	// tests can assert per-role scoping of analyzer input.
-	callMetrics [][]interfaces.ReplicaMetrics
+	callMetrics [][]domain.ReplicaMetrics
 	// analysisByVariant returns the ModelSaturationAnalysis the stub should
 	// produce when a matching variant name appears in the incoming metrics.
-	analysisByVariant map[string]*interfaces.ModelSaturationAnalysis
+	analysisByVariant map[string]*domain.ModelSaturationAnalysis
 	// errByVariant returns an error when a matching variant name appears
 	// in the incoming metrics.
 	errByVariant map[string]error
@@ -55,10 +55,10 @@ type stubAnalyzer struct {
 func (s *stubAnalyzer) AnalyzeModelSaturation(
 	_ context.Context,
 	modelID, namespace string,
-	replicaMetrics []interfaces.ReplicaMetrics,
+	replicaMetrics []domain.ReplicaMetrics,
 	_ config.SaturationScalingConfig,
-) (*interfaces.ModelSaturationAnalysis, error) {
-	s.callMetrics = append(s.callMetrics, append([]interfaces.ReplicaMetrics(nil), replicaMetrics...))
+) (*domain.ModelSaturationAnalysis, error) {
+	s.callMetrics = append(s.callMetrics, append([]domain.ReplicaMetrics(nil), replicaMetrics...))
 	for _, m := range replicaMetrics {
 		if err, ok := s.errByVariant[m.VariantName]; ok {
 			return nil, err
@@ -67,13 +67,13 @@ func (s *stubAnalyzer) AnalyzeModelSaturation(
 			return a, nil
 		}
 	}
-	return &interfaces.ModelSaturationAnalysis{ModelID: modelID, Namespace: namespace}, nil
+	return &domain.ModelSaturationAnalysis{ModelID: modelID, Namespace: namespace}, nil
 }
 
 func (s *stubAnalyzer) CalculateSaturationTargets(
 	_ context.Context,
-	_ *interfaces.ModelSaturationAnalysis,
-	variantStates []interfaces.VariantReplicaState,
+	_ *domain.ModelSaturationAnalysis,
+	variantStates []domain.VariantReplicaState,
 ) map[string]int {
 	if len(variantStates) > 0 {
 		if t, ok := s.targetsByVariant[variantStates[0].VariantName]; ok {
@@ -98,7 +98,7 @@ func engineWithStub(stub *stubAnalyzer) *Engine {
 // uniqueVariantCount returns the number of distinct VariantNames in m,
 // used to assert that each role group's metrics are scoped to exactly the
 // variants in that role.
-func uniqueVariantCount(m []interfaces.ReplicaMetrics) int {
+func uniqueVariantCount(m []domain.ReplicaMetrics) int {
 	seen := map[string]struct{}{}
 	for _, r := range m {
 		seen[r.VariantName] = struct{}{}
@@ -117,11 +117,11 @@ type pdFixture struct {
 func newPDFixture() pdFixture {
 	return pdFixture{
 		data: &modelData{
-			variantStates: []interfaces.VariantReplicaState{
+			variantStates: []domain.VariantReplicaState{
 				{VariantName: "prefill-h100", Role: "prefill", CurrentReplicas: 1},
 				{VariantName: "decode-l4", Role: "decode", CurrentReplicas: 1},
 			},
-			replicaMetrics: []interfaces.ReplicaMetrics{
+			replicaMetrics: []domain.ReplicaMetrics{
 				{VariantName: "prefill-h100", PodName: "pod-p1"},
 				{VariantName: "decode-l4", PodName: "pod-d1"},
 			},
@@ -139,7 +139,7 @@ func collectSafetyNetVAs(calls *[][]string) safetyNetEmitter {
 	return func(
 		_ context.Context,
 		vas []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-		_ map[string]*interfaces.Allocation,
+		_ map[string]*domain.Allocation,
 		_ map[string]scaletarget.ScaleTargetAccessor,
 	) {
 		names := make([]string, 0, len(vas))
@@ -154,25 +154,25 @@ func collectSafetyNetVAs(calls *[][]string) safetyNetEmitter {
 func noopSafetyNet(
 	_ context.Context,
 	_ []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	_ map[string]*interfaces.Allocation,
+	_ map[string]*domain.Allocation,
 	_ map[string]scaletarget.ScaleTargetAccessor,
 ) {
 }
 
 func TestAnalyzeRoleGroups_DisaggregatedModel_TwoIndependentAnalyses(t *testing.T) {
 	stub := &stubAnalyzer{
-		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+		analysisByVariant: map[string]*domain.ModelSaturationAnalysis{
 			"prefill-h100": {
 				ModelID:   "m",
 				Namespace: "ns",
-				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+				VariantAnalyses: []domain.VariantSaturationAnalysis{
 					{VariantName: "prefill-h100", ReplicaCount: 1},
 				},
 			},
 			"decode-l4": {
 				ModelID:   "m",
 				Namespace: "ns",
-				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+				VariantAnalyses: []domain.VariantSaturationAnalysis{
 					{VariantName: "decode-l4", ReplicaCount: 1},
 				},
 			},
@@ -201,7 +201,7 @@ func TestAnalyzeRoleGroups_DisaggregatedModel_TwoIndependentAnalyses(t *testing.
 	}
 
 	// Both role groups must produce a decision; Role field must propagate.
-	byVariant := map[string]interfaces.VariantDecision{}
+	byVariant := map[string]domain.VariantDecision{}
 	for _, d := range decisions {
 		byVariant[d.VariantName] = d
 	}
@@ -209,17 +209,17 @@ func TestAnalyzeRoleGroups_DisaggregatedModel_TwoIndependentAnalyses(t *testing.
 	require.Contains(t, byVariant, "decode-l4")
 	assert.Equal(t, "prefill", byVariant["prefill-h100"].Role)
 	assert.Equal(t, "decode", byVariant["decode-l4"].Role)
-	assert.Equal(t, interfaces.ActionScaleUp, byVariant["prefill-h100"].Action)
-	assert.Equal(t, interfaces.ActionNoChange, byVariant["decode-l4"].Action)
+	assert.Equal(t, domain.ActionScaleUp, byVariant["prefill-h100"].Action)
+	assert.Equal(t, domain.ActionNoChange, byVariant["decode-l4"].Action)
 }
 
 func TestAnalyzeRoleGroups_HomogeneousModel_SingleGroup(t *testing.T) {
 	stub := &stubAnalyzer{
-		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+		analysisByVariant: map[string]*domain.ModelSaturationAnalysis{
 			"variant-a": {
 				ModelID:   "m",
 				Namespace: "ns",
-				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+				VariantAnalyses: []domain.VariantSaturationAnalysis{
 					{VariantName: "variant-a", ReplicaCount: 2},
 					{VariantName: "variant-b", ReplicaCount: 1},
 				},
@@ -232,11 +232,11 @@ func TestAnalyzeRoleGroups_HomogeneousModel_SingleGroup(t *testing.T) {
 	e := engineWithStub(stub)
 
 	data := &modelData{
-		variantStates: []interfaces.VariantReplicaState{
+		variantStates: []domain.VariantReplicaState{
 			{VariantName: "variant-a", Role: "", CurrentReplicas: 2},
 			{VariantName: "variant-b", Role: "", CurrentReplicas: 1},
 		},
-		replicaMetrics: []interfaces.ReplicaMetrics{
+		replicaMetrics: []domain.ReplicaMetrics{
 			{VariantName: "variant-a", PodName: "a-1"},
 			{VariantName: "variant-a", PodName: "a-2"},
 			{VariantName: "variant-b", PodName: "b-1"},
@@ -258,7 +258,7 @@ func TestAnalyzeRoleGroups_HomogeneousModel_SingleGroup(t *testing.T) {
 	require.Len(t, stub.callMetrics, 1, "homogeneous-role model should collapse to a single analyzer call")
 	require.Len(t, decisions, 2)
 	// Role defaults to empty for non-disaggregated variants; propagated verbatim.
-	byVariant := map[string]interfaces.VariantDecision{}
+	byVariant := map[string]domain.VariantDecision{}
 	for _, d := range decisions {
 		byVariant[d.VariantName] = d
 	}
@@ -270,11 +270,11 @@ func TestAnalyzeRoleGroups_PerRoleFailure_SafetyNetScopedToFailingRole(t *testin
 	analysisErr := errors.New("prefill analyzer blew up")
 	stub := &stubAnalyzer{
 		errByVariant: map[string]error{"prefill-h100": analysisErr},
-		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+		analysisByVariant: map[string]*domain.ModelSaturationAnalysis{
 			"decode-l4": {
 				ModelID:   "m",
 				Namespace: "ns",
-				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+				VariantAnalyses: []domain.VariantSaturationAnalysis{
 					{VariantName: "decode-l4", ReplicaCount: 1},
 				},
 			},
@@ -312,18 +312,18 @@ func TestAnalyzeRoleGroups_MergesDecisionsAcrossRoles(t *testing.T) {
 	// merged slice (which optimizeV1 forwards to ScaleToZeroEnforcer) contains
 	// entries from every group.
 	stub := &stubAnalyzer{
-		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+		analysisByVariant: map[string]*domain.ModelSaturationAnalysis{
 			"prefill-h100": {
 				ModelID:   "m",
 				Namespace: "ns",
-				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+				VariantAnalyses: []domain.VariantSaturationAnalysis{
 					{VariantName: "prefill-h100", ReplicaCount: 1},
 				},
 			},
 			"decode-l4": {
 				ModelID:   "m",
 				Namespace: "ns",
-				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+				VariantAnalyses: []domain.VariantSaturationAnalysis{
 					{VariantName: "decode-l4", ReplicaCount: 1},
 				},
 			},
@@ -348,7 +348,7 @@ func TestAnalyzeRoleGroups_MergesDecisionsAcrossRoles(t *testing.T) {
 	roles := map[string]struct{}{}
 	for _, d := range decisions {
 		roles[d.Role] = struct{}{}
-		assert.Equal(t, interfaces.ActionScaleDown, d.Action)
+		assert.Equal(t, domain.ActionScaleDown, d.Action)
 	}
 	assert.Contains(t, roles, "prefill")
 	assert.Contains(t, roles, "decode")
@@ -356,11 +356,11 @@ func TestAnalyzeRoleGroups_MergesDecisionsAcrossRoles(t *testing.T) {
 
 func TestAnalyzeRoleGroups_RoleGroupWithoutMetrics_EmitsSafetyNet(t *testing.T) {
 	stub := &stubAnalyzer{
-		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+		analysisByVariant: map[string]*domain.ModelSaturationAnalysis{
 			"decode-l4": {
 				ModelID:   "m",
 				Namespace: "ns",
-				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+				VariantAnalyses: []domain.VariantSaturationAnalysis{
 					{VariantName: "decode-l4", ReplicaCount: 1},
 				},
 			},
@@ -375,7 +375,7 @@ func TestAnalyzeRoleGroups_RoleGroupWithoutMetrics_EmitsSafetyNet(t *testing.T) 
 	// role must still get safety-net emission (scoped to its own VAs) so
 	// HPA/KEDA does not go dark while prefill waits for metrics to appear.
 	fx := newPDFixture()
-	fx.data.replicaMetrics = []interfaces.ReplicaMetrics{
+	fx.data.replicaMetrics = []domain.ReplicaMetrics{
 		{VariantName: "decode-l4", PodName: "pod-d1"},
 	}
 
@@ -400,7 +400,7 @@ func TestSortedRoleKeys_DeterministicOrder(t *testing.T) {
 	// Exercises the precondition promised in sortedRoleKeys: callers pass
 	// keys that groupByRole has already normalized, so the resulting order
 	// is stable lexicographic.
-	groups := map[string][]interfaces.VariantReplicaState{
+	groups := map[string][]domain.VariantReplicaState{
 		"prefill": nil,
 		"both":    nil,
 		"decode":  nil,
@@ -409,7 +409,7 @@ func TestSortedRoleKeys_DeterministicOrder(t *testing.T) {
 	assert.Equal(t, []string{"both", "decode", "prefill"}, got)
 
 	// Single-group and empty-map cases.
-	assert.Equal(t, []string{interfaces.RoleBoth},
-		sortedRoleKeys(map[string][]interfaces.VariantReplicaState{interfaces.RoleBoth: nil}))
-	assert.Empty(t, sortedRoleKeys(map[string][]interfaces.VariantReplicaState{}))
+	assert.Equal(t, []string{domain.RoleBoth},
+		sortedRoleKeys(map[string][]domain.VariantReplicaState{domain.RoleBoth: nil}))
+	assert.Empty(t, sortedRoleKeys(map[string][]domain.VariantReplicaState{}))
 }

--- a/internal/engines/saturation/role_grouping_test.go
+++ b/internal/engines/saturation/role_grouping_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 )
 
@@ -33,8 +33,8 @@ func TestNormalizeRole(t *testing.T) {
 		input  string
 		expect string
 	}{
-		{"empty maps to both", "", interfaces.RoleBoth},
-		{"both stays both", "both", interfaces.RoleBoth},
+		{"empty maps to both", "", domain.RoleBoth},
+		{"both stays both", "both", domain.RoleBoth},
 		{"prefill stays prefill", "prefill", "prefill"},
 		{"decode stays decode", "decode", "decode"},
 	}
@@ -47,7 +47,7 @@ func TestNormalizeRole(t *testing.T) {
 
 func TestGroupByRole(t *testing.T) {
 	t.Run("non-disaggregated model produces single group", func(t *testing.T) {
-		states := []interfaces.VariantReplicaState{
+		states := []domain.VariantReplicaState{
 			{VariantName: "v1", Role: "both"},
 			{VariantName: "v2", Role: ""},
 			{VariantName: "v3", Role: "both"},
@@ -59,7 +59,7 @@ func TestGroupByRole(t *testing.T) {
 	})
 
 	t.Run("disaggregated model produces per-role groups", func(t *testing.T) {
-		states := []interfaces.VariantReplicaState{
+		states := []domain.VariantReplicaState{
 			{VariantName: "prefill-h100", Role: "prefill"},
 			{VariantName: "prefill-a100", Role: "prefill"},
 			{VariantName: "decode-l4", Role: "decode"},
@@ -71,7 +71,7 @@ func TestGroupByRole(t *testing.T) {
 	})
 
 	t.Run("mixed roles produce three groups", func(t *testing.T) {
-		states := []interfaces.VariantReplicaState{
+		states := []domain.VariantReplicaState{
 			{VariantName: "prefill-h100", Role: "prefill"},
 			{VariantName: "decode-l4", Role: "decode"},
 			{VariantName: "both-a100", Role: "both"},
@@ -90,7 +90,7 @@ func TestGroupByRole(t *testing.T) {
 }
 
 func TestFilterReplicaMetricsByVariants(t *testing.T) {
-	metrics := []interfaces.ReplicaMetrics{
+	metrics := []domain.ReplicaMetrics{
 		{VariantName: "prefill-h100", PodName: "pod-1"},
 		{VariantName: "prefill-h100", PodName: "pod-2"},
 		{VariantName: "decode-l4", PodName: "pod-3"},
@@ -99,7 +99,7 @@ func TestFilterReplicaMetricsByVariants(t *testing.T) {
 	}
 
 	t.Run("filter prefill only", func(t *testing.T) {
-		states := []interfaces.VariantReplicaState{
+		states := []domain.VariantReplicaState{
 			{VariantName: "prefill-h100"},
 		}
 		filtered := filterReplicaMetricsByVariants(metrics, states)
@@ -110,7 +110,7 @@ func TestFilterReplicaMetricsByVariants(t *testing.T) {
 	})
 
 	t.Run("filter decode only", func(t *testing.T) {
-		states := []interfaces.VariantReplicaState{
+		states := []domain.VariantReplicaState{
 			{VariantName: "decode-l4"},
 		}
 		filtered := filterReplicaMetricsByVariants(metrics, states)
@@ -121,7 +121,7 @@ func TestFilterReplicaMetricsByVariants(t *testing.T) {
 	})
 
 	t.Run("filter all variants returns all metrics", func(t *testing.T) {
-		states := []interfaces.VariantReplicaState{
+		states := []domain.VariantReplicaState{
 			{VariantName: "prefill-h100"},
 			{VariantName: "decode-l4"},
 			{VariantName: "both-a100"},
@@ -144,7 +144,7 @@ func TestFilterVAsByVariantStates(t *testing.T) {
 	}
 
 	t.Run("filter to prefill only", func(t *testing.T) {
-		states := []interfaces.VariantReplicaState{
+		states := []domain.VariantReplicaState{
 			{VariantName: "prefill-h100"},
 		}
 		filtered := filterVAsByVariantStates(vas, states)
@@ -153,7 +153,7 @@ func TestFilterVAsByVariantStates(t *testing.T) {
 	})
 
 	t.Run("filter to all returns all", func(t *testing.T) {
-		states := []interfaces.VariantReplicaState{
+		states := []domain.VariantReplicaState{
 			{VariantName: "prefill-h100"},
 			{VariantName: "decode-l4"},
 			{VariantName: "both-a100"},
@@ -169,7 +169,7 @@ func TestFilterVAsByVariantStates(t *testing.T) {
 }
 
 func TestVariantNames(t *testing.T) {
-	states := []interfaces.VariantReplicaState{
+	states := []domain.VariantReplicaState{
 		{VariantName: "v1"},
 		{VariantName: "v2"},
 		{VariantName: "v3"},

--- a/internal/engines/scalefromzero/engine.go
+++ b/internal/engines/scalefromzero/engine.go
@@ -39,9 +39,9 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/common"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/executor"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
@@ -343,7 +343,7 @@ func (e *Engine) processInactiveVariant(ctx context.Context, scaleTargets map[st
 		if err != nil {
 			return err
 		}
-		d := interfaces.VariantDecision{
+		d := domain.VariantDecision{
 			VariantName:        va.Name,
 			Namespace:          va.Namespace,
 			ModelID:            va.Spec.ModelID,
@@ -360,7 +360,7 @@ func (e *Engine) processInactiveVariant(ctx context.Context, scaleTargets map[st
 			MetricsReason:      MetricsReasonAvailable,
 			MetricsMessage:     MetricsMessageAvailable,
 		}
-		d.SetDecisionReason(interfaces.ActionScaleUp, interfaces.DecisionReasonScaleFromZero, string(interfaces.DecisionReasonScaleFromZero)+reasonDetails)
+		d.SetDecisionReason(domain.ActionScaleUp, domain.DecisionReasonScaleFromZero, string(domain.DecisionReasonScaleFromZero)+reasonDetails)
 		common.DecisionCache.Set(va.Name, va.Namespace, d)
 	} else {
 		if decision.CurrentReplicas == 0 {
@@ -371,7 +371,7 @@ func (e *Engine) processInactiveVariant(ctx context.Context, scaleTargets map[st
 			decision.SaturationBased = false
 			decision.SafetyOverride = false
 			decision.ModelBasedDecision = false
-			decision.SetDecisionReason(interfaces.ActionScaleUp, interfaces.DecisionReasonScaleFromZero, string(interfaces.DecisionReasonScaleFromZero)+reasonDetails)
+			decision.SetDecisionReason(domain.ActionScaleUp, domain.DecisionReasonScaleFromZero, string(domain.DecisionReasonScaleFromZero)+reasonDetails)
 			decision.AcceleratorName = accelerator
 			decision.MetricsAvailable = true
 			decision.MetricsReason = MetricsReasonAvailable
@@ -395,11 +395,11 @@ func (e *Engine) processInactiveVariant(ctx context.Context, scaleTargets map[st
 		wvav1alpha1.TypeOptimizationReady,
 		metav1.ConditionTrue,
 		"ScaleFromZeroMode",
-		"scalefromzero decision: "+string(interfaces.DecisionReasonScaleFromZero)+reasonDetails)
+		"scalefromzero decision: "+string(domain.DecisionReasonScaleFromZero)+reasonDetails)
 
 	// Record event just before Actuation.Applied = true
 	if hasDecision && targetWorkloadReplicas > 0 {
-		e.recorder.Eventf(&va, corev1.EventTypeNormal, constants.K8SEventScaledUp, string(interfaces.DecisionReasonScaleFromZero)+reasonDetails)
+		e.recorder.Eventf(&va, corev1.EventTypeNormal, constants.K8SEventScaledUp, string(domain.DecisionReasonScaleFromZero)+reasonDetails)
 	}
 	va.Status.Actuation.Applied = true
 
@@ -408,7 +408,7 @@ func (e *Engine) processInactiveVariant(ctx context.Context, scaleTargets map[st
 		"va", va.Name,
 		"namespace", va.Namespace,
 		"targetReplicas", targetWorkloadReplicas,
-		"reason", string(interfaces.DecisionReasonScaleFromZero)+reasonDetails)
+		"reason", string(domain.DecisionReasonScaleFromZero)+reasonDetails)
 
 	return nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	llmdOptv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -495,7 +495,7 @@ func NewMetricsEmitter() *MetricsEmitter {
 }
 
 // EmitReplicaScalingMetrics emits metrics related to replica scaling
-func (m *MetricsEmitter) EmitReplicaScalingMetrics(ctx context.Context, va *llmdOptv1alpha1.VariantAutoscaling, direction interfaces.SaturationAction, reason interfaces.DecisionReason) error {
+func (m *MetricsEmitter) EmitReplicaScalingMetrics(ctx context.Context, va *llmdOptv1alpha1.VariantAutoscaling, direction domain.SaturationAction, reason domain.DecisionReason) error {
 	labels := prometheus.Labels{
 		constants.LabelVariantName: va.Name,
 		constants.LabelNamespace:   va.Namespace,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	llmdOptv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -441,7 +441,7 @@ var _ = Describe("EmitReplicaScalingMetrics", func() {
 			},
 		}
 
-		err := emitter.EmitReplicaScalingMetrics(ctx, va, interfaces.ActionScaleUp, interfaces.DecisionReasonV2)
+		err := emitter.EmitReplicaScalingMetrics(ctx, va, domain.ActionScaleUp, domain.DecisionReasonV2)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Gather the metric and verify the counter was incremented
@@ -452,8 +452,8 @@ var _ = Describe("EmitReplicaScalingMetrics", func() {
 		labels := map[string]string{
 			constants.LabelVariantName: "test-variant",
 			constants.LabelNamespace:   "test-namespace",
-			constants.LabelDirection:   string(interfaces.ActionScaleUp),
-			constants.LabelReason:      string(interfaces.DecisionReasonV2),
+			constants.LabelDirection:   string(domain.ActionScaleUp),
+			constants.LabelReason:      string(domain.DecisionReasonV2),
 		}
 
 		var found bool

--- a/internal/saturation/analyzer.go
+++ b/internal/saturation/analyzer.go
@@ -8,7 +8,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
@@ -33,12 +33,12 @@ func (a *Analyzer) AnalyzeModelSaturation(
 	ctx context.Context,
 	modelID string,
 	namespace string,
-	replicaMetrics []interfaces.ReplicaMetrics,
+	replicaMetrics []domain.ReplicaMetrics,
 	config config.SaturationScalingConfig,
-) (*interfaces.ModelSaturationAnalysis, error) {
+) (*domain.ModelSaturationAnalysis, error) {
 
 	if len(replicaMetrics) == 0 {
-		return &interfaces.ModelSaturationAnalysis{
+		return &domain.ModelSaturationAnalysis{
 			ModelID:       modelID,
 			Namespace:     namespace,
 			AnalyzedAt:    time.Now(),
@@ -46,11 +46,11 @@ func (a *Analyzer) AnalyzeModelSaturation(
 			ShouldScaleUp: false,
 
 			ScaleDownSafe:   false,
-			VariantAnalyses: []interfaces.VariantSaturationAnalysis{},
+			VariantAnalyses: []domain.VariantSaturationAnalysis{},
 		}, nil
 	}
 
-	analysis := &interfaces.ModelSaturationAnalysis{
+	analysis := &domain.ModelSaturationAnalysis{
 		ModelID:    modelID,
 		Namespace:  namespace,
 		AnalyzedAt: time.Now(),
@@ -64,9 +64,9 @@ func (a *Analyzer) AnalyzeModelSaturation(
 	}
 
 	// Pre-allocate slices with exact Saturation
-	variantMap := make(map[string][]interfaces.ReplicaMetrics, len(variantCounts))
+	variantMap := make(map[string][]domain.ReplicaMetrics, len(variantCounts))
 	for variant, count := range variantCounts {
-		variantMap[variant] = make([]interfaces.ReplicaMetrics, 0, count)
+		variantMap[variant] = make([]domain.ReplicaMetrics, 0, count)
 	}
 
 	// Populate with metrics (no reallocation needed)
@@ -79,7 +79,7 @@ func (a *Analyzer) AnalyzeModelSaturation(
 	var totalSpareQueue float64
 	var nonSaturatedCount int
 
-	variantAnalyses := make([]interfaces.VariantSaturationAnalysis, 0, len(variantMap))
+	variantAnalyses := make([]domain.VariantSaturationAnalysis, 0, len(variantMap))
 
 	for variantName, metrics := range variantMap {
 		variantAnalysis := a.analyzeVariant(ctx, variantName, metrics, config)
@@ -135,11 +135,11 @@ func (a *Analyzer) AnalyzeModelSaturation(
 func (a *Analyzer) analyzeVariant(
 	ctx context.Context,
 	variantName string,
-	metrics []interfaces.ReplicaMetrics,
+	metrics []domain.ReplicaMetrics,
 	config config.SaturationScalingConfig,
-) interfaces.VariantSaturationAnalysis {
+) domain.VariantSaturationAnalysis {
 
-	analysis := interfaces.VariantSaturationAnalysis{
+	analysis := domain.VariantSaturationAnalysis{
 		VariantName:       variantName,
 		ReplicaCount:      len(metrics),
 		SaturatedReplicas: []string{},
@@ -299,8 +299,8 @@ func (a *Analyzer) isScaleDownSafe(
 // - Else: target = currentReplicas
 func (a *Analyzer) CalculateSaturationTargets(
 	ctx context.Context,
-	saturationAnalysis *interfaces.ModelSaturationAnalysis,
-	variantStates []interfaces.VariantReplicaState,
+	saturationAnalysis *domain.ModelSaturationAnalysis,
+	variantStates []domain.VariantReplicaState,
 ) map[string]int {
 
 	targets := make(map[string]int)
@@ -316,7 +316,7 @@ func (a *Analyzer) CalculateSaturationTargets(
 	}
 
 	// Build state map for quick lookup
-	stateMap := make(map[string]interfaces.VariantReplicaState)
+	stateMap := make(map[string]domain.VariantReplicaState)
 	for _, state := range variantStates {
 		stateMap[state.VariantName] = state
 	}
@@ -398,7 +398,7 @@ func (a *Analyzer) CalculateSaturationTargets(
 	switch {
 	case saturationAnalysis.ShouldScaleUp:
 		// Find cheapest variant for scale-up, skipping variants with pending replicas
-		var cheapestVariant *interfaces.VariantSaturationAnalysis
+		var cheapestVariant *domain.VariantSaturationAnalysis
 		for i := range saturationAnalysis.VariantAnalyses {
 			va := &saturationAnalysis.VariantAnalyses[i]
 
@@ -429,7 +429,7 @@ func (a *Analyzer) CalculateSaturationTargets(
 
 	case saturationAnalysis.ScaleDownSafe:
 		// Find most expensive variant for scale-down
-		var mostExpensiveVariant *interfaces.VariantSaturationAnalysis
+		var mostExpensiveVariant *domain.VariantSaturationAnalysis
 		for i := range saturationAnalysis.VariantAnalyses {
 			va := &saturationAnalysis.VariantAnalyses[i]
 			// Can't scale down if at or below minimum (1 replica)

--- a/internal/saturation/analyzer_test.go
+++ b/internal/saturation/analyzer_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
@@ -26,13 +26,13 @@ func TestAnalyzeModelSaturation_ScaleUp(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		replicaMetrics      []interfaces.ReplicaMetrics
+		replicaMetrics      []domain.ReplicaMetrics
 		expectScaleUp       bool
 		expectScaleUpReason string
 	}{
 		{
 			name: "scale up due to low KV spare Saturation",
-			replicaMetrics: []interfaces.ReplicaMetrics{
+			replicaMetrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.75, QueueLength: 2},
 				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.76, QueueLength: 2},
 			},
@@ -40,7 +40,7 @@ func TestAnalyzeModelSaturation_ScaleUp(t *testing.T) {
 		},
 		{
 			name: "scale up due to low queue spare Saturation",
-			replicaMetrics: []interfaces.ReplicaMetrics{
+			replicaMetrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 3},
 				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 3},
 			},
@@ -48,7 +48,7 @@ func TestAnalyzeModelSaturation_ScaleUp(t *testing.T) {
 		},
 		{
 			name: "no scale up - healthy Saturation",
-			replicaMetrics: []interfaces.ReplicaMetrics{
+			replicaMetrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 1},
 				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 1},
 			},
@@ -89,12 +89,12 @@ func TestAnalyzeModelSaturation_ScaleDownSafety(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		replicaMetrics      []interfaces.ReplicaMetrics
+		replicaMetrics      []domain.ReplicaMetrics
 		expectScaleDownSafe bool
 	}{
 		{
 			name: "scale down safe - adequate headroom",
-			replicaMetrics: []interfaces.ReplicaMetrics{
+			replicaMetrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.20, QueueLength: 1},
 				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.30, QueueLength: 1},
 				{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.25, QueueLength: 1},
@@ -103,7 +103,7 @@ func TestAnalyzeModelSaturation_ScaleDownSafety(t *testing.T) {
 		},
 		{
 			name: "scale down unsafe - insufficient headroom",
-			replicaMetrics: []interfaces.ReplicaMetrics{
+			replicaMetrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.70, QueueLength: 2},
 				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.75, QueueLength: 2},
 			},
@@ -111,7 +111,7 @@ func TestAnalyzeModelSaturation_ScaleDownSafety(t *testing.T) {
 		},
 		{
 			name: "scale down unsafe - only one non-saturated replica",
-			replicaMetrics: []interfaces.ReplicaMetrics{
+			replicaMetrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 2},
 			},
 			expectScaleDownSafe: false,
@@ -150,7 +150,7 @@ func TestAnalyzeModelSaturation_MultiVariant(t *testing.T) {
 	}
 
 	// Test with metrics from multiple variants
-	replicaMetrics := []interfaces.ReplicaMetrics{
+	replicaMetrics := []domain.ReplicaMetrics{
 		// Variant 1
 		{PodName: "v1-pod-1", VariantName: "variant-1", ModelID: "model-a", KvCacheUsage: 0.70, QueueLength: 2},
 		{PodName: "v1-pod-2", VariantName: "variant-1", ModelID: "model-a", KvCacheUsage: 0.75, QueueLength: 3},
@@ -205,7 +205,7 @@ func TestAnalyzeModelSaturation_EmptyMetrics(t *testing.T) {
 		context.Background(),
 		"test-model",
 		"test-ns",
-		[]interfaces.ReplicaMetrics{},
+		[]domain.ReplicaMetrics{},
 		config,
 	)
 
@@ -235,7 +235,7 @@ func TestAnalyzeVariant_SaturatedReplicas(t *testing.T) {
 		QueueSpareTrigger:    3,
 	}
 
-	metrics := []interfaces.ReplicaMetrics{
+	metrics := []domain.ReplicaMetrics{
 		{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.85, QueueLength: 2}, // Saturated (KV)
 		{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 6}, // Saturated (Queue)
 		{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.60, QueueLength: 2}, // Not saturated
@@ -276,7 +276,7 @@ func TestAnalyzeModelSaturation_AllSaturated(t *testing.T) {
 	}
 
 	// All replicas are saturated
-	replicaMetrics := []interfaces.ReplicaMetrics{
+	replicaMetrics := []domain.ReplicaMetrics{
 		{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.85, QueueLength: 2}, // Saturated (KV)
 		{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 6}, // Saturated (Queue)
 		{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.90, QueueLength: 7}, // Saturated (both)
@@ -334,7 +334,7 @@ func TestAnalyzeModelSaturation_TimestampSet(t *testing.T) {
 
 	before := time.Now()
 
-	replicaMetrics := []interfaces.ReplicaMetrics{
+	replicaMetrics := []domain.ReplicaMetrics{
 		{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 2, Cost: 10},
 	}
 
@@ -368,19 +368,19 @@ func TestAnalyzeModelSaturation_TimestampSet(t *testing.T) {
 func TestCalculatesaturationTargets_ScaleUpCheapest(t *testing.T) {
 	analyzer := NewAnalyzer()
 
-	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+	saturationAnalysis := &domain.ModelSaturationAnalysis{
 		ModelID:       "test-model",
 		Namespace:     "test-ns",
 		ShouldScaleUp: true,
 		ScaleUpReason: "KV spare Saturation low",
-		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+		VariantAnalyses: []domain.VariantSaturationAnalysis{
 			{VariantName: "v1-expensive", Cost: 20, ReplicaCount: 2},
 			{VariantName: "v2-cheap", Cost: 5, ReplicaCount: 2},
 			{VariantName: "v3-medium", Cost: 15, ReplicaCount: 2},
 		},
 	}
 
-	variantStates := []interfaces.VariantReplicaState{
+	variantStates := []domain.VariantReplicaState{
 		{VariantName: "v1-expensive", CurrentReplicas: 2, DesiredReplicas: 0},
 		{VariantName: "v2-cheap", CurrentReplicas: 2, DesiredReplicas: 0},
 		{VariantName: "v3-medium", CurrentReplicas: 2, DesiredReplicas: 0},
@@ -405,19 +405,19 @@ func TestCalculatesaturationTargets_ScaleUpCheapest(t *testing.T) {
 func TestCalculatesaturationTargets_ScaleDownMostExpensive(t *testing.T) {
 	analyzer := NewAnalyzer()
 
-	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+	saturationAnalysis := &domain.ModelSaturationAnalysis{
 		ModelID:       "test-model",
 		Namespace:     "test-ns",
 		ShouldScaleUp: false,
 		ScaleDownSafe: true,
-		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+		VariantAnalyses: []domain.VariantSaturationAnalysis{
 			{VariantName: "v1-expensive", Cost: 20, ReplicaCount: 2},
 			{VariantName: "v2-cheap", Cost: 5, ReplicaCount: 2},
 			{VariantName: "v3-medium", Cost: 15, ReplicaCount: 2},
 		},
 	}
 
-	variantStates := []interfaces.VariantReplicaState{
+	variantStates := []domain.VariantReplicaState{
 		{VariantName: "v1-expensive", CurrentReplicas: 2, DesiredReplicas: 0},
 		{VariantName: "v2-cheap", CurrentReplicas: 2, DesiredReplicas: 0},
 		{VariantName: "v3-medium", CurrentReplicas: 2, DesiredReplicas: 0},
@@ -442,12 +442,12 @@ func TestCalculatesaturationTargets_ScaleDownMostExpensive(t *testing.T) {
 func TestCalculatesaturationTargets_ModelLevelTransitionBlocking(t *testing.T) {
 	analyzer := NewAnalyzer()
 
-	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+	saturationAnalysis := &domain.ModelSaturationAnalysis{
 		ModelID:       "test-model",
 		Namespace:     "test-ns",
 		ShouldScaleUp: true,
 		ScaleUpReason: "KV spare Saturation low",
-		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+		VariantAnalyses: []domain.VariantSaturationAnalysis{
 			{VariantName: "v1-expensive", Cost: 20, ReplicaCount: 2},
 			{VariantName: "v2-cheap", Cost: 5, ReplicaCount: 2},
 		},
@@ -455,7 +455,7 @@ func TestCalculatesaturationTargets_ModelLevelTransitionBlocking(t *testing.T) {
 
 	// v1 has desired > current (previous optimizer wanted to scale up)
 	// This puts the MODEL in transition state, blocking all scaling decisions
-	variantStates := []interfaces.VariantReplicaState{
+	variantStates := []domain.VariantReplicaState{
 		{VariantName: "v1-expensive", CurrentReplicas: 2, DesiredReplicas: 4},
 		{VariantName: "v2-cheap", CurrentReplicas: 2, DesiredReplicas: 0},
 	}
@@ -477,12 +477,12 @@ func TestCalculatesaturationTargets_ModelLevelTransitionBlocking(t *testing.T) {
 func TestCalculatesaturationTargets_PendingReplicasBlocksScaling(t *testing.T) {
 	analyzer := NewAnalyzer()
 
-	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+	saturationAnalysis := &domain.ModelSaturationAnalysis{
 		ModelID:       "test-model",
 		Namespace:     "test-ns",
 		ShouldScaleUp: true,
 		ScaleUpReason: "KV spare Saturation low",
-		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+		VariantAnalyses: []domain.VariantSaturationAnalysis{
 			{VariantName: "v1-expensive", Cost: 20, ReplicaCount: 2},
 			{VariantName: "v2-cheap", Cost: 5, ReplicaCount: 2},
 		},
@@ -490,7 +490,7 @@ func TestCalculatesaturationTargets_PendingReplicasBlocksScaling(t *testing.T) {
 
 	// v1 has a pending replica (3 current, only 2 ready) - scale-up in progress.
 	// This puts the MODEL in transition state, blocking all scaling decisions.
-	variantStates := []interfaces.VariantReplicaState{
+	variantStates := []domain.VariantReplicaState{
 		{VariantName: "v1-expensive", CurrentReplicas: 3, DesiredReplicas: 0, PendingReplicas: 1},
 		{VariantName: "v2-cheap", CurrentReplicas: 2, DesiredReplicas: 0},
 	}
@@ -517,12 +517,12 @@ func TestCalculatesaturationTargets_PendingReplicasBlocksScaling(t *testing.T) {
 func TestCalculatesaturationTargets_LWSGroupSizeDoesNotBlock(t *testing.T) {
 	analyzer := NewAnalyzer()
 
-	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+	saturationAnalysis := &domain.ModelSaturationAnalysis{
 		ModelID:       "test-model",
 		Namespace:     "test-ns",
 		ShouldScaleUp: true,
 		ScaleUpReason: "KV spare Saturation low",
-		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+		VariantAnalyses: []domain.VariantSaturationAnalysis{
 			// LWS group size 2: 1 group, 2 pods reporting metrics.
 			{VariantName: "lws-variant", Cost: 5, ReplicaCount: 2},
 		},
@@ -530,7 +530,7 @@ func TestCalculatesaturationTargets_LWSGroupSizeDoesNotBlock(t *testing.T) {
 
 	// 1 group (CurrentReplicas), fully ready (PendingReplicas 0). ReplicaCount (2
 	// metric pods) deliberately differs from CurrentReplicas (1 group).
-	variantStates := []interfaces.VariantReplicaState{
+	variantStates := []domain.VariantReplicaState{
 		{VariantName: "lws-variant", CurrentReplicas: 1, DesiredReplicas: 0, PendingReplicas: 0},
 	}
 
@@ -553,13 +553,13 @@ func TestAnalyzeVariant_AvgKvCacheUsage(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		metrics            []interfaces.ReplicaMetrics
+		metrics            []domain.ReplicaMetrics
 		expectedAvgKvUsage float64
 		expectedMaxKvUsage float64
 	}{
 		{
 			name: "uniform KV cache usage",
-			metrics: []interfaces.ReplicaMetrics{
+			metrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 2},
 				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 2},
 				{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.50, QueueLength: 2},
@@ -569,7 +569,7 @@ func TestAnalyzeVariant_AvgKvCacheUsage(t *testing.T) {
 		},
 		{
 			name: "mixed KV cache usage",
-			metrics: []interfaces.ReplicaMetrics{
+			metrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.30, QueueLength: 2},
 				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.60, QueueLength: 2},
 				{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.90, QueueLength: 2},
@@ -579,7 +579,7 @@ func TestAnalyzeVariant_AvgKvCacheUsage(t *testing.T) {
 		},
 		{
 			name: "mixed saturated and non-saturated",
-			metrics: []interfaces.ReplicaMetrics{
+			metrics: []domain.ReplicaMetrics{
 				{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.85, QueueLength: 2}, // Saturated
 				{PodName: "pod-2", VariantName: "v1", KvCacheUsage: 0.40, QueueLength: 2}, // Not saturated
 				{PodName: "pod-3", VariantName: "v1", KvCacheUsage: 0.55, QueueLength: 2}, // Not saturated
@@ -589,7 +589,7 @@ func TestAnalyzeVariant_AvgKvCacheUsage(t *testing.T) {
 		},
 		{
 			name:               "empty metrics",
-			metrics:            []interfaces.ReplicaMetrics{},
+			metrics:            []domain.ReplicaMetrics{},
 			expectedAvgKvUsage: 0.0,
 			expectedMaxKvUsage: 0.0,
 		},

--- a/internal/utils/allocation.go
+++ b/internal/utils/allocation.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 )
@@ -17,11 +17,11 @@ import (
 //
 // This function is placed in utils to avoid import cycles between collector and controller packages.
 func BuildAllocationFromMetrics(
-	metrics interfaces.OptimizerMetrics,
+	metrics domain.OptimizerMetrics,
 	va *variant.VariantAutoscaling,
 	scaleTarget scaletarget.ScaleTargetAccessor,
 	acceleratorCost float64,
-) (interfaces.Allocation, error) {
+) (domain.Allocation, error) {
 	// Extract K8s information
 	// Number of replicas
 	var numReplicas int
@@ -58,14 +58,14 @@ func BuildAllocationFromMetrics(
 	avgOutputTokensStr := strconv.FormatFloat(metrics.AvgOutputTokens, 'f', 2, 64)
 
 	// Build Allocation struct
-	allocation := interfaces.Allocation{
+	allocation := domain.Allocation{
 		Accelerator: acc,
 		NumReplicas: numReplicas,
 		MaxBatch:    maxBatch,
 		// VariantCost removed from Status
 		TTFTAverage: ttftAverageStr,
 		ITLAverage:  itlAverageStr,
-		Load: interfaces.LoadProfile{
+		Load: domain.LoadProfile{
 			ArrivalRate:     arrivalRateStr,
 			AvgInputTokens:  avgInputTokensStr,
 			AvgOutputTokens: avgOutputTokensStr,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
-	interfaces "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/resources"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
@@ -94,9 +94,9 @@ func MarshalStructToJsonString(t any) string {
 }
 
 // Helper to find SLOs for a model variant
-func FindModelSLO(cmData map[string]string, targetModel string) (*interfaces.ServiceClassEntry, string /* class name */, error) {
+func FindModelSLO(cmData map[string]string, targetModel string) (*domain.ServiceClassEntry, string /* class name */, error) {
 	for key, val := range cmData {
-		var sc interfaces.ServiceClass
+		var sc domain.ServiceClass
 		if err := yaml.Unmarshal([]byte(val), &sc); err != nil {
 			return nil, "", fmt.Errorf("failed to parse %s: %w", key, err)
 		}


### PR DESCRIPTION
Relates to #1402 (Section 3 of 7: rename the misnamed internal/interfaces hub; follow-up to #1445)

## Proposed Changes

- :broom: Rename package `internal/interfaces` → `internal/domain` (9 files moved, byte-identical except the `package` declaration)
- :broom: Update all importers: import paths, ~1,265 `interfaces.X` → `domain.X` qualifier references across 71 files, and remove the 4 redundant `interfaces "..."` import aliases
- :broom: Fix stale path/name references in `docs/developer-guide/{multi-analyzer-pipeline,slo-queuemodel}.md` and a package comment in `internal/collector/collector.go`

### Why

`internal/interfaces` was not an interfaces package; it held mostly concrete structs, constants, and methods (`Allocation`, `ReplicaMetrics`, `VariantDecision`, `AnalyzerResult`, `ServiceClass`, ...), with only four small interfaces (`Analyzer`, `AnalyzerConfig`, `Actuator`, `SaturationAnalyzer`). `internal/domain` reflects its real role. This is the lowest-risk option from the issue (a mechanical rename rather than splitting types from interfaces).

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A, pure rename, no behavior change
- [ ] **Docs PR** for any user-facing impact — N/A, internal-only; developer-doc references updated in this PR
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — N/A, no behavior change

**Release Note**

```release-note
NONE
```

**Docs**

```Docs
Developer-doc path references updated
```
---

Verification for reviewers: git tracks all 9 as renames (history preserved); every moved file is byte-identical to its original except the `package` line (confirmed by diff); no string literal in the original code ever contained `interfaces.`, so nothing embedded was corrupted; `go build`, `go vet`, `gofmt -l` (repo-wide clean), `make lint` (0 issues), and the full non-e2e `go test` suite all pass.