### PR TITLE
chore: rename internal/saturation to internal/saturationv1

### DIFF
--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -63,7 +63,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturationv1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
@@ -932,7 +932,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 
 		// Look up cost by VariantAutoscaling namespace/name
-		cost := saturation.DefaultVariantCost
+		cost := saturationv1.DefaultVariantCost
 		if variantCosts != nil {
 			if c, ok := variantCosts[variantKey]; ok {
 				cost = c

--- a/internal/engines/pipeline/enforcer.go
+++ b/internal/engines/pipeline/enforcer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturationv1"
 )
 
 // RequestCountFuncType is the signature for functions that retrieve the total request count
@@ -157,7 +157,7 @@ func (e *Enforcer) ensureMinimumReplicasOnDecisions(
 		}
 		cost := d.Cost
 		if cost <= 0 {
-			cost = saturation.DefaultVariantCost
+			cost = saturationv1.DefaultVariantCost
 		}
 		if cheapestCost < 0 || cost < cheapestCost || (cost == cheapestCost && d.VariantName < decisions[cheapestIdx].VariantName) {
 			cheapestIdx = i

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -46,7 +46,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturationv1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
@@ -60,7 +60,7 @@ type analyzerEntry struct {
 	analyzer domain.Analyzer
 }
 
-// v1Analyzer is the minimal surface of *saturation.Analyzer that optimizeV1
+// v1Analyzer is the minimal surface of *saturationv1.Analyzer that optimizeV1
 // depends on. Defined here so tests can substitute a stub via Engine's
 // v1AnalyzerFactory field without exposing a public interface.
 type v1Analyzer interface {
@@ -80,7 +80,7 @@ type v1Analyzer interface {
 // defaultV1AnalyzerFactory returns a fresh production V1 saturation analyzer.
 // NewEngine wires this into Engine.v1AnalyzerFactory; tests can swap the
 // factory per-instance without touching shared state.
-func defaultV1AnalyzerFactory() v1Analyzer { return saturation.NewAnalyzer() }
+func defaultV1AnalyzerFactory() v1Analyzer { return saturationv1.NewAnalyzer() }
 
 // safetyNetEmitter reports a per-role analysis failure to the saturation
 // engine's safety-net metrics path. Extracted as a function type so the
@@ -466,10 +466,10 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 
 	// Each analyzer has a separate optimize path because they use fundamentally
 	// different analysis types and target-building flows:
-	//   - V1: saturation.Analyzer → ModelSaturationAnalysis → CalculateSaturationTargets → Enforcer → Limiter
+	//   - V1: saturationv1.Analyzer → ModelSaturationAnalysis → CalculateSaturationTargets → Enforcer → Limiter
 	//   - V2 (saturation): saturation_v2.Analyzer → AnalyzerResult → Optimizer.Optimize → Enforcer bridge
 	//   - Queueing model: QueueingModelAnalyzer → AnalyzerResult → Optimizer.Optimize → Enforcer bridge
-	// V1 will be deprecated once V2 is fully validated.
+	// V1 is deprecated in favor of V2; see issue #1441 for the staged removal plan.
 	// Queueing model is activated by presence of wva-queueing-model-config ConfigMap.
 	mode := modeLabelForAnalyzer(analyzerName)
 	switch analyzerName {
@@ -1409,7 +1409,7 @@ func (e *Engine) prepareModelData(
 			continue
 		}
 
-		cost := saturation.DefaultVariantCost
+		cost := saturationv1.DefaultVariantCost
 		if va.Spec.VariantCost != "" {
 			if parsedCost, err := strconv.ParseFloat(va.Spec.VariantCost, 64); err == nil {
 				cost = parsedCost

--- a/internal/saturationv1/analyzer.go
+++ b/internal/saturationv1/analyzer.go
@@ -1,4 +1,4 @@
-package saturation
+package saturationv1
 
 import (
 	"context"

--- a/internal/saturationv1/analyzer_test.go
+++ b/internal/saturationv1/analyzer_test.go
@@ -1,4 +1,4 @@
-package saturation
+package saturationv1
 
 import (
 	"context"

--- a/internal/saturationv1/constants.go
+++ b/internal/saturationv1/constants.go
@@ -1,4 +1,4 @@
-package saturation
+package saturationv1
 
 // Saturation analyzer constants
 const (


### PR DESCRIPTION
Relates to #1402 (Section 4 of 7: resolve the saturation package-name collision)

## Proposed Changes

- :broom: Rename package `internal/saturation` → `internal/saturationv1` (3 files moved, byte-identical except the `package` declaration)
- :broom: Update the 3 importers (`collector/replica_metrics.go`, `engines/pipeline/enforcer.go`, `engines/saturation/engine.go`): import paths + 6 `saturation.X` → `saturationv1.X` references
- :broom: Point the V1 deprecation note in `engine.go` at its tracking issue (#1441) instead of a vague standalone line

### Why

`internal/saturation` (V1 analyzer) and `internal/engines/saturation` (the Engine) were both `package saturation`. Because `engine.go` (itself `package saturation`) imported the V1 package unaliased, `saturation.NewAnalyzer()` in that file resolved to the *imported* package; easy to misread. After this rename, the only remaining `package saturation` is the Engine, so the ambiguity is gone.

V1 is deliberately **not** moved under `internal/engines/analyzers/` alongside throughput/queueing-model/saturation-v2: unlike those, V1 does not implement the `Analyzer` interface (its surface is `AnalyzeModelSaturation` / `CalculateSaturationTargets`), so grouping it there would imply a peer relationship that doesn't exist. It stays the default analyzer path; eventual removal is tracked in #1441.

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A, pure rename, no behavior change
- [ ] **Docs PR** for any user-facing impact — N/A, internal-only, no user-facing surface touched
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — N/A, no behavior change

**Release Note**

```release-note
NONE
```

**Docs**
```docs
None needed. V1 removal is tracked separately in #1441.
```
---

Verification for reviewers: git tracks all 3 as renames (history preserved); the moved files are byte-identical to their originals except the `package` line; the only remaining `package saturation` is `internal/engines/saturation`; no stale `internal/saturation` references anywhere. `go build`, `go vet`, `gofmt -l` (clean), `make lint` (0 issues), and the full non-e2e `go test` suite all pass.