### PR TITLE
feat(saturation-v2): add internal EPP queue demand multiplier

### DIFF
--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -105,7 +105,9 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 	}
 
 	// Add scheduler queue demand (requests queued upstream in llm-d flow control).
-	queueDemand := estimateSchedulerQueueDemand(input.SchedulerQueue, input.ReplicaMetrics, activeRoles)
+	// The EPP queue demand multiplier is an internal knob for now; a follow-up
+	// will source it from satConfig.
+	queueDemand := estimateSchedulerQueueDemand(input.SchedulerQueue, input.ReplicaMetrics, activeRoles, DefaultEPPQueueDemandMultiplier)
 	totalDemand += queueDemand.total
 
 	var utilization float64
@@ -604,6 +606,7 @@ func estimateSchedulerQueueDemand(
 	sq *domain.SchedulerQueueMetrics,
 	replicaMetrics []domain.ReplicaMetrics,
 	activeRoles map[string]bool,
+	demandMultiplier float64,
 ) schedulerQueueDemand {
 	if sq == nil || (sq.QueueSize == 0 && sq.QueueBytes == 0) {
 		return schedulerQueueDemand{}
@@ -625,6 +628,13 @@ func estimateSchedulerQueueDemand(
 
 	// Estimate output tokens (no cache reduction — output must be generated)
 	outputTokens := float64(sq.QueueSize) * avgOutput
+
+	// Apply the EPP queue demand multiplier to both token components so the
+	// model-level total and per-role attribution scale consistently. The
+	// multiplier is currently an internal knob (DefaultEPPQueueDemandMultiplier);
+	// a value of 1.0 is a no-op.
+	inputTokens *= demandMultiplier
+	outputTokens *= demandMultiplier
 
 	total := inputTokens + outputTokens
 

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -661,7 +661,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				QueueBytes: 0, // use count-based estimation only
 			}
 
-			result := estimateSchedulerQueueDemand(sq, metrics, activeRoles)
+			result := estimateSchedulerQueueDemand(sq, metrics, activeRoles, DefaultEPPQueueDemandMultiplier)
 
 			// Input: max(0/4=0, 10*100=1000) = 1000 (no cache hit)
 			// Output: 10 * 50 = 500
@@ -685,10 +685,32 @@ var _ = Describe("SaturationAnalyzer", func() {
 				QueueBytes: 0,
 			}
 
-			result := estimateSchedulerQueueDemand(sq, metrics, activeRoles)
+			result := estimateSchedulerQueueDemand(sq, metrics, activeRoles, DefaultEPPQueueDemandMultiplier)
 
 			Expect(result.total).To(Equal(1500.0))
 			Expect(result.byRole["both"]).To(Equal(1500.0))
+		})
+
+		It("should scale total and per-role demand by the EPP queue multiplier", func() {
+			metrics := []domain.ReplicaMetrics{
+				makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+					5000, 16000, 0, 100, 50),
+			}
+			activeRoles := map[string]bool{"prefill": true, "decode": true}
+			sq := &domain.SchedulerQueueMetrics{
+				QueueSize:  10,
+				QueueBytes: 0, // count-based estimation only
+			}
+
+			// Baseline (multiplier 1.0): input=1000, output=500, total=1500.
+			// With a 2.0 multiplier every component doubles.
+			result := estimateSchedulerQueueDemand(sq, metrics, activeRoles, 2.0)
+
+			Expect(result.total).To(Equal(3000.0))
+			// Prefill gets scaled inputTokens only (1000 * 2)
+			Expect(result.byRole["prefill"]).To(Equal(2000.0))
+			// Decode gets scaled inputTokens + outputTokens ((1000 + 500) * 2)
+			Expect(result.byRole["decode"]).To(Equal(3000.0))
 		})
 
 		It("should return empty byRole when nil activeRoles", func() {
@@ -701,7 +723,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				QueueBytes: 0,
 			}
 
-			result := estimateSchedulerQueueDemand(sq, metrics, nil)
+			result := estimateSchedulerQueueDemand(sq, metrics, nil, DefaultEPPQueueDemandMultiplier)
 
 			Expect(result.total).To(Equal(1500.0))
 			Expect(result.byRole).To(BeEmpty())
@@ -714,7 +736,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 			}
 			activeRoles := map[string]bool{"prefill": true, "decode": true}
 
-			result := estimateSchedulerQueueDemand(nil, metrics, activeRoles)
+			result := estimateSchedulerQueueDemand(nil, metrics, activeRoles, DefaultEPPQueueDemandMultiplier)
 
 			Expect(result.total).To(Equal(0.0))
 			Expect(result.byRole).To(BeNil())
@@ -737,7 +759,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 				QueueBytes: 0,
 			}
 
-			result := estimateSchedulerQueueDemand(sq, metrics, activeRoles)
+			result := estimateSchedulerQueueDemand(sq, metrics, activeRoles, DefaultEPPQueueDemandMultiplier)
 
 			// Input: 10*100=1000, after cache: 1000*(1-0.5)=500
 			// Output: 10*50=500

--- a/internal/engines/analyzers/saturation_v2/constants.go
+++ b/internal/engines/analyzers/saturation_v2/constants.go
@@ -31,6 +31,16 @@ const (
 	// bound on token count) since modern tokenizers achieve 5-6 chars/token.
 	BytesPerToken = 4
 
+	// DefaultEPPQueueDemandMultiplier scales the token demand estimated from
+	// the EPP scheduler queue (requests queued upstream in llm-d flow control)
+	// before it is folded into model-level demand. A value of 1.0 leaves the
+	// estimate unchanged; values > 1.0 inflate queue demand to bias the
+	// autoscaler toward earlier scale-up under upstream queue pressure.
+	//
+	// This is currently an internal, compile-time knob. A follow-up will
+	// promote it to SaturationScalingConfig so it can be tuned per model.
+	DefaultEPPQueueDemandMultiplier = 1.0
+
 	// ShortOutputThreshold is the upper bound (exclusive) for the "short"
 	// output-length bucket used for k2 history keying.
 	ShortOutputThreshold = 100


### PR DESCRIPTION
## Proposed Changes

- :gift: Introduce `DefaultEPPQueueDemandMultiplier`, an internal (compile-time) knob in the V2 saturation analyzer that scales the token demand estimated from the EPP scheduler queue (requests queued upstream in llm-d flow control) before it is folded into model-level demand.
- :broom: Thread the multiplier through `estimateSchedulerQueueDemand`, applying it to both the input- and output-token components so the model-level total **and** the per-role (prefill / decode / both) attribution scale consistently.
- Default value is `1.0`, so this is a no-op for current behavior; a follow-up will promote the knob to `SaturationScalingConfig` for per-model tuning.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **E2E tests** for any new behavior — _N/A: multiplier defaults to 1.0 (no behavior change); covered by a unit test asserting a 2.0 multiplier doubles total and per-role demand._
- [ ] **Docs PR** for any user-facing impact — _N/A: internal knob, not yet surfaced in config._
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — _N/A: no observable behavior change at the default; config-facing proposal will accompany the follow-up._