### PR TITLE
fix(metrics): evict stale replica-gauge series on variant removal

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -389,8 +389,7 @@ func main() {
 
 	// Initialize metrics
 	setupLog.Info("Creating metrics emitter instance")
-	// Force initialization of metrics by creating a metrics emitter
-	_ = metrics.NewMetricsEmitter()
+	metricsEmitter := metrics.NewMetricsEmitter()
 	setupLog.Info("Metrics emitter created successfully")
 
 	// Create ConfigMap reconciler for configuration management.
@@ -562,8 +561,9 @@ func main() {
 
 	// HPAReconciler: tracks namespaces for annotation-based discovery (always registered).
 	if err = (&controller.HPAReconciler{
-		Client:    mgr.GetClient(),
-		Datastore: ds,
+		Client:         mgr.GetClient(),
+		Datastore:      ds,
+		MetricsEmitter: metricsEmitter,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create HPA controller")
 		os.Exit(1)
@@ -572,8 +572,9 @@ func main() {
 	// ScaledObjectReconciler: registered only when KEDA CRD is present.
 	if kedaEnabled {
 		if err = (&controller.ScaledObjectReconciler{
-			Client:    mgr.GetClient(),
-			Datastore: ds,
+			Client:         mgr.GetClient(),
+			Datastore:      ds,
+			MetricsEmitter: metricsEmitter,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create ScaledObject controller")
 			os.Exit(1)

--- a/internal/controller/hpa_reconciler.go
+++ b/internal/controller/hpa_reconciler.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 )
 
 // HPAReconciler tracks namespaces for annotation-based WVA discovery via HPA objects.
@@ -34,7 +35,8 @@ import (
 // loop can scope its List calls to namespaces that contain managed scalers.
 type HPAReconciler struct {
 	client.Client
-	Datastore datastore.Datastore
+	Datastore      datastore.Datastore
+	MetricsEmitter *metrics.MetricsEmitter
 }
 
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
@@ -48,6 +50,7 @@ func (r *HPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err := r.Get(ctx, req.NamespacedName, hpa); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
+			r.MetricsEmitter.DeleteReplicaMetrics(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -55,6 +58,7 @@ func (r *HPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	if !hpa.DeletionTimestamp.IsZero() || !annotations.IsManaged(hpa) {
 		r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
+		r.MetricsEmitter.DeleteReplicaMetrics(req.Name, req.Namespace)
 	} else {
 		r.Datastore.NamespaceTrack("AnnotatedScaler", req.Name, req.Namespace)
 	}

--- a/internal/controller/hpa_reconciler.go
+++ b/internal/controller/hpa_reconciler.go
@@ -50,7 +50,7 @@ func (r *HPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err := r.Get(ctx, req.NamespacedName, hpa); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
-			r.MetricsEmitter.DeleteReplicaMetrics(req.Name, req.Namespace)
+			r.MetricsEmitter.DeleteReplicaMetrics(ctx, req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -58,7 +58,7 @@ func (r *HPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	if !hpa.DeletionTimestamp.IsZero() || !annotations.IsManaged(hpa) {
 		r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
-		r.MetricsEmitter.DeleteReplicaMetrics(req.Name, req.Namespace)
+		r.MetricsEmitter.DeleteReplicaMetrics(ctx, req.Name, req.Namespace)
 	} else {
 		r.Datastore.NamespaceTrack("AnnotatedScaler", req.Name, req.Namespace)
 	}

--- a/internal/controller/hpa_reconciler_test.go
+++ b/internal/controller/hpa_reconciler_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
+	llmdOptv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
+)
+
+var _ = Describe("HPAReconciler metrics eviction wiring", func() {
+	var (
+		reconciler *HPAReconciler
+		emitter    *metrics.MetricsEmitter
+		ds         datastore.Datastore
+		registry   *prometheus.Registry
+		nsName     string
+	)
+
+	seriesCount := func(name string) int {
+		mfs, err := registry.Gather()
+		Expect(err).NotTo(HaveOccurred())
+		for _, mf := range mfs {
+			if mf.GetName() == name {
+				return len(mf.GetMetric())
+			}
+		}
+		return 0
+	}
+
+	allGaugesEmpty := func() bool {
+		return seriesCount(constants.WVACurrentReplicas) == 0 &&
+			seriesCount(constants.WVADesiredReplicas) == 0 &&
+			seriesCount(constants.WVADesiredRatio) == 0
+	}
+
+	BeforeEach(func() {
+		registry = prometheus.NewRegistry()
+		Expect(metrics.InitMetrics(registry)).To(Succeed())
+		emitter = metrics.NewMetricsEmitter()
+		ds = datastore.NewDatastore(config.NewTestConfig())
+		nsName = "hpa-reconciler-test"
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+		Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, ns))).NotTo(HaveOccurred())
+
+		reconciler = &HPAReconciler{
+			Client:         k8sClient,
+			Datastore:      ds,
+			MetricsEmitter: emitter,
+		}
+	})
+
+	It("evicts all replica-gauge series when the managed HPA is deleted", func() {
+		hpaName := "hpa-delete-evict"
+
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hpaName,
+				Namespace: nsName,
+				Annotations: map[string]string{
+					annotations.Managed: "true",
+				},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "target",
+				},
+				MaxReplicas: 5,
+			},
+		}
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		va := &llmdOptv1alpha1.VariantAutoscaling{
+			ObjectMeta: metav1.ObjectMeta{Name: hpaName, Namespace: nsName},
+		}
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 2, 3, "A100")).To(Succeed())
+		Expect(seriesCount(constants.WVACurrentReplicas)).To(Equal(1), "series must exist after emit")
+
+		Expect(k8sClient.Delete(ctx, hpa)).To(Succeed())
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: hpaName, Namespace: nsName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allGaugesEmpty()).To(BeTrue(), "all replica-gauge series must be evicted after HPA deletion")
+	})
+
+	It("evicts replica-gauge series when the managed annotation is removed", func() {
+		hpaName := "hpa-deannotate-evict"
+
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hpaName,
+				Namespace: nsName,
+				Annotations: map[string]string{
+					annotations.Managed: "true",
+				},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "target",
+				},
+				MaxReplicas: 5,
+			},
+		}
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		va := &llmdOptv1alpha1.VariantAutoscaling{
+			ObjectMeta: metav1.ObjectMeta{Name: hpaName, Namespace: nsName},
+		}
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 1, 2, "H100")).To(Succeed())
+		Expect(seriesCount(constants.WVACurrentReplicas)).To(Equal(1), "series must exist after emit")
+
+		// Strip the managed annotation — reconciler must treat this as removal.
+		hpa.Annotations = map[string]string{}
+		Expect(k8sClient.Update(ctx, hpa)).To(Succeed())
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: hpaName, Namespace: nsName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allGaugesEmpty()).To(BeTrue(), "all replica-gauge series must be evicted after annotation removal")
+	})
+})

--- a/internal/controller/scaledobject_reconciler.go
+++ b/internal/controller/scaledobject_reconciler.go
@@ -51,7 +51,7 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.Get(ctx, req.NamespacedName, so); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
-			r.MetricsEmitter.DeleteReplicaMetrics(req.Name, req.Namespace)
+			r.MetricsEmitter.DeleteReplicaMetrics(ctx, req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -59,7 +59,7 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if !so.DeletionTimestamp.IsZero() || !annotations.IsManaged(so) {
 		r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
-		r.MetricsEmitter.DeleteReplicaMetrics(req.Name, req.Namespace)
+		r.MetricsEmitter.DeleteReplicaMetrics(ctx, req.Name, req.Namespace)
 	} else {
 		r.Datastore.NamespaceTrack("AnnotatedScaler", req.Name, req.Namespace)
 	}

--- a/internal/controller/scaledobject_reconciler.go
+++ b/internal/controller/scaledobject_reconciler.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 )
 
 // ScaledObjectReconciler tracks namespaces for annotation-based WVA discovery via KEDA
@@ -35,7 +36,8 @@ import (
 // scalers. Registered only when the KEDA CRD is detected at startup.
 type ScaledObjectReconciler struct {
 	client.Client
-	Datastore datastore.Datastore
+	Datastore      datastore.Datastore
+	MetricsEmitter *metrics.MetricsEmitter
 }
 
 // +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch
@@ -49,6 +51,7 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.Get(ctx, req.NamespacedName, so); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
+			r.MetricsEmitter.DeleteReplicaMetrics(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -56,6 +59,7 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if !so.DeletionTimestamp.IsZero() || !annotations.IsManaged(so) {
 		r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
+		r.MetricsEmitter.DeleteReplicaMetrics(req.Name, req.Namespace)
 	} else {
 		r.Datastore.NamespaceTrack("AnnotatedScaler", req.Name, req.Namespace)
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -579,8 +579,14 @@ func (m *MetricsEmitter) EmitReplicaMetrics(ctx context.Context, va *llmdOptv1al
 		return l
 	}
 
-	// Set the current series first so a concurrent scrape never sees a gap.
+	// Update the tracking map and Set the Prometheus series under the same lock
+	// so that a concurrent DeleteReplicaMetrics cannot remove the map entry and
+	// then delete these series between our Set and our map write.
 	baseLabels := labelsFor(acceleratorType)
+	key := replicaSeriesKey(va.Name, va.Namespace)
+	replicaSeriesMu.Lock()
+	prev, had := replicaSeriesAccel[key]
+	replicaSeriesAccel[key] = acceleratorType
 	currentReplicas.With(baseLabels).Set(float64(current))
 	desiredReplicas.With(baseLabels).Set(float64(desired))
 	// Avoid division by 0 if current replicas is zero: set the ratio to the desired replicas.
@@ -590,14 +596,11 @@ func (m *MetricsEmitter) EmitReplicaMetrics(ctx context.Context, va *llmdOptv1al
 	} else {
 		desiredRatio.With(baseLabels).Set(float64(desired) / float64(current))
 	}
-
-	// If the accelerator label changed since the last emit for this VA, evict the
-	// stale prior series (done after Set, so there is no zero-value window).
-	key := replicaSeriesKey(va.Name, va.Namespace)
-	replicaSeriesMu.Lock()
-	prev, had := replicaSeriesAccel[key]
-	replicaSeriesAccel[key] = acceleratorType
 	replicaSeriesMu.Unlock()
+
+	// Evict the stale prior series if the accelerator label changed (done after
+	// Set so there is no zero-value window; safe to do outside the lock because
+	// we already wrote the new accel to the map).
 	if had && prev != acceleratorType {
 		stale := labelsFor(prev)
 		currentReplicas.Delete(stale)
@@ -613,22 +616,24 @@ func (m *MetricsEmitter) EmitReplicaMetrics(ctx context.Context, va *llmdOptv1al
 // deleted or de-annotated so that stale series are evicted immediately rather
 // than persisting until a controller restart.
 //
+// The map removal and the Prometheus Delete calls are performed under the same
+// lock so that a concurrent EmitReplicaMetrics cannot interleave its own Set
+// between the two steps and produce a stale re-leaked series.
+//
 // If EmitReplicaMetrics was never called for this variant (no entry in the
 // tracking map), this is a no-op.
-func (m *MetricsEmitter) DeleteReplicaMetrics(variantName, namespace string) {
+func (m *MetricsEmitter) DeleteReplicaMetrics(ctx context.Context, variantName, namespace string) {
 	if currentReplicas == nil || desiredReplicas == nil || desiredRatio == nil {
 		return
 	}
 	key := replicaSeriesKey(variantName, namespace)
 	replicaSeriesMu.Lock()
+	defer replicaSeriesMu.Unlock()
 	accel, had := replicaSeriesAccel[key]
-	if had {
-		delete(replicaSeriesAccel, key)
-	}
-	replicaSeriesMu.Unlock()
 	if !had {
 		return
 	}
+	delete(replicaSeriesAccel, key)
 	labels := prometheus.Labels{
 		constants.LabelVariantName:     variantName,
 		constants.LabelNamespace:       namespace,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -23,11 +23,10 @@ const ControllerInstanceEnvVar = "CONTROLLER_INSTANCE"
 // actually changes, instead of delete-and-reset every cycle (which would expose
 // a zero-value gap to a concurrent scrape of the scaling signal).
 //
-// TODO: entries are not pruned on VariantAutoscaling deletion, so the map grows
-// by one small entry per (variant, namespace) ever seen. This matches the
-// pre-existing behavior of the gauge series themselves (also not deleted on VA
-// removal — they expire via Prometheus staleness). Wire a deletion hook if/when
-// per-VA metric cleanup is added.
+// Entries are pruned by DeleteReplicaMetrics when the managing scaler is
+// removed. Without explicit deletion the Prometheus GaugeVec continues
+// exporting the last-seen value on every /metrics scrape; series do NOT
+// expire via Prometheus staleness while the controller process is alive.
 var (
 	replicaSeriesMu    sync.Mutex
 	replicaSeriesAccel = map[string]string{}
@@ -606,6 +605,41 @@ func (m *MetricsEmitter) EmitReplicaMetrics(ctx context.Context, va *llmdOptv1al
 		desiredRatio.Delete(stale)
 	}
 	return nil
+}
+
+// DeleteReplicaMetrics removes all replica-gauge series for the named variant
+// from the /metrics endpoint and prunes its entry from the accelerator-tracking
+// map. Call this when a variant's managed scaler (HPA or ScaledObject) is
+// deleted or de-annotated so that stale series are evicted immediately rather
+// than persisting until a controller restart.
+//
+// If EmitReplicaMetrics was never called for this variant (no entry in the
+// tracking map), this is a no-op.
+func (m *MetricsEmitter) DeleteReplicaMetrics(variantName, namespace string) {
+	if currentReplicas == nil || desiredReplicas == nil || desiredRatio == nil {
+		return
+	}
+	key := replicaSeriesKey(variantName, namespace)
+	replicaSeriesMu.Lock()
+	accel, had := replicaSeriesAccel[key]
+	if had {
+		delete(replicaSeriesAccel, key)
+	}
+	replicaSeriesMu.Unlock()
+	if !had {
+		return
+	}
+	labels := prometheus.Labels{
+		constants.LabelVariantName:     variantName,
+		constants.LabelNamespace:       namespace,
+		constants.LabelAcceleratorType: accel,
+	}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	currentReplicas.Delete(labels)
+	desiredReplicas.Delete(labels)
+	desiredRatio.Delete(labels)
 }
 
 // RecordOptimizerActiveMetric records which optimizer is currently active.

--- a/internal/metrics/replica_metrics_test.go
+++ b/internal/metrics/replica_metrics_test.go
@@ -156,7 +156,6 @@ var _ = Describe("DeleteReplicaMetrics", func() {
 		Expect(InitMetrics(registry)).To(Succeed())
 		emitter = NewMetricsEmitter()
 		ctx = context.Background()
-		_ = ctx // used by EmitReplicaMetrics
 	})
 
 	series := func(name string) []*dto.Metric {
@@ -178,7 +177,7 @@ var _ = Describe("DeleteReplicaMetrics", func() {
 		Expect(series(constants.WVACurrentReplicas)).To(HaveLen(1))
 		Expect(series(constants.WVADesiredRatio)).To(HaveLen(1))
 
-		emitter.DeleteReplicaMetrics("va-x", "ns")
+		emitter.DeleteReplicaMetrics(ctx, "va-x", "ns")
 
 		Expect(series(constants.WVADesiredReplicas)).To(BeEmpty(), "desired_replicas series must be evicted")
 		Expect(series(constants.WVACurrentReplicas)).To(BeEmpty(), "current_replicas series must be evicted")
@@ -195,7 +194,7 @@ var _ = Describe("DeleteReplicaMetrics", func() {
 		replicaSeriesMu.Unlock()
 		Expect(had).To(BeTrue(), "map must contain the entry before deletion")
 
-		emitter.DeleteReplicaMetrics("va-y", "ns")
+		emitter.DeleteReplicaMetrics(ctx, "va-y", "ns")
 
 		replicaSeriesMu.Lock()
 		_, still := replicaSeriesAccel[key]
@@ -209,7 +208,7 @@ var _ = Describe("DeleteReplicaMetrics", func() {
 
 		Expect(series(constants.WVADesiredReplicas)).To(HaveLen(2))
 
-		emitter.DeleteReplicaMetrics("va-del", "ns")
+		emitter.DeleteReplicaMetrics(ctx, "va-del", "ns")
 
 		remaining := series(constants.WVADesiredReplicas)
 		Expect(remaining).To(HaveLen(1), "only the deleted variant's series should be removed")
@@ -219,7 +218,7 @@ var _ = Describe("DeleteReplicaMetrics", func() {
 	It("is a no-op when EmitReplicaMetrics was never called for the variant", func() {
 		// No emit; delete should not panic or affect other series.
 		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("other", "ns"), 1, 2, "A100")).To(Succeed())
-		emitter.DeleteReplicaMetrics("never-emitted", "ns")
+		emitter.DeleteReplicaMetrics(ctx, "never-emitted", "ns")
 		Expect(series(constants.WVADesiredReplicas)).To(HaveLen(1), "unrelated series must survive a no-op delete")
 	})
 
@@ -227,7 +226,7 @@ var _ = Describe("DeleteReplicaMetrics", func() {
 		va := newReplicaTestVA("va-unresolved", "ns")
 		Expect(emitter.EmitReplicaMetrics(ctx, va, 1, 2, "")).To(Succeed())
 
-		emitter.DeleteReplicaMetrics("va-unresolved", "ns")
+		emitter.DeleteReplicaMetrics(ctx, "va-unresolved", "ns")
 
 		Expect(series(constants.WVADesiredReplicas)).To(BeEmpty(), "unresolved-accel series must be evicted")
 	})

--- a/internal/metrics/replica_metrics_test.go
+++ b/internal/metrics/replica_metrics_test.go
@@ -142,3 +142,93 @@ var _ = Describe("EmitReplicaMetrics", func() {
 		Expect(getLabelValue(s[0], constants.LabelControllerInstance)).To(Equal("ctrl-a"))
 	})
 })
+
+var _ = Describe("DeleteReplicaMetrics", func() {
+	var (
+		registry *prometheus.Registry
+		emitter  *MetricsEmitter
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		resetMetrics()
+		registry = prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+		emitter = NewMetricsEmitter()
+		ctx = context.Background()
+		_ = ctx // used by EmitReplicaMetrics
+	})
+
+	series := func(name string) []*dto.Metric {
+		mfs, err := registry.Gather()
+		Expect(err).NotTo(HaveOccurred())
+		for _, mf := range mfs {
+			if mf.GetName() == name {
+				return mf.GetMetric()
+			}
+		}
+		return nil
+	}
+
+	It("evicts all three gauge series for a removed variant", func() {
+		va := newReplicaTestVA("va-x", "ns")
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 2, 3, "A100")).To(Succeed())
+
+		Expect(series(constants.WVADesiredReplicas)).To(HaveLen(1))
+		Expect(series(constants.WVACurrentReplicas)).To(HaveLen(1))
+		Expect(series(constants.WVADesiredRatio)).To(HaveLen(1))
+
+		emitter.DeleteReplicaMetrics("va-x", "ns")
+
+		Expect(series(constants.WVADesiredReplicas)).To(BeEmpty(), "desired_replicas series must be evicted")
+		Expect(series(constants.WVACurrentReplicas)).To(BeEmpty(), "current_replicas series must be evicted")
+		Expect(series(constants.WVADesiredRatio)).To(BeEmpty(), "desired_ratio series must be evicted")
+	})
+
+	It("prunes the accelerator-tracking map entry", func() {
+		va := newReplicaTestVA("va-y", "ns")
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 1, 2, "H100")).To(Succeed())
+
+		key := replicaSeriesKey("va-y", "ns")
+		replicaSeriesMu.Lock()
+		_, had := replicaSeriesAccel[key]
+		replicaSeriesMu.Unlock()
+		Expect(had).To(BeTrue(), "map must contain the entry before deletion")
+
+		emitter.DeleteReplicaMetrics("va-y", "ns")
+
+		replicaSeriesMu.Lock()
+		_, still := replicaSeriesAccel[key]
+		replicaSeriesMu.Unlock()
+		Expect(still).To(BeFalse(), "map entry must be pruned after deletion")
+	})
+
+	It("does not evict a different VA's series in the same namespace", func() {
+		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("va-keep", "ns"), 1, 2, "A100")).To(Succeed())
+		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("va-del", "ns"), 1, 3, "A100")).To(Succeed())
+
+		Expect(series(constants.WVADesiredReplicas)).To(HaveLen(2))
+
+		emitter.DeleteReplicaMetrics("va-del", "ns")
+
+		remaining := series(constants.WVADesiredReplicas)
+		Expect(remaining).To(HaveLen(1), "only the deleted variant's series should be removed")
+		Expect(getLabelValue(remaining[0], constants.LabelVariantName)).To(Equal("va-keep"))
+	})
+
+	It("is a no-op when EmitReplicaMetrics was never called for the variant", func() {
+		// No emit; delete should not panic or affect other series.
+		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("other", "ns"), 1, 2, "A100")).To(Succeed())
+		emitter.DeleteReplicaMetrics("never-emitted", "ns")
+		Expect(series(constants.WVADesiredReplicas)).To(HaveLen(1), "unrelated series must survive a no-op delete")
+	})
+
+	It("evicts series when the accelerator label was unresolved at emit time", func() {
+		va := newReplicaTestVA("va-unresolved", "ns")
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 1, 2, "")).To(Succeed())
+
+		emitter.DeleteReplicaMetrics("va-unresolved", "ns")
+
+		Expect(series(constants.WVADesiredReplicas)).To(BeEmpty(), "unresolved-accel series must be evicted")
+	})
+})


### PR DESCRIPTION
Fixes #1459

## Summary

When a managed HPA or ScaledObject was deleted or de-annotated, the
three replica scaling gauges (`wva_current_replicas`, `wva_desired_replicas`,
`wva_desired_ratio`) and the internal accelerator-tracking map entry were
never cleaned up. The controller kept exporting the last-seen values for
the removed variant on every `/metrics` scrape — not via Prometheus
staleness (which does not apply to live GaugeVec series), but as
permanently orphaned series until the controller process restarted.

## Changes

- **`internal/metrics/metrics.go`**
  - Add `MetricsEmitter.DeleteReplicaMetrics(variantName, namespace string)`:
    deletes all three replica-gauge series for the variant and prunes its
    `replicaSeriesAccel` map entry under the mutex.
  - Correct the misleading comment that claimed series "expire via Prometheus
    staleness" — they do not while the controller is alive.

- **`internal/controller/hpa_reconciler.go`**
  - Add `MetricsEmitter *metrics.MetricsEmitter` field.
  - Call `DeleteReplicaMetrics` on the `IsNotFound` path (HPA gone) and on
    the de-annotation / deletion-timestamp path.

- **`internal/controller/scaledobject_reconciler.go`**
  - Same changes as HPAReconciler for the ScaledObject code path.

- **`cmd/main.go`**
  - Retain the `MetricsEmitter` instance and pass it to both reconcilers.

- **`internal/metrics/replica_metrics_test.go`**
  - 5 new Ginkgo specs under `Describe("DeleteReplicaMetrics")`:
    - evicts all three gauge series for a removed variant
    - prunes the accelerator-tracking map entry
    - does not evict a different VA's series in the same namespace
    - is a no-op when `EmitReplicaMetrics` was never called
    - evicts series when the accelerator label was unresolved at emit time

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/...` — all 26 Ginkgo specs in the metrics suite pass (including 5 new `DeleteReplicaMetrics` specs)
- [x] `go test ./...` (unit) — all packages green