### PR TITLE
fix(coordinator): optimistic locking for gpu-rebalance ceiling patches

### DIFF
--- a/docs/developer-guide/coordinator-rebalancing.md
+++ b/docs/developer-guide/coordinator-rebalancing.md
@@ -143,6 +143,12 @@ The `llm-d.ai/epp-inference-pool` annotation on each HPA is the on/off gate:
 
 `poc-starvation` strips the annotation; `poc-rebalance` adds it back.
 
+Ceiling patches use optimistic concurrency (`MergeFromWithOptimisticLock`): the
+patch pins the object's `resourceVersion`, so a concurrent `maxReplicas` change
+is rejected with a `409 Conflict` instead of being silently overwritten. On
+conflict the Coordinator re-reads the object and re-applies its computed target
+(bounded retry); the Coordinator remains authoritative for the ceiling.
+
 ## Known limitations and TODOs
 
 | Area | Status | Detail |
@@ -152,7 +158,7 @@ The `llm-d.ai/epp-inference-pool` annotation on each HPA is the on/off gate:
 | `minReplicas` floor | TODO | The allocation floor is hardcoded to 1. If an HPA has `spec.minReplicas > 1`, patching `maxReplicas` below it produces an invalid object. Floor should be `max(1, hpa.Spec.MinReplicas)`. |
 | n HPAs > quota | TODO | When more HPAs exist than GPU slots, every pool is clamped to 1 and total allocation exceeds quota. Top-N ranking by queue depth is needed. |
 | Wobble | TODO | Noisy queue readings cause 1-replica flips every tick. A minimum-delta guard and per-HPA cooldown (or EWMA smoothing) are needed. |
-| Stale patch | TODO | `MergeFrom` can silently overwrite a concurrent `maxReplicas` change. Should use `MergeFromWithOptimisticLock`. |
+| Stale patch | Done | Ceiling patches use `MergeFromWithOptimisticLock` with a bounded conflict retry, so a concurrent `maxReplicas` change is no longer silently overwritten. |
 | Pool name collision | TODO | Queue query has no namespace label; pools with the same name in different namespaces inflate each other's readings. |
 
 ## Files

--- a/internal/coordinator/plugins/gpurebalance/plugin.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin.go
@@ -12,6 +12,8 @@ import (
 	"github.com/prometheus/common/model"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -263,23 +265,52 @@ func (p *Plugin) queryQueue(ctx context.Context, inferencePool string) (float64,
 	return float64(vec[0].Value), nil
 }
 
+// setMaxReplicas patches the scaler's max-replica ceiling to target under
+// optimistic concurrency control. Each attempt re-reads the object and patches
+// with MergeFromWithOptimisticLock, which pins resourceVersion on the patch so
+// the API server rejects a stale write with a 409 Conflict rather than silently
+// overwriting a concurrent change. On conflict the write is retried against the
+// freshly read object; the Coordinator remains authoritative for the ceiling,
+// so the recomputed target is re-applied rather than deferring to the other
+// writer.
 func (p *Plugin) setMaxReplicas(ctx context.Context, obj client.Object, target int32) error {
-	// TODO: MergeFrom uses the object captured at List time. If another controller
-	// or user updated maxReplicas between the List and this Patch, the write will
-	// silently overwrite that change. Use MergeFromWithOptimisticLock (which sets
-	// resourceVersion on the patch) so the API server rejects a stale write with
-	// a 409 Conflict, allowing the Coordinator to re-read and retry cleanly.
+	log := ctrl.LoggerFrom(ctx).WithName("gpu-rebalance")
+	key := client.ObjectKeyFromObject(obj)
 
-	switch o := obj.(type) {
+	switch obj.(type) {
 	case *autoscalingv2.HorizontalPodAutoscaler:
-		original := o.DeepCopy()
-		o.Spec.MaxReplicas = target
-		return p.client.Patch(ctx, o, client.MergeFrom(original))
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			cur := &autoscalingv2.HorizontalPodAutoscaler{}
+			if err := p.client.Get(ctx, key, cur); err != nil {
+				return err
+			}
+			original := cur.DeepCopy()
+			cur.Spec.MaxReplicas = target
+			return p.patchWithConflictLog(ctx, log, cur, original, displayKindHPA, key)
+		})
 	case *kedav1alpha1.ScaledObject:
-		original := o.DeepCopy()
-		o.Spec.MaxReplicaCount = ptr.To(target)
-		return p.client.Patch(ctx, o, client.MergeFrom(original))
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			cur := &kedav1alpha1.ScaledObject{}
+			if err := p.client.Get(ctx, key, cur); err != nil {
+				return err
+			}
+			original := cur.DeepCopy()
+			cur.Spec.MaxReplicaCount = ptr.To(target)
+			return p.patchWithConflictLog(ctx, log, cur, original, displayKindScaledObject, key)
+		})
 	default:
 		return fmt.Errorf("unsupported scaler type %T", obj)
 	}
+}
+
+// patchWithConflictLog applies an optimistic-lock patch and, when the write is
+// rejected with a 409 Conflict, logs the concurrent modification before
+// returning the error so RetryOnConflict re-reads and retries.
+func (p *Plugin) patchWithConflictLog(ctx context.Context, log logr.Logger, obj, original client.Object, kind string, key client.ObjectKey) error {
+	err := p.client.Patch(ctx, obj, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{}))
+	if apierrors.IsConflict(err) {
+		log.V(1).Info("Conflict patching max replica ceiling; re-reading and retrying",
+			"kind", kind, "name", key.Name, "namespace", key.Namespace)
+	}
+	return err
 }

--- a/internal/coordinator/plugins/gpurebalance/plugin_test.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin_test.go
@@ -12,13 +12,16 @@ import (
 	"github.com/prometheus/common/model"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // stubPromAPI implements promv1.API with only Query stubbed.
@@ -612,5 +615,104 @@ func TestRebalance_MultiNamespace(t *testing.T) {
 		if got := getMaxReplicas(t, c, tc.hpa); got != tc.want {
 			t.Errorf("%s/%s maxReplicas = %d, want %d", tc.hpa.Namespace, tc.hpa.Name, got, tc.want)
 		}
+	}
+}
+
+// newPluginWithInterceptor builds a plugin whose fake client routes calls
+// through funcs, letting a test inject a transient 409 Conflict on Patch.
+func newPluginWithInterceptor(t *testing.T, funcs interceptor.Funcs, objs ...client.Object) (*Plugin, client.Client) {
+	t.Helper()
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithInterceptorFuncs(funcs).
+		Build()
+	return New(c, &stubPromAPI{}), c
+}
+
+// conflictOnceThenDelegate returns a Patch interceptor that fails the first
+// call with a 409 Conflict and delegates every subsequent call to the real
+// client. patchCalls is incremented on each invocation.
+func conflictOnceThenDelegate(patchCalls *int, gr schema.GroupResource) func(context.Context, client.WithWatch, client.Object, client.Patch, ...client.PatchOption) error {
+	return func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+		*patchCalls++
+		if *patchCalls == 1 {
+			return apierrors.NewConflict(gr, obj.GetName(), errors.New("stale resourceVersion"))
+		}
+		return c.Patch(ctx, obj, patch, opts...)
+	}
+}
+
+// TestSetMaxReplicas_RetriesOnConflictHPA verifies that a transient 409 on the
+// first HPA patch is retried against a freshly read object and the target is
+// applied on the retry.
+func TestSetMaxReplicas_RetriesOnConflictHPA(t *testing.T) {
+	hpa := makeHPA("hpa-a", "ns", "pool-a", 5)
+	var patchCalls int
+	funcs := interceptor.Funcs{
+		Patch: conflictOnceThenDelegate(&patchCalls,
+			schema.GroupResource{Group: "autoscaling", Resource: "horizontalpodautoscalers"}),
+	}
+	p, c := newPluginWithInterceptor(t, funcs, hpa)
+
+	if err := p.setMaxReplicas(context.Background(), hpa, 8); err != nil {
+		t.Fatalf("setMaxReplicas: %v", err)
+	}
+	if patchCalls != 2 {
+		t.Errorf("patch calls = %d, want 2 (one conflict, one success)", patchCalls)
+	}
+	if got := getMaxReplicas(t, c, hpa); got != 8 {
+		t.Errorf("maxReplicas = %d, want 8", got)
+	}
+}
+
+// TestSetMaxReplicas_RetriesOnConflictScaledObject verifies the same retry
+// behavior for KEDA ScaledObjects.
+func TestSetMaxReplicas_RetriesOnConflictScaledObject(t *testing.T) {
+	so := makeScaledObject("so-a", "pool-a", 5)
+	var patchCalls int
+	funcs := interceptor.Funcs{
+		Patch: conflictOnceThenDelegate(&patchCalls,
+			schema.GroupResource{Group: "keda.sh", Resource: "scaledobjects"}),
+	}
+	p, c := newPluginWithInterceptor(t, funcs, so)
+
+	if err := p.setMaxReplicas(context.Background(), so, 8); err != nil {
+		t.Fatalf("setMaxReplicas: %v", err)
+	}
+	if patchCalls != 2 {
+		t.Errorf("patch calls = %d, want 2 (one conflict, one success)", patchCalls)
+	}
+	if got := getMaxReplicaCount(t, c, so); got != 8 {
+		t.Errorf("maxReplicaCount = %d, want 8", got)
+	}
+}
+
+// TestSetMaxReplicas_GivesUpAfterMaxRetries verifies that a persistent conflict
+// exhausts the bounded retry, returns a Conflict error rather than hanging, and
+// leaves the object unchanged.
+func TestSetMaxReplicas_GivesUpAfterMaxRetries(t *testing.T) {
+	hpa := makeHPA("hpa-a", "ns", "pool-a", 5)
+	var patchCalls int
+	funcs := interceptor.Funcs{
+		Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+			patchCalls++
+			return apierrors.NewConflict(
+				schema.GroupResource{Group: "autoscaling", Resource: "horizontalpodautoscalers"},
+				obj.GetName(), errors.New("stale resourceVersion"))
+		},
+	}
+	p, c := newPluginWithInterceptor(t, funcs, hpa)
+
+	err := p.setMaxReplicas(context.Background(), hpa, 8)
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("err = %v, want a Conflict error", err)
+	}
+	if patchCalls != 5 {
+		t.Errorf("patch calls = %d, want 5 (retry.DefaultRetry steps)", patchCalls)
+	}
+	if got := getMaxReplicas(t, c, hpa); got != 5 {
+		t.Errorf("maxReplicas = %d, want 5 (unchanged)", got)
 	}
 }


### PR DESCRIPTION
Fixes #1425

## Proposed Changes

- :bug: Patch `maxReplicas`/`maxReplicaCount` in the gpu-rebalance plugin with `MergeFromWithOptimisticLock` instead of `MergeFrom`, so a concurrent change is rejected with a 409 Conflict rather than silently overwritten
- :bug: Re-read the object and retry the patch on conflict via `retry.RetryOnConflict` (bounded), with a V(1) log when a conflict is observed; applies to both HPA and KEDA ScaledObject paths
- :broom: Update coordinator-rebalancing docs and flip the "Stale patch" TODO to Done

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A, conflict-retry is covered by unit tests against the fake client (interceptor-injected 409); no new e2e surface
- [ ] **Docs PR** for any user-facing impact — N/A, developer-facing behavior; doc updated in this PR
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — N/A, bug fix to existing behavior

**Release Note**

```release-note
NONE
```

Docs

Updated in this PR: docs/developer-guide/coordinator-rebalancing.md (concurrency behavior + resolved TODO). No separate docs PR needed.