### PR TITLE
feat(rescale): priority-weighted GPU rescale under contention (Alpha)

### DIFF
--- a/config/base/manager/saturation-scaling-configmap.yaml
+++ b/config/base/manager/saturation-scaling-configmap.yaml
@@ -37,3 +37,11 @@ data:
     # Enable GPU limiter to constrain scaling based on available cluster resources
     # When true, scale-up decisions are limited by available GPU capacity
     enableLimiter: false
+    # Enable priority-weighted rescale: under GPU contention the V2 optimizer
+    # redistributes the whole budget by priority x demand, reclaiming from
+    # lower-priority models so higher-priority work can run. Off by default.
+    # Budget-scope flag (read only from this `default` entry): the value here
+    # governs the cluster budget; a namespace-local config's `default` governs
+    # that namespace's quota budget. Has no effect without a same-scope GPU budget
+    # (requires enableLimiter and a matching cluster/namespace budget).
+    enableRescale: false

--- a/deploy/configmap-saturation-scaling.yaml
+++ b/deploy/configmap-saturation-scaling.yaml
@@ -43,6 +43,13 @@ data:
     # Enable GPU limiter to constrain scaling based on available cluster resources
     # When true, scale-up decisions are limited by available GPU capacity
     enableLimiter: false
+    # Enable priority-weighted rescale: under GPU contention the V2 optimizer
+    # redistributes the whole budget by priority x demand, reclaiming from
+    # lower-priority models so higher-priority work can run. Off by default.
+    # Budget-scope flag (read only from this `default` entry): the value here
+    # governs the cluster budget; a namespace-local config's `default` governs
+    # that namespace's quota budget. Has no effect without a same-scope GPU budget.
+    enableRescale: false
 
   # Per-model overrides inherit the default's analyzer selection (V2) via
   # field-level merge, so they only need the thresholds they change. Under V2,

--- a/docs/plans/engine/rescale-alpha.md
+++ b/docs/plans/engine/rescale-alpha.md
@@ -1,0 +1,119 @@
+# Plan: Priority-Weighted Rescale — Alpha stage
+
+Implements the **Alpha** milestone of the rescale proposal (`docs/proposals/design-rescale.md`, PR #1238):
+a redistributive, priority-weighted allocation in the V2 GPU-constrained optimizer.
+
+## Goal
+
+Under contention, reallocate the **whole group budget** by each model's `priority × demand`, reclaiming
+GPUs from models holding more than their share (lower-priority, even if still hungry) so higher-priority
+work can run — instead of today's additive fair-share that hands out only *free* GPUs and freezes
+allocation by arrival order once the budget is full.
+
+## Scope
+
+**In Alpha**
+- Opt-in flag; behavior **unchanged when off, or when a group is uncontended**.
+- V2 `GreedyByScoreOptimizer` only (cost-aware/unlimited path untouched).
+- **All models, including P/D** — role-aware reclaim/fill (dependency #1237 *role-aware scale-down* is
+  merged; the machinery — `scaleDownRoleIterated`, `safeRemovalReplicasForRole`,
+  `allocateForModelPaired` — is in `main`).
+- Competition group = **`(accelerator type, budget scope)`** where budget scope is `cluster`
+  (physical #1129 / cluster-scope quota) or `namespace-N` (namespace quota #1162). Namespace-quota
+  budgets come from `availableByNS` (already plumbed: `QuotaInventory.NamespaceResourcePools` →
+  `ResourceConstraints.NamespacePools` → `mergeNamespaceConstraints` → `availableByNS`).
+- Water-filling targets, reclaim-then-fill, **free-capacity-gated fill**, `DecisionReasonRescale` on
+  reclaims.
+
+**Deferred**
+- Physical∧quota **namespace partition** of the cluster budget → needs #1003.
+- **Multi-accelerator** models (variants spanning GPU types) → future scope.
+- **Observability** (`Rescaled` status condition, surfacing a reclaim **stall** when a role can't
+  shed a whole replica) + **hysteresis** (min share-gap / cool-down) → Beta.
+
+## Flag semantics — scope-coupled to the budget
+
+Rescale runs on a group **iff** a budget exists at the group's scope **and** the rescale flag is set at
+that **same** scope. No cross-level effect.
+
+| Budget at scope | Flag at same scope | Result |
+|---|---|---|
+| cluster budget | cluster flag on | cluster rescale (redistribute the cluster budget) |
+| namespace-N quota | namespace-N flag on | namespace-N rescale (redistribute N's quota) |
+| both | both on | both, independently, on their own budgets |
+| namespace-N quota | only cluster flag on | **no effect** (cluster flag doesn't govern N's quota) |
+| cluster budget | only namespace flag on | **no effect** (namespace flag doesn't govern the cluster budget) |
+
+A flag with no same-scope budget is a no-op.
+
+### Config source
+- **cluster flag** = the **global** saturation config `default` entry's `enableRescale`.
+- **namespace-N flag** = **namespace-N's own** saturation config `default`.`enableRescale`, read
+  *namespace-local only* (never the global fallback), so the cluster flag can't leak onto a namespace
+  quota. Requires a config accessor that distinguishes "namespace has its own config" from "falls back
+  to global".
+- Read only from the **`default`** entry — per-model override entries (`modelID#namespace`) never carry
+  it (it is budget-scope, not per-model / per-pool).
+
+## Algorithm (per contended group)
+
+1. **Group** models by `(accType, scope)`. `scope` = `namespace-N` if N is a closed quota allowlist in
+   `availableByNS`, else `cluster`.
+2. **Budget** = free-available for the group (`effectiveAvailable` / `availableByNS`) **+ Σ current GPU
+   usage** of the group's models on that type.
+3. **Enabled?** budget exists at scope **and** same-scope flag on. If not, or budget unlimited
+   (`math.MaxInt`), fall through to today's additive `fairShareScaleUp`.
+4. **Contended?** `Σ demandGPUs > budget`. If not, fall through (no reclaim needed).
+5. **Per model:** `floorᵢ = Σ minReplicas·gpusPerReplica`; `demandGPUsᵢ` = demand→GPUs (per-role for
+   P/D), capped at `maxReplicas`; `weightᵢ = priorityᵢ × demandᵢ` (demand enters only as a ratio, so
+   token units cancel).
+6. **Water-fill:** `shareᵢ = floorᵢ + (budget − Σfloor)·weightᵢ/Σweight`, iteratively capping any model
+   above `min(demandGPUsᵢ, maxGPUsᵢ)` and re-splitting the freed excess; quantize to whole replicas at
+   each variant's `gpusPerReplica` (round down). Surfacing a reclaim **stall** (a role that can't shed
+   a whole replica) is deferred to Beta observability.
+   `Σfloor > budget` → over-budget **Conflict** (log, clamp shares to floors).
+7. **Apply:**
+   - **reclaim** (`targetGPUsᵢ < currentGPUsᵢ`): `scaleDownRoleIterated` (role-aware per-role spare,
+     `minReplicas`, cheapest-at-1); tag decisions `DecisionReasonRescale`.
+   - **fill** (`> currentGPUsᵢ`): `allocateForModelPaired` / cost-eff pick, but only up to
+     `min(target, free-this-cycle)`. Reclaim does not free budget this cycle (usage is
+     `currentReplicas`-based), so fills consume only pre-existing free → the group is **never
+     over-budget**; the remaining fill lands next cycle as reclaims actuate.
+8. **Build decisions** via the existing `buildDecisionsWithOptimizer`.
+
+### Invariants (enforced by tests)
+- `Σ targets ≤ budget` every cycle (free-capacity-gated fill).
+- Reclaim never below `minReplicas`; P/D roles independently served (a slack role never trims a
+  saturated one).
+- Whole-replica quantization (round down at each variant's `gpusPerReplica`).
+
+## Files
+
+| File | Change |
+|---|---|
+| `internal/config/saturation_scaling.go` | `EnableRescale bool` (`yaml:"enableRescale,omitempty"`) + `Merge`; read from `default` only; no default/validation |
+| `internal/interfaces/saturation_analyzer.go` | add `DecisionReasonRescale` |
+| `config/base/manager/saturation-scaling-configmap.yaml`, `deploy/configmap-saturation-scaling.yaml` | document flag (commented, off; cluster-default / per-namespace) |
+| `internal/config/config.go` (or accessor) | namespace-local-only saturation lookup (distinguish own-config vs global fallback) |
+| `internal/engines/saturation/engine.go` | resolve `{cluster, byNamespace}` rescale flags; pass to optimizer |
+| `internal/engines/pipeline/greedy_score_optimizer.go` | group by `(type, scope)`; branch to rescale on enabled+contended groups, else existing path |
+| new `internal/engines/pipeline/rescale.go` | water-fill (`computeRescaleTargets`, pure) + reclaim/fill wiring |
+| new `internal/engines/pipeline/rescale_test.go` | unit tests |
+
+## Tests (proposal's worked examples)
+- Water-fill: budget 8 — A(prio 1, dem 8, holds 8) & B(prio 3, dem 8, holds 0) → **A=2, B=6**; B dem 4 →
+  excess re-splits **A=4, B=4**; `minReplicas` floors reserved first; `gpusPerReplica=2` quantization
+  (A sheds a whole replica; A=4/B=4 = 2 replicas each).
+- Reclaim carries `DecisionReasonRescale`; fill respects free-this-cycle.
+- P/D: reclaim sheds per-role by spare; ratio preserved.
+- Namespace-quota group: reclaim confined to the namespace.
+- Scope-coupling: cluster flag does not rescale a namespace quota, and vice-versa.
+- **Flag off / uncontended → decisions byte-identical to the current path.**
+
+## Commits (each: build + `go test` + golangci-lint via WSL, DCO-signed)
+1. **Config flag + reason** — `EnableRescale` (+ `Merge`) + `DecisionReasonRescale` + configmap docs.
+   Behavior-neutral.
+2. **Water-fill core** — pure `computeRescaleTargets(...)` + unit tests (the worked examples).
+3. **Wiring** — namespace-local flag accessor + engine resolves `{cluster, byNamespace}` + optimizer
+   grouping / contention / reclaim / fill (non-P/D and P/D via the role helpers) + free-capacity
+   gating + tests.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -419,6 +419,32 @@ func (c *Config) SaturationConfigForNamespace(namespace string) map[string]Satur
 	return copySaturationConfig(sourceConfig)
 }
 
+// RescaleEnabledForNamespaceLocal reports the EnableRescale flag from a namespace's
+// OWN saturation config `default` entry, and whether that namespace has its own
+// (non-global) config. It intentionally does NOT fall back to the global config: the
+// scope-coupled rescale flag for a namespace quota is governed only by that
+// namespace's own config, so the cluster (global) flag never leaks onto it.
+func (c *Config) RescaleEnabledForNamespaceLocal(namespace string) (enabled bool, hasLocal bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if namespace == "" {
+		return false, false
+	}
+	nsCfg, ok := c.saturation.namespaceConfigs[namespace]
+	if !ok || len(nsCfg) == 0 {
+		return false, false
+	}
+	return nsCfg["default"].EnableRescale, true
+}
+
+// RescaleEnabledCluster reports the EnableRescale flag from the global saturation
+// config `default` entry — the cluster-budget scope.
+func (c *Config) RescaleEnabledCluster() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.saturation.global["default"].EnableRescale
+}
+
 // copySaturationConfig creates a deep copy of the saturation config map.
 func copySaturationConfig(src map[string]SaturationScalingConfig) map[string]SaturationScalingConfig {
 	if src == nil {

--- a/internal/config/rescale_config_test.go
+++ b/internal/config/rescale_config_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+var _ = Describe("SaturationScalingConfig enableRescale", func() {
+	// Locks the `enableRescale` yaml tag and confirms it defaults to false.
+	DescribeTable("yaml parsing",
+		func(doc string, want bool) {
+			var cfg SaturationScalingConfig
+			Expect(yaml.Unmarshal([]byte(doc), &cfg)).To(Succeed())
+			Expect(cfg.EnableRescale).To(Equal(want))
+		},
+		Entry("absent defaults false", "kvCacheThreshold: 0.8\n", false),
+		Entry("explicit true", "kvCacheThreshold: 0.8\nenableRescale: true\n", true),
+		Entry("explicit false", "enableRescale: false\n", false),
+	)
+
+	// enableRescale is budget-scoped: it is read only from the global/namespace
+	// `default` entry and must NOT be settable via a per-model override, so Merge()
+	// deliberately ignores it. This locks that exclusion against an accidental
+	// copy-paste of the EnableLimiter merge branch that would reintroduce a leak.
+	It("does not let a per-model override set enableRescale via Merge", func() {
+		base := SaturationScalingConfig{EnableRescale: false}
+		base.Merge(SaturationScalingConfig{EnableRescale: true, ModelID: "m", Namespace: "ns"})
+		Expect(base.EnableRescale).To(BeFalse())
+	})
+})
+
+// Scope-coupled flag resolution: the cluster flag from the global default, and the
+// per-namespace flag from a namespace's OWN config only (the cluster flag must never
+// leak onto a namespace quota).
+var _ = Describe("rescale flag accessors", func() {
+	var c *Config
+
+	BeforeEach(func() {
+		c = NewTestConfig()
+		c.UpdateSaturationConfig(map[string]SaturationScalingConfig{"default": {EnableRescale: true}})
+	})
+
+	It("reads the cluster flag from the global default", func() {
+		Expect(c.RescaleEnabledCluster()).To(BeTrue())
+	})
+
+	It("reads a namespace flag from that namespace's own config", func() {
+		c.UpdateSaturationConfigForNamespace("team", map[string]SaturationScalingConfig{"default": {EnableRescale: true}})
+		en, has := c.RescaleEnabledForNamespaceLocal("team")
+		Expect(has).To(BeTrue())
+		Expect(en).To(BeTrue())
+	})
+
+	It("does not leak the cluster flag onto a namespace whose own flag is off", func() {
+		c.UpdateSaturationConfigForNamespace("plain", map[string]SaturationScalingConfig{"default": {KvCacheThreshold: 0.8}})
+		en, has := c.RescaleEnabledForNamespaceLocal("plain")
+		Expect(has).To(BeTrue(), "namespace has a local config")
+		Expect(en).To(BeFalse(), "cluster flag must not leak onto the namespace quota")
+	})
+
+	It("reports no local config for an unconfigured namespace", func() {
+		en, has := c.RescaleEnabledForNamespaceLocal("absent")
+		Expect(has).To(BeFalse())
+		Expect(en).To(BeFalse())
+	})
+})

--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -33,6 +33,18 @@ type SaturationScalingConfig struct {
 	// Default is false (limiter disabled).
 	EnableLimiter bool `yaml:"enableLimiter,omitempty"`
 
+	// EnableRescale: When true, the V2 GPU-constrained optimizer may run the
+	// priority-weighted rescale pass — under contention it redistributes the whole
+	// budget by priority x demand, reclaiming from lower-priority models so
+	// higher-priority work can run. Default is false (additive fair-share only).
+	//
+	// This is a BUDGET-SCOPE flag, read only from the "default" entry: the value in
+	// the global config governs the cluster budget, and a namespace-local config's
+	// "default" governs that namespace's quota budget. It is ignored on per-model
+	// override entries and has no effect unless a same-scope GPU budget exists
+	// (see docs/plans/engine/rescale-alpha.md).
+	EnableRescale bool `yaml:"enableRescale,omitempty"`
+
 	// AnalyzerName selects which saturation analyzer to use.
 	// "saturation" uses the V2 token-based analyzer.
 	// Empty string (default) uses the V1 percentage-based analyzer.

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -22,6 +22,10 @@ const (
 	DecisionReasonSaturationOnly DecisionReason = "saturation-only mode"
 	// DecisionReasonScaleFromZero indicates scale-up from zero replicas.
 	DecisionReasonScaleFromZero DecisionReason = "scale-from-zero"
+	// DecisionReasonRescale indicates a priority-weighted rescale reclaim — a
+	// deliberate, redistributive scale-down (not flappy demand), which downstream
+	// stabilization must not damp as if it were noise.
+	DecisionReasonRescale DecisionReason = "rescale"
 	// DecisionReasonTest is used for test scenarios.
 	DecisionReasonTest DecisionReason = "test"
 )

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -2,7 +2,9 @@ package pipeline
 
 import (
 	"context"
+	"maps"
 	"math"
+	"slices"
 	"sort"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -10,6 +12,20 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
+
+// rolesOf returns the distinct roles among the given variants, sorted for
+// determinism. A variant with no role is the synthetic RoleBoth.
+func rolesOf(vcs []domain.VariantCapacity) []string {
+	set := make(map[string]struct{}, len(vcs))
+	for _, vc := range vcs {
+		r := vc.Role
+		if r == "" {
+			r = domain.RoleBoth
+		}
+		set[r] = struct{}{}
+	}
+	return slices.Sorted(maps.Keys(set))
+}
 
 // applyAllocation subtracts the capacity provided by n replicas of variant v
 // from each analyzer's Remaining counter. Clamps to 0. The slice is the working

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -429,19 +429,7 @@ func scaleDownRoleIterated(
 	if len(stateMap) > 0 {
 		states = stateMap[0]
 	}
-	rolesSet := make(map[string]struct{})
-	for _, vc := range variants {
-		role := vc.Role
-		if role == "" {
-			role = domain.RoleBoth
-		}
-		rolesSet[role] = struct{}{}
-	}
-	roles := make([]string, 0, len(rolesSet))
-	for role := range rolesSet {
-		roles = append(roles, role)
-	}
-	sort.Strings(roles)
+	roles := rolesOf(variants)
 
 	for _, role := range roles {
 		if !needsScaleDownForRole(s, role) {

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -22,7 +22,12 @@ import (
 //   - Fair-shares GPUs across models (highest-priority model gets GPUs first)
 //   - Disaggregated models use paired (n_P, n_D) allocation via the paired helpers
 //   - Scale-down uses scaleDownRoleIterated (role-iterated unified path)
-type GreedyByScoreOptimizer struct{}
+type GreedyByScoreOptimizer struct {
+	// Rescale carries the resolved, scope-coupled rescale enablement for the
+	// current cycle (set by the engine before Optimize). Zero value = off, which
+	// keeps the additive fair-share behaviour unchanged.
+	Rescale RescaleFlags
+}
 
 // NewGreedyByScoreOptimizer creates a new GreedyByScoreOptimizer.
 func NewGreedyByScoreOptimizer() *GreedyByScoreOptimizer {
@@ -98,10 +103,25 @@ func (o *GreedyByScoreOptimizer) Optimize(
 	available := mergeConstraints(constraints)
 	availableByNS := mergeNamespaceConstraints(constraints)
 
+	// Rescale pre-pass: for enabled, contended (type, budget-scope) groups, compute
+	// priority-weighted targets and produce reclaim/fill decisions, consuming free
+	// GPUs from `available`/`availableByNS` so the additive path below sees the
+	// reduced budget. Models it handles are excluded from the additive path. When
+	// rescale is off or no group is contended, `handled` is empty and behaviour is
+	// unchanged.
+	var rescaleDecisions []domain.VariantDecision
+	var handled map[string]bool
+	if o.Rescale.any() {
+		rescaleDecisions, handled = o.applyRescale(ctx, requests, available, availableByNS)
+	}
+
 	var scaleUpWork []*modelWork
 	var otherRequests []ModelScalingRequest
 
 	for _, req := range requests {
+		if handled[modelKey(req)] {
+			continue
+		}
 		satEntry := saturationEntry(req.AnalyzerResults)
 		if satEntry == nil {
 			continue
@@ -156,6 +176,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 		allDecisions = append(allDecisions, decisions...)
 	}
 
+	allDecisions = append(allDecisions, rescaleDecisions...)
 	return allDecisions
 }
 

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -1,0 +1,671 @@
+package pipeline
+
+import (
+	"cmp"
+	"context"
+	"maps"
+	"math"
+	"slices"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+)
+
+// modelKey is a model's identity for rescale bookkeeping. A model is identified by
+// (namespace, ModelID), never ModelID alone: the same ModelID can be served in two
+// namespaces, and both can land in the same cluster-scope competition group. Keying
+// maps by the bare ModelID would collide those models — overwriting targets, double-
+// counting floors, and freezing one namespace's model out of the additive path.
+func modelKey(req ModelScalingRequest) string {
+	return utils.GetNamespacedKey(req.Namespace, req.ModelID)
+}
+
+// RescaleFlags carries the resolved, scope-coupled rescale enablement for one
+// optimize cycle. Cluster governs the cluster budget group; ByNamespace[ns]
+// governs namespace ns's quota budget group. The zero value disables rescale.
+type RescaleFlags struct {
+	Cluster     bool
+	ByNamespace map[string]bool
+}
+
+func (f RescaleFlags) any() bool { return f.Cluster || len(f.ByNamespace) > 0 }
+
+// enabledForScope reports whether rescale is on at a group's budget scope:
+// the namespace flag for a namespace-quota group, else the cluster flag.
+func (f RescaleFlags) enabledForScope(namespace string, namespaceScoped bool) bool {
+	if namespaceScoped {
+		return f.ByNamespace[namespace]
+	}
+	return f.Cluster
+}
+
+// rescaleInput is one model's contribution to the priority-weighted water-filling.
+// All GPU quantities are whole GPUs; Demand is in the analyzer's own unit and is
+// used only inside the weight ratio (priority x demand), so its unit cancels.
+type rescaleInput struct {
+	ID        string
+	Priority  float64 // model priority multiplier (>= 0)
+	Demand    float64 // model demand for the weight (any unit; ratio only)
+	FloorGPUs int     // reserved: sum over variants of minReplicas x gpusPerReplica
+	CapGPUs   int     // upper bound: min(demand-in-GPUs, maxReplicas x gpusPerReplica); >= FloorGPUs
+}
+
+// computeRescaleTargets distributes `budget` GPUs across models by priority-weighted
+// water-filling, returning each model's target GPU allocation.
+//
+//	target_i = floor_i + (budget - Sum floor) * weight_i / Sum weight     (weight_i = priority_i * demand_i)
+//
+// A model wanting less than its share is capped at CapGPUs_i and the freed excess
+// re-splits over the still-hungry models by the same weights, until none exceeds its
+// cap. Floors are always reserved first; when Sum floor > budget the floors cannot be
+// met — every model is clamped to its floor and overBudget is true (a Conflict the
+// caller surfaces). Fractional shares are rounded to whole GPUs by the largest-remainder
+// method, never exceeding a model's cap, so the returned targets sum to at most `budget`.
+func computeRescaleTargets(in []rescaleInput, budget int) (targets map[string]int, overBudget bool) {
+	targets = make(map[string]int, len(in))
+
+	sumFloor := 0
+	for _, m := range in {
+		targets[m.ID] = m.FloorGPUs
+		sumFloor += m.FloorGPUs
+	}
+	if sumFloor >= budget {
+		// Floors already consume (or exceed) the budget: nothing to redistribute.
+		return targets, sumFloor > budget
+	}
+
+	pool := budget - sumFloor // redistributable GPUs above the floors
+
+	// Iterative water-fill in fractional space over `pool`, capping at each model's
+	// headroom (CapGPUs - FloorGPUs) and re-splitting the freed remainder.
+	type active struct {
+		id       string
+		weight   float64
+		headroom int
+	}
+	act := make([]active, 0, len(in))
+	for _, m := range in {
+		hr := m.CapGPUs - m.FloorGPUs
+		if hr < 0 {
+			hr = 0
+		}
+		w := m.Priority * m.Demand
+		if w > 0 && hr > 0 {
+			act = append(act, active{m.ID, w, hr})
+		}
+	}
+
+	extra := make(map[string]float64, len(act))
+	remaining := float64(pool)
+	for len(act) > 0 && remaining > 1e-9 {
+		totalW := 0.0
+		for _, a := range act {
+			totalW += a.weight
+		}
+		if totalW <= 0 {
+			break
+		}
+		// Cap any model whose proportional share reaches its headroom; if none does,
+		// assign the remainder proportionally and finish.
+		capped := false
+		used := 0.0
+		next := act[:0:0]
+		for _, a := range act {
+			share := remaining * a.weight / totalW
+			if share >= float64(a.headroom)-1e-9 {
+				extra[a.id] = float64(a.headroom)
+				used += float64(a.headroom)
+				capped = true
+			} else {
+				next = append(next, a)
+			}
+		}
+		if capped {
+			remaining -= used
+			act = next
+			continue
+		}
+		for _, a := range act {
+			extra[a.id] = remaining * a.weight / totalW
+		}
+		remaining = 0
+		act = nil
+	}
+
+	// Round fractional extras to whole GPUs (largest remainder), respecting each
+	// model's headroom, so the integer total does not exceed the fractional total.
+	roundExtras(in, extra, targets)
+	return targets, false
+}
+
+// roundExtras adds each model's fractional above-floor allocation to its target using
+// the largest-remainder method: floor everything, then hand out the leftover GPUs one at
+// a time to the largest fractional parts, skipping models already at their cap.
+func roundExtras(in []rescaleInput, extra map[string]float64, targets map[string]int) {
+	capOf := make(map[string]int, len(in))
+	for _, m := range in {
+		capOf[m.ID] = m.CapGPUs
+	}
+
+	remainder := make(map[string]float64, len(extra))
+	totalFrac := 0.0
+	sumWhole := 0
+	for id, e := range extra {
+		whole := int(math.Floor(e))
+		targets[id] += whole
+		sumWhole += whole
+		totalFrac += e
+		remainder[id] = e - float64(whole)
+	}
+	// leftover = round(total above-floor allocation) - the whole GPUs already applied.
+	leftover := int(math.Round(totalFrac)) - sumWhole
+	apportionLeftover(targets, remainder, leftover, capOf)
+}
+
+// apportionLeftover hands out `leftover` whole units one at a time to the keys with
+// the largest fractional remainders (deterministic tie-break by key ascending),
+// skipping any key already at capOf[key]. A nil capOf means uncapped. It mutates out.
+func apportionLeftover(out map[string]int, remainder map[string]float64, leftover int, capOf map[string]int) {
+	if leftover <= 0 {
+		return
+	}
+	type kr struct {
+		key  string
+		frac float64
+	}
+	order := make([]kr, 0, len(remainder))
+	for k, v := range remainder {
+		order = append(order, kr{k, v})
+	}
+	// Largest fractional remainder first; deterministic tie-break by key.
+	slices.SortFunc(order, func(a, b kr) int {
+		return cmp.Or(cmp.Compare(b.frac, a.frac), cmp.Compare(a.key, b.key))
+	})
+	for _, o := range order {
+		if leftover <= 0 {
+			break
+		}
+		if capOf != nil {
+			if c, ok := capOf[o.key]; ok && out[o.key] >= c {
+				continue
+			}
+		}
+		out[o.key]++
+		leftover--
+	}
+}
+
+// applyRescale runs the priority-weighted rescale pass for enabled, contended
+// (accelerator type, budget scope) groups. It returns the decisions it produced and
+// the set of model IDs it handled (which the caller excludes from the additive path).
+// Fills consume free GPUs from `available` / `availableByNS` in place; reclaims do not
+// free budget this cycle (usage is CurrentReplicas-based), so fills never over-subscribe.
+//
+// P/D models are handled: a model's GPU target is split across its roles by role
+// demand, and reclaim/fill run per role. Multi-accelerator models (variants spanning
+// GPU types, incl. P/D across types) are skipped (deferred).
+func (o *GreedyByScoreOptimizer) applyRescale(
+	ctx context.Context,
+	requests []ModelScalingRequest,
+	available map[string]int,
+	availableByNS map[string]map[string]int,
+) ([]domain.VariantDecision, map[string]bool) {
+	logger := ctrl.LoggerFrom(ctx).WithName("rescale")
+	handled := make(map[string]bool)
+	var decisions []domain.VariantDecision
+
+	type groupKey struct {
+		accType string
+		scope   string // namespace for namespace-scoped groups, "" for cluster
+	}
+	groups := make(map[groupKey][]ModelScalingRequest)
+	for _, req := range requests {
+		satEntry := saturationEntry(req.AnalyzerResults)
+		if satEntry == nil {
+			continue
+		}
+		accType, ok := singleAccType(satEntry.VariantCapacities)
+		if !ok {
+			continue // multi-accelerator (incl. P/D spanning types): deferred
+		}
+		// A namespace present in availableByNS is a closed quota allowlist → namespace scope.
+		_, nsScoped := availableByNS[req.Namespace]
+		if !o.Rescale.enabledForScope(req.Namespace, nsScoped) {
+			continue
+		}
+		scope := ""
+		if nsScoped {
+			scope = req.Namespace
+		}
+		k := groupKey{accType, scope}
+		groups[k] = append(groups[k], req)
+	}
+
+	// Process groups in a deterministic order. A namespace fill debits the shared
+	// cluster budget, so a cluster-scoped group on the same accelerator type observes
+	// the result — a stable order keeps a cycle reproducible for identical input.
+	keys := slices.Collect(maps.Keys(groups))
+	slices.SortFunc(keys, func(a, b groupKey) int {
+		return cmp.Or(cmp.Compare(a.accType, b.accType), cmp.Compare(a.scope, b.scope))
+	})
+
+	for _, k := range keys {
+		reqs := groups[k]
+		free := available[k.accType]
+		if k.scope != "" {
+			free = availableByNS[k.scope][k.accType]
+		}
+		// Skip unlimited/unknown budgets — there is nothing to redistribute.
+		if free < 0 || free == math.MaxInt {
+			continue
+		}
+
+		currentUsage := 0
+		for _, req := range reqs {
+			currentUsage += modelCurrentGPUs(req, k.accType)
+		}
+		budget := free + currentUsage
+
+		inputs, sumDemandGPUs := rescaleInputsForGroup(reqs, k.accType, budget)
+		if sumDemandGPUs <= budget {
+			continue // uncontended: leave to the additive path
+		}
+
+		targets, overBudget := computeRescaleTargets(inputs, budget)
+		if overBudget {
+			logger.Info("rescale: minReplicas floors exceed the group budget (Conflict); clamping to floors",
+				"accType", k.accType, "scope", k.scope, "budget", budget)
+		}
+
+		// Serve highest-priority models first: same-cycle free GPUs are scarce
+		// (reclaims free nothing until next cycle), so a lower-priority model earlier
+		// in request order must not claim a fill ahead of a higher-priority one.
+		// Deterministic tie-break by the full (namespace, ModelID) identity — a bare
+		// ModelID ties two same-named models in different namespaces, leaving the winner
+		// to randomized request order (flap cycle-to-cycle).
+		slices.SortStableFunc(reqs, func(a, b ModelScalingRequest) int {
+			return cmp.Or(cmp.Compare(b.Priority, a.Priority), cmp.Compare(modelKey(a), modelKey(b)))
+		})
+
+		// GPUs we can physically hand out this cycle. A namespace fill draws from the
+		// shared physical pool, so bound it by the cluster's finite free too — filling
+		// up to the namespace quota alone would emit scale-ups for GPUs that are not
+		// physically free (over-subscription) and drive the cluster budget negative.
+		// The water-fill target above intentionally uses the full quota; fills pace
+		// toward it over cycles as physical GPUs free up.
+		fillable := free
+		if k.scope != "" {
+			if cur, ok := available[k.accType]; ok && cur != math.MaxInt {
+				fillable = min(fillable, cur)
+			}
+		}
+
+		freeThisCycle := fillable
+		for _, req := range reqs {
+			d := o.rescaleModelDecisions(ctx, req, k.accType, targets[modelKey(req)], &freeThisCycle)
+			decisions = append(decisions, d...)
+			handled[modelKey(req)] = true
+		}
+
+		if consumed := fillable - freeThisCycle; consumed > 0 {
+			if k.scope != "" {
+				if availableByNS[k.scope] != nil {
+					availableByNS[k.scope][k.accType] -= consumed
+				}
+				// A namespace fill also draws from the shared physical pool; debit the
+				// finite cluster budget too (mirroring allocateForModel). Bounded by
+				// fillable above, this can never drive the cluster budget negative.
+				if cur, ok := available[k.accType]; ok && cur != math.MaxInt {
+					available[k.accType] -= consumed
+				}
+			} else {
+				available[k.accType] -= consumed
+			}
+		}
+	}
+
+	return decisions, handled
+}
+
+// rescaleModelDecisions drives one model to targetGPUs on accType: reclaim (shed
+// most-expensive-first, respecting minReplicas) or fill (add most-cost-efficient
+// first, gated on *freeThisCycle). Reclaim decisions are tagged DecisionReasonRescale.
+func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
+	ctx context.Context,
+	req ModelScalingRequest,
+	accType string,
+	targetGPUs int,
+	freeThisCycle *int,
+) []domain.VariantDecision {
+	satEntry := saturationEntry(req.AnalyzerResults)
+	stateMap := buildStateMap(req.VariantStates)
+	vcMap := buildCapacityMap(satEntry.VariantCapacities)
+	targets := initTargets(req.VariantStates)
+
+	// Split the model's GPU target across its roles by role demand (a P/D model
+	// must keep both roles served), then reclaim/fill each role toward its share.
+	// A non-disaggregated model has the single synthetic "both" role.
+	roles := modelRolesOnType(satEntry.VariantCapacities, accType)
+	curByRole := make(map[string]int, len(roles))
+	demByRole := make(map[string]int, len(roles))
+	floorByRole := make(map[string]int, len(roles))
+	for _, role := range roles {
+		curByRole[role] = roleCurrentGPUs(req, accType, role)
+		demByRole[role] = roleDemandGPUs(satEntry, stateMap, accType, role)
+		floorByRole[role] = roleFloorGPUs(req, accType, role)
+	}
+	tgtByRole := distributeGPUsByWeight(targetGPUs, roles, demByRole, curByRole, floorByRole)
+
+	for _, role := range roles {
+		rt, rc := tgtByRole[role], curByRole[role]
+		switch {
+		case rt < rc:
+			reclaimRole(ctx, req.AnalyzerResults, satEntry.VariantCapacities, role, stateMap, targets, rc-rt)
+		case rt > rc:
+			want := rt - rc
+			if want > *freeThisCycle {
+				want = *freeThisCycle
+			}
+			*freeThisCycle -= fillRole(satEntry.VariantCapacities, role, stateMap, targets, want)
+		}
+	}
+
+	decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "rescale")
+	for i := range decisions {
+		if decisions[i].Action == domain.ActionScaleDown {
+			decisions[i].SetDecisionReason(domain.ActionScaleDown, domain.DecisionReasonRescale,
+				string(domain.DecisionReasonRescale)+" (optimizer: rescale, reclaim)")
+		}
+	}
+	return decisions
+}
+
+// reclaimRole sheds up to deltaGPUs worth of a role's replicas, most-expensive-first,
+// respecting minReplicas and the cheapest-at-1 protection, via scaleDownVariantSet.
+func reclaimRole(
+	ctx context.Context,
+	s []NamedAnalyzerResult,
+	variants []domain.VariantCapacity,
+	role string,
+	stateMap map[string]domain.VariantReplicaState,
+	targets map[string]int,
+	deltaGPUs int,
+) {
+	remaining := deltaGPUs
+	sorted := sortVariantsForScaleDown(s, variantsForRole(variants, role))
+	scaleDownVariantSet(ctx, sorted, targets, stateMap,
+		func(vc domain.VariantCapacity) int {
+			g := gpusPerReplicaFromState(stateMap, vc.VariantName)
+			if remaining <= 0 || g <= 0 {
+				return 0
+			}
+			return remaining / g // whole replicas that fit in the remaining GPU delta
+		},
+		func(vc domain.VariantCapacity, n int) {
+			remaining -= n * gpusPerReplicaFromState(stateMap, vc.VariantName)
+		},
+	)
+}
+
+// fillRole adds up to wantGPUs worth of a role's replicas, most-cost-efficient-first,
+// respecting maxReplicas. Returns the GPUs actually consumed.
+func fillRole(
+	variants []domain.VariantCapacity,
+	role string,
+	stateMap map[string]domain.VariantReplicaState,
+	targets map[string]int,
+	wantGPUs int,
+) int {
+	spent := 0
+	for _, vc := range sortByCostEfficiencyAsc(variantsForRole(variants, role)) {
+		if wantGPUs-spent <= 0 {
+			break
+		}
+		if vc.PerReplicaCapacity <= 0 {
+			continue
+		}
+		g := gpusPerReplicaFromState(stateMap, vc.VariantName)
+		if g <= 0 {
+			continue
+		}
+		st := stateMap[vc.VariantName]
+		for wantGPUs-spent >= g {
+			if st.MaxReplicas != nil && *st.MaxReplicas > 0 && targets[vc.VariantName] >= *st.MaxReplicas {
+				break
+			}
+			targets[vc.VariantName]++
+			spent += g
+		}
+	}
+	return spent
+}
+
+// singleAccType returns the accelerator type shared by all variants, or false if
+// they span more than one (multi-accelerator, deferred) or none is set.
+func singleAccType(vcs []domain.VariantCapacity) (string, bool) {
+	accType := ""
+	for _, vc := range vcs {
+		if vc.AcceleratorName == "" {
+			continue
+		}
+		if accType == "" {
+			accType = vc.AcceleratorName
+		} else if accType != vc.AcceleratorName {
+			return "", false
+		}
+	}
+	return accType, accType != ""
+}
+
+// modelCurrentGPUs sums CurrentReplicas x GPUsPerReplica over the model's variants
+// on accType.
+func modelCurrentGPUs(req ModelScalingRequest, accType string) int {
+	satEntry := saturationEntry(req.AnalyzerResults)
+	if satEntry == nil {
+		return 0
+	}
+	stateMap := buildStateMap(req.VariantStates)
+	total := 0
+	for _, vc := range satEntry.VariantCapacities {
+		if vc.AcceleratorName != accType {
+			continue
+		}
+		total += stateMap[vc.VariantName].CurrentReplicas * gpusPerReplicaFromState(stateMap, vc.VariantName)
+	}
+	return total
+}
+
+// rescaleInputsForGroup builds the water-filling inputs for a group's models and
+// returns them with the summed demand-in-GPUs (for the contention check).
+func rescaleInputsForGroup(reqs []ModelScalingRequest, accType string, budget int) ([]rescaleInput, int) {
+	inputs := make([]rescaleInput, 0, len(reqs))
+	sumDemandGPUs := 0
+	for _, req := range reqs {
+		satEntry := saturationEntry(req.AnalyzerResults)
+		if satEntry == nil {
+			continue
+		}
+		stateMap := buildStateMap(req.VariantStates)
+
+		floorGPUs, maxGPUs, maxBounded := 0, 0, true
+		for _, vc := range satEntry.VariantCapacities {
+			if vc.AcceleratorName != accType {
+				continue
+			}
+			g := gpusPerReplicaFromState(stateMap, vc.VariantName)
+			st := stateMap[vc.VariantName]
+			if st.MinReplicas != nil && *st.MinReplicas > 0 {
+				floorGPUs += *st.MinReplicas * g
+			}
+			if st.MaxReplicas != nil && *st.MaxReplicas > 0 {
+				maxGPUs += *st.MaxReplicas * g
+			} else {
+				maxBounded = false
+			}
+		}
+
+		demandGPUs := modelDemandGPUs(satEntry, stateMap, accType)
+		capGPUs := demandGPUs
+		if maxBounded {
+			capGPUs = min(capGPUs, maxGPUs)
+		} else {
+			capGPUs = min(capGPUs, budget) // unbounded max: cap at the group budget
+		}
+		capGPUs = max(capGPUs, floorGPUs)
+
+		inputs = append(inputs, rescaleInput{
+			ID:        modelKey(req),
+			Priority:  req.Priority,
+			Demand:    satEntry.TotalDemand,
+			FloorGPUs: floorGPUs,
+			CapGPUs:   capGPUs,
+		})
+		sumDemandGPUs += demandGPUs
+	}
+	return inputs, sumDemandGPUs
+}
+
+// modelDemandGPUs is the model's demand-in-GPUs summed across its roles on accType
+// (a P/D model needs GPUs for both prefill and decode).
+func modelDemandGPUs(satEntry *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType string) int {
+	total := 0
+	for _, role := range modelRolesOnType(satEntry.VariantCapacities, accType) {
+		total += roleDemandGPUs(satEntry, stateMap, accType, role)
+	}
+	return total
+}
+
+// roleDemandGPUs converts a role's token demand to a GPU count via the role's most
+// cost-efficient variant's per-replica capacity. The synthetic "both" role uses the
+// model-level TotalDemand; a P/D role uses its RoleCapacities demand.
+func roleDemandGPUs(satEntry *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType, role string) int {
+	demand := satEntry.TotalDemand
+	if role != domain.RoleBoth {
+		if rc, ok := satEntry.RoleCapacities[role]; ok {
+			demand = rc.TotalDemand
+		}
+	}
+	best := 0.0
+	bestGPUs := 1
+	for _, vc := range sortByCostEfficiencyAsc(variantsForRole(variantsOnType(satEntry.VariantCapacities, accType), role)) {
+		if vc.PerReplicaCapacity <= 0 {
+			continue
+		}
+		best = vc.PerReplicaCapacity
+		bestGPUs = gpusPerReplicaFromState(stateMap, vc.VariantName)
+		break
+	}
+	if best <= 0 {
+		return 0
+	}
+	replicas := int(math.Ceil(demand / best))
+	if replicas < 0 {
+		replicas = 0
+	}
+	return replicas * bestGPUs
+}
+
+// variantsOnType filters variants to those on accType.
+func variantsOnType(vcs []domain.VariantCapacity, accType string) []domain.VariantCapacity {
+	out := make([]domain.VariantCapacity, 0, len(vcs))
+	for _, vc := range vcs {
+		if vc.AcceleratorName == accType {
+			out = append(out, vc)
+		}
+	}
+	return out
+}
+
+// modelRolesOnType returns the distinct roles among a model's variants on accType,
+// sorted for determinism. A variant with no role is the synthetic "both".
+func modelRolesOnType(vcs []domain.VariantCapacity, accType string) []string {
+	return rolesOf(variantsOnType(vcs, accType))
+}
+
+// roleCurrentGPUs sums CurrentReplicas x GPUsPerReplica over a role's variants on accType.
+func roleCurrentGPUs(req ModelScalingRequest, accType, role string) int {
+	satEntry := saturationEntry(req.AnalyzerResults)
+	if satEntry == nil {
+		return 0
+	}
+	stateMap := buildStateMap(req.VariantStates)
+	total := 0
+	for _, vc := range variantsForRole(variantsOnType(satEntry.VariantCapacities, accType), role) {
+		total += stateMap[vc.VariantName].CurrentReplicas * gpusPerReplicaFromState(stateMap, vc.VariantName)
+	}
+	return total
+}
+
+// roleFloorGPUs sums minReplicas x GPUsPerReplica over a role's variants on accType —
+// the GPUs that must stay allocated to the role regardless of the weighted split.
+func roleFloorGPUs(req ModelScalingRequest, accType, role string) int {
+	satEntry := saturationEntry(req.AnalyzerResults)
+	if satEntry == nil {
+		return 0
+	}
+	stateMap := buildStateMap(req.VariantStates)
+	total := 0
+	for _, vc := range variantsForRole(variantsOnType(satEntry.VariantCapacities, accType), role) {
+		st := stateMap[vc.VariantName]
+		if st.MinReplicas != nil && *st.MinReplicas > 0 {
+			total += *st.MinReplicas * gpusPerReplicaFromState(stateMap, vc.VariantName)
+		}
+	}
+	return total
+}
+
+// distributeGPUsByWeight splits total GPUs across roles: each role is first reserved
+// its floor (minReplicas GPUs), then the remainder is split proportional to weight
+// (falling back to `fallback` when all weights are zero), rounded by largest remainder
+// for determinism. Reserving floors first keeps a role's minReplicas from being
+// undercut by the split — e.g. a cold-start P/D model with zero demand and zero current
+// on both roles must still keep each role's floor, not dump everything on one role. The
+// caller reserves the model-level floor before splitting, so total >= sum of role floors.
+func distributeGPUsByWeight(total int, roles []string, weight, fallback, floor map[string]int) map[string]int {
+	out := make(map[string]int, len(roles))
+	if len(roles) <= 1 {
+		if len(roles) == 1 {
+			out[roles[0]] = total
+		}
+		return out
+	}
+
+	// Reserve each role's own floor up front.
+	sumFloor := 0
+	for _, r := range roles {
+		out[r] = floor[r]
+		sumFloor += floor[r]
+	}
+	remaining := total - sumFloor
+	if remaining <= 0 {
+		return out // total only covers the floors; each role keeps exactly its floor
+	}
+
+	w, sum := weight, 0
+	for _, r := range roles {
+		sum += w[r]
+	}
+	if sum == 0 {
+		w, sum = fallback, 0
+		for _, r := range roles {
+			sum += w[r]
+		}
+	}
+	if sum == 0 {
+		out[roles[0]] += remaining // nothing to weight by: deterministic fallback
+		return out
+	}
+	remainder := make(map[string]float64, len(roles))
+	assigned := 0
+	for _, r := range roles {
+		exact := float64(remaining) * float64(w[r]) / float64(sum)
+		whole := int(math.Floor(exact))
+		out[r] += whole
+		assigned += whole
+		remainder[r] = exact - float64(whole)
+	}
+	apportionLeftover(out, remainder, remaining-assigned, nil)
+	return out
+}

--- a/internal/engines/pipeline/rescale_optimize_test.go
+++ b/internal/engines/pipeline/rescale_optimize_test.go
@@ -1,0 +1,683 @@
+package pipeline
+
+import (
+	"context"
+	"math"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+// rescaleReq builds a single-variant, non-disaggregated model request on the
+// A100 accelerator (1 GPU/replica) for the rescale integration tests. Cost and
+// per-replica capacity are fixed fixtures — the reclaim/fill assertions turn on
+// priority, demand and GPU counts, not on the cost score.
+func rescaleReq(id, ns string, priority, demand float64, current int) ModelScalingRequest {
+	v := id + "-v"
+	r := &domain.AnalyzerResult{
+		ModelID:     id,
+		Namespace:   ns,
+		TotalDemand: demand,
+		VariantCapacities: []domain.VariantCapacity{
+			{VariantName: v, AcceleratorName: "A100", Cost: 5, ReplicaCount: current, PerReplicaCapacity: 1000},
+		},
+	}
+	return withSatEntry(r, ModelScalingRequest{
+		ModelID:   id,
+		Namespace: ns,
+		Priority:  priority,
+		VariantStates: []domain.VariantReplicaState{
+			{VariantName: v, CurrentReplicas: current, GPUsPerReplica: 1},
+		},
+	})
+}
+
+// nsModelReq builds a single-variant request with an explicit ModelID, namespace, and
+// variant name — so a caller can place the same ModelID in two namespaces with distinct
+// variants (the real multi-tenant shape) to exercise (namespace, ModelID) keying.
+func nsModelReq(modelID, ns, variant string, priority, demand float64, current int) ModelScalingRequest {
+	r := &domain.AnalyzerResult{
+		ModelID:     modelID,
+		Namespace:   ns,
+		TotalDemand: demand,
+		VariantCapacities: []domain.VariantCapacity{
+			{VariantName: variant, AcceleratorName: "A100", Cost: 5, ReplicaCount: current, PerReplicaCapacity: 1000},
+		},
+	}
+	return withSatEntry(r, ModelScalingRequest{
+		ModelID:   modelID,
+		Namespace: ns,
+		Priority:  priority,
+		VariantStates: []domain.VariantReplicaState{
+			{VariantName: variant, CurrentReplicas: current, GPUsPerReplica: 1},
+		},
+	})
+}
+
+func hasRescaleReason(dm map[string]domain.VariantDecision) bool {
+	for _, d := range dm {
+		if d.ReasonCategory() == domain.DecisionReasonRescale {
+			return true
+		}
+	}
+	return false
+}
+
+var _ = Describe("GreedyByScoreOptimizer rescale", func() {
+	// Budget 8 fully used by A (holds 8); B (higher priority) is starved. Water-fill
+	// yields A2/B6, but reclaim frees nothing this cycle, so B cannot fill yet:
+	// A reclaims to 2, B stays 0 (paced convergence, never over-budget).
+	It("paces reclaim when no GPUs are free this cycle", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 8),
+			rescaleReq("B", "default", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		da := dm["A-v"]
+		Expect(da.TargetReplicas).To(Equal(2), "A reclaims to 2")
+		Expect(da.Action).To(Equal(domain.ActionScaleDown))
+		Expect(da.ReasonCategory()).To(Equal(domain.DecisionReasonRescale))
+		Expect(dm["B-v"].TargetReplicas).To(Equal(0), "B fill gated: no free GPUs this cycle")
+	})
+
+	// Budget 8 with 3 free (A holds 5). A reclaims 5->2; B fills only up to the 3 free
+	// GPUs this cycle -> B=3. Total never exceeds the budget.
+	It("gates fill on the GPUs freed this cycle", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 5),
+			rescaleReq("B", "default", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 5}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(dm["A-v"].TargetReplicas).To(Equal(2))
+		Expect(dm["B-v"].TargetReplicas).To(Equal(3), "free-gated")
+		Expect(dm["B-v"].Action).To(Equal(domain.ActionScaleUp))
+		Expect(dm["A-v"].TargetReplicas + dm["B-v"].TargetReplicas).To(BeNumerically("<=", 8))
+	})
+
+	// Rescale off: additive path only, no reclaim, no rescale reason; A stays at 8.
+	It("leaves the additive path untouched when off", func() {
+		o := NewGreedyByScoreOptimizer() // Rescale zero value = off
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 8),
+			rescaleReq("B", "default", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(dm["A-v"].TargetReplicas).To(Equal(8), "no reclaim when off")
+		Expect(hasRescaleReason(dm)).To(BeFalse())
+	})
+
+	// Plenty of budget (sum demand <= budget): no rescale, no reclaim.
+	It("does not rescale an uncontended budget", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 2000, 2),
+			rescaleReq("B", "default", 3, 2000, 2),
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 20, Used: 4}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(hasRescaleReason(dm)).To(BeFalse())
+		Expect(dm["A-v"].TargetReplicas).To(BeNumerically(">=", 2), "A not reclaimed while uncontended")
+	})
+
+	// Scope-coupling: models under a namespace quota with only the cluster flag set are
+	// NOT rescaled (the cluster flag doesn't govern a namespace quota).
+	It("does not let the cluster flag rescale a namespace quota", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true} // no ByNamespace["team"]
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "team", 1, 8000, 8),
+			rescaleReq("B", "team", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{
+			Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}},
+			NamespacePools: map[string]map[string]ResourcePool{
+				"team": {"A100": {Limit: 8, Used: 8}},
+			},
+		}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(hasRescaleReason(dm)).To(BeFalse(), "cluster flag rescaled a namespace-quota group")
+	})
+
+	// Same setup, but the namespace flag is on -> the namespace quota IS rescaled.
+	It("rescales a namespace quota when the namespace flag is on", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{ByNamespace: map[string]bool{"team": true}}
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "team", 1, 8000, 8),
+			rescaleReq("B", "team", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{
+			Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}},
+			NamespacePools: map[string]map[string]ResourcePool{
+				"team": {"A100": {Limit: 8, Used: 8}},
+			},
+		}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		da := dm["A-v"]
+		Expect(da.TargetReplicas).To(Equal(2))
+		Expect(da.ReasonCategory()).To(Equal(domain.DecisionReasonRescale))
+	})
+
+	// A P/D (disaggregated) low-priority model holding prefill 4 + decode 4 is reclaimed
+	// to 2 total GPUs; the reclaim is split across roles by role demand (equal here), so
+	// prefill and decode each drop to 1 — a slack role never trims the other.
+	It("splits a P/D reclaim across roles by role demand", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		a := &domain.AnalyzerResult{
+			ModelID:     "A",
+			Namespace:   "default",
+			TotalDemand: 8000,
+			RoleCapacities: map[string]domain.RoleCapacity{
+				"prefill": {TotalDemand: 4000},
+				"decode":  {TotalDemand: 4000},
+			},
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "A-prefill", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "prefill", ReplicaCount: 4},
+				{VariantName: "A-decode", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "decode", ReplicaCount: 4},
+			},
+		}
+		reqA := withSatEntry(a, ModelScalingRequest{
+			ModelID: "A", Namespace: "default", Priority: 1, Disaggregated: true,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "A-prefill", CurrentReplicas: 4, GPUsPerReplica: 1, Role: "prefill"},
+				{VariantName: "A-decode", CurrentReplicas: 4, GPUsPerReplica: 1, Role: "decode"},
+			},
+		})
+		reqB := rescaleReq("B", "default", 3, 8000, 0)
+
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqA, reqB}, cons))
+
+		pf, dc := dm["A-prefill"], dm["A-decode"]
+		Expect(pf.TargetReplicas).To(Equal(1), "prefill reclaimed to 1")
+		Expect(dc.TargetReplicas).To(Equal(1), "decode reclaimed to 1")
+		Expect(pf.ReasonCategory()).To(Equal(domain.DecisionReasonRescale))
+		Expect(dc.ReasonCategory()).To(Equal(domain.DecisionReasonRescale))
+	})
+
+	// Unequal role demand (prefill 6000 / decode 2000) must split the reclaim 3:1, not
+	// evenly. A holds prefill 4 + decode 4 (8 GPUs) and is reclaimed to 4 total: prefill
+	// -> 3, decode -> 1. A 50/50 split would give 2/2 and fail.
+	It("splits a P/D reclaim proportionally to unequal role demand", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		a := &domain.AnalyzerResult{
+			ModelID:     "A",
+			Namespace:   "default",
+			TotalDemand: 8000,
+			RoleCapacities: map[string]domain.RoleCapacity{
+				"prefill": {TotalDemand: 6000},
+				"decode":  {TotalDemand: 2000},
+			},
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "A-prefill", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "prefill", ReplicaCount: 4},
+				{VariantName: "A-decode", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "decode", ReplicaCount: 4},
+			},
+		}
+		reqA := withSatEntry(a, ModelScalingRequest{
+			ModelID: "A", Namespace: "default", Priority: 1, Disaggregated: true,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "A-prefill", CurrentReplicas: 4, GPUsPerReplica: 1, Role: "prefill"},
+				{VariantName: "A-decode", CurrentReplicas: 4, GPUsPerReplica: 1, Role: "decode"},
+			},
+		})
+		// Equal-priority, equal-demand peer holding nothing → water-fill gives A a
+		// target of 4 (half the budget of 8).
+		reqB := rescaleReq("B", "default", 1, 8000, 0)
+
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqA, reqB}, cons))
+
+		Expect(dm["A-prefill"].TargetReplicas).To(Equal(3), "prefill keeps 3 of 4 (demand 6:2)")
+		Expect(dm["A-decode"].TargetReplicas).To(Equal(1), "decode drops to 1 of 4 (demand 6:2)")
+	})
+
+	// A namespace-scoped rescale FILL must debit BOTH the namespace quota AND the shared
+	// cluster budget (a namespace quota draws from the same physical pool), or a later
+	// cluster-scope allocation on the additive path could double-spend those GPUs.
+	// applyRescale mutates the budget maps in place, so assert both are decremented.
+	It("debits both the namespace and cluster budgets on a namespace fill", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{ByNamespace: map[string]bool{"team": true}}
+
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "team", 1, 8000, 8), // low prio, holds the team quota
+			rescaleReq("B", "team", 3, 8000, 0), // high prio, starved → fills the 2 free GPUs
+		}
+		available := map[string]int{"A100": 5}                          // cluster free
+		availableByNS := map[string]map[string]int{"team": {"A100": 2}} // team free = 2
+		_, handled := o.applyRescale(context.Background(), reqs, available, availableByNS)
+
+		Expect(handled).To(HaveKeyWithValue("team/B", true))
+		Expect(availableByNS["team"]["A100"]).To(Equal(0), "team quota debited by the 2-GPU fill")
+		Expect(available["A100"]).To(Equal(3), "cluster budget must also drop by 2, not stay at 5")
+	})
+
+	// The physical cluster pool, not the namespace quota, bounds how many GPUs a
+	// namespace fill may take this cycle. Here team's quota has 5 free but the cluster
+	// physically has only 1 free, so B may fill at most 1 — and the cluster budget must
+	// land at 0, never negative (which would corrupt the additive path this cycle).
+	It("bounds a namespace fill by the cluster physical free, not the quota", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{ByNamespace: map[string]bool{"team": true}}
+
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "team", 1, 8000, 8), // low prio, holds the quota
+			rescaleReq("B", "team", 3, 8000, 0), // high prio, starved
+		}
+		available := map[string]int{"A100": 1}                          // cluster physically tight
+		availableByNS := map[string]map[string]int{"team": {"A100": 5}} // quota looser than physical
+		_, handled := o.applyRescale(context.Background(), reqs, available, availableByNS)
+
+		Expect(handled).To(HaveKeyWithValue("team/B", true))
+		Expect(available["A100"]).To(Equal(0), "fill bounded by the 1 physical GPU; budget not driven negative")
+		Expect(availableByNS["team"]["A100"]).To(Equal(4), "quota debited by the 1 GPU actually filled")
+	})
+
+	// Two groups on the same accelerator type share one physical pool. Groups are
+	// processed in a deterministic (accType, scope) order — cluster scope ("") sorts
+	// before any namespace — so the cluster group consumes the 2 physical GPUs first and
+	// the namespace group's fill is then gated to 0. This pins the deterministic ordering:
+	// X (cluster) wins, A (team) is starved even though its quota still shows 5 free.
+	It("processes groups in a deterministic order across a shared pool", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true, ByNamespace: map[string]bool{"team": true}}
+
+		reqs := []ModelScalingRequest{
+			rescaleReq("X", "solo", 1, 8000, 0), // cluster-scope filler
+			rescaleReq("A", "team", 1, 8000, 0), // namespace-scope filler
+		}
+		available := map[string]int{"A100": 2}                          // shared physical free
+		availableByNS := map[string]map[string]int{"team": {"A100": 5}} // team quota looser
+		decisions, _ := o.applyRescale(context.Background(), reqs, available, availableByNS)
+		dm := decisionMap(decisions)
+
+		Expect(dm["X-v"].TargetReplicas).To(Equal(2), "cluster group processed first, takes the 2 physical GPUs")
+		Expect(dm["A-v"].TargetReplicas).To(Equal(0), "namespace group gated to 0 by the depleted shared pool")
+		Expect(available["A100"]).To(Equal(0))
+		Expect(availableByNS["team"]["A100"]).To(Equal(5), "team quota untouched: it never got a physical GPU")
+	})
+
+	// A filler's MaxReplicas caps how far rescale grows it, even when more GPUs are free.
+	// B (high prio) would take ~6 of the 6 free GPUs by priority weight, but MaxReplicas=2
+	// caps its target at 2. Fails if the MaxReplicas-derived cap is dropped.
+	It("caps a fill at the model's MaxReplicas", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		max2 := 2
+		bAnalyzer := &domain.AnalyzerResult{
+			ModelID: "B", Namespace: "default", TotalDemand: 8000,
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "B-v", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, ReplicaCount: 0},
+			},
+		}
+		reqB := withSatEntry(bAnalyzer, ModelScalingRequest{
+			ModelID: "B", Namespace: "default", Priority: 3,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "B-v", CurrentReplicas: 0, GPUsPerReplica: 1, MaxReplicas: &max2},
+			},
+		})
+		reqA := rescaleReq("A", "default", 1, 8000, 4) // holds 4, absorbs the rest
+
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 10, Used: 4}}}} // free = 6
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqA, reqB}, cons))
+
+		Expect(dm["B-v"].TargetReplicas).To(Equal(2), "capped at MaxReplicas despite 6 free GPUs and high priority")
+	})
+
+	// Two models in one contended group both want to fill, but only 1 GPU is free this
+	// cycle. The higher-priority filler must win it regardless of request order — so with
+	// input order [C, A(low), B(high)], B (not the earlier-listed A) gets the GPU. This
+	// fails if the priority sort before the fill loop is removed.
+	It("serves the higher-priority filler first when free GPUs are scarce", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		reqs := []ModelScalingRequest{
+			rescaleReq("C", "default", 1, 4000, 4), // over-share, reclaims (frees nothing this cycle)
+			rescaleReq("A", "default", 2, 4000, 0), // lower-priority filler, listed first
+			rescaleReq("B", "default", 4, 4000, 0), // higher-priority filler
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 5, Used: 4}}}} // free = 1
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(dm["B-v"].TargetReplicas).To(Equal(1), "high-priority filler wins the single free GPU")
+		Expect(dm["A-v"].TargetReplicas).To(Equal(0), "lower-priority filler starved despite being listed first")
+		Expect(dm["C-v"].TargetReplicas).To(Equal(1), "over-share model reclaimed 4 -> 1")
+	})
+
+	// A multi-accelerator model (variants spanning A100 + H100) is out of Alpha scope and
+	// must be skipped by rescale — never tagged DecisionReasonRescale — while a co-running
+	// single-accelerator contended pair still rescales normally.
+	It("skips multi-accelerator models but still rescales single-type groups", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		m := &domain.AnalyzerResult{
+			ModelID:     "M",
+			Namespace:   "default",
+			TotalDemand: 8000,
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "M-a100", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, ReplicaCount: 4},
+				{VariantName: "M-h100", AcceleratorName: "H100", Cost: 8, PerReplicaCapacity: 2000, ReplicaCount: 0},
+			},
+		}
+		reqM := withSatEntry(m, ModelScalingRequest{
+			ModelID: "M", Namespace: "default", Priority: 1,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "M-a100", CurrentReplicas: 4, GPUsPerReplica: 1},
+				{VariantName: "M-h100", CurrentReplicas: 0, GPUsPerReplica: 1},
+			},
+		})
+		// Single-accelerator contended pair on A100 that rescale as usual.
+		reqA := rescaleReq("A", "default", 1, 8000, 8)
+		reqB := rescaleReq("B", "default", 3, 8000, 0)
+
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}, "H100": {Limit: 4, Used: 0}}}}
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqM, reqA, reqB}, cons))
+
+		ma, mh, av := dm["M-a100"], dm["M-h100"], dm["A-v"]
+		Expect(ma.ReasonCategory()).ToNot(Equal(domain.DecisionReasonRescale), "multi-accel model must not be rescaled")
+		Expect(mh.ReasonCategory()).ToNot(Equal(domain.DecisionReasonRescale), "multi-accel model must not be rescaled")
+		// Proof that rescale did run this cycle on the single-type group.
+		Expect(av.ReasonCategory()).To(Equal(domain.DecisionReasonRescale))
+	})
+
+	// The same ModelID served in two namespaces must not collide in rescale's bookkeeping
+	// (a model's identity is (namespace, ModelID)). Both "llama" models land in the same
+	// cluster-scope group; they must get independent priority-weighted targets, not be
+	// driven to a shared one. With bare-ModelID keying, team/llama would inherit
+	// prod/llama's target and never be reclaimed.
+	It("keeps same-ModelID models in different namespaces independent within a group", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		reqs := []ModelScalingRequest{
+			nsModelReq("llama", "team", "llama-team-v", 1, 8000, 6), // low prio, over-share
+			nsModelReq("llama", "prod", "llama-prod-v", 3, 8000, 0), // high prio, starved
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 6}}}} // free = 2
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(dm["llama-team-v"].TargetReplicas).To(Equal(2), "team/llama reclaimed to its own share, not left at prod/llama's target")
+		Expect(dm["llama-prod-v"].TargetReplicas).To(Equal(2), "prod/llama fills the 2 free GPUs")
+	})
+
+	// A model handled by rescale in one namespace must not freeze the same ModelID in
+	// another namespace out of the additive path. team/llama is rescaled (namespace flag);
+	// prod/llama is cluster-scope with the cluster flag off, so it must still get a normal
+	// additive decision. With bare-ModelID keying, handled["llama"] would skip prod/llama
+	// entirely, producing no decision for it.
+	It("does not freeze a same-ModelID model in another namespace", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{ByNamespace: map[string]bool{"team": true}} // cluster flag off
+
+		reqs := []ModelScalingRequest{
+			nsModelReq("llama", "team", "llama-team-v", 1, 10000, 4), // rescaled (contended namespace quota)
+			nsModelReq("llama", "prod", "llama-prod-v", 1, 3000, 3),  // cluster-scope, additive path
+		}
+		cons := []*ResourceConstraints{{
+			Pools: map[string]ResourcePool{"A100": {Limit: 20, Used: 7}},
+			NamespacePools: map[string]map[string]ResourcePool{
+				"team": {"A100": {Limit: 6, Used: 4}}, // team free = 2, contended
+			},
+		}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(dm).To(HaveKey("llama-prod-v"), "prod/llama must not be frozen out by team/llama being handled")
+		Expect(dm["llama-prod-v"].TargetReplicas).To(Equal(3), "prod/llama gets its normal additive decision")
+	})
+
+	// Reclaim quantizes to whole replicas at the variant's GPUsPerReplica. A holds 4
+	// replicas x 2 GPUs = 8 GPUs; its water-fill target is 3 GPUs, but with 2 GPUs/replica
+	// it can only shed whole replicas, so it rounds down to 2 replicas (4 GPUs) rather
+	// than a fractional 3-GPU target. Exercises the gpusPerReplica>1 quantization path.
+	It("quantizes a reclaim to whole replicas at GPUsPerReplica > 1", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		aAnalyzer := &domain.AnalyzerResult{
+			ModelID: "A", Namespace: "default", TotalDemand: 8000,
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "A-v", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, ReplicaCount: 4},
+			},
+		}
+		reqA := withSatEntry(aAnalyzer, ModelScalingRequest{
+			ModelID: "A", Namespace: "default", Priority: 1,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "A-v", CurrentReplicas: 4, GPUsPerReplica: 2}, // 8 GPUs
+			},
+		})
+		reqB := nsModelReq("B", "default", "B-v", 2, 8000, 0) // higher prio, 1 GPU/replica
+
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqA, reqB}, cons))
+
+		Expect(dm["A-v"].TargetReplicas).To(Equal(2), "8 GPUs -> 4 GPUs (2 replicas); the odd 3rd GPU can't be shed")
+	})
+
+	// An unlimited (math.MaxInt) cluster budget for the type is skipped — there is nothing
+	// to redistribute, so rescale leaves the group to the additive path (no rescale reason,
+	// no panic/overflow from water-filling against MaxInt).
+	It("skips a group whose budget is unlimited", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 8),
+			rescaleReq("B", "default", 3, 8000, 0),
+		}
+		available := map[string]int{"A100": math.MaxInt} // unlimited budget for this type
+		decisions, handled := o.applyRescale(context.Background(), reqs, available, nil)
+
+		Expect(handled).To(BeEmpty(), "unlimited budget: nothing rescaled")
+		Expect(hasRescaleReason(decisionMap(decisions))).To(BeFalse())
+		Expect(available["A100"]).To(Equal(math.MaxInt), "unlimited budget untouched")
+	})
+
+	// An already-over-subscribed pool (Used > Limit -> negative free) is skipped: there is
+	// no budget to redistribute, and water-filling a negative budget would be nonsensical.
+	It("skips a group whose budget is already over-subscribed", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 8),
+			rescaleReq("B", "default", 3, 8000, 0),
+		}
+		available := map[string]int{"A100": -2} // Used exceeds Limit
+		decisions, handled := o.applyRescale(context.Background(), reqs, available, nil)
+
+		Expect(handled).To(BeEmpty(), "over-subscribed budget: nothing rescaled")
+		Expect(hasRescaleReason(decisionMap(decisions))).To(BeFalse())
+		Expect(available["A100"]).To(Equal(-2), "over-subscribed budget untouched")
+	})
+
+	// A P/D role whose fill is capped by MaxReplicas must free the unused budget for later
+	// fillers this cycle — freeThisCycle is decremented by the GPUs actually spent, not the
+	// amount wanted. B (high prio) has prefill capped at 1 replica; the GPU its prefill
+	// couldn't use must flow to C (lower prio). With a want-based decrement, C would get 0.
+	It("returns a MaxReplicas-capped role's unused fill budget to later models", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		prefMax := 1
+		bAnalyzer := &domain.AnalyzerResult{
+			ModelID: "B", Namespace: "default", TotalDemand: 8000,
+			RoleCapacities: map[string]domain.RoleCapacity{
+				"prefill": {TotalDemand: 3000},
+				"decode":  {TotalDemand: 1000},
+			},
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "B-prefill", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "prefill", ReplicaCount: 0},
+				{VariantName: "B-decode", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "decode", ReplicaCount: 0},
+			},
+		}
+		reqB := withSatEntry(bAnalyzer, ModelScalingRequest{
+			ModelID: "B", Namespace: "default", Priority: 3, Disaggregated: true,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "B-prefill", CurrentReplicas: 0, GPUsPerReplica: 1, Role: "prefill", MaxReplicas: &prefMax},
+				{VariantName: "B-decode", CurrentReplicas: 0, GPUsPerReplica: 1, Role: "decode"},
+			},
+		})
+		reqA := rescaleReq("A", "default", 1, 8000, 5) // over-share, reclaims (frees nothing this cycle)
+		reqC := rescaleReq("C", "default", 2, 8000, 0) // lower-priority filler that should get the leftover
+
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 5}}}} // free = 3
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqA, reqB, reqC}, cons))
+
+		Expect(dm["B-prefill"].TargetReplicas).To(Equal(1), "prefill capped at MaxReplicas")
+		Expect(dm["C-v"].TargetReplicas).To(Equal(1), "C gets the GPU prefill couldn't use (spent-, not want-, accounting)")
+	})
+
+	// Fill ties are broken by the full (namespace, ModelID) identity, not bare ModelID.
+	// Two equal-priority "llama" fillers in different namespaces compete for one free GPU;
+	// the winner must be deterministic (modelKey order: "prod/llama" < "team/llama"),
+	// regardless of team being listed first. With a bare-ModelID tie-break, the winner
+	// would follow randomized request order.
+	It("breaks fill ties deterministically by namespace, not just ModelID", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		reqs := []ModelScalingRequest{
+			rescaleReq("C", "default", 1, 8000, 4),                  // over-share, reclaims
+			nsModelReq("llama", "team", "llama-team-v", 2, 8000, 0), // equal-priority filler, listed first
+			nsModelReq("llama", "prod", "llama-prod-v", 2, 8000, 0), // equal-priority filler
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 5, Used: 4}}}} // free = 1
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(dm["llama-prod-v"].TargetReplicas).To(Equal(1), "prod/llama wins the tie (lower modelKey)")
+		Expect(dm["llama-team-v"].TargetReplicas).To(Equal(0), "team/llama loses despite being listed first")
+	})
+
+	// P/D fill: a starved disaggregated model fills across roles proportional to role
+	// demand (6:2 -> 3:1), sharing one freeThisCycle counter. With 8 free GPUs its target
+	// of 8 fills fully as prefill 6 / decode 2 — not evenly (4/4) and not dumped on one role.
+	It("splits a P/D fill proportionally to role demand", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		b := &domain.AnalyzerResult{
+			ModelID: "B", Namespace: "default", TotalDemand: 8000,
+			RoleCapacities: map[string]domain.RoleCapacity{
+				"prefill": {TotalDemand: 6000},
+				"decode":  {TotalDemand: 2000},
+			},
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "B-prefill", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "prefill", ReplicaCount: 0},
+				{VariantName: "B-decode", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "decode", ReplicaCount: 0},
+			},
+		}
+		reqB := withSatEntry(b, ModelScalingRequest{
+			ModelID: "B", Namespace: "default", Priority: 3, Disaggregated: true,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "B-prefill", CurrentReplicas: 0, GPUsPerReplica: 1, Role: "prefill"},
+				{VariantName: "B-decode", CurrentReplicas: 0, GPUsPerReplica: 1, Role: "decode"},
+			},
+		})
+		reqA := rescaleReq("A", "default", 1, 8000, 6) // low prio, holds part of the budget
+
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 14, Used: 6}}}} // free = 8
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqA, reqB}, cons))
+
+		Expect(dm["B-prefill"].TargetReplicas).To(Equal(6), "prefill gets 6 of 8 (demand 6:2)")
+		Expect(dm["B-decode"].TargetReplicas).To(Equal(2), "decode gets 2 of 8 (demand 6:2)")
+	})
+
+	// Scope-coupling no-op row: a namespace whose own flag is on but that has NO quota
+	// (no availableByNS entry) is classified cluster-scope; with the cluster flag off, the
+	// namespace flag governs nothing, so rescale must not run.
+	It("does not rescale when the namespace flag has no same-scope budget", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{ByNamespace: map[string]bool{"ns": true}} // cluster flag off
+
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "ns", 1, 8000, 8),
+			rescaleReq("B", "ns", 3, 8000, 0),
+		}
+		// No NamespacePools for "ns" -> models are cluster-scoped; the namespace flag has
+		// no budget at its scope to govern.
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		Expect(hasRescaleReason(dm)).To(BeFalse())
+	})
+
+	// Fill-side whole-replica quantization at GPUsPerReplica > 1: a starved 2-GPU/replica
+	// model with a 5-GPU water-fill target and only 3 GPUs free this cycle fills 1 replica
+	// (2 GPUs) — floor(3/2) — not a fractional or rounded-up amount.
+	It("quantizes a fill to whole replicas at GPUsPerReplica > 1", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		bAnalyzer := &domain.AnalyzerResult{
+			ModelID: "B", Namespace: "default", TotalDemand: 8000,
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "B-v", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, ReplicaCount: 0},
+			},
+		}
+		reqB := withSatEntry(bAnalyzer, ModelScalingRequest{
+			ModelID: "B", Namespace: "default", Priority: 3,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "B-v", CurrentReplicas: 0, GPUsPerReplica: 2},
+			},
+		})
+		reqA := rescaleReq("A", "default", 1, 8000, 4) // holds 4, reclaims
+
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 7, Used: 4}}}} // free = 3
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqA, reqB}, cons))
+
+		Expect(dm["B-v"].TargetReplicas).To(Equal(1), "3 free GPUs at 2 GPUs/replica -> 1 whole replica, odd GPU unfilled")
+	})
+
+	// Conflict path (Σ floors > budget) driven through Optimize: two models both below
+	// their minReplicas=4 (floors sum 8 > budget 7). The clamp-to-floors path must complete
+	// without panic and never reclaim a model below its current holdings.
+	It("handles the floors-exceed-budget Conflict path without violating floors", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		min4 := 4
+		mk := func(id string, prio float64, cur int) ModelScalingRequest {
+			a := &domain.AnalyzerResult{
+				ModelID: id, Namespace: "default", TotalDemand: 8000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: id + "-v", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, ReplicaCount: cur},
+				},
+			}
+			return withSatEntry(a, ModelScalingRequest{
+				ModelID: id, Namespace: "default", Priority: prio,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: id + "-v", CurrentReplicas: cur, GPUsPerReplica: 1, MinReplicas: &min4},
+				},
+			})
+		}
+		reqs := []ModelScalingRequest{mk("A", 1, 2), mk("B", 3, 2)}                                   // both under minReplicas
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 7, Used: 4}}}} // free 3, budget 7 < Σfloor 8
+
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+		Expect(dm["A-v"].TargetReplicas).To(BeNumerically(">=", 2), "not reclaimed below current in Conflict")
+		Expect(dm["B-v"].TargetReplicas).To(BeNumerically(">=", 2), "not reclaimed below current in Conflict")
+	})
+})

--- a/internal/engines/pipeline/rescale_test.go
+++ b/internal/engines/pipeline/rescale_test.go
@@ -1,0 +1,150 @@
+package pipeline
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+func sumTargets(t map[string]int) int {
+	s := 0
+	for _, v := range t {
+		s += v
+	}
+	return s
+}
+
+var _ = Describe("computeRescaleTargets", func() {
+	DescribeTable("priority-weighted water-filling",
+		func(in []rescaleInput, budget int, want map[string]int, overBudget bool) {
+			got, over := computeRescaleTargets(in, budget)
+			Expect(over).To(Equal(overBudget))
+			for id, w := range want {
+				Expect(got[id]).To(Equal(w), "target[%s]", id)
+			}
+			if !overBudget {
+				// Invariant: the split never over-allocates the budget.
+				Expect(sumTargets(got)).To(BeNumerically("<=", budget))
+			}
+			for _, m := range in {
+				// Invariant: no model exceeds its cap.
+				Expect(got[m.ID]).To(BeNumerically("<=", m.CapGPUs), "cap for %s", m.ID)
+			}
+		},
+		// Proposal worked example: A holds the pool, B (higher priority) is starved;
+		// rescale reclaims from A to give B its priority-weighted share.
+		Entry("proposal: A prio1 dem8, B prio3 dem8, budget 8 -> A2 B6",
+			[]rescaleInput{{ID: "A", Priority: 1, Demand: 8, CapGPUs: 8}, {ID: "B", Priority: 3, Demand: 8, CapGPUs: 8}},
+			8, map[string]int{"A": 2, "B": 6}, false),
+		// B wants less than its share (demand 4): its 4.8 caps at 4 and the freed
+		// excess flows back to A.
+		Entry("proposal: B demand 4 caps and re-splits -> A4 B4",
+			[]rescaleInput{{ID: "A", Priority: 1, Demand: 8, CapGPUs: 8}, {ID: "B", Priority: 3, Demand: 4, CapGPUs: 4}},
+			8, map[string]int{"A": 4, "B": 4}, false),
+		Entry("minReplicas floors reserved first",
+			[]rescaleInput{{ID: "A", Priority: 1, Demand: 10, FloorGPUs: 2, CapGPUs: 10}, {ID: "B", Priority: 1, Demand: 10, CapGPUs: 10}},
+			6, map[string]int{"A": 4, "B": 2}, false),
+		Entry("fractional shares round by largest remainder (tie by id)",
+			[]rescaleInput{{ID: "A", Priority: 1, Demand: 1, CapGPUs: 7}, {ID: "B", Priority: 1, Demand: 1, CapGPUs: 7}},
+			7, map[string]int{"A": 4, "B": 3}, false),
+		Entry("zero-demand model gets floor only",
+			[]rescaleInput{{ID: "idle", Priority: 1, Demand: 0, FloorGPUs: 1, CapGPUs: 5}, {ID: "busy", Priority: 1, Demand: 8, CapGPUs: 8}},
+			6, map[string]int{"idle": 1, "busy": 5}, false),
+		Entry("floors exceed budget -> conflict (clamp to floors)",
+			[]rescaleInput{{ID: "A", Priority: 1, Demand: 5, FloorGPUs: 4, CapGPUs: 5}, {ID: "B", Priority: 1, Demand: 5, FloorGPUs: 3, CapGPUs: 5}},
+			6, map[string]int{"A": 4, "B": 3}, true),
+	)
+
+	It("is deterministic across runs", func() {
+		in := []rescaleInput{
+			{ID: "z", Priority: 1, Demand: 1, CapGPUs: 9},
+			{ID: "a", Priority: 1, Demand: 1, CapGPUs: 9},
+			{ID: "m", Priority: 1, Demand: 1, CapGPUs: 9},
+		}
+		first, _ := computeRescaleTargets(in, 7)
+		for i := 0; i < 20; i++ {
+			got, _ := computeRescaleTargets(in, 7)
+			Expect(got).To(Equal(first))
+		}
+	})
+})
+
+var _ = Describe("roundExtras", func() {
+	// The water-fill caps at headroom before rounding, so this cap-skip guard is
+	// unreachable through computeRescaleTargets; exercise it directly. The model with
+	// the largest fractional remainder is already at its cap, so the leftover GPU must
+	// skip to the next-largest remainder instead of breaching the cap.
+	It("skips a largest-remainder model already at its cap", func() {
+		in := []rescaleInput{{ID: "A", CapGPUs: 2}, {ID: "B", CapGPUs: 5}}
+		targets := map[string]int{"A": 2, "B": 0} // A already at its cap of 2
+		roundExtras(in, map[string]float64{"A": 0.9, "B": 0.4}, targets)
+		Expect(targets["A"]).To(Equal(2), "A is at cap; leftover must not push it to 3")
+		Expect(targets["B"]).To(Equal(1), "leftover GPU falls to B")
+	})
+})
+
+var _ = Describe("distributeGPUsByWeight", func() {
+	It("splits proportionally to weight, not evenly", func() {
+		// 4 GPUs with role demand 6:2 must split 3:1 — a 50/50 split (2:2) or a
+		// swapped/ignored weight map would fail here.
+		out := distributeGPUsByWeight(4, []string{"decode", "prefill"},
+			map[string]int{"prefill": 6, "decode": 2}, nil, nil)
+		Expect(out["prefill"]).To(Equal(3))
+		Expect(out["decode"]).To(Equal(1))
+	})
+
+	It("falls back to the fallback weights when all weights are zero", func() {
+		out := distributeGPUsByWeight(4, []string{"decode", "prefill"},
+			map[string]int{"prefill": 0, "decode": 0},
+			map[string]int{"prefill": 3, "decode": 1}, nil)
+		Expect(out["prefill"]).To(Equal(3))
+		Expect(out["decode"]).To(Equal(1))
+	})
+
+	It("gives a single role the whole total", func() {
+		out := distributeGPUsByWeight(5, []string{"both"}, map[string]int{"both": 0}, nil, nil)
+		Expect(out["both"]).To(Equal(5))
+	})
+
+	It("reserves each role's floor before the weighted split", func() {
+		// Cold-start P/D: zero demand and zero current on both roles, but each role has
+		// a floor of 1. Without floor reservation the whole total lands on the
+		// alphabetically-first role (decode), starving prefill's minReplicas.
+		out := distributeGPUsByWeight(2, []string{"decode", "prefill"},
+			map[string]int{"prefill": 0, "decode": 0}, // demand
+			map[string]int{"prefill": 0, "decode": 0}, // current
+			map[string]int{"prefill": 1, "decode": 1}) // floor
+		Expect(out["prefill"]).To(Equal(1), "prefill floor honored")
+		Expect(out["decode"]).To(Equal(1), "decode floor honored")
+	})
+
+	It("gives the weighted remainder on top of reserved floors", func() {
+		// 6 GPUs, floors 1:1 (reserve 2), remainder 4 split by demand 3:1 → prefill 3+1,
+		// decode 1+1.
+		out := distributeGPUsByWeight(6, []string{"decode", "prefill"},
+			map[string]int{"prefill": 3, "decode": 1},
+			map[string]int{"prefill": 0, "decode": 0},
+			map[string]int{"prefill": 1, "decode": 1})
+		Expect(out["prefill"]).To(Equal(4))
+		Expect(out["decode"]).To(Equal(2))
+	})
+})
+
+var _ = Describe("roleDemandGPUs", func() {
+	It("rounds token demand up to whole replicas (ceil)", func() {
+		// 8500 tokens / 1000 per-replica capacity = 8.5 -> ceil = 9 replicas (9 GPUs).
+		// Guards against a regression to floor (which would under-count demand at 8).
+		sat := &domain.AnalyzerResult{
+			ModelID:     "A",
+			TotalDemand: 8500,
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "A-v", AcceleratorName: "A100", PerReplicaCapacity: 1000},
+			},
+		}
+		stateMap := map[string]domain.VariantReplicaState{
+			"A-v": {VariantName: "A-v", GPUsPerReplica: 1},
+		}
+		Expect(roleDemandGPUs(sat, stateMap, "A100", domain.RoleBoth)).To(Equal(9))
+	})
+})

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -831,6 +831,29 @@ func (e *Engine) selectV2Optimizer(
 	return optimizer, constraints
 }
 
+// resolveRescaleFlags builds the scope-coupled rescale enablement for this cycle:
+// the cluster flag from the global saturation `default` config, plus a per-namespace
+// flag from each active namespace's OWN `default` config (never the global fallback,
+// so the cluster flag cannot enable rescale on a namespace quota).
+func (e *Engine) resolveRescaleFlags(requests []pipeline.ModelScalingRequest) pipeline.RescaleFlags {
+	flags := pipeline.RescaleFlags{Cluster: e.Config.RescaleEnabledCluster()}
+	seen := make(map[string]bool)
+	for _, req := range requests {
+		ns := req.Namespace
+		if ns == "" || seen[ns] {
+			continue
+		}
+		seen[ns] = true
+		if enabled, hasLocal := e.Config.RescaleEnabledForNamespaceLocal(ns); hasLocal && enabled {
+			if flags.ByNamespace == nil {
+				flags.ByNamespace = make(map[string]bool)
+			}
+			flags.ByNamespace[ns] = true
+		}
+	}
+	return flags
+}
+
 // optimizeV2 runs the V2 token-based optimizer path (saturation-token-based).
 // Collects AnalyzerResults for all models, calls the optimizer once, then applies enforcer per-model.
 func (e *Engine) optimizeV2(
@@ -902,6 +925,11 @@ func (e *Engine) optimizeV2(
 
 	// Stage 2: Compute GPU constraints and call optimizer
 	optimizer, constraints := e.selectV2Optimizer(ctx, requests)
+	// Scope-coupled rescale enablement (cluster + per-namespace) is resolved from
+	// config and handed to the GPU-aware optimizer for this cycle.
+	if g, ok := optimizer.(*pipeline.GreedyByScoreOptimizer); ok {
+		g.Rescale = e.resolveRescaleFlags(requests)
+	}
 	allDecisions := optimizer.Optimize(ctx, requests, constraints)
 	logScalingDecisions(ctx, requests, allDecisions)
 

--- a/internal/engines/saturation/engine_rescale_test.go
+++ b/internal/engines/saturation/engine_rescale_test.go
@@ -1,0 +1,52 @@
+package saturation
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+)
+
+var _ = Describe("Engine.resolveRescaleFlags", func() {
+	// Builds a config with a global default flag plus per-namespace defaults, then
+	// checks the scope-coupled resolution: cluster from the global default, each
+	// namespace flag from its OWN default only (no global fallback).
+	newEngine := func(clusterOn bool) *Engine {
+		c := config.NewTestConfig()
+		c.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{"default": {EnableRescale: clusterOn}})
+		// team: its own flag on. plain: has a local config but flag off. absent: no config.
+		c.UpdateSaturationConfigForNamespace("team", map[string]config.SaturationScalingConfig{"default": {EnableRescale: true}})
+		c.UpdateSaturationConfigForNamespace("plain", map[string]config.SaturationScalingConfig{"default": {KvCacheThreshold: 0.8}})
+		return &Engine{Config: c}
+	}
+
+	req := func(ns string) pipeline.ModelScalingRequest {
+		return pipeline.ModelScalingRequest{Namespace: ns}
+	}
+
+	It("sets the cluster flag from the global default", func() {
+		flags := newEngine(true).resolveRescaleFlags([]pipeline.ModelScalingRequest{req("team")})
+		Expect(flags.Cluster).To(BeTrue())
+	})
+
+	It("leaves the cluster flag off when the global default is off", func() {
+		flags := newEngine(false).resolveRescaleFlags([]pipeline.ModelScalingRequest{req("team")})
+		Expect(flags.Cluster).To(BeFalse())
+	})
+
+	It("enables only namespaces whose own default sets the flag", func() {
+		reqs := []pipeline.ModelScalingRequest{
+			req("team"), req("team"), // duplicate namespace must dedup, not double-count
+			req("plain"),  // local config, flag off → excluded
+			req("absent"), // no local config → excluded (no global fallback)
+			req(""),       // empty namespace → skipped
+		}
+		flags := newEngine(true).resolveRescaleFlags(reqs)
+
+		Expect(flags.ByNamespace).To(HaveKeyWithValue("team", true))
+		Expect(flags.ByNamespace).ToNot(HaveKey("plain"), "cluster flag must not leak onto a namespace quota")
+		Expect(flags.ByNamespace).ToNot(HaveKey("absent"))
+		Expect(flags.ByNamespace).ToNot(HaveKey(""))
+	})
+})


### PR DESCRIPTION
Implements the **Alpha** stage of priority-weighted rescale for the V2 GPU-constrained optimizer.

Today the V2 optimizer only *adds* GPUs when they are free; under contention it cannot take capacity back from a low-priority model that is holding more than its fair share. This PR adds an opt-in pass that, when GPUs are contended, redistributes a competition group's whole budget by `priority × demand` — reclaiming from over-share (lower-priority) models and giving that capacity to starved higher-priority ones.

## Proposed Changes

- :gift: **Opt-in, off-by-default `enableRescale` flag** on the saturation-scaling config. Rescale runs only on the GPU-limited (`greedy-by-score`) path; with the flag off (or without the GPU limiter) behavior is unchanged.
- :gift: **Priority-weighted water-filling** (`computeRescaleTargets`): `minReplicas` floors reserved first, `share = floor + (budget − Σfloor)·weight/Σweight`, iteratively capped at `min(demand, maxReplicas)` with the freed excess re-split, largest-remainder integer rounding, and whole-replica quantization at each variant's `gpusPerReplica`.
- :gift: **Paced, never-over-budget convergence.** Reclaims free nothing the same cycle (usage is `CurrentReplicas`-based); fills are gated by the GPUs *physically* free this cycle, so a group is never over-budget. A namespace fill is bounded by `min(namespace quota free, cluster physical free)` and debits **both** budgets, so it can never over-subscribe the shared physical pool.
- :gift: **P/D (disaggregated) models**: the model's GPU target is split across prefill/decode by role demand with each role's floor reserved first; reclaim/fill run per role sharing one free-this-cycle counter.
- :gift: **Scope-coupled enablement**: rescale runs at scope *X* iff a budget exists at *X* **and** the flag is set at *X* — cluster flag from the global `default`; per-namespace flag from that namespace's **own** `default` only (never the global fallback), so the cluster flag cannot leak onto a namespace quota.
- :broom: Reclaim scale-down decisions are tagged `DecisionReasonRescale` so downstream stabilization does not damp them as noise. Bookkeeping is keyed by `(namespace, ModelID)`; group and intra-group processing order are deterministic.

**Deferred to Beta / follow-ups:** observability (a `Rescaled` status condition and surfacing a reclaim *stall* when a role can't shed a whole replica) and hysteresis (min share-gap / cool-down); the physical∧quota namespace budget partition (#1003); multi-accelerator models (variants spanning GPU types).

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — *Alpha scope:* covered by extensive unit + envtest specs (water-filling worked examples, reclaim/fill pacing, cluster-vs-namespace budget bounding and double-debit, `(namespace, ModelID)` isolation, scope-coupling matrix, P/D role split, `min`/`maxReplicas` and `gpusPerReplica>1` quantization, deterministic ordering, Conflict path). The engine-level wiring is a 2-line type-assert whose both sides are unit-tested; a full `engine.optimize` e2e (requires VA + metrics + inventory scaffolding) is deferred.
- [ ] **Docs PR** for any user-facing impact — feature is **off by default**; the `enableRescale` setting is documented inline in both saturation configmaps and in `docs/plans/engine/rescale-alpha.md`. User-facing guide/docs to land when the feature graduates from Alpha.
- [x] **Proposal PR** — design proposal `docs/proposals/design-rescale.md` (PR #1238).

**Release Note**

```release-note
Adds an opt-in, off-by-default `enableRescale` saturation-scaling setting. When enabled (alongside the GPU limiter), the autoscaler redistributes a competition group's GPU budget by model priority and demand under contention — reclaiming capacity from lower-priority models to serve higher-priority ones, without ever exceeding physical or namespace-quota capacity. No behavior change unless explicitly enabled.
```
