### PR TITLE
fix(saturation_v2): count DP-rank instances, not pods, in aggregateByVariant

### DIFF
--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -368,6 +368,9 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 		// supply totals — so both must stay in sync. Defaults to readyCount (pod
 		// count) for the fallback branches, which have no per-instance data.
 		replicaCount := readyCount
+		// pendingCount must match replicaCount's unit (SumTotalAnticipatedSupply
+		// adds them); converted to instances below when replicaCount switches.
+		pendingCount := vs.PendingReplicas
 
 		var capacityLabel string
 		if len(replicas) > 0 {
@@ -381,6 +384,22 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			}
 			perReplicaCapacity = float64(median(capacities))
 			replicaCount = len(replicas)
+			// Convert pending to instance units. readyCount and vs.PendingReplicas
+			// share the scale-target unit (pods for Deployment, groups for LWS), so
+			// len(replicas)/readyCount approximates the instances-per-unit (DP)
+			// factor. This is exact only in steady state: len(replicas) is live
+			// metrics while readyCount is (lagging) scale-target status, so during a
+			// scale-up — when new instances report metrics before their unit is
+			// counted ready — the ratio is inflated and pendingCount overshoots
+			// (understating RequiredCapacity). A metrics-derived instances-per-unit
+			// (grouping by pod/LWS group) would remove this skew; tracked as a
+			// follow-up. TODO: scale-from-zero (readyCount == 0) can't infer DP at
+			// all and is left unconverted here.
+			if readyCount > 0 {
+				if instancesPerUnit := len(replicas) / readyCount; instancesPerUnit > 1 {
+					pendingCount = vs.PendingReplicas * instancesPerUnit
+				}
+			}
 			if accelerator == "" {
 				accelerator = replicas[0].AcceleratorName
 			}
@@ -411,7 +430,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			Cost:               cost,
 			Role:               vs.Role,
 			ReplicaCount:       replicaCount,
-			PendingReplicas:    vs.PendingReplicas,
+			PendingReplicas:    pendingCount,
 			PerReplicaCapacity: perReplicaCapacity,
 			TotalCapacity:      totalCapacity,
 			TotalDemand:        totalDemand,

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -363,15 +363,24 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			readyCount = 0
 		}
 
+		// replicaCount multiplies perReplicaCapacity to form TotalCapacity. It also
+		// sets VariantCapacity.ReplicaCount, which aggregation.go uses to recompute
+		// supply totals — so both must stay in sync. Defaults to readyCount (pod
+		// count) for the fallback branches, which have no per-instance data.
+		replicaCount := readyCount
+
 		var capacityLabel string
 		if len(replicas) > 0 {
-			// Use median effective capacity from ready pods
+			// len(replicas) counts vLLM engine instances (DP ranks), not pods: a DP=8
+			// pod hosts 8 independently-capacitied instances. Using the pod count would
+			// undercount TotalCapacity by the DP factor.
 			capacities := make([]int64, 0, len(replicas))
 			for _, rc := range replicas {
 				capacities = append(capacities, rc.EffectiveCapacity)
 				totalDemand += float64(rc.ReplicaDemand)
 			}
 			perReplicaCapacity = float64(median(capacities))
+			replicaCount = len(replicas)
 			if accelerator == "" {
 				accelerator = replicas[0].AcceleratorName
 			}
@@ -389,7 +398,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			capacityLabel = satReasonNoData
 		}
 
-		totalCapacity := float64(readyCount) * perReplicaCapacity
+		totalCapacity := float64(replicaCount) * perReplicaCapacity
 
 		var utilization float64
 		if totalCapacity > 0 {
@@ -401,7 +410,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			AcceleratorName:    accelerator,
 			Cost:               cost,
 			Role:               vs.Role,
-			ReplicaCount:       readyCount,
+			ReplicaCount:       replicaCount,
 			PendingReplicas:    vs.PendingReplicas,
 			PerReplicaCapacity: perReplicaCapacity,
 			TotalCapacity:      totalCapacity,

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -1417,3 +1417,45 @@ var _ = Describe("k2SourceLabel", func() {
 		Expect(k2SourceLabel(nil)).To(Equal(""))
 	})
 })
+
+var _ = Describe("aggregateByVariant DP>1 with pending replicas", func() {
+	var (
+		analyzer *SaturationAnalyzer
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		analyzer = NewSaturationAnalyzer(NewCapacityKnowledgeStore())
+		ctx = context.Background()
+	})
+
+	It("converts pending pods to instance units in anticipated supply", func() {
+		// One ready pod hosts 8 DP-rank instances (8 ReplicaMetrics sharing a
+		// PodName). State: 1 ready + 1 pending pod → instances-per-pod = 8/1 = 8,
+		// so the pending pod must count as 8 instances, not 1.
+		metrics := make([]domain.ReplicaMetrics, 0, 8)
+		for i := 0; i < 8; i++ {
+			metrics = append(metrics, makeReplicaMetrics("pod-1", "decode-v1", "H100", 10.0,
+				8000, 16000, 0, 100, 50))
+		}
+
+		input := makeAnalyzerInput(
+			metrics,
+			[]domain.VariantReplicaState{
+				{VariantName: "decode-v1", CurrentReplicas: 2, PendingReplicas: 1, GPUsPerReplica: 8},
+			},
+		)
+
+		result, err := analyzer.Analyze(ctx, input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.VariantCapacities).To(HaveLen(1))
+
+		vc := result.VariantCapacities[0]
+		Expect(vc.ReplicaCount).To(Equal(8))    // 8 scraped instances
+		Expect(vc.PendingReplicas).To(Equal(8)) // 1 pending pod × 8 instances-per-pod
+
+		// TotalAnticipatedSupply = (ReplicaCount + PendingReplicas) × PerReplicaCapacity
+		want := float64(vc.ReplicaCount+vc.PendingReplicas) * vc.PerReplicaCapacity
+		Expect(result.TotalAnticipatedSupply).To(Equal(want))
+	})
+})


### PR DESCRIPTION
## Summary

In `aggregateByVariant()` (`internal/engines/analyzers/saturation_v2/analyzer.go`), `TotalCapacity` and `ReplicaCount` were computed from the **pod count** (`readyCount`), but `perReplicaCapacity` is a **per-instance** value.

For a data-parallel (DP>1) vLLM deployment, one pod runs N engine instances, each with its own port and KV-cache pool. Multiplying a per-instance capacity by the pod count makes `TotalCapacity` N times too small.

## Impact

`Utilization = TotalDemand / TotalCapacity` becomes N times too high, triggering scale-up that is not needed.

Example (DP=8 decode deployment): 7 ready pods = 56 instances.

- Before: `TotalCapacity = 7 × perReplica` → `Utilization ≈ 5.89` (impossible; utilization is at most 1.0).
- After: `TotalCapacity = 56 × perReplica` → `Utilization ≈ 0.74` (below the 0.85 scale-up threshold, so no scale-up — which matches reality).

## Fix

Scale `TotalCapacity` and `ReplicaCount` by `len(replicas)` (live per-instance records) instead of `readyCount`, mirroring the throughput analyzer's `computeVariantSupply`/`nKV` pattern.

Both fields must change: `aggregation.go` ignores the `TotalCapacity` field and recomputes totals as `ReplicaCount × PerReplicaCapacity` (in `SumTotalSupply`, `SumTotalAnticipatedSupply`, `AggregateByRole`), so fixing `TotalCapacity` alone would still leave the wrong value downstream.

This is the aggregation-layer follow-up to #1121, which added per-instance metric keying at the collector layer but did not update this multiplier.

Fixes #1467