### PR TITLE
fix(saturation-v2): charge waiting requests by P/D role

### DIFF
--- a/docs/developer-guide/cycle-log.md
+++ b/docs/developer-guide/cycle-log.md
@@ -30,8 +30,8 @@ optimizer actually receives.
   "scaleUpThreshold": 1.1,
   "scaleDownBoundary": 0.7,
   "variants": [
-    {"name": "primary", "prc": 1152000, "reason": "P3-k2"},
-    {"name": "v2",      "prc":  403391, "reason": "P1-obs"}
+    {"name": "primary", "prc": 1152000, "role": "both", "reason": "P3-k2"},
+    {"name": "v2",      "prc":  403391, "role": "both", "reason": "P1-obs"}
   ]
 }
 ```
@@ -42,7 +42,7 @@ optimizer actually receives.
 | `namespace` | Kubernetes namespace |
 | `analyzer` | Analyzer name, e.g. `"saturation"`, `"throughput"` |
 | `supply` | Total token supply across ready replicas (readyCount × perReplicaCapacity) |
-| `demand` | Total observed token demand |
+| `demand` | Total token demand. Not purely observed: for saturation V2 it is the sum of three terms — resident KV tokens, a role-aware projection of requests waiting in each replica's local engine queue, and a model-level, prefix-cache-discounted projection of requests still queued upstream in llm-d flow control (`SchedulerQueue`, not attributed to any variant). See [saturation-scaling-config.md](saturation-scaling-config.md) |
 | `util` | `demand / supply`; > 1.0 means the model is over capacity |
 | `rc` | Required capacity signal (post-threshold): > 0 triggers scale-up |
 | `sc` | Spare capacity signal (post-threshold): > 0 permits scale-down |
@@ -50,6 +50,7 @@ optimizer actually receives.
 | `scaleDownBoundary` | Scale-down boundary resolved for this analyzer (from config) |
 | `variants[].name` | Variant name |
 | `variants[].prc` | Per-replica capacity in analyzer units (tokens for saturation) |
+| `variants[].role` | Resolved P/D role: `prefill`, `decode`, or `both`. Renders as `both` both when the scale target has no `llm-d.ai/role` label and when the analyzer does not populate the role at all. Saturation V2 charges waiting requests by this role, so it is needed to interpret `demand` |
 | `variants[].reason` | How the variant's capacity was computed (see below) |
 
 If an analyzer does not compute per-variant capacity, `variants` is an empty

--- a/docs/developer-guide/prometheus.md
+++ b/docs/developer-guide/prometheus.md
@@ -510,7 +510,7 @@ With WVA metrics, the value for the label `namespace` is the WVA controller name
 
 ### `wva_saturation_utilization`
 - **Type**: Gauge
-- **Description**: Per-variant utilization ratio (0.0-1.0) from saturation analysis. V1 path: mean of per-replica KV-cache-usage fractions (matches the per-replica threshold V1 checks). V2 path: TotalDemand / TotalCapacity from the analyzer result. Numerically equivalent for uniform-capacity replicas; V2 is capacity-weighted for mixed-capacity cases.
+- **Description**: Per-variant utilization ratio from saturation analysis. V1 path: mean of per-replica KV-cache-usage fractions, bounded 0.0-1.0 (matches the per-replica threshold V1 checks). V2 path: TotalDemand / TotalCapacity from the analyzer result — **unbounded above**, where > 1.0 means demand exceeds supply. Numerically equivalent for uniform-capacity replicas; V2 is capacity-weighted for mixed-capacity cases.
 - **Labels**:
   - `variant_name`: Name of the variant
   - `namespace`: Kubernetes namespace

--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -263,6 +263,69 @@ kv-tokens; throughput: tokens/sec). Each analyzer also decides how to
 attribute that demand across roles or variants — sat_v2 splits it among
 active roles.
 
+#### Per-replica demand and the role-aware waiting-queue charge
+
+Distinct from `SchedulerQueue` above, each replica also reports its own **local
+engine queue** (`vllm:num_requests_waiting` / `sglang:num_queue_reqs`) — requests
+already admitted to that pod but not yet generating. sat_v2 charges them to the
+replica, so per-replica demand has two terms:
+
+```
+replicaDemand = <resident KV tokens> + QueueLength × <per-request charge>
+```
+
+The resident term is `TokensInUse` on the main path, or
+`KvCacheUsage × effectiveCapacity` on the fallback path (no
+`vllm:cache_config_info`). The per-request charge depends on the variant's P/D
+role, because a replica only pays for KV it actually materializes:
+
+| Role | Per-request charge | Rationale |
+|------|--------------------|-----------|
+| `prefill` | `AvgInputTokens` | Prompt KV only; output is generated on a decode pod |
+| `decode` | `AvgInputTokens + AvgOutputTokens` | Holds prompt KV and grows it per generated token |
+| `both` (default) | `AvgInputTokens + AvgOutputTokens` | Handles the full request lifecycle |
+
+An absent or empty role canonicalizes to `both`, so **non-disaggregated
+deployments take the decode-style charge** — correct for a replica serving the
+whole request, but it means the majority of deployments include output tokens.
+
+`AvgInputTokens + AvgOutputTokens` is the footprint at a request's *final* decode
+step, chosen as a peak / no-preemption planning charge: KV grows monotonically
+once generation starts and cannot be shed without preemption and recompute.
+
+**`I + O` is the saturation analyzer's demand-side unit; `ILeff + O/2` is the
+throughput analyzer's.** The two are separate analyzers with separate
+demand/supply models, so the difference is by design, not an inconsistency:
+
+| Analyzer | Per-request KV unit | Meaning |
+|----------|--------------------|---------|
+| Saturation V2 (demand) | `I + O` | Peak footprint — what a replica must be able to hold |
+| Throughput (`WorkloadShape.KVreq`) | `ILeff + O/2` | Time-averaged residency (`ILeff = I × (1 − PrefixHitRate)`) |
+
+One asymmetry *is* internal to saturation V2 and should not be confused with the
+above: its own k2 derivation (`estimateCapacityFromParams`) prices a *concurrent*
+request at `I + O/2`. So a queued request is charged more than it occupies on
+average, biasing this term toward scale-up — accepted deliberately, since
+under-provisioning decode capacity causes preemption thrash. Changing it means
+moving the demand/capacity pair together. See the `waitingQueueDemand` doc
+comment for the full trade-off.
+
+Note both demand terms derive from 1-minute maxima (`max_over_time` on
+`kv_cache_usage_perc` and `num_requests_waiting`), whose peaks need not coincide,
+so their sum can exceed any single instant's demand. That is a property of the
+collector's queries, not of the role charge.
+
+> **Operational note.** Because the default role is `both`, enabling or upgrading
+> into this behavior raises computed demand wherever replicas have a non-empty
+> local queue and report token metrics. `wva_saturation_utilization` and
+> `wva_required_capacity{unit="continuous"}` step up, `wva_spare_capacity` steps
+> down, and `wva_desired_replicas` may take a one-time step.
+> `wva_kv_cache_tokens_used` is unaffected — it sums raw `TokensInUse` and does
+> not include the queue projection. Utilization-based alerts (such as the sample
+> `wva_saturation_utilization > 0.85` in
+> [prometheus.md](prometheus.md)) may need re-baselining. The resolved role is
+> emitted per variant on the `analyzer-result` log line.
+
 #### Linearity invariant
 
 The optimizer's per-variant scaling math (`bottleneckReplicas`, `safeRemovalReplicas`, `applyAllocation`) assumes that `n` replicas of variant `v` reduce model-level RC by exactly `n × PRC[v]`. That means `Total*` must equal the canonical sum over variants:

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -35,6 +35,9 @@ const RoleBoth = "both"
 // RolePrefill represents the prefill-only role in a P/D disaggregated deployment.
 const RolePrefill = "prefill"
 
+// RoleDecode represents the decode-only role in a P/D disaggregated deployment.
+const RoleDecode = "decode"
+
 // ReplicaMetrics holds per-replica metrics used by both the saturation analyzer
 // and the queueing model analyzer. Saturation analysis uses KV cache, queue, and
 // token-capacity fields, while the queueing model analyzer uses

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -3,6 +3,7 @@ package saturation_v2
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -65,10 +66,14 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 		return nil, fmt.Errorf("expected *SaturationScalingConfig, got %T", input.Config)
 	}
 
-	// Build GPU count lookup from variant states
+	// Build GPU count and P/D role lookups from variant states. The role decides
+	// how a waiting request is charged against a replica's KV capacity, so it must
+	// be known before per-replica demand is computed.
 	gpusByVariant := make(map[string]int, len(input.VariantStates))
+	rolesByVariant := make(map[string]string, len(input.VariantStates))
 	for _, vs := range input.VariantStates {
 		gpusByVariant[vs.VariantName] = vs.GPUsPerReplica
+		rolesByVariant[vs.VariantName] = vs.Role
 	}
 
 	// Phase 1: Per-replica capacity computation
@@ -80,7 +85,7 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 		default:
 		}
 		gpuCount := gpusByVariant[rm.VariantName]
-		rc := a.computeReplicaCapacity(rm, satConfig, input.ModelID, input.Namespace, gpuCount)
+		rc := a.computeReplicaCapacity(rm, satConfig, input.ModelID, input.Namespace, gpuCount, rolesByVariant[rm.VariantName])
 		if rc != nil {
 			replicaCapacities = append(replicaCapacities, *rc)
 		}
@@ -97,11 +102,7 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 	// Track active roles for queue demand attribution.
 	activeRoles := make(map[string]bool)
 	for _, vc := range variantCapacities {
-		role := vc.Role
-		if role == "" {
-			role = domain.RoleBoth
-		}
-		activeRoles[role] = true
+		activeRoles[canonicalRole(vc.Role)] = true
 	}
 
 	// Add scheduler queue demand (requests queued upstream in llm-d flow control).
@@ -138,12 +139,16 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 }
 
 // computeReplicaCapacity computes the capacity breakdown for a single replica.
+// The role argument is the replica's P/D role, which determines how requests
+// waiting in the local engine queue are charged (see waitingQueueDemand).
+// An empty role is treated as domain.RoleBoth.
 // Returns nil if the replica has no V2 capacity data (TotalKvCapacityTokens == 0).
 func (a *SaturationAnalyzer) computeReplicaCapacity(
 	rm domain.ReplicaMetrics,
 	config *config.SaturationScalingConfig,
 	modelID, namespace string,
 	gpuCount int,
+	role string,
 ) *ReplicaCapacity {
 	if rm.TotalKvCapacityTokens <= 0 {
 		// TODO: implement proper demand estimation when vllm:cache_config_info is absent.
@@ -151,14 +156,12 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		// capacity from the capacity store. A better approach would be to estimate
 		// TotalKvCapacityTokens from deployment args (num_gpu_blocks_override, block_size)
 		// or use a dedicated percentage-based demand signal.
-		return a.computeReplicaCapacityFallback(rm, config, modelID, namespace)
+		return a.computeReplicaCapacityFallback(rm, config, modelID, namespace, role)
 	}
 
-	// Compute demand
-	replicaDemand := rm.TokensInUse
-	if rm.AvgInputTokens > 0 {
-		replicaDemand += int64(rm.QueueLength) * int64(rm.AvgInputTokens)
-	}
+	// Compute demand: tokens already resident in KV cache plus the role-aware
+	// footprint of requests still waiting in the local engine queue.
+	replicaDemand := rm.TokensInUse + waitingQueueDemand(rm, role)
 
 	// k1: memory-bound capacity
 	k1 := int64(float64(rm.TotalKvCapacityTokens) * config.KvCacheThreshold)
@@ -226,6 +229,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
 	rm domain.ReplicaMetrics,
 	cfg *config.SaturationScalingConfig,
 	modelID, namespace string,
+	role string,
 ) *ReplicaCapacity {
 	rec := a.capacityStore.Get(namespace, modelID, rm.VariantName)
 	if rec == nil || rec.EffectiveCapacity <= 0 {
@@ -245,10 +249,19 @@ func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
 	// exact token demand — but it's sufficient when token-level metrics are absent.
 	replicaDemand := int64(rm.KvCacheUsage * float64(effectiveCapacity))
 
-	// Add queue-based demand if we have average input token info
-	if rm.AvgInputTokens > 0 {
-		replicaDemand += int64(rm.QueueLength) * int64(rm.AvgInputTokens)
-	}
+	// Add the role-aware footprint of requests waiting in the local engine queue,
+	// matching the main path.
+	//
+	// Caveat, pre-existing and not introduced here: for a deployment-derived
+	// record, EffectiveCapacity is EffectiveMaxBatchedTokens — a *per-step* token
+	// budget the store itself calls "a safe lower bound" — while this addend is in
+	// absolute KV tokens. The two are not the same unit, so on that record a deep
+	// queue can push replicaDemand past effectiveCapacity and report saturation
+	// that the replica's actual KV occupancy does not support. Raising the
+	// per-request charge lowers the queue depth at which that happens. Tracked
+	// separately; fixing it means pairing the fallback's demand and capacity units,
+	// not adjusting this line.
+	replicaDemand += waitingQueueDemand(rm, role)
 
 	isSaturated := replicaDemand >= effectiveCapacity
 
@@ -571,6 +584,111 @@ func computeModelWorkloadAverages(replicaMetrics []domain.ReplicaMetrics) (avgIn
 	return avgInput, avgOutput, avgHitRate
 }
 
+// canonicalRole normalizes an empty variant role to domain.RoleBoth, matching
+// aggregation.AggregateByRole.
+func canonicalRole(role string) string {
+	if role == "" {
+		return domain.RoleBoth
+	}
+	return role
+}
+
+// waitingQueueDemand estimates the KV-token demand of the requests waiting in a
+// replica's local engine queue (vllm:num_requests_waiting / sglang:num_queue_reqs).
+// Their footprint is projected from the replica's average request shape, since
+// the queue metric carries no per-request token counts.
+//
+// Note these requests are not uniformly blockless: on the decode side a
+// transfer-pending request (vLLM's WAITING_FOR_REMOTE_KVS) has already had
+// blocks allocated, so part of its prompt KV is also inside KvCacheUsage and is
+// counted twice. The overlap shrinks toward zero under KV pressure, when block
+// allocation starts failing — i.e. in the saturated regime where the scaling
+// decision is actually made.
+//
+// The per-request cost is role-aware, because a replica only pays for the KV it
+// actually materializes:
+//
+//	Prefill:      AvgInputTokens                   (prompt KV only; output is generated elsewhere)
+//	Decode/Both:  AvgInputTokens + AvgOutputTokens (holds prompt KV and grows it per generated token)
+//
+// Charging decode replicas for input alone understates demand for
+// long-generation workloads, which are precisely the ones whose KV pressure is
+// output-driven. That is the under-reporting this addresses. It mirrors the role
+// attribution estimateSchedulerQueueDemand already applies model-wide.
+//
+// # Why the full output length, and how it relates to the capacity side
+//
+// I+O is a request's KV footprint at its LAST decode step, not its mean. It is
+// deliberately a peak, no-preemption planning charge: once admitted, a decode
+// request's KV grows monotonically and the engine cannot shed it without
+// preemption and recompute, so a replica expected to host the request needs room
+// for its final size.
+//
+// I+O is this analyzer's demand-side unit. It is deliberately not the unit used
+// by the time-averaged models elsewhere, and the distinction matters when reading
+// the two together:
+//
+//   - Saturation V2 (here, demand): I+O — peak footprint. Sizes for what a
+//     replica must be able to hold, not what it holds on average.
+//   - Throughput analyzer (throughput.WorkloadShape.KVreq): ILeff + O/2 —
+//     time-averaged. A SEPARATE analyzer with its own model and its own
+//     supply/demand pairing; it does not constrain this term and is not
+//     inconsistent with it.
+//
+// One asymmetry is genuinely internal to this analyzer and should not be confused
+// with the above: estimateCapacityFromParams prices a *concurrent* request at
+// I + O/2 when deriving k2, so a queued request is charged more than it will
+// occupy on average, and its charge drops once it is admitted and starts being
+// measured through KvCacheUsage instead. Both effects bias this term toward
+// scale-up.
+//
+// Note also that this term and the resident term are both derived from 1-minute
+// maxima (max_over_time on kv_cache_usage_perc and num_requests_waiting), whose
+// peaks need not coincide, so their sum can exceed any demand the replica
+// actually saw at a single instant. That is a pre-existing property of the
+// collector's queries, not of this function, but it compounds the bias above.
+//
+// That trade is chosen on purpose: under-provisioning decode capacity causes
+// preemption and recompute thrash, which costs more than a spare replica.
+// Revisiting it means changing the demand/capacity pair together, not this
+// function alone.
+//
+// Returns 0 when the queue is empty, or when token metrics are absent or
+// non-finite.
+func waitingQueueDemand(rm domain.ReplicaMetrics, role string) int64 {
+	if rm.QueueLength <= 0 {
+		return 0
+	}
+
+	tokensPerRequest := rm.AvgInputTokens
+	if canonicalRole(role) != domain.RolePrefill {
+		tokensPerRequest += rm.AvgOutputTokens
+	}
+	// Compute in float64 and validate before converting, so one check covers
+	// NaN, infinities, and finite values too large for an int64. Converting an
+	// out-of-range float64 to int64 is implementation-defined in Go (amd64
+	// yields math.MinInt64, arm64 saturates), and either way the result is
+	// garbage that reads downstream as "idle, remove replicas" or as enormous
+	// demand. Note `x <= 0` would NOT catch NaN, since every NaN comparison is
+	// false. The collector filters NaN/Inf on the token averages, so this is a
+	// guard rather than a live bug; it does not filter QueueLength, which is a
+	// bare int conversion, but a garbage value there is caught either by the
+	// QueueLength <= 0 check above or by the range bound below.
+	//
+	// Multiplying before truncating also drops the per-request rounding the
+	// previous truncate-then-multiply form accumulated: at queue 3 and an average
+	// of 100.9 tokens this yields 302 rather than 300.
+	// The bound is >=, not >: float64(math.MaxInt64) rounds up to 2^63, which is
+	// one past the largest representable int64, so a demand of exactly 2^63 would
+	// pass a > check and then overflow to MinInt64.
+	demand := float64(rm.QueueLength) * tokensPerRequest
+	if !(demand > 0) || demand >= float64(math.MaxInt64) {
+		return 0
+	}
+
+	return int64(demand)
+}
+
 // schedulerQueueDemand holds the estimated token demand from scheduler-queued
 // requests, broken down by P/D role for disaggregated models.
 type schedulerQueueDemand struct {
@@ -633,11 +751,11 @@ func estimateSchedulerQueueDemand(
 	if len(activeRoles) > 0 {
 		for role := range activeRoles {
 			switch role {
-			case "prefill":
-				byRole["prefill"] = inputTokens
-			case "decode":
-				byRole["decode"] = inputTokens + outputTokens
-			default: // "both" or unknown
+			case domain.RolePrefill:
+				byRole[domain.RolePrefill] = inputTokens
+			case domain.RoleDecode:
+				byRole[domain.RoleDecode] = inputTokens + outputTokens
+			default: // domain.RoleBoth or unknown
 				byRole[role] = total
 			}
 		}

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -2,6 +2,7 @@ package saturation_v2
 
 import (
 	"context"
+	"math"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1015,7 +1016,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			TotalKvCapacityTokens: 0,
 		}
 
-		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns")
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleBoth)
 		Expect(result).To(BeNil())
 	})
 
@@ -1031,7 +1032,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			KvCacheUsage: 0.5,
 		}
 
-		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns")
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleBoth)
 		Expect(result).To(BeNil())
 	})
 
@@ -1051,7 +1052,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			TotalKvCapacityTokens: 0,
 		}
 
-		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns")
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleBoth)
 		Expect(result).NotTo(BeNil())
 		// effectiveCapacity = 10000 * 0.8 (KvCacheThreshold) = 8000
 		Expect(result.EffectiveCapacity).To(Equal(int64(8000)))
@@ -1075,7 +1076,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			TotalKvCapacityTokens: 0,
 		}
 
-		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns")
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleBoth)
 		Expect(result).NotTo(BeNil())
 		// effectiveCapacity = 10000 * 0.8 = 8000
 		// demand = 1.0 * 8000 = 8000 >= 8000
@@ -1100,7 +1101,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			TotalKvCapacityTokens: 0,
 		}
 
-		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns")
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleBoth)
 		Expect(result).NotTo(BeNil())
 		// effectiveCapacity = 10000 * 0.8 = 8000
 		// demand = 0.9 * 8000 = 7200
@@ -1129,7 +1130,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			AvgInputTokens:        500,
 		}
 
-		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns")
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleBoth)
 		Expect(result).NotTo(BeNil())
 		// effectiveCapacity = 10000 * 0.8 = 8000
 		// demand = 0.5 * 8000 + 3 * 500 = 4000 + 1500 = 5500
@@ -1137,7 +1138,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 		Expect(result.IsSaturated).To(BeFalse())
 	})
 
-	It("should not add queue demand when avg input tokens is zero", func() {
+	It("should not add queue demand when token metrics are unavailable", func() {
 		store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
 			AcceleratorName:   "H100",
 			EffectiveCapacity: 10000,
@@ -1154,11 +1155,73 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			AvgInputTokens:        0,
 		}
 
-		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns")
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleBoth)
 		Expect(result).NotTo(BeNil())
 		// effectiveCapacity = 10000 * 0.8 = 8000
 		// demand = 0.3 * 8000 = 2400 (no queue contribution)
 		Expect(result.ReplicaDemand).To(Equal(int64(2400)))
+	})
+
+	It("should charge queue demand by role", func() {
+		store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
+			AcceleratorName:   "H100",
+			EffectiveCapacity: 10000,
+			LearnedFrom:       "deployment",
+		})
+
+		rm := domain.ReplicaMetrics{
+			PodName:               "pod-1",
+			VariantName:           "variant-a",
+			AcceleratorName:       "H100",
+			KvCacheUsage:          0.5,
+			TotalKvCapacityTokens: 0,
+			QueueLength:           3,
+			AvgInputTokens:        500,
+			AvgOutputTokens:       250,
+		}
+
+		// effectiveCapacity = 10000 * 0.8 = 8000; resident = 0.5 * 8000 = 4000.
+		prefill := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RolePrefill)
+		Expect(prefill).NotTo(BeNil())
+		// 4000 + 3 * 500 = 5500 — output tokens excluded.
+		Expect(prefill.ReplicaDemand).To(Equal(int64(5500)))
+
+		decode := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleDecode)
+		Expect(decode).NotTo(BeNil())
+		// 4000 + 3 * (500 + 250) = 6250 — output tokens included.
+		Expect(decode.ReplicaDemand).To(Equal(int64(6250)))
+	})
+
+	It("should not report saturation for an idle replica with a shallow queue", func() {
+		// The fallback denominator is a per-step batched-token budget, while the
+		// queue charge is in absolute KV tokens — a dimensional mismatch this
+		// path inherits. Raising the per-request charge moves the point where
+		// that mismatch invents saturation, so pin the safe end: a mostly-idle
+		// replica with a few queued requests must not read as saturated.
+		store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
+			AcceleratorName:   "H100",
+			EffectiveCapacity: 8192,
+			LearnedFrom:       "deployment",
+		})
+
+		rm := domain.ReplicaMetrics{
+			PodName:               "pod-1",
+			VariantName:           "variant-a",
+			AcceleratorName:       "H100",
+			KvCacheUsage:          0.10,
+			TotalKvCapacityTokens: 0,
+			QueueLength:           2,
+			AvgInputTokens:        200,
+			AvgOutputTokens:       100,
+		}
+
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleDecode)
+		Expect(result).NotTo(BeNil())
+		// effectiveCapacity = 8192 * 0.8 = 6553
+		// demand = 0.10 * 6553 + 2 * (200 + 100) = 655 + 600 = 1255
+		Expect(result.EffectiveCapacity).To(Equal(int64(6553)))
+		Expect(result.ReplicaDemand).To(Equal(int64(1255)))
+		Expect(result.IsSaturated).To(BeFalse())
 	})
 
 	It("should populate all ReplicaCapacity fields correctly", func() {
@@ -1176,7 +1239,7 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 			TotalKvCapacityTokens: 0,
 		}
 
-		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns")
+		result := analyzer.computeReplicaCapacityFallback(rm, cfg, "test-model", "test-ns", domain.RoleBoth)
 		Expect(result).NotTo(BeNil())
 		// effectiveCapacity = 10000 * 0.8 = 8000
 		Expect(result.PodName).To(Equal("pod-1"))
@@ -1189,6 +1252,249 @@ var _ = Describe("computeReplicaCapacityFallback", func() {
 		// demand = 0.4 * 8000 = 3200
 		Expect(result.TokensInUse).To(Equal(int64(3200)))
 		Expect(result.ReplicaDemand).To(Equal(int64(3200)))
+	})
+})
+
+var _ = Describe("waitingQueueDemand", func() {
+	// Average request shape shared by the role cases: a waiting request costs
+	// 100 input tokens and, once it starts generating, 50 more output tokens.
+	rm := domain.ReplicaMetrics{
+		QueueLength:     4,
+		AvgInputTokens:  100,
+		AvgOutputTokens: 50,
+	}
+
+	It("charges prefill replicas for input tokens only", func() {
+		// Prompt KV is all a prefill replica materializes: 4 * 100.
+		Expect(waitingQueueDemand(rm, domain.RolePrefill)).To(Equal(int64(400)))
+	})
+
+	It("charges decode replicas for input plus output tokens", func() {
+		// Decode holds the transferred prompt KV and grows it per generated
+		// token: 4 * (100 + 50).
+		Expect(waitingQueueDemand(rm, domain.RoleDecode)).To(Equal(int64(600)))
+	})
+
+	It("charges 'both' replicas for input plus output tokens", func() {
+		Expect(waitingQueueDemand(rm, domain.RoleBoth)).To(Equal(int64(600)))
+	})
+
+	It("treats an empty role as 'both'", func() {
+		Expect(waitingQueueDemand(rm, "")).To(Equal(int64(600)))
+	})
+
+	It("treats an unknown role as 'both'", func() {
+		Expect(waitingQueueDemand(rm, "some-future-role")).To(Equal(int64(600)))
+	})
+
+	It("returns zero for an empty queue regardless of role", func() {
+		empty := rm
+		empty.QueueLength = 0
+		for _, role := range []string{domain.RolePrefill, domain.RoleDecode, domain.RoleBoth, ""} {
+			Expect(waitingQueueDemand(empty, role)).To(BeZero())
+		}
+	})
+
+	It("returns zero for a negative queue length", func() {
+		negative := rm
+		negative.QueueLength = -1
+		Expect(waitingQueueDemand(negative, domain.RoleDecode)).To(BeZero())
+	})
+
+	It("returns zero when no token metrics are available", func() {
+		noTokens := domain.ReplicaMetrics{QueueLength: 10}
+		Expect(waitingQueueDemand(noTokens, domain.RolePrefill)).To(BeZero())
+		Expect(waitingQueueDemand(noTokens, domain.RoleDecode)).To(BeZero())
+	})
+
+	It("returns zero for non-finite token metrics", func() {
+		// Converting a non-finite float64 to int64 is implementation-defined in
+		// Go, so an unguarded NaN yields garbage demand — hugely negative on
+		// amd64. A `<= 0` check does not catch NaN, hence the explicit guard.
+		for _, bad := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+			Expect(waitingQueueDemand(
+				domain.ReplicaMetrics{QueueLength: 3, AvgInputTokens: bad}, domain.RolePrefill)).To(BeZero())
+			Expect(waitingQueueDemand(
+				domain.ReplicaMetrics{QueueLength: 3, AvgOutputTokens: bad}, domain.RoleDecode)).To(BeZero())
+			Expect(waitingQueueDemand(
+				domain.ReplicaMetrics{QueueLength: 3, AvgInputTokens: 100, AvgOutputTokens: bad}, domain.RoleDecode)).To(BeZero())
+		}
+	})
+
+	It("returns zero for finite token metrics too large for an int64", func() {
+		// Finite but out of int64 range hits the same implementation-defined
+		// conversion as NaN, so the guard must cover it too.
+		Expect(waitingQueueDemand(
+			domain.ReplicaMetrics{QueueLength: 3, AvgInputTokens: 1e300}, domain.RolePrefill)).To(BeZero())
+		Expect(waitingQueueDemand(
+			domain.ReplicaMetrics{QueueLength: 1e9, AvgInputTokens: 1e12}, domain.RoleDecode)).To(BeZero())
+
+		// Exactly 2^63: float64(math.MaxInt64) rounds up to this value, so a
+		// `>` bound would admit it and overflow to MinInt64.
+		Expect(waitingQueueDemand(
+			domain.ReplicaMetrics{QueueLength: 2, AvgInputTokens: math.Pow(2, 62)}, domain.RolePrefill)).To(BeZero())
+	})
+
+	It("charges decode replicas for output even when input tokens are unreported", func() {
+		// A decode replica whose prompt-token metric is missing still pays for
+		// generation; the old input-only formula returned 0 here.
+		outputOnly := domain.ReplicaMetrics{QueueLength: 4, AvgOutputTokens: 50}
+		Expect(waitingQueueDemand(outputOnly, domain.RoleDecode)).To(Equal(int64(200)))
+		Expect(waitingQueueDemand(outputOnly, domain.RolePrefill)).To(BeZero())
+	})
+})
+
+var _ = Describe("Analyze per-replica waiting-queue demand by role", func() {
+	var (
+		analyzer *SaturationAnalyzer
+		store    *CapacityKnowledgeStore
+		ctx      context.Context
+		satCfg   *config.SaturationScalingConfig
+	)
+
+	BeforeEach(func() {
+		store = NewCapacityKnowledgeStore()
+		analyzer = NewSaturationAnalyzer(store)
+		ctx = context.Background()
+		satCfg = &config.SaturationScalingConfig{
+			KvCacheThreshold:     0.8,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.1,
+			QueueSpareTrigger:    3,
+			AnalyzerName:         "saturation",
+			ScaleUpThreshold:     0.85,
+			ScaleDownBoundary:    0.70,
+		}
+	})
+
+	// replicaFor builds a replica with 1000 tokens resident and 4 requests
+	// waiting, each averaging 100 input and 50 output tokens.
+	replicaFor := func(variant string) domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               variant + "-pod-1",
+			VariantName:           variant,
+			AcceleratorName:       "H100",
+			ModelID:               "test-model",
+			Namespace:             "test-ns",
+			Cost:                  10.0,
+			TotalKvCapacityTokens: 10000,
+			TokensInUse:           1000,
+			QueueLength:           4,
+			AvgInputTokens:        100,
+			AvgOutputTokens:       50,
+		}
+	}
+
+	demandFor := func(role string) float64 {
+		input := domain.AnalyzerInput{
+			ModelID:        "test-model",
+			Namespace:      "test-ns",
+			ReplicaMetrics: []domain.ReplicaMetrics{replicaFor("variant-a")},
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1, Role: role},
+			},
+			Config: satCfg,
+		}
+
+		result, err := analyzer.Analyze(ctx, input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.VariantCapacities).To(HaveLen(1))
+		return result.VariantCapacities[0].TotalDemand
+	}
+
+	It("excludes output tokens for a prefill variant", func() {
+		// 1000 resident + 4 * 100 input = 1400
+		Expect(demandFor(domain.RolePrefill)).To(BeNumerically("==", 1400))
+	})
+
+	It("includes output tokens for a decode variant", func() {
+		// 1000 resident + 4 * (100 + 50) = 1600
+		Expect(demandFor(domain.RoleDecode)).To(BeNumerically("==", 1600))
+	})
+
+	It("includes output tokens for a 'both' variant", func() {
+		Expect(demandFor(domain.RoleBoth)).To(BeNumerically("==", 1600))
+	})
+
+	// The fallback path (no vllm:cache_config_info) must honour the role too.
+	// These go through Analyze so they pin the role forwarding from
+	// computeReplicaCapacity into computeReplicaCapacityFallback, not just the
+	// helper — hardcoding a role at that hand-off would otherwise go unnoticed.
+	Context("on the fallback path (no cache_config_info)", func() {
+		fallbackDemandFor := func(role string) float64 {
+			store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
+				AcceleratorName:   "H100",
+				EffectiveCapacity: 10000,
+				LearnedFrom:       "deployment",
+			})
+
+			rm := replicaFor("variant-a")
+			rm.TotalKvCapacityTokens = 0 // forces the fallback
+			rm.TokensInUse = 0           // fallback derives demand from KvCacheUsage
+			rm.KvCacheUsage = 0.5
+
+			input := domain.AnalyzerInput{
+				ModelID:        "test-model",
+				Namespace:      "test-ns",
+				ReplicaMetrics: []domain.ReplicaMetrics{rm},
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1, Role: role},
+				},
+				Config: satCfg,
+			}
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.VariantCapacities).To(HaveLen(1))
+			return result.VariantCapacities[0].TotalDemand
+		}
+
+		It("excludes output tokens for a prefill variant", func() {
+			// effectiveCapacity = 10000 * 0.8 = 8000
+			// 0.5 * 8000 + 4 * 100 input = 4000 + 400 = 4400
+			Expect(fallbackDemandFor(domain.RolePrefill)).To(BeNumerically("==", 4400))
+		})
+
+		It("includes output tokens for a decode variant", func() {
+			// 0.5 * 8000 + 4 * (100 + 50) = 4000 + 600 = 4600
+			Expect(fallbackDemandFor(domain.RoleDecode)).To(BeNumerically("==", 4600))
+		})
+	})
+
+	It("includes output tokens when the role is unset", func() {
+		// An unset role canonicalizes to "both", so non-disaggregated
+		// deployments get the full-lifecycle charge.
+		Expect(demandFor("")).To(BeNumerically("==", 1600))
+	})
+
+	It("charges each role correctly in a P/D disaggregated model", func() {
+		input := domain.AnalyzerInput{
+			ModelID:   "test-model",
+			Namespace: "test-ns",
+			ReplicaMetrics: []domain.ReplicaMetrics{
+				replicaFor("prefill-variant"),
+				replicaFor("decode-variant"),
+			},
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "prefill-variant", CurrentReplicas: 1, GPUsPerReplica: 1, Role: domain.RolePrefill},
+				{VariantName: "decode-variant", CurrentReplicas: 1, GPUsPerReplica: 1, Role: domain.RoleDecode},
+			},
+			Config: satCfg,
+		}
+
+		result, err := analyzer.Analyze(ctx, input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.VariantCapacities).To(HaveLen(2))
+
+		byVariant := map[string]float64{}
+		for _, vc := range result.VariantCapacities {
+			byVariant[vc.VariantName] = vc.TotalDemand
+		}
+		Expect(byVariant["prefill-variant"]).To(BeNumerically("==", 1400))
+		Expect(byVariant["decode-variant"]).To(BeNumerically("==", 1600))
+
+		// Model-level demand is the sum of both roles.
+		Expect(result.TotalDemand).To(BeNumerically("==", 3000))
 	})
 })
 

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -40,7 +40,12 @@ type ReplicaCapacity struct {
 	K2Priority            k2Source // how k2 was computed
 	EffectiveCapacity     int64    // min(k1, k2)
 	IsSaturated           bool
-	ReplicaDemand         int64 // tokensInUse + queueLength * avgInputTokens
+	// ReplicaDemand is the replica's resident KV tokens — TokensInUse on the main
+	// path, kvCacheUsage * effectiveCapacity on the fallback path — plus the
+	// role-aware waiting-queue footprint: queueLength * avgInputTokens for
+	// prefill replicas, and queueLength * (avgInputTokens + avgOutputTokens) for
+	// decode/"both". See waitingQueueDemand.
+	ReplicaDemand int64
 }
 
 // classifyOutputLength returns a workload bucket name based on average

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -430,15 +430,28 @@ func logAnalyzerResult(ctx context.Context, modelID, namespace string, nr pipeli
 	logger := ctrl.LoggerFrom(ctx)
 
 	type variantEntry struct {
-		Name   string  `json:"name"`
-		PRC    float64 `json:"prc"`
-		Reason string  `json:"reason,omitempty"`
+		Name string  `json:"name"`
+		PRC  float64 `json:"prc"`
+		// Role is included because V2 charges waiting requests by P/D role, so
+		// demand is not interpretable without knowing which role was resolved —
+		// a missing llm-d.ai/role label reads as "both" and changes the charge.
+		// Emitted unconditionally: an analyzer that leaves Role unset (the
+		// queueing model does) is treated as "both" downstream, so the value is
+		// canonicalized below and the field always carries a meaningful role
+		// rather than being absent.
+		Role   string `json:"role"`
+		Reason string `json:"reason,omitempty"`
 	}
 	variants := make([]variantEntry, 0, len(nr.Result.VariantCapacities))
 	for _, vc := range nr.Result.VariantCapacities {
+		role := vc.Role
+		if role == "" {
+			role = domain.RoleBoth
+		}
 		variants = append(variants, variantEntry{
 			Name:   vc.VariantName,
 			PRC:    vc.PerReplicaCapacity,
+			Role:   role,
 			Reason: vc.Reason,
 		})
 	}

--- a/internal/engines/saturation/engine_v2_log_test.go
+++ b/internal/engines/saturation/engine_v2_log_test.go
@@ -42,6 +42,7 @@ func TestLogAnalyzerResult_EmitsRequiredFields(t *testing.T) {
 					VariantName:        "primary",
 					PerReplicaCapacity: 50000,
 					Cost:               10,
+					Role:               domain.RoleDecode,
 					Reason:             "P2-hist",
 				},
 			},
@@ -69,6 +70,32 @@ func TestLogAnalyzerResult_EmitsRequiredFields(t *testing.T) {
 	assert.Contains(t, variantsJSON, `"reason"`, "variants entry must include reason field")
 	assert.Contains(t, variantsJSON, "P2-hist", "label value must be present")
 	assert.NotContains(t, variantsJSON, `"cost"`, "cost must not appear in variants entry")
+
+	// V2 charges waiting requests by P/D role, so demand is not interpretable
+	// without the resolved role on this line.
+	assert.Contains(t, variantsJSON, `"role"`, "variants entry must include role field")
+	assert.Contains(t, variantsJSON, domain.RoleDecode, "resolved role value must be present")
+}
+
+// An analyzer that leaves Role unset is treated as "both" downstream, so the log
+// line must say "both" rather than omitting the field — that is precisely the
+// case a reader needs to distinguish from an explicitly-roled variant.
+func TestLogAnalyzerResult_DefaultRoleRendersAsBoth(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+
+	logAnalyzerResult(ctx, "mymodel", "ns", pipeline.NamedAnalyzerResult{
+		Name: "saturation",
+		Result: &domain.AnalyzerResult{
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "primary", PerReplicaCapacity: 50000, Role: ""},
+			},
+		},
+	})
+
+	require.Equal(t, 1, logs.Len())
+	b, err := json.Marshal(logs.All()[0].ContextMap()["variants"])
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"role":"both"`, "unset role must render as the canonical %q", domain.RoleBoth)
 }
 
 func TestLogAnalyzerResult_NilResultSkipped(t *testing.T) {

--- a/test/e2e/throughput_analyzer_test.go
+++ b/test/e2e/throughput_analyzer_test.go
@@ -67,8 +67,9 @@ analyzers:
 // so a static value is stable. With the simulator's kv-cache-size=1 × block-size=8 (kvMax=8)
 // and throughputBothEnabledConfig (kvCacheThreshold=0.80 → perReplicaCapacity≈6.4,
 // scaleUpThreshold=0.85), RequiredCapacity > 0 requires kv·8/0.85 > 6.4, i.e. kv > 0.68;
-// 0.9 clears it with margin. running/waiting are cosmetic for V2 (queue demand uses the
-// rate-based AvgInputTokens, which is 0 under static fakes).
+// 0.9 clears it with margin. running/waiting are cosmetic for V2: these variants carry no
+// llm-d.ai/role label, so they resolve to role "both" and queue demand charges the
+// rate-based AvgInputTokens + AvgOutputTokens — both of which are 0 under static fakes.
 const throughputScaleUpFakeMetricsJSON = `{"kv-cache-usage":0.9,"running-requests":5,"waiting-requests":20}`
 
 // throughputSustainedLoadScript is an inline shell script for a Kubernetes Job that


### PR DESCRIPTION
Fixes #1456

## Proposed Changes

- :bug: Charge requests waiting in a replica's **local engine queue** by P/D role. Previously every replica was charged `QueueLength × AvgInputTokens` regardless of role. Decode and `both` replicas grow KV per generated token, so long-generation workloads under-reported demand — by 81× for an illustrative 100-input/8000-output request — making them look cheaper than they are and delaying scale-up.

  | Role | Per-request charge |
  |------|--------------------|
  | `prefill` | `AvgInputTokens` |
  | `decode` / `both` | `AvgInputTokens + AvgOutputTokens` |

  This mirrors the role attribution `estimateSchedulerQueueDemand` already applied model-wide. The role is plumbed from `VariantStates` through **both** the main and the fallback (no `vllm:cache_config_info`) demand paths, with a new `waitingQueueDemand` helper as the single charge site.

- :broom: Harden the charge against bad inputs. The gate now validates in `float64` before converting to `int64`, so one check covers NaN, infinities, and finite-but-out-of-range values. The previous `AvgInputTokens > 0` gate rejected NaN but a `<= 0` gate does not (every NaN comparison is false), and an out-of-range float→int conversion is implementation-defined in Go. The collector filters NaN/Inf on the token averages, so this is a guard rather than a live bug. Multiplying before truncating also drops the per-request rounding the old truncate-then-multiply form accumulated (queue 3 at avg 100.9 tokens now yields 302 rather than 300).

- :broom: Gate on the *combined* per-request cost rather than input alone, so a decode replica reporting only generation tokens is no longer charged zero for its queue.

- :gift: Add `domain.RoleDecode`, and switch `estimateSchedulerQueueDemand` off its bare `"prefill"` / `"decode"` string literals.

- :broom: Emit the resolved role per variant on the `analyzer-result` log line. Demand is no longer interpretable without it — a missing `llm-d.ai/role` label reads as `both` and changes the charge. Canonicalized so an analyzer that leaves the role unset still logs a meaningful value.

- :broom: Docs: document the per-role formula and its operator-visible impact in `saturation-scaling-config.md`; add `variants[].role` to the `analyzer-result` schema in `cycle-log.md` and replace its "total observed token demand" description, which named neither the local-queue projection nor the scheduler-queue term; note in `prometheus.md` that V2 utilization is unbounded above.

### Why `I + O` and not `I + O/2`

`I + O` is this analyzer's **demand-side** unit: a request's footprint at its final decode step, chosen as a peak / no-preemption planning charge, since KV grows monotonically once generation starts and cannot be shed without preemption and recompute. Two distinctions are documented in the code so they aren't mistaken for inconsistencies:

- The throughput analyzer's `ILeff + O/2` is time-averaged, but it is a **separate analyzer** with its own demand/supply pairing.
- Internal to saturation V2, `estimateCapacityFromParams` prices a *concurrent* request at `I + O/2` when deriving k2. This term is therefore deliberately more conservative than the capacity it is compared against, biasing toward scale-up — accepted, because under-provisioning decode capacity causes preemption and recompute thrash. Revisiting that means moving the demand/capacity pair together, not this function alone.

### Scope note

Because an absent role canonicalizes to `both`, **non-disaggregated deployments also include output tokens now**. That is the physically correct charge for a replica handling the full request lifecycle, but it means the common single-variant case sees higher computed demand wherever replicas have a non-empty local queue. See the release note.

### Reviewer notes

- **A pre-existing unit mismatch on the fallback path is documented, not changed.** For a deployment-derived record, `EffectiveCapacity` is `EffectiveMaxBatchedTokens` — a *per-step* budget the store itself calls "a safe lower bound" — while this addend is absolute KV tokens. A deep queue can therefore report saturation the replica's actual KV occupancy doesn't support, and raising the per-request charge lowers the queue depth at which that happens. Fixing it means pairing that path's demand and capacity units, which is out of scope here. A test pins the safe end (idle replica, shallow queue → not saturated). Happy to file this and the other pre-existing items as separate issues.
- Residual risk worth watching after merge is **not** the coefficient but its interaction with P1-observed k2: when `queueLen >= queueLengthThreshold`, k2 is pinned to `tokensInUse`, so utilization becomes `1 + q·(I+O)/tokensInUse`. For long-generation workloads that factor lands on the *magnitude* of the first scale-up step, not just its trigger.

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — **not added; see below.** No V2 e2e fixture can exercise this. All V2 suites drive the analyzer with `--fake-metrics`, which sets only `kv-cache-usage` / `running-requests` / `waiting-requests`; `AvgInputTokens` and `AvgOutputTokens` come from 5m-rate PromQL over token histograms that static fakes never populate, so both are `0` and the queue term is inert. The one fixture emitting real token metrics is the SGLang emulator, which is explicitly pinned to V1 by a guard carrying `TODO(v2): recalibrate the SGLang fixture metrics + assertion for the V2 analyzer and drop this guard`. Notably this change may unblock that TODO — the fixture sits exactly at V2's `0.85` threshold (which V2 must *exceed*), and the queue term would rise from `3×500` to `3×750`, plausibly making the V2 arc deterministic. That needs a real kind-cluster run to confirm and is left as follow-up. Unit coverage is thorough instead: all role variants, empty/negative queue, missing metrics, output-only decode, non-finite and out-of-int64-range values, both demand paths, and end-to-end `Analyze` assertions including a two-variant P/D model.
- [x] **Docs PR** for any user-facing impact — included in this PR (`saturation-scaling-config.md`, `cycle-log.md`, `prometheus.md`), since the affected docs live in this repo.
- [ ] **Proposal PR** — not applicable. This corrects an existing demand term to match the role attribution the codebase already applied at model level; it does not introduce a new mechanism.

**Release Note**

```release-note
Saturation V2 now accounts for output tokens when estimating demand from requests waiting in a replica's local engine queue. Decode and non-disaggregated ("both") replicas are charged the average input plus output tokens per waiting request; prefill replicas remain input-only. This corrects a significant under-estimate of demand for long-generation workloads, which could delay scale-up.

Because a variant with no `llm-d.ai/role` label is treated as "both", this affects non-disaggregated deployments as well. Where replicas have a non-empty local queue, expect `wva_saturation_utilization` and `wva_required_capacity{unit="continuous"}` to step up, `wva_spare_capacity` to step down, and `wva_desired_replicas` to take a one-time step. `wva_kv_cache_tokens_used` is unaffected. Alerts thresholded on saturation utilization may need re-baselining.
```

**Docs**

Documentation for this change lives in this repo and is included in this PR. No `llm-d/llm-d` docs change is needed — the per-role charge is an internal demand-model detail, and the user-facing knobs (`scaleUpThreshold`, `scaleDownBoundary`) are unchanged.
