### PR TITLE
test(e2e): validate the llm-d KEDA EPP guide with the WVA Kind lifecycle

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -168,6 +168,45 @@ jobs:
         run: |
           make test-e2e-smoke-with-setup
 
+  # Canonical queue-guide qualification: CPU-only, direct KEDA, and a fresh
+  # disposable Kind cluster. This label is not selected by smoke/full jobs.
+  keda-epp-guide:
+    runs-on: ubuntu-latest
+    needs: [lint-and-test, check-code-changes]
+    if: needs.check-code-changes.outputs.has_code_changes == 'true'
+    # 34m of bounded setup waits + 70m Go timeout, with final diagnostics and
+    # fresh-cluster cleanup still inside the job-level boundary.
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    env:
+      CLUSTER_NAME: wva-keda-epp-guide-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Extract Go version from go.mod
+        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> "$GITHUB_ENV"
+
+      - name: Set up Go with cache
+        uses: actions/setup-go@v6
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: ./go.sum
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Install Kind
+        run: deploy/ci-pr-checks/install-kind.sh
+
+      - name: Run KEDA+EPP guide contract
+        shell: bash
+        run: |
+          make test-e2e-keda-epp-guide-with-setup \
+            CLUSTER_NAME="$CLUSTER_NAME" \
+            LLMD_SOURCE=""
+
   # Full Kind E2E - runs automatically on every PR with code changes.
   # Add "e2e-tests-full" as a required status check in branch protection so it appears on every PR
   # and must run and pass before merge.

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,27 @@ test-e2e-smoke: ## Run smoke e2e tests
 	echo "=========================================="; \
 	exit $$TEST_EXIT_CODE
 
+# Runs only the direct KEDA+EPP guide contract against resources already applied
+# from the llm-d repository. The WVA controller is intentionally not required.
+# The guide's bounded inner waits total less than 30m; 40m reserves time for diagnostics and cleanup.
+.PHONY: test-e2e-keda-epp-guide
+test-e2e-keda-epp-guide: ## Run the llm-d KEDA+EPP guide contract
+	@echo "Running direct KEDA+EPP guide contract..."
+	KUBECONFIG=$(KUBECONFIG) \
+	ENVIRONMENT=kind-emulator \
+	DEPLOY_WVA=false \
+	WVA_NAMESPACE=workload-variant-autoscaler-system \
+	LLMD_NAMESPACE=llm-d-optimized-baseline \
+	MONITORING_NAMESPACE=llm-d-monitoring \
+	KEDA_NAMESPACE=keda \
+	EPP_SERVICE_NAME=optimized-baseline-epp \
+	USE_SIMULATOR=true \
+	SCALE_TO_ZERO_ENABLED=false \
+	SCALER_BACKEND=keda \
+	MODEL_ID=Qwen/Qwen3-32B \
+	go test ./test/e2e/ -timeout 40m -v -ginkgo.v \
+		-ginkgo.label-filter="keda-epp-guide"
+
 # Runs the complete e2e test suite (KEDA backend, excluding smoke and flaky tests).
 .PHONY: test-e2e-full
 test-e2e-full: ## Run full e2e test suite

--- a/Makefile
+++ b/Makefile
@@ -316,8 +316,8 @@ test-e2e-smoke: ## Run smoke e2e tests
 
 # Runs only the direct KEDA+EPP guide contract against resources already applied
 # from the llm-d repository. The WVA controller is intentionally not required.
-# Its successful-spec observation bound is 55m30s; Ginkgo gets 65m and Go gets
-# 70m so suite preflight, diagnostics, and cleanup remain outside that bound.
+# Ginkgo gets 65m and Go gets 70m so suite preflight, diagnostics, and cleanup
+# remain inside the outer test-process boundary.
 .PHONY: test-e2e-keda-epp-guide
 test-e2e-keda-epp-guide: ## Run the llm-d KEDA+EPP guide contract
 	@echo "Running direct KEDA+EPP guide contract..."

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IMAGE_TAG_BASE ?= ghcr.io/llm-d
 IMG_TAG ?= latest
 IMG ?= $(IMAGE_TAG_BASE)/llm-d-workload-variant-autoscaler:$(IMG_TAG)
 KIND_ARGS ?= -t mix -n 3 -g 2   # Default: 3 nodes, 2 GPUs per node, mixed vendors
+CLUSTER_NAME ?= kind-wva-gpu-cluster
 CLUSTER_GPU_TYPE ?= nvidia-mix
 CLUSTER_NODES ?= 3
 CLUSTER_GPUS ?= 4
@@ -33,6 +34,8 @@ E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
 E2E_KEDA_NAMESPACE          ?= keda-system
 E2E_WVA_SECONDARY_OVERLAY_PATH ?= $(CURDIR)/test/e2e/testdata/secondary-controller
+LLMD_SOURCE                 ?=
+LLMD_SOURCE_SHA             ?=
 # llm-d-benchmark CLI configuration
 # Ensure brew-installed tools (helm >=3.19) take precedence over Rancher Desktop
 export PATH := /opt/homebrew/bin:$(PATH)
@@ -132,12 +135,12 @@ test: manifests generate fmt vet setup-envtest helm ## Run tests.
 .PHONY: create-kind-cluster
 create-kind-cluster:
 	export KIND=$(KIND) KUBECTL=$(KUBECTL) && \
-		deploy/kind-emulator/setup.sh -t $(CLUSTER_GPU_TYPE) -n $(CLUSTER_NODES) -g $(CLUSTER_GPUS)
+		deploy/kind-emulator/setup.sh -c $(CLUSTER_NAME) -t $(CLUSTER_GPU_TYPE) -n $(CLUSTER_NODES) -g $(CLUSTER_GPUS)
 
 # Destroys the Kind cluster created by `create-kind-cluster`
 .PHONY: destroy-kind-cluster
 destroy-kind-cluster:
-	export KIND=$(KIND) KUBECTL=$(KUBECTL) && \
+	export KIND=$(KIND) KUBECTL=$(KUBECTL) KIND_NAME=$(CLUSTER_NAME) && \
         deploy/kind-emulator/teardown.sh
 
 
@@ -238,6 +241,53 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + EPP; no model server 
 	fi
 
 
+# Deploys the canonical llm-d KEDA+EPP guide contract through the existing
+# controller-free e2e infrastructure lifecycle. This target requires a fresh,
+# uniquely named Kind cluster created separately with create-kind-cluster.
+.PHONY: deploy-e2e-keda-epp-guide
+deploy-e2e-keda-epp-guide: ## Deploy the llm-d KEDA+EPP guide contract on disposable Kind
+	@echo "Deploying direct KEDA+EPP guide contract..."
+	@KUBECONFIG=$(KUBECONFIG) \
+		CLUSTER_NAME=$(CLUSTER_NAME) \
+		LLMD_SOURCE="$(LLMD_SOURCE)" \
+		LLMD_SOURCE_SHA="$(LLMD_SOURCE_SHA)" \
+		LLMD_NS=llm-d-optimized-baseline \
+		MONITORING_NAMESPACE=$(E2E_MONITORING_NAMESPACE) \
+		KEDA_NAMESPACE=$(E2E_KEDA_NAMESPACE) \
+		WVA_PROJECT=$(CURDIR) \
+		MAKE="$(MAKE)" \
+		./deploy/lib/deploy_keda_epp_guide.sh
+
+# Owns the complete disposable lifecycle. The default cluster name is replaced
+# with a unique guide-specific name; an explicitly supplied name must not exist.
+.PHONY: test-e2e-keda-epp-guide-with-setup
+test-e2e-keda-epp-guide-with-setup: ## Create fresh Kind, deploy, test, diagnose, and tear down the guide contract
+	@set -Eeuo pipefail; \
+	cluster_name="$(CLUSTER_NAME)"; \
+	if [ "$$cluster_name" = "kind-wva-gpu-cluster" ]; then \
+		cluster_name="wva-keda-epp-guide-$$(date +%s)-$$$$"; \
+	fi; \
+	if $(KIND) get clusters 2>/dev/null | grep -Fxq "$$cluster_name"; then \
+		echo "ERROR: Kind cluster '$$cluster_name' already exists; choose a fresh unique name" >&2; \
+		exit 1; \
+	fi; \
+	cleanup() { \
+		$(MAKE) destroy-kind-cluster CLUSTER_NAME="$$cluster_name"; \
+	}; \
+	trap cleanup EXIT; \
+	trap 'exit 130' INT; \
+	trap 'exit 143' TERM; \
+	$(MAKE) create-kind-cluster \
+		CLUSTER_NAME="$$cluster_name" \
+		CLUSTER_NODES=1 \
+		CLUSTER_GPUS=0 \
+		CLUSTER_GPU_TYPE=nvidia; \
+	$(MAKE) deploy-e2e-keda-epp-guide \
+		CLUSTER_NAME="$$cluster_name" \
+		LLMD_SOURCE="$(LLMD_SOURCE)" \
+		LLMD_SOURCE_SHA="$(LLMD_SOURCE_SHA)"; \
+	$(MAKE) test-e2e-keda-epp-guide CLUSTER_NAME="$$cluster_name"
+
 # Runs the smoke subset of the e2e suite. KEDA is the only scaler backend.
 .PHONY: test-e2e-smoke
 test-e2e-smoke: ## Run smoke e2e tests
@@ -266,7 +316,8 @@ test-e2e-smoke: ## Run smoke e2e tests
 
 # Runs only the direct KEDA+EPP guide contract against resources already applied
 # from the llm-d repository. The WVA controller is intentionally not required.
-# The guide's bounded inner waits total less than 30m; 40m reserves time for diagnostics and cleanup.
+# Its successful-spec observation bound is 55m30s; Ginkgo gets 65m and Go gets
+# 70m so suite preflight, diagnostics, and cleanup remain outside that bound.
 .PHONY: test-e2e-keda-epp-guide
 test-e2e-keda-epp-guide: ## Run the llm-d KEDA+EPP guide contract
 	@echo "Running direct KEDA+EPP guide contract..."
@@ -275,14 +326,21 @@ test-e2e-keda-epp-guide: ## Run the llm-d KEDA+EPP guide contract
 	DEPLOY_WVA=false \
 	WVA_NAMESPACE=workload-variant-autoscaler-system \
 	LLMD_NAMESPACE=llm-d-optimized-baseline \
-	MONITORING_NAMESPACE=llm-d-monitoring \
-	KEDA_NAMESPACE=keda \
+	MONITORING_NAMESPACE=$(E2E_MONITORING_NAMESPACE) \
+	KEDA_NAMESPACE=$(E2E_KEDA_NAMESPACE) \
 	EPP_SERVICE_NAME=optimized-baseline-epp \
 	USE_SIMULATOR=true \
 	SCALE_TO_ZERO_ENABLED=false \
 	SCALER_BACKEND=keda \
 	MODEL_ID=Qwen/Qwen3-32B \
-	go test ./test/e2e/ -timeout 40m -v -ginkgo.v \
+	POD_READY_TIMEOUT=120 \
+	SCALE_UP_TIMEOUT=300 \
+	E2E_EVENTUALLY_SHORT=30 \
+	E2E_EVENTUALLY_MEDIUM=60 \
+	E2E_EVENTUALLY_STANDARD=90 \
+	E2E_EVENTUALLY_LONG=90 \
+	E2E_EVENTUALLY_EXTENDED=180 \
+	go test ./test/e2e/ -timeout 70m -v -ginkgo.v -ginkgo.timeout=65m \
 		-ginkgo.label-filter="keda-epp-guide"
 
 # Runs the complete e2e test suite (KEDA backend, excluding smoke and flaky tests).

--- a/deploy/kind-emulator/install.sh
+++ b/deploy/kind-emulator/install.sh
@@ -25,8 +25,8 @@ WVA_PROJECT=${WVA_PROJECT:-$PWD}
 NAMESPACE_SUFFIX="sim"
 
 # Namespaces
-LLMD_NS="llm-d-$NAMESPACE_SUFFIX"
-MONITORING_NAMESPACE="workload-variant-autoscaler-monitoring"
+LLMD_NS=${LLMD_NS:-"llm-d-$NAMESPACE_SUFFIX"}
+MONITORING_NAMESPACE=${MONITORING_NAMESPACE:-"workload-variant-autoscaler-monitoring"}
 WVA_NS=${WVA_NS:-"workload-variant-autoscaler-system"}
 
 # Simulator image — must match defaultModelServiceSimulatorImage in test/e2e/fixtures/model_service_conventions.go
@@ -37,7 +37,7 @@ WVA_RECONCILE_INTERVAL=${WVA_RECONCILE_INTERVAL:-"60s"} # WVA controller reconci
 SKIP_TLS_VERIFY=true  # Skip TLS verification in emulated environments
 WVA_LOG_LEVEL="debug" # WVA log level set to debug for emulated environments
 # Prometheus Configuration
-PROMETHEUS_SVC_NAME="kube-prometheus-stack-prometheus"
+PROMETHEUS_SVC_NAME=${PROMETHEUS_SVC_NAME:-"kube-prometheus-stack-prometheus"}
 PROMETHEUS_BASE_URL="https://$PROMETHEUS_SVC_NAME.$MONITORING_NAMESPACE.svc.cluster.local"
 PROMETHEUS_PORT="9090"
 PROMETHEUS_URL="$PROMETHEUS_BASE_URL:$PROMETHEUS_PORT"
@@ -104,8 +104,12 @@ check_specific_prerequisites() {
     fi
     log_success "Using KIND cluster '${CLUSTER_NAME}'"
 
-    # Load WVA image into KIND cluster
-    load_image
+    # Load the WVA image only when the controller is part of this deployment.
+    if [ "${DEPLOY_WVA:-true}" = "true" ]; then
+        load_image
+    else
+        log_info "Skipping WVA image load (DEPLOY_WVA=false)"
+    fi
 
     # Pre-load the simulator image so tests don't pull it cold (avoids PodReadyTimeout).
     load_sim_image

--- a/deploy/kind-emulator/install.sh
+++ b/deploy/kind-emulator/install.sh
@@ -230,6 +230,30 @@ _load_into_kind() {
 load_sim_image() {
     log_info "Pre-loading simulator image '$SIM_IMAGE' into KIND cluster..."
 
+    # Digest-pinned images can be imported incorrectly by `kind load docker-image`
+    # and left behind as broken containerd import-* references. Pull them directly
+    # into each KIND node's containerd store instead.
+    if [[ "$SIM_IMAGE" == *@sha256:* ]]; then
+        log_info "Simulator image is digest-pinned; pulling directly into KIND node containerd..."
+
+        local nodes
+        if ! nodes="$(kind get nodes --name "$CLUSTER_NAME")"; then
+            log_warning "Failed to list KIND nodes for simulator image preload"
+            return
+        fi
+
+        local node
+        for node in $nodes; do
+            if ! docker exec "$node" crictl pull "$SIM_IMAGE"; then
+                log_warning "Failed to pre-pull simulator image '$SIM_IMAGE' on node '$node'"
+                return
+            fi
+        done
+
+        log_success "Simulator image '$SIM_IMAGE' pulled directly into KIND cluster '$CLUSTER_NAME' nodes"
+        return
+    fi
+
     local platform="${KIND_IMAGE_PLATFORM:-}"
     if [ -z "$platform" ]; then
         case "$(uname -m)" in
@@ -243,7 +267,8 @@ load_sim_image() {
         return
     fi
 
-    _load_into_kind "$SIM_IMAGE" || log_warning "Failed to load simulator image into KIND cluster — tests may be slow on first run"
+    _load_into_kind "$SIM_IMAGE" ||
+        log_warning "Failed to load simulator image into KIND cluster — tests may be slow on first run"
 }
 
 KUBE_LIKE_VALUES_DEV_IF_PRESENT=true

--- a/deploy/lib/deploy_keda_epp_guide.sh
+++ b/deploy/lib/deploy_keda_epp_guide.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+#
+# Deploy the canonical llm-d KEDA+EPP guide contract through the existing WVA
+# Kind e2e lifecycle. All llm-d-derived files remain temporary.
+
+set -Eeuo pipefail
+
+readonly WVA_PROJECT="${WVA_PROJECT:?WVA_PROJECT must name the WVA repository}"
+readonly CLUSTER_NAME="${CLUSTER_NAME:?CLUSTER_NAME must name the Kind cluster}"
+readonly LLMD_REPOSITORY_URL="https://github.com/llm-d/llm-d"
+readonly LLMD_NS="${LLMD_NS:-llm-d-optimized-baseline}"
+readonly MONITORING_NAMESPACE="${MONITORING_NAMESPACE:-workload-variant-autoscaler-monitoring}"
+readonly KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda-system}"
+readonly PROMETHEUS_RELEASE_NAME="${PROMETHEUS_RELEASE_NAME:-kube-prometheus-stack}"
+readonly PROMETHEUS_SVC_NAME="${PROMETHEUS_SVC_NAME:-${PROMETHEUS_RELEASE_NAME}-prometheus}"
+readonly PROMETHEUS_PORT="${PROMETHEUS_PORT:-9090}"
+readonly PROMETHEUS_SECRET_NAME="${PROMETHEUS_SECRET_NAME:-prometheus-web-tls}"
+readonly GUIDE_SIMULATOR_DEPLOYMENT="optimized-baseline-nvidia-gpu-vllm-decode"
+readonly GUIDE_SIMULATOR_MANIFEST="$WVA_PROJECT/test/e2e/fixtures/keda_epp_guide_simulator.yaml"
+
+work_dir=""
+runtime_started=false
+
+collect_setup_diagnostics() {
+    [ "$runtime_started" = "true" ] || return 0
+
+    echo "=== KEDA+EPP guide setup diagnostics ===" >&2
+    kubectl --request-timeout=10s get pods,svc,endpoints,deployments -n "$LLMD_NS" -o wide >&2 || true
+    kubectl --request-timeout=10s get servicemonitor -n "$LLMD_NS" -o yaml >&2 || true
+    kubectl --request-timeout=10s get scaledobject,hpa -n "$LLMD_NS" -o yaml >&2 || true
+    kubectl --request-timeout=10s get pods,deployments -n "$MONITORING_NAMESPACE" -o wide >&2 || true
+    kubectl --request-timeout=10s get pods,deployments -n "$KEDA_NAMESPACE" -o wide >&2 || true
+    kubectl --request-timeout=10s logs -n "$LLMD_NS" -l app.kubernetes.io/name=optimized-baseline-epp \
+        --all-containers --tail=300 >&2 || true
+    kubectl --request-timeout=10s logs -n "$KEDA_NAMESPACE" -l app.kubernetes.io/name=keda-operator \
+        --all-containers --tail=300 >&2 || true
+    for namespace in "$LLMD_NS" "$MONITORING_NAMESPACE" "$KEDA_NAMESPACE"; do
+        kubectl --request-timeout=10s get events -n "$namespace" --sort-by=.lastTimestamp >&2 || true
+    done
+    echo "=== end KEDA+EPP guide setup diagnostics ===" >&2
+}
+
+on_error() {
+    local status=$?
+    trap - ERR
+    collect_setup_diagnostics
+    return "$status"
+}
+
+cleanup() {
+    if [ -n "$work_dir" ] && [ "$work_dir" != "/" ] &&
+        [[ "$(basename "$work_dir")" == wva-keda-epp-guide.* ]]; then
+        rm -rf -- "$work_dir"
+    fi
+}
+trap cleanup EXIT
+trap on_error ERR
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+extract_rendered_document() {
+    local wanted_kind="$1"
+    local wanted_name="$2"
+    local source_file="$3"
+
+    awk -v wanted_kind="$wanted_kind" -v wanted_name="$wanted_name" '
+        function emit() {
+            if (document ~ ("(^|\\n)kind: " wanted_kind "(\\n|$)") &&
+                document ~ ("\\n  name: " wanted_name "(\\n|$)")) {
+                printf "%s", document
+            }
+        }
+        /^---[[:space:]]*$/ {
+            emit()
+            document = ""
+            next
+        }
+        { document = document $0 ORS }
+        END { emit() }
+    ' "$source_file"
+}
+
+require_line_count() {
+    local expected_count="$1"
+    local pattern="$2"
+    local source_file="$3"
+    local description="$4"
+    local actual_count
+
+    actual_count="$(grep -Ec "$pattern" "$source_file" || true)"
+    [ "$actual_count" -eq "$expected_count" ] ||
+        fail "$description: expected $expected_count matching line(s), found $actual_count"
+}
+
+require_files_equal() {
+    local expected_file="$1"
+    local actual_file="$2"
+    local description="$3"
+
+    if ! cmp -s "$expected_file" "$actual_file"; then
+        diff -u "$expected_file" "$actual_file" >&2 || true
+        fail "$description"
+    fi
+}
+
+normalize_contract_environment() {
+    local source_file="$1"
+    local destination_file="$2"
+
+    sed \
+        -e 's/^  namespace: .*$/  namespace: <environment-namespace>/' \
+        -e 's|^      serverAddress: .*$|      serverAddress: <environment-prometheus-endpoint>|' \
+        "$source_file" >"$destination_file"
+}
+
+for command_name in cmp curl diff git helm kubectl tar; do
+    require_command "$command_name"
+done
+
+[ "$LLMD_NS" = "llm-d-optimized-baseline" ] ||
+    fail "LLMD_NS must remain llm-d-optimized-baseline for this canonical contract"
+[ -r "$GUIDE_SIMULATOR_MANIFEST" ] ||
+    fail "guide simulator manifest is missing or unreadable: $GUIDE_SIMULATOR_MANIFEST"
+
+selected_llmd_source_sha=""
+if [ -n "${LLMD_SOURCE_SHA:-}" ]; then
+    [[ "$LLMD_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+        fail "LLMD_SOURCE_SHA override must be a 40-character lowercase hexadecimal full commit SHA"
+    selected_llmd_source_sha="$LLMD_SOURCE_SHA"
+    echo "Selected llm-d source SHA: ${selected_llmd_source_sha} (explicit LLMD_SOURCE_SHA override)"
+else
+    echo "Resolving official llm-d main once from ${LLMD_REPOSITORY_URL}..."
+    official_main_result="$(git ls-remote --exit-code \
+        "$LLMD_REPOSITORY_URL" refs/heads/main)" ||
+        fail "could not resolve official llm-d main from ${LLMD_REPOSITORY_URL}"
+    [[ "$official_main_result" != *$'\n'* ]] ||
+        fail "official llm-d main resolution returned more than one revision"
+    read -r selected_llmd_source_sha official_main_ref unexpected_field <<<"$official_main_result"
+    [ "$official_main_ref" = "refs/heads/main" ] && [ -z "${unexpected_field:-}" ] ||
+        fail "official llm-d main resolution returned an unexpected ref"
+    [[ "$selected_llmd_source_sha" =~ ^[0-9a-f]{40}$ ]] ||
+        fail "official llm-d main did not resolve to a full lowercase commit SHA"
+    echo "Selected llm-d source SHA: ${selected_llmd_source_sha} (official main resolved once)"
+fi
+readonly selected_llmd_source_sha
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/wva-keda-epp-guide.XXXXXX")"
+
+if [ -n "${LLMD_SOURCE:-}" ]; then
+    llmd_git_root="$(git -C "$LLMD_SOURCE" rev-parse --show-toplevel)" ||
+        fail "LLMD_SOURCE is not a readable git checkout: $LLMD_SOURCE"
+    git -C "$llmd_git_root" cat-file -e "${selected_llmd_source_sha}^{commit}" 2>/dev/null ||
+        fail "LLMD_SOURCE does not contain selected commit ${selected_llmd_source_sha}; no fallback revision will be used"
+    llmd_root="$work_dir/llm-d-source"
+    mkdir -p "$llmd_root"
+    echo "Extracting selected llm-d source ${selected_llmd_source_sha} from read-only checkout: $llmd_git_root"
+    git -C "$llmd_git_root" archive "$selected_llmd_source_sha" | tar -x -C "$llmd_root"
+else
+    echo "Downloading selected llm-d source at ${selected_llmd_source_sha} into temporary storage..."
+    curl --fail --location --silent --show-error \
+        --connect-timeout 10 \
+        --max-time 120 \
+        "https://github.com/llm-d/llm-d/archive/${selected_llmd_source_sha}.tar.gz" \
+        --output "$work_dir/llm-d.tar.gz"
+    tar -xzf "$work_dir/llm-d.tar.gz" -C "$work_dir"
+    llmd_root="$work_dir/llm-d-${selected_llmd_source_sha}"
+fi
+
+readonly guide_root="$llmd_root/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-queue"
+readonly canonical_kustomization="$guide_root/k8s/kustomization.yaml"
+readonly canonical_router_base_values="$llmd_root/guides/recipes/router/base.values.yaml"
+readonly canonical_optimized_baseline_values="$llmd_root/guides/optimized-baseline/router/optimized-baseline.values.yaml"
+readonly canonical_router_values="$guide_root/router.values.yaml"
+readonly canonical_router_monitoring_values="$llmd_root/guides/recipes/router/features/monitoring.values.yaml"
+readonly kind_router_values="$WVA_PROJECT/deploy/lib/keda-epp-guide-kind.values.yaml"
+readonly kind_monitoring_values="$WVA_PROJECT/deploy/lib/keda-epp-guide-monitoring.values.yaml"
+readonly kind_keda_values="$WVA_PROJECT/deploy/lib/keda-epp-guide-keda.values.yaml"
+
+for canonical_asset in \
+    "$canonical_kustomization" \
+    "$canonical_router_base_values" \
+    "$canonical_optimized_baseline_values" \
+    "$canonical_router_values" \
+    "$canonical_router_monitoring_values" \
+    "$kind_router_values" \
+    "$kind_monitoring_values" \
+    "$kind_keda_values"; do
+    [ -r "$canonical_asset" ] ||
+        fail "canonical llm-d asset is missing or unreadable: $canonical_asset"
+done
+
+# This array is the single source for the runtime install: canonical base ->
+# optimized baseline -> monitoring -> queue guide
+# -> the narrow WVA Kind override.
+epp_helm_values=(
+    "$canonical_router_base_values"
+    "$canonical_optimized_baseline_values"
+    "$canonical_router_monitoring_values"
+    "$canonical_router_values"
+    "$kind_router_values"
+)
+printf -v epp_helm_values_list '%s\n' "${epp_helm_values[@]}"
+
+guide_simulator_image="$(awk '$1 == "image:" { print $2 }' "$GUIDE_SIMULATOR_MANIFEST")"
+[ -n "$guide_simulator_image" ] ||
+    fail "guide simulator manifest must contain one image"
+require_line_count 1 '^[[:space:]]*image:[[:space:]]+[^[:space:]]+$' \
+    "$GUIDE_SIMULATOR_MANIFEST" "guide simulator image contract"
+
+prometheus_fqdn="${PROMETHEUS_SVC_NAME}.${MONITORING_NAMESPACE}.svc.cluster.local"
+prometheus_url="https://${prometheus_fqdn}:${PROMETHEUS_PORT}"
+
+overlay_dir="$work_dir/kustomize"
+mkdir -p "$overlay_dir"
+ln -s "$guide_root/k8s" "$overlay_dir/canonical"
+cat >"$overlay_dir/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: llm-d-optimized-baseline
+resources:
+  - canonical
+patches:
+  - target:
+      group: keda.sh
+      version: v1alpha1
+      kind: ScaledObject
+      name: optimized-baseline-keda-epp
+    patch: |-
+      - op: replace
+        path: /spec/triggers/0/metadata/serverAddress
+        value: ${prometheus_url}
+      - op: replace
+        path: /spec/triggers/1/metadata/serverAddress
+        value: ${prometheus_url}
+EOF
+
+rendered_contract="$work_dir/keda-epp-guide.yaml"
+kubectl kustomize "$overlay_dir" --load-restrictor=LoadRestrictionsNone >"$rendered_contract"
+
+canonical_contract="$work_dir/keda-epp-guide-canonical.yaml"
+canonical_normalized="$work_dir/keda-epp-guide-canonical.normalized.yaml"
+rendered_normalized="$work_dir/keda-epp-guide.normalized.yaml"
+kubectl kustomize "$guide_root/k8s" --load-restrictor=LoadRestrictionsNone >"$canonical_contract"
+normalize_contract_environment "$canonical_contract" "$canonical_normalized"
+normalize_contract_environment "$rendered_contract" "$rendered_normalized"
+require_files_equal \
+    "$canonical_normalized" \
+    "$rendered_normalized" \
+    "temporary overlay may change only resource namespace and Prometheus serverAddress"
+
+[ "$(grep -c '^kind: TriggerAuthentication$' "$rendered_contract")" -eq 1 ] ||
+    fail "rendered contract must contain exactly one TriggerAuthentication"
+[ "$(grep -c '^kind: ScaledObject$' "$rendered_contract")" -eq 1 ] ||
+    fail "rendered contract must contain exactly one ScaledObject"
+[ "$(grep -c '^  namespace: llm-d-optimized-baseline$' "$rendered_contract")" -eq 2 ] ||
+    fail "both rendered resources must use namespace llm-d-optimized-baseline"
+[ "$(grep -Fc "serverAddress: ${prometheus_url}" "$rendered_contract")" -eq 2 ] ||
+    fail "both Prometheus triggers must use ${prometheus_url}"
+[ "$(grep -Fc 'name: keda-prometheus-auth' "$rendered_contract")" -eq 4 ] ||
+    fail "TriggerAuthentication, its Secret ref, and both triggers must use keda-prometheus-auth"
+
+rendered_scaled_object="$work_dir/scaledobject.yaml"
+rendered_authentication="$work_dir/triggerauthentication.yaml"
+extract_rendered_document ScaledObject optimized-baseline-keda-epp \
+    "$rendered_contract" >"$rendered_scaled_object"
+extract_rendered_document TriggerAuthentication keda-prometheus-auth \
+    "$rendered_contract" >"$rendered_authentication"
+[ -s "$rendered_scaled_object" ] || fail "canonical ScaledObject document is missing"
+[ -s "$rendered_authentication" ] || fail "canonical TriggerAuthentication document is missing"
+
+require_line_count 1 '^    name: optimized-baseline-nvidia-gpu-vllm-decode$' \
+    "$rendered_scaled_object" "canonical ScaledObject scaleTargetRef target"
+require_line_count 1 '^  minReplicaCount: 1$' \
+    "$rendered_scaled_object" "canonical ScaledObject minimum replica bound"
+require_line_count 1 '^  maxReplicaCount: 8$' \
+    "$rendered_scaled_object" "canonical ScaledObject maximum replica bound"
+require_line_count 1 '^      name: keda-hpa-optimized-baseline$' \
+    "$rendered_scaled_object" "canonical generated HPA name"
+require_line_count 1 '^      query: sum\(llm_d_epp_flow_control_queue_size\{namespace="llm-d-optimized-baseline",service="optimized-baseline-epp",model_name="Qwen/Qwen3-32B"\}\)$' \
+    "$rendered_scaled_object" "canonical queue trigger query"
+require_line_count 1 '^      query: sum\(llm_d_epp_request_running\{namespace="llm-d-optimized-baseline",service="optimized-baseline-epp",model_name="Qwen/Qwen3-32B"\}\)$' \
+    "$rendered_scaled_object" "canonical running trigger query"
+require_line_count 1 '^      threshold: "1"$' \
+    "$rendered_scaled_object" "canonical queue trigger threshold"
+require_line_count 1 '^      threshold: "16"$' \
+    "$rendered_scaled_object" "canonical running trigger threshold"
+require_line_count 1 '^    name: epp-queue-size$' \
+    "$rendered_scaled_object" "canonical queue trigger name"
+require_line_count 1 '^    name: epp-running-requests$' \
+    "$rendered_scaled_object" "canonical running trigger name"
+require_line_count 2 '^    type: prometheus$' \
+    "$rendered_scaled_object" "canonical Prometheus trigger types"
+require_line_count 2 '^    metricType: AverageValue$' \
+    "$rendered_scaled_object" "canonical Prometheus trigger metric types"
+require_line_count 2 '^      name: keda-prometheus-auth$' \
+    "$rendered_scaled_object" "canonical trigger authentication references"
+require_line_count 1 '^        scaleUp:$' \
+    "$rendered_scaled_object" "canonical HPA scale-up rules"
+require_line_count 1 '^          stabilizationWindowSeconds: 0$' \
+    "$rendered_scaled_object" "canonical HPA scale-up stabilization"
+require_line_count 1 '^        scaleDown:$' \
+    "$rendered_scaled_object" "canonical HPA scale-down rules"
+require_line_count 1 '^          stabilizationWindowSeconds: 300$' \
+    "$rendered_scaled_object" "canonical HPA scale-down stabilization"
+require_line_count 2 '^          - periodSeconds: 15$' \
+    "$rendered_scaled_object" "canonical HPA policy periods"
+require_line_count 2 '^            type: Percent$' \
+    "$rendered_scaled_object" "canonical HPA policy types"
+require_line_count 2 '^            value: 100$' \
+    "$rendered_scaled_object" "canonical HPA policy values"
+
+require_line_count 1 '^kind: TriggerAuthentication$' \
+    "$rendered_authentication" "canonical TriggerAuthentication kind"
+require_line_count 1 '^  name: keda-prometheus-auth$' \
+    "$rendered_authentication" "canonical TriggerAuthentication name"
+require_line_count 1 '^  secretTargetRef:$' \
+    "$rendered_authentication" "canonical TriggerAuthentication Secret references"
+require_line_count 1 '^  - key: ca\.crt$' \
+    "$rendered_authentication" "canonical TriggerAuthentication CA key"
+require_line_count 1 '^    name: keda-prometheus-auth$' \
+    "$rendered_authentication" "canonical TriggerAuthentication Secret name"
+require_line_count 1 '^    parameter: ca$' \
+    "$rendered_authentication" "canonical TriggerAuthentication CA parameter"
+
+require_line_count 1 '^    caDirs:$' \
+    "$kind_keda_values" "Kind KEDA operator CA directories"
+require_line_count 2 '^[[:space:]]*- /custom/ca$|^[[:space:]]*mountPath: /custom/ca$' \
+    "$kind_keda_values" "Kind KEDA public-CA trust path"
+require_line_count 1 '^[[:space:]]*secretName: llmd-prometheus-ca$' \
+    "$kind_keda_values" "Kind KEDA public-CA Secret mount"
+if grep -Eiq 'unsafeSsl|insecureSkipVerify|tlsSkipVerify' \
+    "$kind_keda_values" "$rendered_contract"; then
+    fail "Kind KEDA trust must not disable TLS verification"
+fi
+
+for command_name in kind openssl; do
+    require_command "$command_name"
+done
+
+# Freshness is established by the exact current context and absence of guide
+# namespaces and KEDA.
+kind get clusters 2>/dev/null | grep -Fxq "$CLUSTER_NAME" ||
+    fail "Kind cluster '$CLUSTER_NAME' does not exist; create it first"
+[ "$(kubectl config current-context)" = "kind-${CLUSTER_NAME}" ] ||
+    fail "current kubectl context must be kind-${CLUSTER_NAME}"
+for namespace in "$LLMD_NS" "$MONITORING_NAMESPACE" "$KEDA_NAMESPACE"; do
+    if kubectl get namespace "$namespace" >/dev/null 2>&1; then
+        fail "namespace '$namespace' already exists; use a fresh disposable Kind cluster"
+    fi
+done
+if kubectl get crd scaledobjects.keda.sh >/dev/null 2>&1; then
+    fail "KEDA is already present; use a fresh disposable Kind cluster"
+fi
+runtime_started=true
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+    -keyout "$work_dir/ca.key" -out "$work_dir/ca.crt" \
+    -subj "/CN=wva-keda-epp-guide-ca" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes \
+    -keyout "$work_dir/prometheus.key" -out "$work_dir/prometheus.csr" \
+    -subj "/CN=${PROMETHEUS_SVC_NAME}" >/dev/null 2>&1
+printf 'subjectAltName=DNS:%s,DNS:%s.%s.svc\n' \
+    "$prometheus_fqdn" "$PROMETHEUS_SVC_NAME" "$MONITORING_NAMESPACE" \
+    >"$work_dir/prometheus.ext"
+openssl x509 -req -days 365 \
+    -in "$work_dir/prometheus.csr" \
+    -CA "$work_dir/ca.crt" -CAkey "$work_dir/ca.key" -CAcreateserial \
+    -out "$work_dir/prometheus.crt" \
+    -extfile "$work_dir/prometheus.ext" >/dev/null 2>&1
+
+for namespace in "$LLMD_NS" "$MONITORING_NAMESPACE" "$KEDA_NAMESPACE"; do
+    kubectl create namespace "$namespace"
+done
+
+kubectl create secret generic "$PROMETHEUS_SECRET_NAME" \
+    -n "$MONITORING_NAMESPACE" \
+    --from-file=tls.crt="$work_dir/prometheus.crt" \
+    --from-file=tls.key="$work_dir/prometheus.key" \
+    --from-file=ca.crt="$work_dir/ca.crt" \
+    --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic llmd-prometheus-ca \
+    -n "$KEDA_NAMESPACE" \
+    --from-file=ca.crt="$work_dir/ca.crt" \
+    --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic keda-prometheus-auth \
+    -n "$LLMD_NS" \
+    --from-file=ca.crt="$work_dir/ca.crt" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+env \
+    IMG="" \
+    KUBECONFIG="${KUBECONFIG:-}" \
+    ENVIRONMENT=kind-emulator \
+    CLUSTER_NAME="$CLUSTER_NAME" \
+    LLMD_NS="$LLMD_NS" \
+    MONITORING_NAMESPACE="$MONITORING_NAMESPACE" \
+    KEDA_NAMESPACE="$KEDA_NAMESPACE" \
+    DEPLOY_WVA=false \
+    SCALER_BACKEND=keda \
+    SCALE_TO_ZERO_ENABLED=false \
+    DEPLOY_OPERATIONAL_DASHBOARD=false \
+    PROMETHEUS_RELEASE_NAME="$PROMETHEUS_RELEASE_NAME" \
+    PROMETHEUS_SVC_NAME="$PROMETHEUS_SVC_NAME" \
+    PROMETHEUS_CHART_VERSION=62.7.0 \
+    PROMETHEUS_HELM_VALUES="$kind_monitoring_values" \
+    PROMETHEUS_TLS_SECRET_PRECREATED=true \
+    KEDA_CHART_VERSION=2.20.0 \
+    KEDA_HELM_VALUES="$kind_keda_values" \
+    KEDA_HELM_TIMEOUT=10m \
+    LLM_D_ROUTER_VERSION=v0.9.0 \
+    GAIE_VERSION=v1.5.0 \
+    EPP_HELM_VALUES_LIST="$epp_helm_values_list" \
+    SIM_IMAGE="$guide_simulator_image" \
+    WVA_PROJECT="$WVA_PROJECT" \
+    "${MAKE:-make}" -C "$WVA_PROJECT" deploy-e2e-infra
+
+echo "Installing the guide-owned deterministic simulator..."
+kubectl apply -f "$GUIDE_SIMULATOR_MANIFEST"
+kubectl wait \
+    --for=jsonpath='{.status.readyReplicas}'=1 \
+    deployment/"$GUIDE_SIMULATOR_DEPLOYMENT" \
+    -n "$LLMD_NS" --timeout=10m
+
+simulator_spec_replicas="$(kubectl get deployment "$GUIDE_SIMULATOR_DEPLOYMENT" \
+    -n "$LLMD_NS" -o jsonpath='{.spec.replicas}')"
+simulator_ready_replicas="$(kubectl get deployment "$GUIDE_SIMULATOR_DEPLOYMENT" \
+    -n "$LLMD_NS" -o jsonpath='{.status.readyReplicas}')"
+[ "$simulator_spec_replicas" = "1" ] && [ "$simulator_ready_replicas" = "1" ] ||
+    fail "guide simulator must have exactly one desired and Ready replica"
+
+echo "Applying the canonical TriggerAuthentication and ScaledObject..."
+kubectl apply -f "$rendered_contract"
+
+echo "Canonical KEDA+EPP guide contract deployed."
+echo "Final cleanup boundary: make destroy-kind-cluster CLUSTER_NAME=${CLUSTER_NAME}"

--- a/deploy/lib/deploy_keda_epp_guide.sh
+++ b/deploy/lib/deploy_keda_epp_guide.sh
@@ -65,40 +65,6 @@ require_command() {
     command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
 }
 
-extract_rendered_document() {
-    local wanted_kind="$1"
-    local wanted_name="$2"
-    local source_file="$3"
-
-    awk -v wanted_kind="$wanted_kind" -v wanted_name="$wanted_name" '
-        function emit() {
-            if (document ~ ("(^|\\n)kind: " wanted_kind "(\\n|$)") &&
-                document ~ ("\\n  name: " wanted_name "(\\n|$)")) {
-                printf "%s", document
-            }
-        }
-        /^---[[:space:]]*$/ {
-            emit()
-            document = ""
-            next
-        }
-        { document = document $0 ORS }
-        END { emit() }
-    ' "$source_file"
-}
-
-require_line_count() {
-    local expected_count="$1"
-    local pattern="$2"
-    local source_file="$3"
-    local description="$4"
-    local actual_count
-
-    actual_count="$(grep -Ec "$pattern" "$source_file" || true)"
-    [ "$actual_count" -eq "$expected_count" ] ||
-        fail "$description: expected $expected_count matching line(s), found $actual_count"
-}
-
 require_files_equal() {
     local expected_file="$1"
     local actual_file="$2"
@@ -173,7 +139,7 @@ else
     llmd_root="$work_dir/llm-d-${selected_llmd_source_sha}"
 fi
 
-readonly guide_root="$llmd_root/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-queue"
+readonly guide_root="$llmd_root/guides/workload-autoscaling/keda-epp-queue/optimized-baseline"
 readonly canonical_kustomization="$guide_root/k8s/kustomization.yaml"
 readonly canonical_router_base_values="$llmd_root/guides/recipes/router/base.values.yaml"
 readonly canonical_optimized_baseline_values="$llmd_root/guides/optimized-baseline/router/optimized-baseline.values.yaml"
@@ -208,11 +174,22 @@ epp_helm_values=(
 )
 printf -v epp_helm_values_list '%s\n' "${epp_helm_values[@]}"
 
-guide_simulator_image="$(awk '$1 == "image:" { print $2 }' "$GUIDE_SIMULATOR_MANIFEST")"
-[ -n "$guide_simulator_image" ] ||
-    fail "guide simulator manifest must contain one image"
-require_line_count 1 '^[[:space:]]*image:[[:space:]]+[^[:space:]]+$' \
-    "$GUIDE_SIMULATOR_MANIFEST" "guide simulator image contract"
+guide_simulator_image="$(awk '
+        $1 == "image:" {
+            if (NF != 2) {
+                exit 1
+            }
+            image = $2
+            count++
+        }
+        END {
+            if (count != 1 || image == "") {
+                exit 1
+            }
+            print image
+        }
+    ' "$GUIDE_SIMULATOR_MANIFEST")" ||
+    fail "guide simulator manifest must contain exactly one container image"
 
 prometheus_fqdn="${PROMETHEUS_SVC_NAME}.${MONITORING_NAMESPACE}.svc.cluster.local"
 prometheus_url="https://${prometheus_fqdn}:${PROMETHEUS_PORT}"
@@ -254,91 +231,6 @@ require_files_equal \
     "$canonical_normalized" \
     "$rendered_normalized" \
     "temporary overlay may change only resource namespace and Prometheus serverAddress"
-
-[ "$(grep -c '^kind: TriggerAuthentication$' "$rendered_contract")" -eq 1 ] ||
-    fail "rendered contract must contain exactly one TriggerAuthentication"
-[ "$(grep -c '^kind: ScaledObject$' "$rendered_contract")" -eq 1 ] ||
-    fail "rendered contract must contain exactly one ScaledObject"
-[ "$(grep -c '^  namespace: llm-d-optimized-baseline$' "$rendered_contract")" -eq 2 ] ||
-    fail "both rendered resources must use namespace llm-d-optimized-baseline"
-[ "$(grep -Fc "serverAddress: ${prometheus_url}" "$rendered_contract")" -eq 2 ] ||
-    fail "both Prometheus triggers must use ${prometheus_url}"
-[ "$(grep -Fc 'name: keda-prometheus-auth' "$rendered_contract")" -eq 4 ] ||
-    fail "TriggerAuthentication, its Secret ref, and both triggers must use keda-prometheus-auth"
-
-rendered_scaled_object="$work_dir/scaledobject.yaml"
-rendered_authentication="$work_dir/triggerauthentication.yaml"
-extract_rendered_document ScaledObject optimized-baseline-keda-epp \
-    "$rendered_contract" >"$rendered_scaled_object"
-extract_rendered_document TriggerAuthentication keda-prometheus-auth \
-    "$rendered_contract" >"$rendered_authentication"
-[ -s "$rendered_scaled_object" ] || fail "canonical ScaledObject document is missing"
-[ -s "$rendered_authentication" ] || fail "canonical TriggerAuthentication document is missing"
-
-require_line_count 1 '^    name: optimized-baseline-nvidia-gpu-vllm-decode$' \
-    "$rendered_scaled_object" "canonical ScaledObject scaleTargetRef target"
-require_line_count 1 '^  minReplicaCount: 1$' \
-    "$rendered_scaled_object" "canonical ScaledObject minimum replica bound"
-require_line_count 1 '^  maxReplicaCount: 8$' \
-    "$rendered_scaled_object" "canonical ScaledObject maximum replica bound"
-require_line_count 1 '^      name: keda-hpa-optimized-baseline$' \
-    "$rendered_scaled_object" "canonical generated HPA name"
-require_line_count 1 '^      query: sum\(llm_d_epp_flow_control_queue_size\{namespace="llm-d-optimized-baseline",service="optimized-baseline-epp",model_name="Qwen/Qwen3-32B"\}\)$' \
-    "$rendered_scaled_object" "canonical queue trigger query"
-require_line_count 1 '^      query: sum\(llm_d_epp_request_running\{namespace="llm-d-optimized-baseline",service="optimized-baseline-epp",model_name="Qwen/Qwen3-32B"\}\)$' \
-    "$rendered_scaled_object" "canonical running trigger query"
-require_line_count 1 '^      threshold: "1"$' \
-    "$rendered_scaled_object" "canonical queue trigger threshold"
-require_line_count 1 '^      threshold: "16"$' \
-    "$rendered_scaled_object" "canonical running trigger threshold"
-require_line_count 1 '^    name: epp-queue-size$' \
-    "$rendered_scaled_object" "canonical queue trigger name"
-require_line_count 1 '^    name: epp-running-requests$' \
-    "$rendered_scaled_object" "canonical running trigger name"
-require_line_count 2 '^    type: prometheus$' \
-    "$rendered_scaled_object" "canonical Prometheus trigger types"
-require_line_count 2 '^    metricType: AverageValue$' \
-    "$rendered_scaled_object" "canonical Prometheus trigger metric types"
-require_line_count 2 '^      name: keda-prometheus-auth$' \
-    "$rendered_scaled_object" "canonical trigger authentication references"
-require_line_count 1 '^        scaleUp:$' \
-    "$rendered_scaled_object" "canonical HPA scale-up rules"
-require_line_count 1 '^          stabilizationWindowSeconds: 0$' \
-    "$rendered_scaled_object" "canonical HPA scale-up stabilization"
-require_line_count 1 '^        scaleDown:$' \
-    "$rendered_scaled_object" "canonical HPA scale-down rules"
-require_line_count 1 '^          stabilizationWindowSeconds: 300$' \
-    "$rendered_scaled_object" "canonical HPA scale-down stabilization"
-require_line_count 2 '^          - periodSeconds: 15$' \
-    "$rendered_scaled_object" "canonical HPA policy periods"
-require_line_count 2 '^            type: Percent$' \
-    "$rendered_scaled_object" "canonical HPA policy types"
-require_line_count 2 '^            value: 100$' \
-    "$rendered_scaled_object" "canonical HPA policy values"
-
-require_line_count 1 '^kind: TriggerAuthentication$' \
-    "$rendered_authentication" "canonical TriggerAuthentication kind"
-require_line_count 1 '^  name: keda-prometheus-auth$' \
-    "$rendered_authentication" "canonical TriggerAuthentication name"
-require_line_count 1 '^  secretTargetRef:$' \
-    "$rendered_authentication" "canonical TriggerAuthentication Secret references"
-require_line_count 1 '^  - key: ca\.crt$' \
-    "$rendered_authentication" "canonical TriggerAuthentication CA key"
-require_line_count 1 '^    name: keda-prometheus-auth$' \
-    "$rendered_authentication" "canonical TriggerAuthentication Secret name"
-require_line_count 1 '^    parameter: ca$' \
-    "$rendered_authentication" "canonical TriggerAuthentication CA parameter"
-
-require_line_count 1 '^    caDirs:$' \
-    "$kind_keda_values" "Kind KEDA operator CA directories"
-require_line_count 2 '^[[:space:]]*- /custom/ca$|^[[:space:]]*mountPath: /custom/ca$' \
-    "$kind_keda_values" "Kind KEDA public-CA trust path"
-require_line_count 1 '^[[:space:]]*secretName: llmd-prometheus-ca$' \
-    "$kind_keda_values" "Kind KEDA public-CA Secret mount"
-if grep -Eiq 'unsafeSsl|insecureSkipVerify|tlsSkipVerify' \
-    "$kind_keda_values" "$rendered_contract"; then
-    fail "Kind KEDA trust must not disable TLS verification"
-fi
 
 for command_name in kind openssl; do
     require_command "$command_name"

--- a/deploy/lib/deploy_prometheus_kube_stack.sh
+++ b/deploy/lib/deploy_prometheus_kube_stack.sh
@@ -3,12 +3,19 @@
 # Shared kube-prometheus-stack install for Kubernetes-like environments
 # (vanilla Kubernetes, Kind emulator, etc.). Sourced by deploy/*/install.sh.
 # Requires vars: MONITORING_NAMESPACE, PROMETHEUS_SECRET_NAME,
-# PROMETHEUS_PORT, PROMETHEUS_URL.
+# PROMETHEUS_SVC_NAME, PROMETHEUS_PORT, PROMETHEUS_URL.
+# Optional vars: PROMETHEUS_RELEASE_NAME, PROMETHEUS_CHART_VERSION,
+# PROMETHEUS_HELM_VALUES, PROMETHEUS_TLS_SECRET_PRECREATED.
 # Requires funcs: log_info/log_warning/log_success.
 #
 
 deploy_prometheus_kube_stack() {
     log_info "Deploying kube-prometheus-stack with TLS..."
+
+    local release_name="${PROMETHEUS_RELEASE_NAME:-kube-prometheus-stack}"
+    local chart_version="${PROMETHEUS_CHART_VERSION:-}"
+    local helm_values="${PROMETHEUS_HELM_VALUES:-}"
+    local tls_secret_precreated="${PROMETHEUS_TLS_SECRET_PRECREATED:-false}"
 
     helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
     if [ "${SKIP_HELM_REPO_UPDATE:-}" = "true" ]; then
@@ -17,23 +24,28 @@ deploy_prometheus_kube_stack() {
         helm repo update
     fi
 
-    log_info "Creating self-signed TLS certificate for Prometheus"
-    openssl req -x509 -newkey rsa:2048 -nodes \
-        -keyout /tmp/prometheus-tls.key \
-        -out /tmp/prometheus-tls.crt \
-        -days 365 \
-        -subj "/CN=prometheus" \
-        -addext "subjectAltName=DNS:kube-prometheus-stack-prometheus.${MONITORING_NAMESPACE}.svc.cluster.local,DNS:kube-prometheus-stack-prometheus.${MONITORING_NAMESPACE}.svc,DNS:prometheus,DNS:localhost" \
-        &> /dev/null
+    if [ "$tls_secret_precreated" = "true" ]; then
+        log_info "Using caller-provided Prometheus TLS Secret '$PROMETHEUS_SECRET_NAME'"
+        kubectl get secret "$PROMETHEUS_SECRET_NAME" -n "$MONITORING_NAMESPACE" >/dev/null
+    else
+        log_info "Creating self-signed TLS certificate for Prometheus"
+        openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout /tmp/prometheus-tls.key \
+            -out /tmp/prometheus-tls.crt \
+            -days 365 \
+            -subj "/CN=prometheus" \
+            -addext "subjectAltName=DNS:${PROMETHEUS_SVC_NAME}.${MONITORING_NAMESPACE}.svc.cluster.local,DNS:${PROMETHEUS_SVC_NAME}.${MONITORING_NAMESPACE}.svc,DNS:prometheus,DNS:localhost" \
+            &> /dev/null
 
-    log_info "Creating Kubernetes secret for Prometheus TLS"
-    kubectl create secret tls "$PROMETHEUS_SECRET_NAME" \
-        --cert=/tmp/prometheus-tls.crt \
-        --key=/tmp/prometheus-tls.key \
-        -n "$MONITORING_NAMESPACE" \
-        --dry-run=client -o yaml | kubectl apply -f - &> /dev/null
+        log_info "Creating Kubernetes secret for Prometheus TLS"
+        kubectl create secret tls "$PROMETHEUS_SECRET_NAME" \
+            --cert=/tmp/prometheus-tls.crt \
+            --key=/tmp/prometheus-tls.key \
+            -n "$MONITORING_NAMESPACE" \
+            --dry-run=client -o yaml | kubectl apply -f - &> /dev/null
 
-    rm -f /tmp/prometheus-tls.key /tmp/prometheus-tls.crt
+        rm -f /tmp/prometheus-tls.key /tmp/prometheus-tls.crt
+    fi
 
     log_info "Installing kube-prometheus-stack with TLS configuration"
     # Create the wva-operation-dashboard ConfigMap from the JSON file with Grafana sidecar label
@@ -47,30 +59,42 @@ deploy_prometheus_kube_stack() {
         kubectl apply -f -
     fi
 
-    helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
-        -n "$MONITORING_NAMESPACE" \
-        --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
-        --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
-        --set prometheus.service.type=ClusterIP \
-        --set prometheus.service.port="$PROMETHEUS_PORT" \
-        --set prometheus.prometheusSpec.web.tlsConfig.cert.secret.name="$PROMETHEUS_SECRET_NAME" \
-        --set prometheus.prometheusSpec.web.tlsConfig.cert.secret.key=tls.crt \
-        --set prometheus.prometheusSpec.web.tlsConfig.keySecret.name="$PROMETHEUS_SECRET_NAME" \
-        --set prometheus.prometheusSpec.web.tlsConfig.keySecret.key=tls.key \
-        --set grafana.enabled="$DEPLOY_OPERATIONAL_DASHBOARD" \
-        --set grafana.sidecar.dashboards.enabled=true \
-        --set grafana.sidecar.dashboards.label=grafana_dashboard \
-        --set 'grafana.datasources.datasources\.yaml.apiVersion=1' \
-        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].name=Prometheus' \
-        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].type=prometheus' \
-        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].url=https://kube-prometheus-stack-prometheus.'"$MONITORING_NAMESPACE"'.svc.cluster.local:9090' \
-        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].access=proxy' \
-        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].jsonData.httpMethod=POST' \
-        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].jsonData.timeInterval=30s' \
-        --set 'grafana.datasources.datasources\.yaml.datasources[0].jsonData.tlsSkipVerify=true' \
-        --set alertmanager.enabled=false \
-        --timeout=10m \
+    local helm_args=(
+        upgrade --install "$release_name" prometheus-community/kube-prometheus-stack
+    )
+    if [ -n "$chart_version" ]; then
+        helm_args+=(--version "$chart_version")
+    fi
+    if [ -n "$helm_values" ]; then
+        helm_args+=(--values "$helm_values")
+    fi
+    helm_args+=(
+        -n "$MONITORING_NAMESPACE"
+        --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false
+        --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false
+        --set prometheus.service.type=ClusterIP
+        --set prometheus.service.port="$PROMETHEUS_PORT"
+        --set prometheus.prometheusSpec.web.tlsConfig.cert.secret.name="$PROMETHEUS_SECRET_NAME"
+        --set prometheus.prometheusSpec.web.tlsConfig.cert.secret.key=tls.crt
+        --set prometheus.prometheusSpec.web.tlsConfig.keySecret.name="$PROMETHEUS_SECRET_NAME"
+        --set prometheus.prometheusSpec.web.tlsConfig.keySecret.key=tls.key
+        --set grafana.enabled="$DEPLOY_OPERATIONAL_DASHBOARD"
+        --set grafana.sidecar.dashboards.enabled=true
+        --set grafana.sidecar.dashboards.label=grafana_dashboard
+        --set 'grafana.datasources.datasources\.yaml.apiVersion=1'
+        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].name=Prometheus'
+        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].type=prometheus'
+        --set-string "grafana.datasources.datasources\\.yaml.datasources[0].url=https://${PROMETHEUS_SVC_NAME}.${MONITORING_NAMESPACE}.svc.cluster.local:${PROMETHEUS_PORT}"
+        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].access=proxy'
+        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].jsonData.httpMethod=POST'
+        --set-string 'grafana.datasources.datasources\.yaml.datasources[0].jsonData.timeInterval=30s'
+        --set 'grafana.datasources.datasources\.yaml.datasources[0].jsonData.tlsSkipVerify=true'
+        --set alertmanager.enabled=false
+        --timeout=10m
         --wait
+    )
+
+    helm "${helm_args[@]}"
 
     log_success "kube-prometheus-stack deployed with TLS"
     log_info "Prometheus URL: $PROMETHEUS_URL"
@@ -79,10 +103,13 @@ deploy_prometheus_kube_stack() {
 undeploy_prometheus_kube_stack() {
     log_info "Uninstalling kube-prometheus-stack..."
 
-    helm uninstall kube-prometheus-stack -n "$MONITORING_NAMESPACE" 2>/dev/null || \
+    local release_name="${PROMETHEUS_RELEASE_NAME:-kube-prometheus-stack}"
+    helm uninstall "$release_name" -n "$MONITORING_NAMESPACE" 2>/dev/null || \
         log_warning "Prometheus stack not found or already uninstalled"
 
-    kubectl delete secret "$PROMETHEUS_SECRET_NAME" -n "$MONITORING_NAMESPACE" --ignore-not-found
+    if [ "${PROMETHEUS_TLS_SECRET_PRECREATED:-false}" != "true" ]; then
+        kubectl delete secret "$PROMETHEUS_SECRET_NAME" -n "$MONITORING_NAMESPACE" --ignore-not-found
+    fi
 
     log_success "Prometheus stack uninstalled"
 }

--- a/deploy/lib/infra_epp.sh
+++ b/deploy/lib/infra_epp.sh
@@ -6,7 +6,10 @@
 # Required vars: LLM_D_ROUTER_VERSION, GAIE_VERSION, LLMD_NS
 #   LLM_D_ROUTER_VERSION  — chart + EPP image tag from llm-d/llm-d-router (e.g. v0.9.0)
 #   GAIE_VERSION          — kubernetes-sigs GAIE CRDs ref (e.g. v1.5.0)
-# Required funcs: log_info, log_success, log_warning
+# Optional vars:
+#   EPP_HELM_VALUES_LIST  — newline-delimited complete ordered values chain.
+# When unset, the existing WVA base + optimized-baseline defaults are unchanged.
+# Required funcs: log_info, log_success, log_warning, log_error
 #
 
 GATEWAY_API_VERSION=${GATEWAY_API_VERSION:-"v1.2.0"}
@@ -65,27 +68,50 @@ deploy_epp() {
     # to fit a kind cluster.
     log_info "Installing llm-d-router-standalone chart (release=optimized-baseline, version=${LLM_D_ROUTER_VERSION})..."
 
+    # A caller-provided list is a complete chain. This lets the guide path use
+    # its immutable current llm-d inputs without prepending the repository's
+    # historical v0.8.1 defaults. Callers that do not provide the list retain
+    # the existing WVA behavior exactly.
+    local epp_helm_args=()
+    local epp_resource_args=()
+    if [ -n "${EPP_HELM_VALUES_LIST:-}" ]; then
+        local helm_values_file
+        while IFS= read -r helm_values_file; do
+            [ -n "$helm_values_file" ] || continue
+            if [ ! -r "$helm_values_file" ]; then
+                log_error "EPP_HELM_VALUES_LIST contains an unreadable file: $helm_values_file"
+            fi
+            log_info "Layering caller-provided EPP Helm values: $helm_values_file"
+            epp_helm_args+=(-f "$helm_values_file")
+        done <<< "$EPP_HELM_VALUES_LIST"
+    else
+        epp_helm_args=(
+            -f "$_lib_dir/epp-base.values.yaml"
+            -f "$_lib_dir/epp-optimized-baseline.values.yaml"
+        )
+        epp_resource_args=(
+            --set router.epp.resources.requests.cpu=100m
+            --set router.epp.resources.requests.memory=256Mi
+            --set router.epp.resources.limits.cpu=500m
+            --set router.epp.resources.limits.memory=512Mi
+            --set router.proxy.resources.requests.cpu=100m
+            --set router.proxy.resources.requests.memory=128Mi
+            --set router.proxy.resources.limits.cpu=500m
+            --set router.proxy.resources.limits.memory=256Mi
+        )
+    fi
+
     # When scale-to-zero is enabled, add flowControl feature gate to EPP config so the
     # scale-from-zero engine can read inference_extension_flow_control_queue_size metrics.
-    local extra_helm_args=()
     if [ "${ENABLE_SCALE_TO_ZERO:-false}" = "true" ]; then
         log_info "ENABLE_SCALE_TO_ZERO=true: enabling EPP flowControl feature gate..."
-        extra_helm_args=(-f "$_lib_dir/epp-flow-control.values.yaml")
+        epp_helm_args+=(-f "$_lib_dir/epp-flow-control.values.yaml")
     fi
 
     helm upgrade --install optimized-baseline \
         oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
-        -f "$_lib_dir/epp-base.values.yaml" \
-        -f "$_lib_dir/epp-optimized-baseline.values.yaml" \
-        "${extra_helm_args[@]}" \
-        --set router.epp.resources.requests.cpu=100m \
-        --set router.epp.resources.requests.memory=256Mi \
-        --set router.epp.resources.limits.cpu=500m \
-        --set router.epp.resources.limits.memory=512Mi \
-        --set router.proxy.resources.requests.cpu=100m \
-        --set router.proxy.resources.requests.memory=128Mi \
-        --set router.proxy.resources.limits.cpu=500m \
-        --set router.proxy.resources.limits.memory=256Mi \
+        "${epp_helm_args[@]}" \
+        "${epp_resource_args[@]}" \
         -n "$LLMD_NS" --version "$LLM_D_ROUTER_VERSION" --create-namespace
 
     # Grant EPP SA permission to create tokenreviews/subjectaccessreviews so its

--- a/deploy/lib/keda-epp-guide-keda.values.yaml
+++ b/deploy/lib/keda-epp-guide-keda.values.yaml
@@ -1,0 +1,38 @@
+# WVA-owned KEDA 2.20 Kind compatibility. The public Prometheus CA is mounted
+# into the operator's verified outbound trust store; TLS verification stays on.
+image:
+  pullPolicy: IfNotPresent
+webhooks:
+  enabled: false
+resources:
+  operator:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  metricServer:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+certificates:
+  operator:
+    caDirs:
+      - /custom/ca
+volumes:
+  keda:
+    extraVolumes:
+      - name: llmd-prometheus-ca
+        secret:
+          secretName: llmd-prometheus-ca
+          items:
+            - key: ca.crt
+              path: ca.crt
+    extraVolumeMounts:
+      - name: llmd-prometheus-ca
+        mountPath: /custom/ca
+        readOnly: true

--- a/deploy/lib/keda-epp-guide-kind.values.yaml
+++ b/deploy/lib/keda-epp-guide-kind.values.yaml
@@ -1,0 +1,73 @@
+# WVA-owned deterministic Kind override. Layer this only after the immutable
+# canonical router base, optimized-baseline, monitoring, and queue-guide values.
+router:
+  epp:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 384Mi
+    pluginsCustomConfig:
+      optimized-baseline-keda-epp-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        featureGates:
+        - flowControl
+        plugins:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        - type: round-robin-fairness-policy
+        - type: fcfs-ordering-policy
+        - type: concurrency-detector
+          parameters:
+            maxConcurrency: 1
+            concurrencyMode: requests
+            headroom: 0.0
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2
+        flowControl:
+          maxBytes: 1Mi
+          maxRequests: "10"
+          defaultRequestTTL: 1500s
+          saturationDetector:
+            pluginRef: concurrency-detector
+          priorityBands:
+          - priority: 0
+            maxRequests: "10"
+            fairnessPolicyRef: round-robin-fairness-policy
+            orderingPolicyRef: fcfs-ordering-policy
+  proxy:
+    args:
+      - --service-node
+      - envoy-sidecar
+      - --log-level
+      - warn
+      - --concurrency
+      - "1"
+      - --drain-strategy
+      - immediate
+      - --drain-time-s
+      - "10"
+      - -c
+      - /etc/envoy/envoy.yaml
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 192Mi

--- a/deploy/lib/keda-epp-guide-monitoring.values.yaml
+++ b/deploy/lib/keda-epp-guide-monitoring.values.yaml
@@ -1,0 +1,69 @@
+# WVA-owned low-resource monitoring profile for the disposable Kind contract.
+alertmanager:
+  enabled: false
+grafana:
+  enabled: false
+defaultRules:
+  create: false
+kubeStateMetrics:
+  enabled: false
+nodeExporter:
+  enabled: false
+kubeApiServer:
+  enabled: false
+kubelet:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+coreDns:
+  enabled: false
+kubeDns:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+prometheusOperator:
+  tls:
+    enabled: false
+  admissionWebhooks:
+    enabled: false
+  serviceMonitor:
+    selfMonitor: false
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+prometheus:
+  serviceMonitor:
+    selfMonitor: false
+  prometheusSpec:
+    replicas: 1
+    retention: 1h
+    retentionSize: 256MB
+    walCompression: false
+    scrapeInterval: 5s
+    scrapeTimeout: 4s
+    evaluationInterval: 5s
+    maximumStartupDurationSeconds: 180
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector: {}
+    serviceMonitorNamespaceSelector: {}
+    podMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelector: {}
+    podMonitorNamespaceSelector: {}
+    ruleSelectorNilUsesHelmValues: false
+    ruleSelector: {}
+    ruleNamespaceSelector: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 768Mi

--- a/deploy/lib/scaler_runtime.sh
+++ b/deploy/lib/scaler_runtime.sh
@@ -2,6 +2,7 @@
 #
 # Scaler backend deployment/runtime helpers for deploy/install.sh.
 # Requires vars: MONITORING_NAMESPACE, KEDA_NAMESPACE, KEDA_CHART_VERSION.
+# Optional vars: KEDA_HELM_VALUES, KEDA_HELM_TIMEOUT.
 # Requires funcs: log_info/log_warning/log_success/log_error,
 # should_skip_helm_repo_update().
 #
@@ -65,16 +66,24 @@ deploy_keda() {
         helm repo update
     fi
 
-    if ! helm upgrade -i "$KEDA_RELEASE_NAME" kedacore/keda \
-        --version "$KEDA_CHART_VERSION" \
-        -n "$KEDA_NAMESPACE" \
-        --set prometheus.metricServer.enabled=true \
-        --set prometheus.operator.enabled=true \
-        --wait \
-        --timeout=5m; then
+    local helm_args=(
+        upgrade -i "$KEDA_RELEASE_NAME" kedacore/keda
+        --version "$KEDA_CHART_VERSION"
+        -n "$KEDA_NAMESPACE"
+    )
+    if [ -n "${KEDA_HELM_VALUES:-}" ]; then
+        helm_args+=(--values "$KEDA_HELM_VALUES")
+    fi
+    helm_args+=(
+        --set prometheus.metricServer.enabled=true
+        --set prometheus.operator.enabled=true
+        --wait
+        --timeout="${KEDA_HELM_TIMEOUT:-5m}"
+    )
+
+    if ! helm "${helm_args[@]}"; then
         log_error "KEDA Helm installation failed (SCALER_BACKEND=keda)"
     else
         log_success "KEDA deployed in $KEDA_NAMESPACE"
     fi
 }
-

--- a/deploy/lib/verify.sh
+++ b/deploy/lib/verify.sh
@@ -11,14 +11,19 @@ verify_deployment() {
 
     local all_good=true
 
-    # --- WVA
-    log_info "Checking WVA controller pods..."
     sleep "$DEFAULT_VERIFY_STARTUP_SLEEP_SECONDS"
-    if kubectl get pods -n "$WVA_NS" -l "$WVA_CONTROLLER_LABEL_SELECTOR" 2>/dev/null | grep -q Running; then
-        log_success "WVA controller is running"
+
+    # --- WVA
+    if [ "${DEPLOY_WVA:-true}" = "true" ]; then
+        log_info "Checking WVA controller pods..."
+        if kubectl get pods -n "$WVA_NS" -l "$WVA_CONTROLLER_LABEL_SELECTOR" 2>/dev/null | grep -q Running; then
+            log_success "WVA controller is running"
+        else
+            log_warning "WVA controller may still be starting"
+            all_good=false
+        fi
     else
-        log_warning "WVA controller may still be starting"
-        all_good=false
+        log_info "Skipping WVA controller verification (DEPLOY_WVA=false)"
     fi
 
     # --- Monitoring

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -185,55 +185,121 @@ See the [E2E Test Suite README](../../test/e2e/README.md) for full configuration
 
 ### Direct KEDA+EPP guide contract
 
-`test-e2e-keda-epp-guide` is a narrow, controller-free contract for the
-canonical KEDA+EPP guide in the `llm-d/llm-d` repository. It observes resources
-that the caller already installed; it does not create a replacement
-`ScaledObject`, deploy the WVA controller, or provide a generic guide runner.
+`test-e2e-keda-epp-guide-with-setup` is a narrow, controller-free contract for
+the canonical KEDA+EPP guide in the `llm-d/llm-d` repository. It qualifies an
+optimized-baseline-compatible KEDA+EPP guide topology, not the full
+optimized-baseline behavior. The deploy target
+composes the existing `deploy-e2e-infra` lifecycle with `DEPLOY_WVA=false` and
+`SCALER_BACKEND=keda`; it does not deploy the WVA controller, copy the guide's
+autoscaling resources into this repository, or provide a generic guide runner.
 
-Before invoking the target, the caller must create a fresh disposable Kind
-cluster and install the following from the matching llm-d checkout:
+Run the complete fresh-cluster lifecycle with one command:
 
-- GAIE CRDs and the guide's CPU-only inference simulator overlay;
-- the low-resource kube-prometheus-stack values, HTTPS server certificate, and
-  `llm-d-monitoring/prometheus-web-tls` Secret;
-- stock KEDA and the guide's Kind-only operator-wide CA values;
-- the router chart with the canonical guide values layering;
-- the guide Kustomize output, including its own `TriggerAuthentication` and
-  `ScaledObject`.
+```bash
+# Optional: materialize the selected revision from a nearby read-only checkout.
+export LLMD_SOURCE=../llm-d
+make test-e2e-keda-epp-guide-with-setup LLMD_SOURCE="${LLMD_SOURCE:-}"
+```
 
-The target uses the canonical guide inputs directly:
+The simulator is CPU-only: its Deployment has no GPU resource request even
+though its canonical guide labels and name describe the NVIDIA GPU variant.
+`CLUSTER_GPUS=0` therefore exercises the contract without a GPU. Never point
+this flow at an existing or shared cluster. The exact current Kind context,
+absence of the guide namespaces, and absence of KEDA are checked before
+deployment; the whole fresh cluster remains the final cleanup guarantee.
+The deploy target installs this guide-owned simulator after the existing
+Prometheus, KEDA, and EPP infrastructure, waits for its single replica to be
+Ready, and only then applies the canonical `TriggerAuthentication` and
+`ScaledObject`. The test observes that pre-created Deployment and deletes it
+during its isolated cleanup.
+
+Current official llm-d `main` is the normal source. At the start of each guide
+setup, the deploy target resolves `main` from the official llm-d repository
+exactly once to a full immutable commit SHA, logs that SHA, and uses only that
+revision for canonical rendering, deployment, and the remainder of the run.
+This intentionally exposes llm-d/WVA drift when a later run selects a newer
+`main` revision.
+
+Set `LLMD_SOURCE_SHA=<full SHA>` only as an explicit pin for reproducibility,
+debugging, compatibility investigation, or temporary stabilization. The pin
+takes precedence over `main` resolution and is not the normal operating mode.
+`LLMD_SOURCE` is optional and never selects a revision: when set, it only
+materializes the already selected commit from that read-only checkout without
+reading or changing its checked-out branch, `HEAD`, local `main`, or tracking
+refs. If the selected object is absent, setup fails rather than falling back to
+another revision. When `LLMD_SOURCE` is empty, the selected immutable commit is
+downloaded into temporary storage.
+
+With either source location, the target layers exactly the current canonical
+router base, optimized-baseline topology, monitoring, and KEDA+EPP queue
+values, followed by one WVA-owned deterministic Kind override. The historical
+WVA v0.8.1 base and optimized-baseline values remain defaults for existing
+callers but do not participate in this guide path. It applies the canonical
+`TriggerAuthentication` and `ScaledObject` through a temporary Kustomize
+overlay. The temporary overlay changes the environment-specific namespace and
+Prometheus endpoint. The canonical trigger queries, thresholds, replica bounds,
+scale target, HPA behavior, and authentication wiring remain unchanged.
+
+The deployed and tested inputs are:
 
 | Input | Required value |
 |-------|----------------|
 | Environment | `kind-emulator` |
 | WVA controller | disabled with `DEPLOY_WVA=false` |
 | llm-d namespace | `llm-d-optimized-baseline` |
-| Prometheus namespace | `llm-d-monitoring` |
-| KEDA namespace | `keda` |
+| Prometheus namespace | `workload-variant-autoscaler-monitoring` |
+| KEDA namespace | `keda-system` |
 | EPP Service | `optimized-baseline-epp` |
 | Model | `Qwen/Qwen3-32B` |
 
-Run only the direct-KEDA spec with the kubeconfig for that disposable cluster:
+For this disposable Kind flow, KEDA `2.20.0` is installed with WVA-owned Kind
+values that mount the Prometheus public CA into the KEDA operator trust
+store. The Prometheus serving key remains only in the monitoring namespace;
+the KEDA operator namespace and `keda-prometheus-auth` Secret receive only the
+public CA. This is a Kind-only TLS compatibility boundary, not production
+authentication guidance and not an OpenShift configuration.
 
-```bash
-make test-e2e-keda-epp-guide KUBECONFIG=/path/to/disposable-kind.kubeconfig
-```
+The `keda-epp-guide` job in `.github/workflows/ci-pr-checks.yaml` runs this same
+fresh Kind lifecycle for WVA pull requests. The target selects only Ginkgo label
+`keda-epp-guide`; WVA smoke, scale-from-zero, and controller-dependent specs are
+excluded. This lane sets guide-specific bounds of 120 seconds for simulator
+readiness, 60 seconds for medium waits, 90 seconds for standard and metric
+waits, 180 seconds for extended waits, and 300 seconds for scale-up. Individual
+Kubernetes API calls are bounded at 10 seconds. A curl probe attempt is bounded
+at 100 seconds: 60 seconds for Pod completion plus four 10-second API/log/cleanup
+allowances.
 
-The target selects only Ginkgo label `keda-epp-guide`; WVA smoke,
-scale-from-zero, and controller-dependent specs are excluded. Its 40-minute Go
-test timeout covers the bounded guide assertions and reserves time for failure
-diagnostics and best-effort request-Pod cleanup. Infrastructure setup is
-outside that timeout and must be budgeted separately by the caller.
+Those actual waits produce two request-survival bounds. Warmup is at most 1130
+seconds (request creation and startup, ServiceMonitor/trust checks, and five
+metric probes); the deterministic one-to-two phase is at most 810 seconds
+(request startup, running-metric observation, Phase A, and scale-up, including
+the maximum API-call overrun per polling iteration). Flow Control
+`defaultRequestTTL`, the simulator response time, and curl `--max-time` are all
+1500 seconds, strictly above the larger 1130-second bound with a 370-second
+margin.
 
-Within the spec, individual Kubernetes API calls are bounded at 10 seconds and each request client is bounded at 900 seconds; the existing readiness and scale-up waits remain bounded by the shared e2e configuration.
+The complete successful-spec observation bound is 3330 seconds (55m30s),
+including reset, readiness, baseline, stage-boundary log checks, and explicit
+and deferred stimulus cleanup. Ginkgo is bounded at 65 minutes and Go at 70
+minutes, leaving room for suite preflight and diagnostics. The CI job is bounded
+at 120 minutes; this contains the setup's 34 minutes of declared Kind,
+Prometheus, KEDA, EPP, and simulator readiness waits, the 70-minute Go boundary,
+and a final diagnostics/cluster-cleanup reserve. Normal success is expected to
+finish far below these failure-path ceilings.
 
-The fresh uniquely named Kind cluster is the final cleanup boundary. The
-caller must always delete only that cluster on success, failure, or interruption
-and must never target a pre-existing cluster.
+The repository-default Kind image currently uses Kubernetes v1.32. KEDA 2.20 does
+not list Kubernetes v1.32 in its tested compatibility matrix,
+even though KEDA's deployment prerequisites allow Kubernetes 1.30 and newer.
+Treat that pairing as a CI compatibility risk, not as evidence
+of official KEDA support; this lane intentionally does not
+carry an unvalidated Kubernetes v1.33 override.
 
-This contract deliberately excludes nightly or stable-promotion qualification,
-sustained or performance load, scale-down, post-scale inference, real models,
-GPUs, and OpenShift behavior.
+This contract proves the request → EPP Flow Control → queue/running metrics →
+Prometheus → secure KEDA external metrics → KEDA-owned HPA → Deployment chain
+and one bounded `1 -> 2` transition. It deliberately excludes nightly or
+stable-promotion qualification, sustained or performance load, scale-down,
+post-scale inference, real models, GPUs, KV-event routing, and OpenShift/Thanos
+behavior.
 
 ### Quick Start
 

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -183,6 +183,58 @@ make test-e2e-full
 
 See the [E2E Test Suite README](../../test/e2e/README.md) for full configuration options and examples.
 
+### Direct KEDA+EPP guide contract
+
+`test-e2e-keda-epp-guide` is a narrow, controller-free contract for the
+canonical KEDA+EPP guide in the `llm-d/llm-d` repository. It observes resources
+that the caller already installed; it does not create a replacement
+`ScaledObject`, deploy the WVA controller, or provide a generic guide runner.
+
+Before invoking the target, the caller must create a fresh disposable Kind
+cluster and install the following from the matching llm-d checkout:
+
+- GAIE CRDs and the guide's CPU-only inference simulator overlay;
+- the low-resource kube-prometheus-stack values, HTTPS server certificate, and
+  `llm-d-monitoring/prometheus-web-tls` Secret;
+- stock KEDA and the guide's Kind-only operator-wide CA values;
+- the router chart with the canonical guide values layering;
+- the guide Kustomize output, including its own `TriggerAuthentication` and
+  `ScaledObject`.
+
+The target uses the canonical guide inputs directly:
+
+| Input | Required value |
+|-------|----------------|
+| Environment | `kind-emulator` |
+| WVA controller | disabled with `DEPLOY_WVA=false` |
+| llm-d namespace | `llm-d-optimized-baseline` |
+| Prometheus namespace | `llm-d-monitoring` |
+| KEDA namespace | `keda` |
+| EPP Service | `optimized-baseline-epp` |
+| Model | `Qwen/Qwen3-32B` |
+
+Run only the direct-KEDA spec with the kubeconfig for that disposable cluster:
+
+```bash
+make test-e2e-keda-epp-guide KUBECONFIG=/path/to/disposable-kind.kubeconfig
+```
+
+The target selects only Ginkgo label `keda-epp-guide`; WVA smoke,
+scale-from-zero, and controller-dependent specs are excluded. Its 40-minute Go
+test timeout covers the bounded guide assertions and reserves time for failure
+diagnostics and best-effort request-Pod cleanup. Infrastructure setup is
+outside that timeout and must be budgeted separately by the caller.
+
+Within the spec, individual Kubernetes API calls are bounded at 10 seconds and each request client is bounded at 900 seconds; the existing readiness and scale-up waits remain bounded by the shared e2e configuration.
+
+The fresh uniquely named Kind cluster is the final cleanup boundary. The
+caller must always delete only that cluster on success, failure, or interruption
+and must never target a pre-existing cluster.
+
+This contract deliberately excludes nightly or stable-promotion qualification,
+sustained or performance load, scale-down, post-scale inference, real models,
+GPUs, and OpenShift behavior.
+
 ### Quick Start
 
 ```bash

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -262,30 +262,19 @@ authentication guidance and not an OpenShift configuration.
 The `keda-epp-guide` job in `.github/workflows/ci-pr-checks.yaml` runs this same
 fresh Kind lifecycle for WVA pull requests. The target selects only Ginkgo label
 `keda-epp-guide`; WVA smoke, scale-from-zero, and controller-dependent specs are
-excluded. This lane sets guide-specific bounds of 120 seconds for simulator
-readiness, 60 seconds for medium waits, 90 seconds for standard and metric
-waits, 180 seconds for extended waits, and 300 seconds for scale-up. Individual
-Kubernetes API calls are bounded at 10 seconds. A curl probe attempt is bounded
-at 100 seconds: 60 seconds for Pod completion plus four 10-second API/log/cleanup
-allowances.
+excluded. The guide spec uses semantically named bounds: 120 seconds for
+simulator readiness, 60 seconds for request startup and probe completion, 90
+seconds for metric observation, 180 seconds for stabilization, and 300 seconds
+for the scale transition. Individual Kubernetes API and bounded log calls use a
+10-second timeout; normal and quick polling use five and two seconds.
 
-Those actual waits produce two request-survival bounds. Warmup is at most 1130
-seconds (request creation and startup, ServiceMonitor/trust checks, and five
-metric probes); the deterministic one-to-two phase is at most 810 seconds
-(request startup, running-metric observation, Phase A, and scale-up, including
-the maximum API-call overrun per polling iteration). Flow Control
-`defaultRequestTTL`, the simulator response time, and curl `--max-time` are all
-1500 seconds, strictly above the larger 1130-second bound with a 370-second
-margin.
-
-The complete successful-spec observation bound is 3330 seconds (55m30s),
-including reset, readiness, baseline, stage-boundary log checks, and explicit
-and deferred stimulus cleanup. Ginkgo is bounded at 65 minutes and Go at 70
-minutes, leaving room for suite preflight and diagnostics. The CI job is bounded
-at 120 minutes; this contains the setup's 34 minutes of declared Kind,
-Prometheus, KEDA, EPP, and simulator readiness waits, the 70-minute Go boundary,
-and a final diagnostics/cluster-cleanup reserve. Normal success is expected to
-finish far below these failure-path ceilings.
+The complete request-bearing observation budget has a conservative 20-minute
+cap. Flow Control `defaultRequestTTL`, the simulator response time, and curl
+`--max-time` remain aligned at 1500 seconds (25 minutes), so the stimulus lives
+strictly longer than that cap. Ginkgo is bounded at 65 minutes and Go at 70
+minutes, leaving room for suite preflight and diagnostics. The CI job remains
+bounded at 120 minutes, containing setup, the Go boundary, final diagnostics,
+and fresh-cluster cleanup.
 
 The repository-default Kind image currently uses Kubernetes v1.32. KEDA 2.20 does
 not list Kubernetes v1.32 in its tested compatibility matrix,

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -10,6 +10,8 @@ type E2EConfig struct {
 	testconfig.SharedConfig
 
 	// Feature gates
+	// DeployWVA: env DEPLOY_WVA — require the WVA controller for this suite run.
+	DeployWVA bool
 	// ScaleToZeroEnabled: env SCALE_TO_ZERO_ENABLED — assume native HPA may use minReplicas=0
 	// ("scale-to-zero" via HPAScaleToZero). Distinct from scale-from-zero (scale up from zero replicas).
 	ScaleToZeroEnabled bool
@@ -36,6 +38,7 @@ func LoadConfigFromEnv() E2EConfig {
 	cfg := E2EConfig{
 		SharedConfig: testconfig.LoadSharedConfig(),
 
+		DeployWVA:          testconfig.GetEnvBool("DEPLOY_WVA", true),
 		ScaleToZeroEnabled: testconfig.GetEnvBool("SCALE_TO_ZERO_ENABLED", false),
 
 		PodReadyTimeout: testconfig.GetEnvInt("POD_READY_TIMEOUT", 300), // 5 minutes

--- a/test/e2e/fixtures/keda_epp_guide_simulator.yaml
+++ b/test/e2e/fixtures/keda_epp_guide_simulator.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optimized-baseline-nvidia-gpu-vllm-decode
+  namespace: llm-d-optimized-baseline
+  labels:
+    llm-d.ai/accelerator-variant: gpu
+    llm-d.ai/accelerator-vendor: nvidia
+    llm-d.ai/guide: optimized-baseline
+    llm-d.ai/model: Qwen3-32B
+    llm-d.ai/role: decode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/guide: optimized-baseline
+      llm-d.ai/model: Qwen3-32B
+      llm-d.ai/role: decode
+  template:
+    metadata:
+      labels:
+        llm-d.ai/accelerator-variant: gpu
+        llm-d.ai/accelerator-vendor: nvidia
+        llm-d.ai/guide: optimized-baseline
+        llm-d.ai/model: Qwen3-32B
+        llm-d.ai/role: decode
+    spec:
+      containers:
+        - name: modelserver
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.9.0@sha256:be957b008416a645f206532aad408b5ff29dc81c628b8486479e79d0c2b3801b
+          imagePullPolicy: IfNotPresent
+          args:
+            - --model
+            - random/model
+            - --served-model-name
+            - Qwen/Qwen3-32B
+            - --port
+            - "8000"
+            - --latency-calculator
+            - constant
+            - --time-to-first-token
+            - 1500s
+            - --time-to-first-token-std-dev
+            - 0s
+            - --inter-token-latency
+            - 10ms
+            - --inter-token-latency-std-dev
+            - 0s
+            - --max-num-seqs
+            - "1"
+            - --seed
+            - "1"
+          ports:
+            - name: modelserver
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            timeoutSeconds: 2
+            periodSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            periodSeconds: 30
+            failureThreshold: 120
+      restartPolicy: Always

--- a/test/e2e/keda_epp_guide_test.go
+++ b/test/e2e/keda_epp_guide_test.go
@@ -2,13 +2,16 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,87 +23,198 @@ import (
 )
 
 const (
-	kedaEPPGuideScaledObject = "optimized-baseline-keda-epp"
-	kedaEPPGuideDeployment   = "optimized-baseline-nvidia-gpu-vllm-decode"
-	kedaEPPGuideQueueTrigger = "epp-queue-size"
-	kedaEPPGuideRunTrigger   = "epp-running-requests"
-	kedaEPPGuideStableCount  = 3
-	kedaEPPGuideRequestLimit = 900
-	kedaEPPGuideAPITimeout   = 10 * time.Second
-	kedaEPPGuideCurlImage    = "quay.io/curl/curl:8.11.1@sha256:2db4e6a8fd6a0e4d0db5828b2722cf6db15c3005178a4c65588b903e4784ba11"
+	kedaEPPGuideScaledObject   = "optimized-baseline-keda-epp"
+	kedaEPPGuideDeployment     = "optimized-baseline-nvidia-gpu-vllm-decode"
+	kedaEPPGuideAuthentication = "keda-prometheus-auth"
+	kedaEPPGuideQueueTrigger   = "epp-queue-size"
+	kedaEPPGuideRunTrigger     = "epp-running-requests"
+	kedaEPPGuideQueueQuery     = `sum(llm_d_epp_flow_control_queue_size{namespace="llm-d-optimized-baseline",service="optimized-baseline-epp",model_name="Qwen/Qwen3-32B"})`
+	kedaEPPGuideRunQuery       = `sum(llm_d_epp_request_running{namespace="llm-d-optimized-baseline",service="optimized-baseline-epp",model_name="Qwen/Qwen3-32B"})`
+	kedaEPPGuideQueueThreshold = "1"
+	kedaEPPGuideRunThreshold   = "16"
+	kedaEPPGuideHPAName        = "keda-hpa-optimized-baseline"
+	kedaEPPGuideServiceMonitor = "optimized-baseline-epp-monitor"
+	kedaEPPGuidePrometheusSvc  = "kube-prometheus-stack-prometheus"
+	kedaEPPGuideMinReplicas    = int32(1)
+	kedaEPPGuideMaxReplicas    = int32(8)
+	kedaEPPGuideStableCount    = 3
+	kedaEPPGuideRequestLimit   = 1500
+	kedaEPPGuideAPITimeout     = 10 * time.Second
+	kedaEPPGuideProbeTimeout   = 60 * time.Second
+	kedaEPPGuideLogTailLines   = int64(300)
+	kedaEPPGuideLogSinceSecs   = int64(1800)
+	kedaEPPGuideMaxLogStreams  = 2
+	kedaEPPGuideCurlImage      = "quay.io/curl/curl:8.11.1@sha256:2db4e6a8fd6a0e4d0db5828b2722cf6db15c3005178a4c65588b903e4784ba11"
 )
 
 var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, func() {
 	var requestPods []string
 
 	deleteRequests := func() {
-		grace := int64(0)
-		for _, name := range requestPods {
-			deleteContext, cancelDelete := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
-			err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Delete(deleteContext, name, metav1.DeleteOptions{
-				GracePeriodSeconds: &grace,
-			})
-			cancelDelete()
-			if err != nil && !apierrors.IsNotFound(err) {
-				GinkgoWriter.Printf("WARNING: failed to delete request pod %s: %v\n", name, err)
-			}
-		}
+		deleteKEDAEPPGuidePods(requestPods)
 	}
 
 	BeforeAll(func() {
 		Expect(cfg.DeployWVA).To(BeFalse(), "the direct-KEDA guide spec must run with DEPLOY_WVA=false")
+		Expect(cfg.UseSimulator).To(BeTrue(), "the direct-KEDA guide spec uses a deterministic simulator workload")
+		Expect(cfg.ModelID).To(Equal("Qwen/Qwen3-32B"), "the simulator and canonical EPP metrics must use the same model")
+		warmupBudget := kedaEPPGuideWarmupObservationBudget()
+		deterministicBudget := kedaEPPGuideDeterministicObservationBudget()
+		maxObservationBudget := max(warmupBudget, deterministicBudget)
+		requestLifetime := time.Duration(kedaEPPGuideRequestLimit) * time.Second
+		GinkgoWriter.Printf(
+			"KEDA+EPP timing hierarchy: warmup=%s deterministic=%s required=%s requestLifetime=%s completeSpec=%s\n",
+			warmupBudget,
+			deterministicBudget,
+			maxObservationBudget,
+			requestLifetime,
+			kedaEPPGuideCompleteSpecBudget(),
+		)
+		Expect(requestLifetime).To(
+			BeNumerically(">", maxObservationBudget),
+			"request lifetime must strictly exceed the complete warmup and deterministic observation bounds",
+		)
+
+		By("observing the pre-created guide-owned deterministic simulator")
+		DeferCleanup(func() {
+			deleteContext, cancelDelete := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+			defer cancelDelete()
+			err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(
+				deleteContext,
+				kedaEPPGuideDeployment,
+				metav1.DeleteOptions{},
+			)
+			Expect(err == nil || apierrors.IsNotFound(err)).To(
+				BeTrue(),
+				"failed to delete guide-owned simulator Deployment: %v",
+				err,
+			)
+		})
+
 		DeferCleanup(deleteRequests)
+
+		By("waiting for the guide-owned simulator to be available")
+		Eventually(func(g Gomega) {
+			callContext, cancelCall := kedaEPPGuideCallContext()
+			deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(
+				callContext,
+				kedaEPPGuideDeployment,
+				metav1.GetOptions{},
+			)
+			cancelCall()
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)))
+		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 	})
 
 	It("observes the canonical guide and performs one bounded 1-to-2 transition", func() {
-		scaledObject := waitForKEDAEPPGuideScaledObject()
+		scaledObject := waitForKEDAEPPGuideScaledObjectCreated()
+		Expect(scaledObject.Spec.ScaleTargetRef).NotTo(BeNil())
+		Expect(scaledObject.Spec.ScaleTargetRef.APIVersion).To(Equal("apps/v1"))
+		Expect(scaledObject.Spec.ScaleTargetRef.Kind).To(Equal("Deployment"))
 		Expect(scaledObject.Spec.ScaleTargetRef.Name).To(Equal(kedaEPPGuideDeployment))
+		Expect(scaledObject.Spec.MinReplicaCount).NotTo(BeNil())
+		Expect(*scaledObject.Spec.MinReplicaCount).To(Equal(kedaEPPGuideMinReplicas))
+		Expect(scaledObject.Spec.MaxReplicaCount).NotTo(BeNil())
+		Expect(*scaledObject.Spec.MaxReplicaCount).To(Equal(kedaEPPGuideMaxReplicas))
+		Expect(scaledObject.Spec.Advanced).NotTo(BeNil())
+		Expect(scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig).NotTo(BeNil())
+		Expect(scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig.Name).To(Equal(kedaEPPGuideHPAName))
+		assertKEDAEPPGuideHPABehavior(scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig.Behavior)
 		Expect(scaledObject.Spec.Triggers).To(HaveLen(2))
 
-		var queueThreshold, runningThreshold resource.Quantity
+		seenTriggers := map[string]bool{}
 		for _, trigger := range scaledObject.Spec.Triggers {
+			Expect(seenTriggers).NotTo(HaveKey(trigger.Name), "canonical trigger %s must be unique", trigger.Name)
+			seenTriggers[trigger.Name] = true
 			Expect(trigger.Type).To(Equal("prometheus"))
 			Expect(trigger.MetricType).To(Equal(autoscalingv2.AverageValueMetricType))
+			Expect(trigger.AuthenticationRef).NotTo(BeNil(), "trigger %s must retain its guide authenticationRef", trigger.Name)
+			Expect(trigger.AuthenticationRef.Name).To(Equal(kedaEPPGuideAuthentication), "trigger %s must retain its guide authenticationRef", trigger.Name)
 
-			threshold, err := resource.ParseQuantity(trigger.Metadata["threshold"])
-			Expect(err).NotTo(HaveOccurred(), "trigger %s should have a numeric threshold", trigger.Name)
+			var expectedQuery, expectedThreshold string
 			switch trigger.Name {
 			case kedaEPPGuideQueueTrigger:
-				queueThreshold = threshold
+				expectedQuery = kedaEPPGuideQueueQuery
+				expectedThreshold = kedaEPPGuideQueueThreshold
 			case kedaEPPGuideRunTrigger:
-				runningThreshold = threshold
+				expectedQuery = kedaEPPGuideRunQuery
+				expectedThreshold = kedaEPPGuideRunThreshold
 			default:
 				Fail(fmt.Sprintf("unexpected Prometheus trigger %q on the canonical ScaledObject", trigger.Name))
 			}
+			Expect(trigger.Metadata).To(HaveKeyWithValue("query", expectedQuery), "trigger %s must retain its exact canonical query", trigger.Name)
+			Expect(trigger.Metadata).To(HaveKeyWithValue("threshold", expectedThreshold), "trigger %s must retain its exact canonical threshold", trigger.Name)
+			_, err := resource.ParseQuantity(trigger.Metadata["threshold"])
+			Expect(err).NotTo(HaveOccurred(), "trigger %s should have a numeric threshold", trigger.Name)
 		}
-		Expect(queueThreshold.IsZero()).To(BeFalse(), "queue trigger threshold should be non-zero")
-		Expect(runningThreshold.IsZero()).To(BeFalse(), "running trigger threshold should be non-zero")
+		Expect(seenTriggers).To(HaveKey(kedaEPPGuideQueueTrigger))
+		Expect(seenTriggers).To(HaveKey(kedaEPPGuideRunTrigger))
 
+		By("sending a bounded warmup before requiring lazy EPP metric-series liveness")
+		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
+		waitForKEDAEPPGuideRequestPods(requestPods)
+		assertKEDAEPPGuideServiceMonitor()
+		assertKEDAEPPGuideSecureTrust()
+		waitForKEDAEPPGuideDirectMetric(kedaEPPGuideRunTrigger, 1)
+		waitForKEDAEPPGuideDirectMetric(kedaEPPGuideQueueTrigger, 0)
+		waitForKEDAEPPGuidePrometheusTarget()
+		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideRunQuery, 1)
+		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideQueueQuery, 0)
+
+		By("ending warmup and proving it cannot contaminate the deterministic phases")
+		deleteKEDAEPPGuidePods(requestPods)
+		waitForKEDAEPPGuidePodsDeleted(requestPods)
+		requestPods = nil
+		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideRunQuery, 0)
+		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideQueueQuery, 0)
+
+		By("requiring KEDA liveness only after both per-model series exist")
+		scaledObject = waitForKEDAEPPGuideScaledObjectReady()
+		Expect(scaledObject.Status.HpaName).To(Equal(kedaEPPGuideHPAName))
 		hpa := waitForKEDAEPPGuideHPA(scaledObject)
+		Expect(hpa.Spec.MinReplicas).NotTo(BeNil())
+		Expect(*hpa.Spec.MinReplicas).To(Equal(kedaEPPGuideMinReplicas))
+		Expect(hpa.Spec.MaxReplicas).To(Equal(kedaEPPGuideMaxReplicas))
 		Expect(hpa.Spec.ScaleTargetRef.APIVersion).To(Equal("apps/v1"))
 		Expect(hpa.Spec.ScaleTargetRef.Kind).To(Equal("Deployment"))
 		Expect(hpa.Spec.ScaleTargetRef.Name).To(Equal(kedaEPPGuideDeployment))
+		assertKEDAEPPGuideHPABehavior(hpa.Spec.Behavior)
 		Expect(hpa.Spec.Metrics).To(HaveLen(2))
 
+		queueTarget := resource.MustParse(kedaEPPGuideQueueThreshold)
+		runningTarget := resource.MustParse(kedaEPPGuideRunThreshold)
 		metricNames := map[string]string{}
 		for _, metric := range hpa.Spec.Metrics {
 			Expect(metric.Type).To(Equal(autoscalingv2.ExternalMetricSourceType))
 			Expect(metric.External).NotTo(BeNil())
+			Expect(metric.External.Metric.Selector).NotTo(BeNil())
+			Expect(metric.External.Metric.Selector.MatchLabels).To(Equal(map[string]string{
+				"scaledobject.keda.sh/name": kedaEPPGuideScaledObject,
+			}))
+			Expect(metric.External.Metric.Selector.MatchExpressions).To(BeEmpty())
 			Expect(metric.External.Target.Type).To(Equal(autoscalingv2.AverageValueMetricType))
 			Expect(metric.External.Target.AverageValue).NotTo(BeNil())
 
 			switch {
-			case metric.External.Target.AverageValue.Cmp(queueThreshold) == 0:
+			case metric.External.Target.AverageValue.Cmp(queueTarget) == 0:
 				metricNames[kedaEPPGuideQueueTrigger] = metric.External.Metric.Name
-			case metric.External.Target.AverageValue.Cmp(runningThreshold) == 0:
+			case metric.External.Target.AverageValue.Cmp(runningTarget) == 0:
 				metricNames[kedaEPPGuideRunTrigger] = metric.External.Metric.Name
 			default:
-				Fail(fmt.Sprintf("generated HPA metric %q does not match a live guide trigger target", metric.External.Metric.Name))
+				Fail(fmt.Sprintf("generated HPA metric %q does not match canonical target 1 or 16", metric.External.Metric.Name))
 			}
 		}
 		Expect(metricNames).To(HaveKey(kedaEPPGuideQueueTrigger))
 		Expect(metricNames).To(HaveKey(kedaEPPGuideRunTrigger))
 		Expect(metricNames[kedaEPPGuideQueueTrigger]).NotTo(Equal(metricNames[kedaEPPGuideRunTrigger]))
+		Eventually(func(g Gomega) {
+			for triggerName, metricName := range metricNames {
+				value, err := kedaEPPGuideExternalMetric(metricName)
+				g.Expect(err).NotTo(HaveOccurred(), "external metric for %s should be live", triggerName)
+				g.Expect(value).To(BeNumerically("==", 0), "external metric for %s should be reset after warmup", triggerName)
+			}
+		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
 		waitForKEDAEPPGuideBaseline(scaledObject.Status.HpaName)
 		assertKEDAOperatorLogsClean()
@@ -116,12 +230,21 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 			g.Expect(value).To(BeNumerically("==", 1))
 		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
 
-		By("starting exactly two additional requests that remain queued")
+		By("starting one additional request that remains queued")
 		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
+		waitForKEDAEPPGuidePhaseA(
+			scaledObject.Status.HpaName,
+			metricNames[kedaEPPGuideRunTrigger],
+			metricNames[kedaEPPGuideQueueTrigger],
+			requestPods,
+		)
+
+		By("starting exactly one additional request for the bounded scale transition")
 		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
 
 		waitForKEDAEPPGuideScaleUp(
 			scaledObject.Status.HpaName,
+			metricNames[kedaEPPGuideRunTrigger],
 			metricNames[kedaEPPGuideQueueTrigger],
 			requestPods,
 		)
@@ -132,13 +255,29 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 	})
 })
 
-func waitForKEDAEPPGuideScaledObject() *kedav1alpha1.ScaledObject {
+func waitForKEDAEPPGuideScaledObjectCreated() *kedav1alpha1.ScaledObject {
+	GinkgoHelper()
+
+	var scaledObject *kedav1alpha1.ScaledObject
+	Eventually(func(g Gomega) {
+		current := &kedav1alpha1.ScaledObject{}
+		callContext, cancelCall := kedaEPPGuideCallContext()
+		err := crClient.Get(callContext, client.ObjectKey{
+			Namespace: cfg.LLMDNamespace,
+			Name:      kedaEPPGuideScaledObject,
+		}, current)
+		cancelCall()
+		g.Expect(err).NotTo(HaveOccurred())
+		scaledObject = current
+	}, time.Duration(cfg.EventuallyMediumSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+	return scaledObject
+}
+
+func waitForKEDAEPPGuideScaledObjectReady() *kedav1alpha1.ScaledObject {
 	GinkgoHelper()
 
 	deadline := time.Now().Add(time.Duration(cfg.EventuallyExtendedSec) * time.Second)
 	for time.Now().Before(deadline) {
-		assertKEDAOperatorLogsClean()
-
 		scaledObject := &kedav1alpha1.ScaledObject{}
 		callContext, cancelCall := kedaEPPGuideCallContext()
 		err := crClient.Get(callContext, client.ObjectKey{
@@ -266,6 +405,315 @@ func createKEDAEPPGuideRequestPod() string {
 	return pod.Name
 }
 
+func deleteKEDAEPPGuidePods(names []string) {
+	GinkgoHelper()
+
+	grace := int64(0)
+	for _, name := range names {
+		deleteContext, cancelDelete := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+		err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Delete(deleteContext, name, metav1.DeleteOptions{
+			GracePeriodSeconds: &grace,
+		})
+		cancelDelete()
+		if err != nil && !apierrors.IsNotFound(err) {
+			GinkgoWriter.Printf("WARNING: failed to delete guide pod %s: %v\n", name, err)
+		}
+	}
+}
+
+func waitForKEDAEPPGuidePodsDeleted(names []string) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		for _, name := range names {
+			callContext, cancelCall := kedaEPPGuideCallContext()
+			_, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Get(callContext, name, metav1.GetOptions{})
+			cancelCall()
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "guide pod %s should be deleted, got %v", name, err)
+		}
+	}, time.Duration(cfg.EventuallyMediumSec)*time.Second, time.Duration(cfg.PollIntervalQuickSec)*time.Second).Should(Succeed())
+}
+
+func assertKEDAEPPGuideServiceMonitor() {
+	GinkgoHelper()
+
+	serviceMonitor := &promoperator.ServiceMonitor{}
+	Eventually(func(g Gomega) {
+		callContext, cancelCall := kedaEPPGuideCallContext()
+		err := crClient.Get(callContext, client.ObjectKey{
+			Namespace: cfg.LLMDNamespace,
+			Name:      kedaEPPGuideServiceMonitor,
+		}, serviceMonitor)
+		cancelCall()
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(serviceMonitor.Spec.Endpoints).To(HaveLen(1))
+		g.Expect(serviceMonitor.Spec.Endpoints[0].Port).To(Equal("http-metrics"))
+		g.Expect(serviceMonitor.Spec.Endpoints[0].Path).To(Equal("/metrics"))
+	}, time.Duration(cfg.EventuallyMediumSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+}
+
+func assertKEDAEPPGuideSecureTrust() {
+	GinkgoHelper()
+
+	for namespace, name := range map[string]string{
+		cfg.LLMDNamespace: "keda-prometheus-auth",
+		cfg.KEDANamespace: "llmd-prometheus-ca",
+	} {
+		callContext, cancelCall := kedaEPPGuideCallContext()
+		secret, err := k8sClient.CoreV1().Secrets(namespace).Get(callContext, name, metav1.GetOptions{})
+		cancelCall()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Data).To(HaveLen(1), "%s/%s must contain only the public CA", namespace, name)
+		Expect(secret.Data).To(HaveKey("ca.crt"), "%s/%s must contain the public CA", namespace, name)
+	}
+
+	callContext, cancelCall := kedaEPPGuideCallContext()
+	operator, err := k8sClient.AppsV1().Deployments(cfg.KEDANamespace).Get(callContext, "keda-operator", metav1.GetOptions{})
+	cancelCall()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(operator.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+	operatorContainer := operator.Spec.Template.Spec.Containers[0]
+	Expect(operatorContainer.Args).To(ContainElement("--ca-dir=/custom/ca"))
+
+	foundMount := false
+	for _, mount := range operatorContainer.VolumeMounts {
+		if mount.Name == "llmd-prometheus-ca" && mount.MountPath == "/custom/ca" && mount.ReadOnly {
+			foundMount = true
+		}
+	}
+	Expect(foundMount).To(BeTrue(), "KEDA operator must mount the public Prometheus CA read-only")
+}
+
+func waitForKEDAEPPGuideDirectMetric(triggerName string, expected float64) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		output, err := runKEDAEPPGuideCurlProbe(
+			"direct-metrics",
+			[]string{
+				"--fail", "--silent", "--show-error", "--connect-timeout", "10", "--max-time", "30",
+				fmt.Sprintf("http://%s.%s.svc.cluster.local:9090/metrics", cfg.EPPServiceName, cfg.LLMDNamespace),
+			},
+			false,
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		aggregate, matches, err := kedaEPPGuideDirectMetricValue(output, triggerName)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(matches).To(BeNumerically(">=", 1), "direct EPP metric %s must expose at least one matching per-model series", triggerName)
+		g.Expect(aggregate).To(BeNumerically("==", expected))
+	}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+}
+
+func kedaEPPGuideDirectMetricValue(output, triggerName string) (float64, int, error) {
+	metricName := map[string]string{
+		kedaEPPGuideQueueTrigger: "llm_d_epp_flow_control_queue_size",
+		kedaEPPGuideRunTrigger:   "llm_d_epp_request_running",
+	}[triggerName]
+	if metricName == "" {
+		return 0, 0, fmt.Errorf("unknown guide trigger %q", triggerName)
+	}
+
+	matches := 0
+	aggregate := float64(0)
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, metricName+"{") ||
+			!strings.Contains(line, `model_name="Qwen/Qwen3-32B"`) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return 0, matches, fmt.Errorf("unexpected direct metric line %q", line)
+		}
+		parsed, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil {
+			return 0, matches, fmt.Errorf("parse direct metric value %q: %w", fields[1], err)
+		}
+		matches++
+		aggregate += parsed
+	}
+	return aggregate, matches, nil
+}
+
+type kedaEPPGuidePrometheusQueryResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		Result []struct {
+			Value []json.RawMessage `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+func waitForKEDAEPPGuidePrometheusValue(query string, expected float64) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		value, cardinality, err := kedaEPPGuidePrometheusValue(query)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(cardinality).To(Equal(1), "PromQL must return exactly one result rather than treating absence as zero")
+		g.Expect(value).To(BeNumerically("==", expected))
+	}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+}
+
+func kedaEPPGuidePrometheusValue(query string) (float64, int, error) {
+	prometheusURL := fmt.Sprintf(
+		"https://%s.%s.svc.cluster.local:9090/api/v1/query",
+		kedaEPPGuidePrometheusSvc,
+		cfg.MonitoringNS,
+	)
+	output, err := runKEDAEPPGuideCurlProbe(
+		"prom-query",
+		[]string{
+			"--fail", "--silent", "--show-error", "--connect-timeout", "10", "--max-time", "30",
+			"--cacert", "/var/run/prometheus-ca/ca.crt", "--get", "--data-urlencode", "query=" + query,
+			prometheusURL,
+		},
+		true,
+	)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	response := kedaEPPGuidePrometheusQueryResponse{}
+	if err := json.Unmarshal([]byte(output), &response); err != nil {
+		return 0, 0, fmt.Errorf("decode Prometheus query response: %w", err)
+	}
+	if response.Status != "success" {
+		return 0, 0, fmt.Errorf("Prometheus query status is %q", response.Status)
+	}
+	if len(response.Data.Result) != 1 {
+		return 0, len(response.Data.Result), nil
+	}
+	if len(response.Data.Result[0].Value) != 2 {
+		return 0, 1, fmt.Errorf("Prometheus result has %d value fields, want 2", len(response.Data.Result[0].Value))
+	}
+	var stringValue string
+	if err := json.Unmarshal(response.Data.Result[0].Value[1], &stringValue); err != nil {
+		return 0, 1, fmt.Errorf("decode Prometheus numeric value: %w", err)
+	}
+	value, err := strconv.ParseFloat(stringValue, 64)
+	if err != nil {
+		return 0, 1, fmt.Errorf("parse Prometheus numeric value %q: %w", stringValue, err)
+	}
+	return value, 1, nil
+}
+
+type kedaEPPGuidePrometheusTargetsResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ActiveTargets []struct {
+			Labels    map[string]string `json:"labels"`
+			Health    string            `json:"health"`
+			LastError string            `json:"lastError"`
+		} `json:"activeTargets"`
+	} `json:"data"`
+}
+
+func waitForKEDAEPPGuidePrometheusTarget() {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		prometheusURL := fmt.Sprintf(
+			"https://%s.%s.svc.cluster.local:9090/api/v1/targets?state=active",
+			kedaEPPGuidePrometheusSvc,
+			cfg.MonitoringNS,
+		)
+		output, err := runKEDAEPPGuideCurlProbe(
+			"prom-targets",
+			[]string{
+				"--fail", "--silent", "--show-error", "--connect-timeout", "10", "--max-time", "30",
+				"--cacert", "/var/run/prometheus-ca/ca.crt", prometheusURL,
+			},
+			true,
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		response := kedaEPPGuidePrometheusTargetsResponse{}
+		g.Expect(json.Unmarshal([]byte(output), &response)).To(Succeed())
+		g.Expect(response.Status).To(Equal("success"))
+
+		matched := 0
+		for _, target := range response.Data.ActiveTargets {
+			if target.Labels["namespace"] == cfg.LLMDNamespace && target.Labels["service"] == cfg.EPPServiceName {
+				matched++
+				g.Expect(target.Health).To(Equal("up"), "EPP Prometheus target is unhealthy: %s", target.LastError)
+			}
+		}
+		g.Expect(matched).To(Equal(1), "Prometheus must discover exactly one EPP target")
+	}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+}
+
+func runKEDAEPPGuideCurlProbe(nameSuffix string, args []string, mountPrometheusCA bool) (string, error) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "keda-epp-guide-" + nameSuffix + "-",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "keda-epp-guide-probe",
+				"test-resource":          boolTrue,
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: ptr.To(int64(0)),
+			Containers: []corev1.Container{{
+				Name:  "probe",
+				Image: kedaEPPGuideCurlImage,
+				Args:  args,
+			}},
+		},
+	}
+	if mountPrometheusCA {
+		pod.Spec.Volumes = []corev1.Volume{{
+			Name: "prometheus-ca",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+				SecretName: "keda-prometheus-auth",
+			}},
+		}}
+		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+			Name:      "prometheus-ca",
+			MountPath: "/var/run/prometheus-ca",
+			ReadOnly:  true,
+		}}
+	}
+
+	callContext, cancelCall := kedaEPPGuideCallContext()
+	created, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Create(callContext, pod, metav1.CreateOptions{})
+	cancelCall()
+	if err != nil {
+		return "", fmt.Errorf("create %s probe: %w", nameSuffix, err)
+	}
+	defer func() {
+		grace := int64(0)
+		deleteContext, cancelDelete := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+		defer cancelDelete()
+		_ = k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Delete(deleteContext, created.Name, metav1.DeleteOptions{
+			GracePeriodSeconds: &grace,
+		})
+	}()
+
+	deadline := time.Now().Add(kedaEPPGuideProbeTimeout)
+	for time.Now().Before(deadline) {
+		getContext, cancelGet := kedaEPPGuideCallContext()
+		current, getErr := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Get(getContext, created.Name, metav1.GetOptions{})
+		cancelGet()
+		if getErr != nil {
+			return "", fmt.Errorf("get %s probe %s: %w", nameSuffix, created.Name, getErr)
+		}
+		if current.Status.Phase == corev1.PodSucceeded || current.Status.Phase == corev1.PodFailed {
+			logContext, cancelLogs := context.WithTimeout(ctx, kedaEPPGuideAPITimeout)
+			logs, logErr := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).GetLogs(created.Name, &corev1.PodLogOptions{}).DoRaw(logContext)
+			cancelLogs()
+			if logErr != nil {
+				return "", fmt.Errorf("read %s probe %s logs: %w", nameSuffix, created.Name, logErr)
+			}
+			if current.Status.Phase == corev1.PodFailed {
+				return string(logs), fmt.Errorf("%s probe %s failed: %s", nameSuffix, created.Name, strings.TrimSpace(string(logs)))
+			}
+			return string(logs), nil
+		}
+		time.Sleep(time.Duration(cfg.PollIntervalQuickSec) * time.Second)
+	}
+	return "", fmt.Errorf("%s probe %s did not complete within %s", nameSuffix, created.Name, kedaEPPGuideProbeTimeout)
+}
+
 func waitForKEDAEPPGuideRequestPods(names []string) {
 	GinkgoHelper()
 
@@ -318,30 +766,15 @@ func kedaEPPGuideExternalMetric(metricName string) (float64, error) {
 	return quantity.AsApproximateFloat64(), nil
 }
 
-func nestedMetricValue(object map[string]any) (string, bool, error) {
-	value, found := object["value"]
-	if !found {
-		return "", false, nil
-	}
-	stringValue, ok := value.(string)
-	if !ok {
-		return "", true, fmt.Errorf("metric value has type %T, want string", value)
-	}
-	return stringValue, true, nil
-}
-
-func waitForKEDAEPPGuideScaleUp(hpaName, queueMetricName string, requestPods []string) {
+func waitForKEDAEPPGuidePhaseA(hpaName, runningMetricName, queueMetricName string, requestPods []string) {
 	GinkgoHelper()
 
-	deadline := time.Now().Add(time.Duration(cfg.ScaleUpTimeout) * time.Second)
-	desiredTransitionSeen := false
-	queueTwoSeen := false
+	deadline := time.Now().Add(time.Duration(cfg.EventuallyExtendedSec) * time.Second)
 	stable := 0
 	sample := 0
 
 	for time.Now().Before(deadline) {
 		sample++
-		assertKEDAOperatorLogsClean()
 		assertKEDAEPPGuideRequestsActive(requestPods)
 
 		hpaContext, cancelHPA := kedaEPPGuideCallContext()
@@ -367,9 +800,106 @@ func waitForKEDAEPPGuideScaleUp(hpaName, queueMetricName string, requestPods []s
 			}
 		}
 
-		queueValue, metricErr := kedaEPPGuideExternalMetric(queueMetricName)
-		if metricErr == nil && queueValue == 2 {
-			queueTwoSeen = true
+		runningValue, runningErr := kedaEPPGuideExternalMetric(runningMetricName)
+		queueValue, queueErr := kedaEPPGuideExternalMetric(queueMetricName)
+		exactPhaseA := runningErr == nil &&
+			queueErr == nil &&
+			runningValue == 1 &&
+			queueValue == 1 &&
+			hpa.Status.CurrentReplicas == 1 &&
+			hpa.Status.DesiredReplicas == 1 &&
+			*deployment.Spec.Replicas == 1 &&
+			deployment.Status.Replicas == 1 &&
+			deployment.Status.ReadyReplicas == 1
+		if exactPhaseA {
+			stable++
+		} else {
+			stable = 0
+		}
+
+		GinkgoWriter.Printf(
+			"guide phase A sample=%d hpa=%d/%d deployment=%d/%d/%d rawRunning=%v runningErr=%v rawQueue=%v queueErr=%v stable=%d\n",
+			sample,
+			hpa.Status.CurrentReplicas,
+			hpa.Status.DesiredReplicas,
+			*deployment.Spec.Replicas,
+			deployment.Status.Replicas,
+			deployment.Status.ReadyReplicas,
+			runningValue,
+			runningErr,
+			queueValue,
+			queueErr,
+			stable,
+		)
+
+		if stable >= kedaEPPGuideStableCount {
+			return
+		}
+		time.Sleep(time.Duration(cfg.PollIntervalQuickSec) * time.Second)
+	}
+
+	Fail("guide Phase A did not produce stable one-running/one-queued exact-one state")
+}
+
+func nestedMetricValue(object map[string]any) (string, bool, error) {
+	value, found := object["value"]
+	if !found {
+		return "", false, nil
+	}
+	stringValue, ok := value.(string)
+	if !ok {
+		return "", true, fmt.Errorf("metric value has type %T, want string", value)
+	}
+	return stringValue, true, nil
+}
+
+func waitForKEDAEPPGuideScaleUp(hpaName, runningMetricName, queueMetricName string, requestPods []string) {
+	GinkgoHelper()
+	Expect(requestPods).To(HaveLen(3), "Phase B must retain exactly three bounded request pods")
+
+	deadline := time.Now().Add(time.Duration(cfg.ScaleUpTimeout) * time.Second)
+	desiredTransitionSeen := false
+	phaseBMetricsSeen := false
+	stable := 0
+	sample := 0
+
+	for time.Now().Before(deadline) {
+		sample++
+		assertKEDAEPPGuideRequestsActive(requestPods)
+
+		hpaContext, cancelHPA := kedaEPPGuideCallContext()
+		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, hpaName, metav1.GetOptions{})
+		cancelHPA()
+		Expect(err).NotTo(HaveOccurred())
+		deploymentContext, cancelDeployment := kedaEPPGuideCallContext()
+		deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(deploymentContext, kedaEPPGuideDeployment, metav1.GetOptions{})
+		cancelDeployment()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Replicas).NotTo(BeNil())
+
+		values := map[string]int32{
+			"hpaCurrent":       hpa.Status.CurrentReplicas,
+			"hpaDesired":       hpa.Status.DesiredReplicas,
+			"deploymentSpec":   *deployment.Spec.Replicas,
+			"deploymentStatus": deployment.Status.Replicas,
+			"deploymentReady":  deployment.Status.ReadyReplicas,
+		}
+		for name, value := range values {
+			if value > 2 {
+				Fail(fmt.Sprintf("bounded guide stimulus observed %s=%d (>2)", name, value))
+			}
+		}
+
+		runningValue, runningErr := kedaEPPGuideExternalMetric(runningMetricName)
+		queueValue, queueErr := kedaEPPGuideExternalMetric(queueMetricName)
+		if runningErr == nil && runningValue > 2 {
+			Fail(fmt.Sprintf("bounded guide stimulus observed rawRunning=%v (>2)", runningValue))
+		}
+		if queueErr == nil && queueValue > 2 {
+			Fail(fmt.Sprintf("bounded guide stimulus observed rawQueue=%v (>2)", queueValue))
+		}
+		if runningErr == nil && queueErr == nil && runningValue == 1 && queueValue == 2 {
+			phaseBMetricsSeen = true
 		}
 
 		if !desiredTransitionSeen && hpa.Status.DesiredReplicas != 1 {
@@ -394,30 +924,53 @@ func waitForKEDAEPPGuideScaleUp(hpaName, queueMetricName string, requestPods []s
 		}
 
 		GinkgoWriter.Printf(
-			"guide scale sample=%d hpa=%d/%d deployment=%d/%d/%d rawQueue=%v queueErr=%v transition=%v stable=%d\n",
+			"guide scale sample=%d hpa=%d/%d deployment=%d/%d/%d rawRunning=%v runningErr=%v rawQueue=%v queueErr=%v phaseBMetrics=%v transition=%v stable=%d\n",
 			sample,
 			hpa.Status.CurrentReplicas,
 			hpa.Status.DesiredReplicas,
 			*deployment.Spec.Replicas,
 			deployment.Status.Replicas,
 			deployment.Status.ReadyReplicas,
+			runningValue,
+			runningErr,
 			queueValue,
-			metricErr,
+			queueErr,
+			phaseBMetricsSeen,
 			desiredTransitionSeen,
 			stable,
 		)
 
-		if desiredTransitionSeen && queueTwoSeen && stable >= kedaEPPGuideStableCount {
+		if desiredTransitionSeen && phaseBMetricsSeen && stable >= kedaEPPGuideStableCount {
+			Expect(requestPods).To(HaveLen(3), "Phase B success must retain exactly three bounded request pods")
+			assertKEDAEPPGuideRequestsActive(requestPods)
 			return
 		}
 		time.Sleep(time.Duration(cfg.PollIntervalQuickSec) * time.Second)
 	}
 
 	Fail(fmt.Sprintf(
-		"bounded guide stimulus did not produce stable exact-two state (desiredTransitionSeen=%v queueTwoSeen=%v)",
+		"bounded guide stimulus did not produce stable exact-two state (desiredTransitionSeen=%v phaseBMetricsSeen=%v)",
 		desiredTransitionSeen,
-		queueTwoSeen,
+		phaseBMetricsSeen,
 	))
+}
+
+func assertKEDAEPPGuideHPABehavior(behavior *autoscalingv2.HorizontalPodAutoscalerBehavior) {
+	GinkgoHelper()
+	Expect(behavior).NotTo(BeNil(), "canonical HPA behavior must be present")
+	assertKEDAEPPGuideHPAScalingRules("scaleUp", behavior.ScaleUp, 0)
+	assertKEDAEPPGuideHPAScalingRules("scaleDown", behavior.ScaleDown, 300)
+}
+
+func assertKEDAEPPGuideHPAScalingRules(name string, rules *autoscalingv2.HPAScalingRules, stabilizationWindow int32) {
+	GinkgoHelper()
+	Expect(rules).NotTo(BeNil(), "canonical HPA %s rules must be present", name)
+	Expect(rules.StabilizationWindowSeconds).NotTo(BeNil(), "canonical HPA %s stabilization must be explicit", name)
+	Expect(*rules.StabilizationWindowSeconds).To(Equal(stabilizationWindow), "canonical HPA %s stabilization drifted", name)
+	Expect(rules.Policies).To(HaveLen(1), "canonical HPA %s must retain one policy", name)
+	Expect(rules.Policies[0].Type).To(Equal(autoscalingv2.PercentScalingPolicy), "canonical HPA %s policy type drifted", name)
+	Expect(rules.Policies[0].Value).To(Equal(int32(100)), "canonical HPA %s policy value drifted", name)
+	Expect(rules.Policies[0].PeriodSeconds).To(Equal(int32(15)), "canonical HPA %s policy period drifted", name)
 }
 
 func assertKEDAEPPGuideRequestsActive(names []string) {
@@ -432,6 +985,65 @@ func assertKEDAEPPGuideRequestsActive(names []string) {
 			Fail(fmt.Sprintf("bounded request pod %s exited before scale evidence (phase=%s)", name, pod.Status.Phase))
 		}
 	}
+}
+
+func kedaEPPGuideEventuallyBudget(timeoutSeconds, apiCallsPerAttempt int) time.Duration {
+	return time.Duration(timeoutSeconds)*time.Second +
+		time.Duration(apiCallsPerAttempt)*kedaEPPGuideAPITimeout
+}
+
+// A probe attempt can spend one API deadline creating the Pod, the probe
+// deadline waiting for it, one final Get deadline, one log-read deadline, and
+// one best-effort delete deadline. Eventually may start that full attempt just
+// before its own deadline, so both bounds are additive.
+func kedaEPPGuideProbeAttemptBudget() time.Duration {
+	return kedaEPPGuideProbeTimeout + 4*kedaEPPGuideAPITimeout
+}
+
+func kedaEPPGuideProbeObservationBudget() time.Duration {
+	return time.Duration(cfg.EventuallyLongSec)*time.Second + kedaEPPGuideProbeAttemptBudget()
+}
+
+func kedaEPPGuideWarmupObservationBudget() time.Duration {
+	return kedaEPPGuideAPITimeout + // create the warmup request
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // request Pod startup
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // ServiceMonitor
+		3*kedaEPPGuideAPITimeout + // two CA Secrets and the KEDA operator Deployment
+		5*kedaEPPGuideProbeObservationBudget() // two direct metrics, target, two PromQL queries
+}
+
+func kedaEPPGuideDeterministicObservationBudget() time.Duration {
+	return kedaEPPGuideAPITimeout + // first request create
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // first request Pod startup
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyLongSec, 1) + // running external metric
+		kedaEPPGuideAPITimeout + // second request create
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyExtendedSec, 6) + // Phase A: two Pods, HPA, Deployment, two metrics
+		kedaEPPGuideAPITimeout + // third request create
+		kedaEPPGuideEventuallyBudget(cfg.ScaleUpTimeout, 7) // Phase B: three Pods, HPA, Deployment, two metrics
+}
+
+// This is the complete successful-spec observation bound. It includes every
+// bounded wait in BeforeAll and the It body, materially extending API calls,
+// both stage-boundary log checks, and explicit/deferred stimulus cleanup. The
+// suite preflight and failure diagnostics are reserved outside this bound by
+// the Ginkgo/Go/CI timeout hierarchy in the Make target and workflow.
+func kedaEPPGuideCompleteSpecBudget() time.Duration {
+	operatorLogBudget := time.Duration(1+kedaEPPGuideMaxLogStreams) * kedaEPPGuideAPITimeout
+	return kedaEPPGuideEventuallyBudget(cfg.PodReadyTimeout, 1) + // simulator Ready in BeforeAll
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // ScaledObject created
+		kedaEPPGuideWarmupObservationBudget() +
+		kedaEPPGuideAPITimeout + // delete warmup request
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // warmup deletion observed
+		2*kedaEPPGuideProbeObservationBudget() + // both PromQL series reset
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyExtendedSec, 1) + // ScaledObject Ready
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyStandardSec, 1) + // generated HPA
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyLongSec, 2) + // both external metrics reset
+		kedaEPPGuideEventuallyBudget(cfg.EventuallyExtendedSec, 2) + // stable one-replica baseline
+		operatorLogBudget +
+		kedaEPPGuideDeterministicObservationBudget() +
+		3*kedaEPPGuideAPITimeout + // explicit request deletion
+		operatorLogBudget +
+		4*kedaEPPGuideAPITimeout // deferred three-request and simulator deletion
 }
 
 func kedaEPPGuideCallContext() (context.Context, context.CancelFunc) {
@@ -464,7 +1076,7 @@ func assertKEDAOperatorLogsClean() {
 
 	for _, operatorLog := range operatorLogs {
 		lower := strings.ToLower(operatorLog.content)
-		for _, pattern := range []string{"x509", "unknown authority", "triggererror"} {
+		for _, pattern := range []string{"x509", "unknown authority"} {
 			if strings.Contains(lower, pattern) {
 				Fail(fmt.Sprintf("KEDA operator logs from %s contain %q: %s", operatorLog.source, pattern, strings.TrimSpace(operatorLog.content)))
 			}
@@ -490,12 +1102,17 @@ func readKEDAEPPGuideOperatorLogs() ([]kedaEPPGuideOperatorLog, error) {
 		return nil, fmt.Errorf("no KEDA operator pods found in namespace %s", cfg.KEDANamespace)
 	}
 
-	var operatorLogs []kedaEPPGuideOperatorLog
+	operatorLogs := make([]kedaEPPGuideOperatorLog, 0, kedaEPPGuideMaxLogStreams)
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
+			if len(operatorLogs) >= kedaEPPGuideMaxLogStreams {
+				return operatorLogs, nil
+			}
 			logContext, cancelLogs := context.WithTimeout(ctx, 10*time.Second)
 			logs, err := k8sClient.CoreV1().Pods(cfg.KEDANamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
-				Container: container.Name,
+				Container:    container.Name,
+				SinceSeconds: ptr.To(kedaEPPGuideLogSinceSecs),
+				TailLines:    ptr.To(kedaEPPGuideLogTailLines),
 			}).DoRaw(logContext)
 			cancelLogs()
 			if err != nil {
@@ -519,4 +1136,126 @@ func dumpKEDAEPPGuideOperatorLogs() {
 	for _, operatorLog := range operatorLogs {
 		GinkgoWriter.Printf("\n=== KEDA operator logs: %s ===\n%s\n", operatorLog.source, operatorLog.content)
 	}
+}
+
+func dumpKEDAEPPGuideDiagnostics() {
+	GinkgoWriter.Println("\n=== KEDA+EPP guide focused diagnostics ===")
+	dumpKEDAEPPGuideOperatorLogs()
+
+	for _, namespace := range []string{cfg.LLMDNamespace, cfg.MonitoringNS, cfg.KEDANamespace} {
+		listContext, cancelList := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+		pods, err := k8sClient.CoreV1().Pods(namespace).List(listContext, metav1.ListOptions{})
+		cancelList()
+		if err != nil {
+			GinkgoWriter.Printf("pods namespace=%s error=%v\n", namespace, err)
+		} else {
+			for _, pod := range pods.Items {
+				GinkgoWriter.Printf("pod namespace=%s name=%s %s\n", namespace, pod.Name, kedaEPPGuidePodState(&pod))
+			}
+		}
+
+		eventContext, cancelEvents := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+		events, err := k8sClient.CoreV1().Events(namespace).List(eventContext, metav1.ListOptions{})
+		cancelEvents()
+		if err != nil {
+			GinkgoWriter.Printf("events namespace=%s error=%v\n", namespace, err)
+		} else {
+			for _, event := range events.Items {
+				GinkgoWriter.Printf(
+					"event namespace=%s object=%s/%s reason=%s message=%s\n",
+					namespace,
+					event.InvolvedObject.Kind,
+					event.InvolvedObject.Name,
+					event.Reason,
+					event.Message,
+				)
+			}
+		}
+	}
+
+	deploymentContext, cancelDeployments := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+	deployments, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).List(deploymentContext, metav1.ListOptions{})
+	cancelDeployments()
+	if err != nil {
+		GinkgoWriter.Printf("deployments namespace=%s error=%v\n", cfg.LLMDNamespace, err)
+	} else {
+		for _, deployment := range deployments.Items {
+			desired := int32(-1)
+			if deployment.Spec.Replicas != nil {
+				desired = *deployment.Spec.Replicas
+			}
+			GinkgoWriter.Printf(
+				"deployment namespace=%s name=%s desired=%d current=%d ready=%d available=%d\n",
+				cfg.LLMDNamespace,
+				deployment.Name,
+				desired,
+				deployment.Status.Replicas,
+				deployment.Status.ReadyReplicas,
+				deployment.Status.AvailableReplicas,
+			)
+		}
+	}
+
+	scaledObject := &kedav1alpha1.ScaledObject{}
+	soContext, cancelSO := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+	err = crClient.Get(soContext, client.ObjectKey{Namespace: cfg.LLMDNamespace, Name: kedaEPPGuideScaledObject}, scaledObject)
+	cancelSO()
+	if err != nil {
+		GinkgoWriter.Printf("scaledobject namespace=%s name=%s error=%v\n", cfg.LLMDNamespace, kedaEPPGuideScaledObject, err)
+	} else {
+		GinkgoWriter.Printf(
+			"scaledobject namespace=%s name=%s hpa=%s conditions=%+v triggers=%+v\n",
+			cfg.LLMDNamespace,
+			scaledObject.Name,
+			scaledObject.Status.HpaName,
+			scaledObject.Status.Conditions,
+			scaledObject.Spec.Triggers,
+		)
+	}
+
+	hpaContext, cancelHPA := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+	hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, kedaEPPGuideHPAName, metav1.GetOptions{})
+	cancelHPA()
+	if err != nil {
+		GinkgoWriter.Printf("hpa namespace=%s name=%s error=%v\n", cfg.LLMDNamespace, kedaEPPGuideHPAName, err)
+	} else {
+		GinkgoWriter.Printf("hpa namespace=%s name=%s spec=%+v status=%+v owners=%+v\n", cfg.LLMDNamespace, hpa.Name, hpa.Spec, hpa.Status, hpa.OwnerReferences)
+	}
+
+	serviceMonitor := &promoperator.ServiceMonitor{}
+	smContext, cancelSM := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+	err = crClient.Get(smContext, client.ObjectKey{Namespace: cfg.LLMDNamespace, Name: kedaEPPGuideServiceMonitor}, serviceMonitor)
+	cancelSM()
+	if err != nil {
+		GinkgoWriter.Printf("servicemonitor namespace=%s name=%s error=%v\n", cfg.LLMDNamespace, kedaEPPGuideServiceMonitor, err)
+	} else {
+		GinkgoWriter.Printf("servicemonitor namespace=%s name=%s selector=%+v endpoints=%+v\n", cfg.LLMDNamespace, serviceMonitor.Name, serviceMonitor.Spec.Selector, serviceMonitor.Spec.Endpoints)
+	}
+
+	directMetrics, directErr := runKEDAEPPGuideCurlProbe(
+		"diagnostic-metrics",
+		[]string{
+			"--fail", "--silent", "--show-error", "--connect-timeout", "10", "--max-time", "30",
+			fmt.Sprintf("http://%s.%s.svc.cluster.local:9090/metrics", cfg.EPPServiceName, cfg.LLMDNamespace),
+		},
+		false,
+	)
+	if directErr != nil {
+		GinkgoWriter.Printf("direct EPP metrics error=%v\n", directErr)
+	} else {
+		for _, line := range strings.Split(directMetrics, "\n") {
+			if strings.HasPrefix(line, "llm_d_epp_flow_control_queue_size{") || strings.HasPrefix(line, "llm_d_epp_request_running{") {
+				GinkgoWriter.Printf("direct EPP metric %s\n", line)
+			}
+		}
+	}
+
+	for name, query := range map[string]string{
+		"queue":   kedaEPPGuideQueueQuery,
+		"running": kedaEPPGuideRunQuery,
+	} {
+		value, cardinality, queryErr := kedaEPPGuidePrometheusValue(query)
+		GinkgoWriter.Printf("Prometheus query=%s cardinality=%d value=%v error=%v\n", name, cardinality, value, queryErr)
+	}
+	GinkgoWriter.Println("=== end KEDA+EPP guide focused diagnostics ===")
 }

--- a/test/e2e/keda_epp_guide_test.go
+++ b/test/e2e/keda_epp_guide_test.go
@@ -1,0 +1,522 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	kedaEPPGuideScaledObject = "optimized-baseline-keda-epp"
+	kedaEPPGuideDeployment   = "optimized-baseline-nvidia-gpu-vllm-decode"
+	kedaEPPGuideQueueTrigger = "epp-queue-size"
+	kedaEPPGuideRunTrigger   = "epp-running-requests"
+	kedaEPPGuideStableCount  = 3
+	kedaEPPGuideRequestLimit = 900
+	kedaEPPGuideAPITimeout   = 10 * time.Second
+	kedaEPPGuideCurlImage    = "quay.io/curl/curl:8.11.1@sha256:2db4e6a8fd6a0e4d0db5828b2722cf6db15c3005178a4c65588b903e4784ba11"
+)
+
+var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, func() {
+	var requestPods []string
+
+	deleteRequests := func() {
+		grace := int64(0)
+		for _, name := range requestPods {
+			deleteContext, cancelDelete := context.WithTimeout(context.Background(), kedaEPPGuideAPITimeout)
+			err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Delete(deleteContext, name, metav1.DeleteOptions{
+				GracePeriodSeconds: &grace,
+			})
+			cancelDelete()
+			if err != nil && !apierrors.IsNotFound(err) {
+				GinkgoWriter.Printf("WARNING: failed to delete request pod %s: %v\n", name, err)
+			}
+		}
+	}
+
+	BeforeAll(func() {
+		Expect(cfg.DeployWVA).To(BeFalse(), "the direct-KEDA guide spec must run with DEPLOY_WVA=false")
+		DeferCleanup(deleteRequests)
+	})
+
+	It("observes the canonical guide and performs one bounded 1-to-2 transition", func() {
+		scaledObject := waitForKEDAEPPGuideScaledObject()
+		Expect(scaledObject.Spec.ScaleTargetRef.Name).To(Equal(kedaEPPGuideDeployment))
+		Expect(scaledObject.Spec.Triggers).To(HaveLen(2))
+
+		var queueThreshold, runningThreshold resource.Quantity
+		for _, trigger := range scaledObject.Spec.Triggers {
+			Expect(trigger.Type).To(Equal("prometheus"))
+			Expect(trigger.MetricType).To(Equal(autoscalingv2.AverageValueMetricType))
+
+			threshold, err := resource.ParseQuantity(trigger.Metadata["threshold"])
+			Expect(err).NotTo(HaveOccurred(), "trigger %s should have a numeric threshold", trigger.Name)
+			switch trigger.Name {
+			case kedaEPPGuideQueueTrigger:
+				queueThreshold = threshold
+			case kedaEPPGuideRunTrigger:
+				runningThreshold = threshold
+			default:
+				Fail(fmt.Sprintf("unexpected Prometheus trigger %q on the canonical ScaledObject", trigger.Name))
+			}
+		}
+		Expect(queueThreshold.IsZero()).To(BeFalse(), "queue trigger threshold should be non-zero")
+		Expect(runningThreshold.IsZero()).To(BeFalse(), "running trigger threshold should be non-zero")
+
+		hpa := waitForKEDAEPPGuideHPA(scaledObject)
+		Expect(hpa.Spec.ScaleTargetRef.APIVersion).To(Equal("apps/v1"))
+		Expect(hpa.Spec.ScaleTargetRef.Kind).To(Equal("Deployment"))
+		Expect(hpa.Spec.ScaleTargetRef.Name).To(Equal(kedaEPPGuideDeployment))
+		Expect(hpa.Spec.Metrics).To(HaveLen(2))
+
+		metricNames := map[string]string{}
+		for _, metric := range hpa.Spec.Metrics {
+			Expect(metric.Type).To(Equal(autoscalingv2.ExternalMetricSourceType))
+			Expect(metric.External).NotTo(BeNil())
+			Expect(metric.External.Target.Type).To(Equal(autoscalingv2.AverageValueMetricType))
+			Expect(metric.External.Target.AverageValue).NotTo(BeNil())
+
+			switch {
+			case metric.External.Target.AverageValue.Cmp(queueThreshold) == 0:
+				metricNames[kedaEPPGuideQueueTrigger] = metric.External.Metric.Name
+			case metric.External.Target.AverageValue.Cmp(runningThreshold) == 0:
+				metricNames[kedaEPPGuideRunTrigger] = metric.External.Metric.Name
+			default:
+				Fail(fmt.Sprintf("generated HPA metric %q does not match a live guide trigger target", metric.External.Metric.Name))
+			}
+		}
+		Expect(metricNames).To(HaveKey(kedaEPPGuideQueueTrigger))
+		Expect(metricNames).To(HaveKey(kedaEPPGuideRunTrigger))
+		Expect(metricNames[kedaEPPGuideQueueTrigger]).NotTo(Equal(metricNames[kedaEPPGuideRunTrigger]))
+
+		waitForKEDAEPPGuideBaseline(scaledObject.Status.HpaName)
+		assertKEDAOperatorLogsClean()
+
+		By("starting one bounded request")
+		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
+		waitForKEDAEPPGuideRequestPods(requestPods)
+
+		By("waiting until KEDA observes exactly one running request")
+		Eventually(func(g Gomega) {
+			value, err := kedaEPPGuideExternalMetric(metricNames[kedaEPPGuideRunTrigger])
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(value).To(BeNumerically("==", 1))
+		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+
+		By("starting exactly two additional requests that remain queued")
+		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
+		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
+
+		waitForKEDAEPPGuideScaleUp(
+			scaledObject.Status.HpaName,
+			metricNames[kedaEPPGuideQueueTrigger],
+			requestPods,
+		)
+
+		By("terminating the bounded stimulus after exact-two evidence")
+		deleteRequests()
+		assertKEDAOperatorLogsClean()
+	})
+})
+
+func waitForKEDAEPPGuideScaledObject() *kedav1alpha1.ScaledObject {
+	GinkgoHelper()
+
+	deadline := time.Now().Add(time.Duration(cfg.EventuallyExtendedSec) * time.Second)
+	for time.Now().Before(deadline) {
+		assertKEDAOperatorLogsClean()
+
+		scaledObject := &kedav1alpha1.ScaledObject{}
+		callContext, cancelCall := kedaEPPGuideCallContext()
+		err := crClient.Get(callContext, client.ObjectKey{
+			Namespace: cfg.LLMDNamespace,
+			Name:      kedaEPPGuideScaledObject,
+		}, scaledObject)
+		cancelCall()
+		if err == nil {
+			ready := scaledObject.Status.Conditions.GetReadyCondition()
+			if ready.Status == metav1.ConditionTrue && scaledObject.Status.HpaName != "" {
+				return scaledObject
+			}
+		} else if !apierrors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+		time.Sleep(time.Duration(cfg.PollIntervalSec) * time.Second)
+	}
+
+	Fail(fmt.Sprintf("ScaledObject %s/%s did not reach Ready=True", cfg.LLMDNamespace, kedaEPPGuideScaledObject))
+	return nil
+}
+
+func waitForKEDAEPPGuideHPA(scaledObject *kedav1alpha1.ScaledObject) *autoscalingv2.HorizontalPodAutoscaler {
+	GinkgoHelper()
+
+	var hpa *autoscalingv2.HorizontalPodAutoscaler
+	Eventually(func(g Gomega) {
+		callContext, cancelCall := kedaEPPGuideCallContext()
+		current, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(
+			callContext,
+			scaledObject.Status.HpaName,
+			metav1.GetOptions{},
+		)
+		cancelCall()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		owned := false
+		for _, owner := range current.OwnerReferences {
+			if owner.UID == scaledObject.UID &&
+				owner.APIVersion == "keda.sh/v1alpha1" &&
+				owner.Kind == "ScaledObject" &&
+				owner.Name == scaledObject.Name &&
+				owner.Controller != nil && *owner.Controller {
+				owned = true
+				break
+			}
+		}
+		g.Expect(owned).To(BeTrue(), "generated HPA should be owned by the current ScaledObject UID")
+		hpa = current
+	}).Should(Succeed())
+	return hpa
+}
+
+func waitForKEDAEPPGuideBaseline(hpaName string) {
+	GinkgoHelper()
+
+	stable := 0
+	Eventually(func(g Gomega) {
+		hpaContext, cancelHPA := kedaEPPGuideCallContext()
+		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, hpaName, metav1.GetOptions{})
+		cancelHPA()
+		g.Expect(err).NotTo(HaveOccurred())
+		deploymentContext, cancelDeployment := kedaEPPGuideCallContext()
+		deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(deploymentContext, kedaEPPGuideDeployment, metav1.GetOptions{})
+		cancelDeployment()
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(deployment.Spec.Replicas).NotTo(BeNil())
+
+		if hpa.Status.CurrentReplicas == 1 &&
+			hpa.Status.DesiredReplicas == 1 &&
+			*deployment.Spec.Replicas == 1 &&
+			deployment.Status.Replicas == 1 &&
+			deployment.Status.ReadyReplicas == 1 {
+			stable++
+		} else {
+			stable = 0
+		}
+		g.Expect(stable).To(BeNumerically(">=", kedaEPPGuideStableCount))
+	}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+}
+
+func createKEDAEPPGuideRequestPod() string {
+	GinkgoHelper()
+
+	targetURL := fmt.Sprintf(
+		"http://%s.%s.svc.cluster.local:80/v1/chat/completions",
+		cfg.EPPServiceName,
+		cfg.LLMDNamespace,
+	)
+	payload := fmt.Sprintf(
+		`{"model":%q,"messages":[{"role":"user","content":"bounded deterministic contract probe"}],"max_tokens":8,"temperature":0}`,
+		cfg.ModelID,
+	)
+	callContext, cancelCall := kedaEPPGuideCallContext()
+	pod, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Create(callContext, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "keda-epp-guide-request-",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "keda-epp-guide-request",
+				"test-resource":          boolTrue,
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: ptr.To(int64(0)),
+			Containers: []corev1.Container{{
+				Name:    "request",
+				Image:   kedaEPPGuideCurlImage,
+				Command: []string{"sh", "-ec"},
+				Args: []string{
+					fmt.Sprintf(
+						`exec curl --fail --silent --show-error --connect-timeout 10 --max-time %d -H 'Content-Type: application/json' --data-binary "$PAYLOAD" "$TARGET_URL"`,
+						kedaEPPGuideRequestLimit,
+					),
+				},
+				Env: []corev1.EnvVar{
+					{Name: "TARGET_URL", Value: targetURL},
+					{Name: "PAYLOAD", Value: payload},
+				},
+			}},
+		},
+	}, metav1.CreateOptions{})
+	cancelCall()
+	Expect(err).NotTo(HaveOccurred())
+	return pod.Name
+}
+
+func waitForKEDAEPPGuideRequestPods(names []string) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		for _, name := range names {
+			callContext, cancelCall := kedaEPPGuideCallContext()
+			pod, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Get(callContext, name, metav1.GetOptions{})
+			cancelCall()
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pod.Status.Phase).To(
+				Equal(corev1.PodRunning),
+				"request pod %s should remain active: %s",
+				name,
+				kedaEPPGuidePodState(pod),
+			)
+			g.Expect(pod.Status.ContainerStatuses).To(HaveLen(1))
+			g.Expect(pod.Status.ContainerStatuses[0].State.Running).NotTo(BeNil(), "request pod %s curl should be running", name)
+		}
+	}, time.Duration(cfg.EventuallyMediumSec)*time.Second, time.Duration(cfg.PollIntervalQuickSec)*time.Second).Should(Succeed())
+}
+
+func kedaEPPGuideExternalMetric(metricName string) (float64, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "external.metrics.k8s.io",
+		Version:  "v1beta1",
+		Resource: metricName,
+	}
+	callContext, cancelCall := kedaEPPGuideCallContext()
+	values, err := dynamicClient.Resource(gvr).Namespace(cfg.LLMDNamespace).List(callContext, metav1.ListOptions{
+		LabelSelector: "scaledobject.keda.sh/name=" + kedaEPPGuideScaledObject,
+	})
+	cancelCall()
+	if err != nil {
+		return 0, err
+	}
+	if len(values.Items) != 1 {
+		return 0, fmt.Errorf("external metric %s returned %d items, want exactly one", metricName, len(values.Items))
+	}
+	value, found, err := nestedMetricValue(values.Items[0].Object)
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, fmt.Errorf("external metric %s has no value", metricName)
+	}
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return 0, fmt.Errorf("external metric %s returned invalid value %q: %w", metricName, value, err)
+	}
+	return quantity.AsApproximateFloat64(), nil
+}
+
+func nestedMetricValue(object map[string]any) (string, bool, error) {
+	value, found := object["value"]
+	if !found {
+		return "", false, nil
+	}
+	stringValue, ok := value.(string)
+	if !ok {
+		return "", true, fmt.Errorf("metric value has type %T, want string", value)
+	}
+	return stringValue, true, nil
+}
+
+func waitForKEDAEPPGuideScaleUp(hpaName, queueMetricName string, requestPods []string) {
+	GinkgoHelper()
+
+	deadline := time.Now().Add(time.Duration(cfg.ScaleUpTimeout) * time.Second)
+	desiredTransitionSeen := false
+	queueTwoSeen := false
+	stable := 0
+	sample := 0
+
+	for time.Now().Before(deadline) {
+		sample++
+		assertKEDAOperatorLogsClean()
+		assertKEDAEPPGuideRequestsActive(requestPods)
+
+		hpaContext, cancelHPA := kedaEPPGuideCallContext()
+		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, hpaName, metav1.GetOptions{})
+		cancelHPA()
+		Expect(err).NotTo(HaveOccurred())
+		deploymentContext, cancelDeployment := kedaEPPGuideCallContext()
+		deployment, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(deploymentContext, kedaEPPGuideDeployment, metav1.GetOptions{})
+		cancelDeployment()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Replicas).NotTo(BeNil())
+
+		values := map[string]int32{
+			"hpaCurrent":       hpa.Status.CurrentReplicas,
+			"hpaDesired":       hpa.Status.DesiredReplicas,
+			"deploymentSpec":   *deployment.Spec.Replicas,
+			"deploymentStatus": deployment.Status.Replicas,
+			"deploymentReady":  deployment.Status.ReadyReplicas,
+		}
+		for name, value := range values {
+			if value > 2 {
+				Fail(fmt.Sprintf("bounded guide stimulus observed %s=%d (>2)", name, value))
+			}
+		}
+
+		queueValue, metricErr := kedaEPPGuideExternalMetric(queueMetricName)
+		if metricErr == nil && queueValue == 2 {
+			queueTwoSeen = true
+		}
+
+		if !desiredTransitionSeen && hpa.Status.DesiredReplicas != 1 {
+			if hpa.Status.DesiredReplicas != 2 {
+				Fail(fmt.Sprintf(
+					"first HPA desired transition was 1 -> %d, want exactly 1 -> 2",
+					hpa.Status.DesiredReplicas,
+				))
+			}
+			desiredTransitionSeen = true
+		}
+
+		exactTwo := hpa.Status.CurrentReplicas == 2 &&
+			hpa.Status.DesiredReplicas == 2 &&
+			*deployment.Spec.Replicas == 2 &&
+			deployment.Status.Replicas == 2 &&
+			deployment.Status.ReadyReplicas == 2
+		if exactTwo {
+			stable++
+		} else {
+			stable = 0
+		}
+
+		GinkgoWriter.Printf(
+			"guide scale sample=%d hpa=%d/%d deployment=%d/%d/%d rawQueue=%v queueErr=%v transition=%v stable=%d\n",
+			sample,
+			hpa.Status.CurrentReplicas,
+			hpa.Status.DesiredReplicas,
+			*deployment.Spec.Replicas,
+			deployment.Status.Replicas,
+			deployment.Status.ReadyReplicas,
+			queueValue,
+			metricErr,
+			desiredTransitionSeen,
+			stable,
+		)
+
+		if desiredTransitionSeen && queueTwoSeen && stable >= kedaEPPGuideStableCount {
+			return
+		}
+		time.Sleep(time.Duration(cfg.PollIntervalQuickSec) * time.Second)
+	}
+
+	Fail(fmt.Sprintf(
+		"bounded guide stimulus did not produce stable exact-two state (desiredTransitionSeen=%v queueTwoSeen=%v)",
+		desiredTransitionSeen,
+		queueTwoSeen,
+	))
+}
+
+func assertKEDAEPPGuideRequestsActive(names []string) {
+	GinkgoHelper()
+
+	for _, name := range names {
+		callContext, cancelCall := kedaEPPGuideCallContext()
+		pod, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Get(callContext, name, metav1.GetOptions{})
+		cancelCall()
+		Expect(err).NotTo(HaveOccurred())
+		if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+			Fail(fmt.Sprintf("bounded request pod %s exited before scale evidence (phase=%s)", name, pod.Status.Phase))
+		}
+	}
+}
+
+func kedaEPPGuideCallContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, kedaEPPGuideAPITimeout)
+}
+
+func kedaEPPGuidePodState(pod *corev1.Pod) string {
+	containerStates := make([]string, 0, len(pod.Status.ContainerStatuses))
+	for _, status := range pod.Status.ContainerStatuses {
+		state := "unknown"
+		switch {
+		case status.State.Waiting != nil:
+			state = "waiting:" + status.State.Waiting.Reason
+		case status.State.Running != nil:
+			state = "running"
+		case status.State.Terminated != nil:
+			state = fmt.Sprintf("terminated:%s:%d", status.State.Terminated.Reason, status.State.Terminated.ExitCode)
+		}
+		containerStates = append(containerStates, status.Name+"="+state)
+	}
+	return fmt.Sprintf("phase=%s containers=[%s]", pod.Status.Phase, strings.Join(containerStates, ","))
+}
+
+func assertKEDAOperatorLogsClean() {
+	GinkgoHelper()
+
+	operatorLogs, err := readKEDAEPPGuideOperatorLogs()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(operatorLogs).NotTo(BeEmpty(), "KEDA operator pod should exist before guide validation")
+
+	for _, operatorLog := range operatorLogs {
+		lower := strings.ToLower(operatorLog.content)
+		for _, pattern := range []string{"x509", "unknown authority", "triggererror"} {
+			if strings.Contains(lower, pattern) {
+				Fail(fmt.Sprintf("KEDA operator logs from %s contain %q: %s", operatorLog.source, pattern, strings.TrimSpace(operatorLog.content)))
+			}
+		}
+	}
+}
+
+type kedaEPPGuideOperatorLog struct {
+	source  string
+	content string
+}
+
+func readKEDAEPPGuideOperatorLogs() ([]kedaEPPGuideOperatorLog, error) {
+	listContext, cancelList := context.WithTimeout(ctx, 10*time.Second)
+	pods, err := k8sClient.CoreV1().Pods(cfg.KEDANamespace).List(listContext, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=keda-operator",
+	})
+	cancelList()
+	if err != nil {
+		return nil, fmt.Errorf("list KEDA operator pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no KEDA operator pods found in namespace %s", cfg.KEDANamespace)
+	}
+
+	var operatorLogs []kedaEPPGuideOperatorLog
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			logContext, cancelLogs := context.WithTimeout(ctx, 10*time.Second)
+			logs, err := k8sClient.CoreV1().Pods(cfg.KEDANamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+				Container: container.Name,
+			}).DoRaw(logContext)
+			cancelLogs()
+			if err != nil {
+				return nil, fmt.Errorf("read KEDA operator logs for %s/%s: %w", pod.Name, container.Name, err)
+			}
+			operatorLogs = append(operatorLogs, kedaEPPGuideOperatorLog{
+				source:  pod.Name + "/" + container.Name,
+				content: string(logs),
+			})
+		}
+	}
+	return operatorLogs, nil
+}
+
+func dumpKEDAEPPGuideOperatorLogs() {
+	operatorLogs, err := readKEDAEPPGuideOperatorLogs()
+	if err != nil {
+		GinkgoWriter.Printf("Failed to collect KEDA operator logs: %v\n", err)
+		return
+	}
+	for _, operatorLog := range operatorLogs {
+		GinkgoWriter.Printf("\n=== KEDA operator logs: %s ===\n%s\n", operatorLog.source, operatorLog.content)
+	}
+}

--- a/test/e2e/keda_epp_guide_test.go
+++ b/test/e2e/keda_epp_guide_test.go
@@ -38,13 +38,22 @@ const (
 	kedaEPPGuideMinReplicas    = int32(1)
 	kedaEPPGuideMaxReplicas    = int32(8)
 	kedaEPPGuideStableCount    = 3
-	kedaEPPGuideRequestLimit   = 1500
-	kedaEPPGuideAPITimeout     = 10 * time.Second
-	kedaEPPGuideProbeTimeout   = 60 * time.Second
 	kedaEPPGuideLogTailLines   = int64(300)
 	kedaEPPGuideLogSinceSecs   = int64(1800)
 	kedaEPPGuideMaxLogStreams  = 2
 	kedaEPPGuideCurlImage      = "quay.io/curl/curl:8.11.1@sha256:2db4e6a8fd6a0e4d0db5828b2722cf6db15c3005178a4c65588b903e4784ba11"
+
+	kedaEPPGuideAPITimeout                   = 10 * time.Second
+	kedaEPPGuideProbeTimeout                 = 60 * time.Second
+	kedaEPPGuideRequestStartupTimeout        = 60 * time.Second
+	kedaEPPGuideMetricObservationTimeout     = 90 * time.Second
+	kedaEPPGuideStabilizationTimeout         = 180 * time.Second
+	kedaEPPGuideScaleTransitionTimeout       = 300 * time.Second
+	kedaEPPGuideSimulatorReadinessTimeout    = 120 * time.Second
+	kedaEPPGuideRequestLifetime              = 1500 * time.Second
+	kedaEPPGuideRequestBearingObservationCap = 20 * time.Minute
+	kedaEPPGuidePollInterval                 = 5 * time.Second
+	kedaEPPGuideQuickPollInterval            = 2 * time.Second
 )
 
 var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, func() {
@@ -58,21 +67,14 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 		Expect(cfg.DeployWVA).To(BeFalse(), "the direct-KEDA guide spec must run with DEPLOY_WVA=false")
 		Expect(cfg.UseSimulator).To(BeTrue(), "the direct-KEDA guide spec uses a deterministic simulator workload")
 		Expect(cfg.ModelID).To(Equal("Qwen/Qwen3-32B"), "the simulator and canonical EPP metrics must use the same model")
-		warmupBudget := kedaEPPGuideWarmupObservationBudget()
-		deterministicBudget := kedaEPPGuideDeterministicObservationBudget()
-		maxObservationBudget := max(warmupBudget, deterministicBudget)
-		requestLifetime := time.Duration(kedaEPPGuideRequestLimit) * time.Second
 		GinkgoWriter.Printf(
-			"KEDA+EPP timing hierarchy: warmup=%s deterministic=%s required=%s requestLifetime=%s completeSpec=%s\n",
-			warmupBudget,
-			deterministicBudget,
-			maxObservationBudget,
-			requestLifetime,
-			kedaEPPGuideCompleteSpecBudget(),
+			"KEDA+EPP request timing: requestBearingObservationCap=%s requestLifetime=%s\n",
+			kedaEPPGuideRequestBearingObservationCap,
+			kedaEPPGuideRequestLifetime,
 		)
-		Expect(requestLifetime).To(
-			BeNumerically(">", maxObservationBudget),
-			"request lifetime must strictly exceed the complete warmup and deterministic observation bounds",
+		Expect(kedaEPPGuideRequestLifetime).To(
+			BeNumerically(">", kedaEPPGuideRequestBearingObservationCap),
+			"request lifetime must strictly exceed the complete request-bearing observation cap",
 		)
 
 		By("observing the pre-created guide-owned deterministic simulator")
@@ -104,60 +106,18 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 			cancelCall()
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)))
-		}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+		}, kedaEPPGuideSimulatorReadinessTimeout, kedaEPPGuidePollInterval).Should(Succeed())
 	})
 
 	It("observes the canonical guide and performs one bounded 1-to-2 transition", func() {
-		scaledObject := waitForKEDAEPPGuideScaledObjectCreated()
-		Expect(scaledObject.Spec.ScaleTargetRef).NotTo(BeNil())
-		Expect(scaledObject.Spec.ScaleTargetRef.APIVersion).To(Equal("apps/v1"))
-		Expect(scaledObject.Spec.ScaleTargetRef.Kind).To(Equal("Deployment"))
-		Expect(scaledObject.Spec.ScaleTargetRef.Name).To(Equal(kedaEPPGuideDeployment))
-		Expect(scaledObject.Spec.MinReplicaCount).NotTo(BeNil())
-		Expect(*scaledObject.Spec.MinReplicaCount).To(Equal(kedaEPPGuideMinReplicas))
-		Expect(scaledObject.Spec.MaxReplicaCount).NotTo(BeNil())
-		Expect(*scaledObject.Spec.MaxReplicaCount).To(Equal(kedaEPPGuideMaxReplicas))
-		Expect(scaledObject.Spec.Advanced).NotTo(BeNil())
-		Expect(scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig).NotTo(BeNil())
-		Expect(scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig.Name).To(Equal(kedaEPPGuideHPAName))
-		assertKEDAEPPGuideHPABehavior(scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig.Behavior)
-		Expect(scaledObject.Spec.Triggers).To(HaveLen(2))
-
-		seenTriggers := map[string]bool{}
-		for _, trigger := range scaledObject.Spec.Triggers {
-			Expect(seenTriggers).NotTo(HaveKey(trigger.Name), "canonical trigger %s must be unique", trigger.Name)
-			seenTriggers[trigger.Name] = true
-			Expect(trigger.Type).To(Equal("prometheus"))
-			Expect(trigger.MetricType).To(Equal(autoscalingv2.AverageValueMetricType))
-			Expect(trigger.AuthenticationRef).NotTo(BeNil(), "trigger %s must retain its guide authenticationRef", trigger.Name)
-			Expect(trigger.AuthenticationRef.Name).To(Equal(kedaEPPGuideAuthentication), "trigger %s must retain its guide authenticationRef", trigger.Name)
-
-			var expectedQuery, expectedThreshold string
-			switch trigger.Name {
-			case kedaEPPGuideQueueTrigger:
-				expectedQuery = kedaEPPGuideQueueQuery
-				expectedThreshold = kedaEPPGuideQueueThreshold
-			case kedaEPPGuideRunTrigger:
-				expectedQuery = kedaEPPGuideRunQuery
-				expectedThreshold = kedaEPPGuideRunThreshold
-			default:
-				Fail(fmt.Sprintf("unexpected Prometheus trigger %q on the canonical ScaledObject", trigger.Name))
-			}
-			Expect(trigger.Metadata).To(HaveKeyWithValue("query", expectedQuery), "trigger %s must retain its exact canonical query", trigger.Name)
-			Expect(trigger.Metadata).To(HaveKeyWithValue("threshold", expectedThreshold), "trigger %s must retain its exact canonical threshold", trigger.Name)
-			_, err := resource.ParseQuantity(trigger.Metadata["threshold"])
-			Expect(err).NotTo(HaveOccurred(), "trigger %s should have a numeric threshold", trigger.Name)
-		}
-		Expect(seenTriggers).To(HaveKey(kedaEPPGuideQueueTrigger))
-		Expect(seenTriggers).To(HaveKey(kedaEPPGuideRunTrigger))
+		scaledObject, authentication := waitForKEDAEPPGuideRuntimeObjects()
+		assertKEDAEPPGuideScaledObjectContract(scaledObject)
+		assertKEDAEPPGuideAuthenticationContract(authentication)
 
 		By("sending a bounded warmup before requiring lazy EPP metric-series liveness")
 		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
 		waitForKEDAEPPGuideRequestPods(requestPods)
-		assertKEDAEPPGuideServiceMonitor()
 		assertKEDAEPPGuideSecureTrust()
-		waitForKEDAEPPGuideDirectMetric(kedaEPPGuideRunTrigger, 1)
-		waitForKEDAEPPGuideDirectMetric(kedaEPPGuideQueueTrigger, 0)
 		waitForKEDAEPPGuidePrometheusTarget()
 		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideRunQuery, 1)
 		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideQueueQuery, 0)
@@ -166,13 +126,12 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 		deleteKEDAEPPGuidePods(requestPods)
 		waitForKEDAEPPGuidePodsDeleted(requestPods)
 		requestPods = requestPods[:0]
-		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideRunQuery, 0)
-		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideQueueQuery, 0)
 
 		By("requiring KEDA liveness only after both per-model series exist")
 		scaledObject = waitForKEDAEPPGuideScaledObjectReady()
-		Expect(scaledObject.Status.HpaName).To(Equal(kedaEPPGuideHPAName))
 		hpa := waitForKEDAEPPGuideHPA(scaledObject)
+		Expect(hpa.Name).To(Equal(kedaEPPGuideHPAName))
+		Expect(hpa.Namespace).To(Equal(cfg.LLMDNamespace))
 		Expect(hpa.Spec.MinReplicas).NotTo(BeNil())
 		Expect(*hpa.Spec.MinReplicas).To(Equal(kedaEPPGuideMinReplicas))
 		Expect(hpa.Spec.MaxReplicas).To(Equal(kedaEPPGuideMaxReplicas))
@@ -194,7 +153,9 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 			}))
 			Expect(metric.External.Metric.Selector.MatchExpressions).To(BeEmpty())
 			Expect(metric.External.Target.Type).To(Equal(autoscalingv2.AverageValueMetricType))
+			Expect(metric.External.Target.Value).To(BeNil())
 			Expect(metric.External.Target.AverageValue).NotTo(BeNil())
+			Expect(metric.External.Target.AverageUtilization).To(BeNil())
 
 			switch {
 			case metric.External.Target.AverageValue.Cmp(queueTarget) == 0:
@@ -209,31 +170,20 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 		Expect(metricNames).To(HaveKey(kedaEPPGuideRunTrigger))
 		Expect(metricNames[kedaEPPGuideQueueTrigger]).NotTo(Equal(metricNames[kedaEPPGuideRunTrigger]))
 		Eventually(func(g Gomega) {
-			for triggerName, metricName := range metricNames {
-				value, err := kedaEPPGuideExternalMetric(metricName)
-				g.Expect(err).NotTo(HaveOccurred(), "external metric for %s should be live", triggerName)
-				g.Expect(value).To(BeNumerically("==", 0), "external metric for %s should be reset after warmup", triggerName)
-			}
-		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+			value, err := kedaEPPGuideExternalMetric(metricNames[kedaEPPGuideRunTrigger])
+			g.Expect(err).NotTo(HaveOccurred(), "running external metric should be live")
+			g.Expect(value).To(BeNumerically("==", 0), "running external metric should be reset after warmup")
+		}, kedaEPPGuideMetricObservationTimeout, kedaEPPGuidePollInterval).Should(Succeed())
 
-		waitForKEDAEPPGuideBaseline(scaledObject.Status.HpaName)
-		assertKEDAOperatorLogsClean()
+		waitForKEDAEPPGuideBaseline()
 
 		By("starting one bounded request")
 		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
 		waitForKEDAEPPGuideRequestPods(requestPods)
 
-		By("waiting until KEDA observes exactly one running request")
-		Eventually(func(g Gomega) {
-			value, err := kedaEPPGuideExternalMetric(metricNames[kedaEPPGuideRunTrigger])
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(value).To(BeNumerically("==", 1))
-		}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
-
 		By("starting one additional request that remains queued")
 		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
 		waitForKEDAEPPGuidePhaseA(
-			scaledObject.Status.HpaName,
 			metricNames[kedaEPPGuideRunTrigger],
 			metricNames[kedaEPPGuideQueueTrigger],
 			requestPods,
@@ -243,7 +193,6 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 		requestPods = append(requestPods, createKEDAEPPGuideRequestPod())
 
 		waitForKEDAEPPGuideScaleUp(
-			scaledObject.Status.HpaName,
 			metricNames[kedaEPPGuideRunTrigger],
 			metricNames[kedaEPPGuideQueueTrigger],
 			requestPods,
@@ -255,28 +204,102 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 	})
 })
 
-func waitForKEDAEPPGuideScaledObjectCreated() *kedav1alpha1.ScaledObject {
+func waitForKEDAEPPGuideRuntimeObjects() (*kedav1alpha1.ScaledObject, *kedav1alpha1.TriggerAuthentication) {
 	GinkgoHelper()
 
 	var scaledObject *kedav1alpha1.ScaledObject
+	var authentication *kedav1alpha1.TriggerAuthentication
 	Eventually(func(g Gomega) {
-		current := &kedav1alpha1.ScaledObject{}
+		scaledObjects := &kedav1alpha1.ScaledObjectList{}
 		callContext, cancelCall := kedaEPPGuideCallContext()
-		err := crClient.Get(callContext, client.ObjectKey{
-			Namespace: cfg.LLMDNamespace,
-			Name:      kedaEPPGuideScaledObject,
-		}, current)
+		err := crClient.List(callContext, scaledObjects, client.InNamespace(cfg.LLMDNamespace))
 		cancelCall()
 		g.Expect(err).NotTo(HaveOccurred())
-		scaledObject = current
-	}, time.Duration(cfg.EventuallyMediumSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
-	return scaledObject
+		g.Expect(scaledObjects.Items).To(HaveLen(1), "guide namespace must contain exactly the intended ScaledObject")
+		g.Expect(scaledObjects.Items[0].Name).To(Equal(kedaEPPGuideScaledObject))
+
+		authentications := &kedav1alpha1.TriggerAuthenticationList{}
+		callContext, cancelCall = kedaEPPGuideCallContext()
+		err = crClient.List(callContext, authentications, client.InNamespace(cfg.LLMDNamespace))
+		cancelCall()
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(authentications.Items).To(HaveLen(1), "guide namespace must contain exactly the intended TriggerAuthentication")
+		g.Expect(authentications.Items[0].Name).To(Equal(kedaEPPGuideAuthentication))
+
+		scaledObject = scaledObjects.Items[0].DeepCopy()
+		authentication = authentications.Items[0].DeepCopy()
+	}, kedaEPPGuideRequestStartupTimeout, kedaEPPGuidePollInterval).Should(Succeed())
+	return scaledObject, authentication
+}
+
+func assertKEDAEPPGuideScaledObjectContract(scaledObject *kedav1alpha1.ScaledObject) {
+	GinkgoHelper()
+
+	Expect(scaledObject.Namespace).To(Equal(cfg.LLMDNamespace))
+	Expect(scaledObject.Name).To(Equal(kedaEPPGuideScaledObject))
+	Expect(scaledObject.Spec.Triggers).To(HaveLen(2))
+
+	serverAddress := fmt.Sprintf(
+		"https://%s.%s.svc.cluster.local:9090",
+		kedaEPPGuidePrometheusSvc,
+		cfg.MonitoringNS,
+	)
+	expectedTriggers := map[string]map[string]string{
+		kedaEPPGuideQueueTrigger: {
+			"query":         kedaEPPGuideQueueQuery,
+			"threshold":     kedaEPPGuideQueueThreshold,
+			"serverAddress": serverAddress,
+		},
+		kedaEPPGuideRunTrigger: {
+			"query":         kedaEPPGuideRunQuery,
+			"threshold":     kedaEPPGuideRunThreshold,
+			"serverAddress": serverAddress,
+		},
+	}
+
+	seenTriggers := map[string]bool{}
+	for _, trigger := range scaledObject.Spec.Triggers {
+		expectedMetadata, expected := expectedTriggers[trigger.Name]
+		Expect(expected).To(BeTrue(), "unexpected Prometheus trigger %q on the canonical ScaledObject", trigger.Name)
+		Expect(seenTriggers).NotTo(HaveKey(trigger.Name), "canonical trigger %s must be unique", trigger.Name)
+		seenTriggers[trigger.Name] = true
+		Expect(trigger.Type).To(Equal("prometheus"))
+		Expect(trigger.MetricType).To(Equal(autoscalingv2.AverageValueMetricType))
+		Expect(trigger.Metadata).To(
+			Equal(expectedMetadata),
+			"trigger %s metadata must contain only its exact query, threshold, and verified HTTPS endpoint",
+			trigger.Name,
+		)
+		Expect(trigger.AuthenticationRef).To(Equal(&kedav1alpha1.AuthenticationRef{
+			Name: kedaEPPGuideAuthentication,
+		}), "trigger %s must use the namespaced TriggerAuthentication", trigger.Name)
+	}
+	Expect(seenTriggers).To(Equal(map[string]bool{
+		kedaEPPGuideQueueTrigger: true,
+		kedaEPPGuideRunTrigger:   true,
+	}))
+}
+
+func assertKEDAEPPGuideAuthenticationContract(authentication *kedav1alpha1.TriggerAuthentication) {
+	GinkgoHelper()
+
+	Expect(authentication.Namespace).To(Equal(cfg.LLMDNamespace))
+	Expect(authentication.Name).To(Equal(kedaEPPGuideAuthentication))
+	Expect(authentication.Spec).To(Equal(kedav1alpha1.TriggerAuthenticationSpec{
+		SecretTargetRef: []kedav1alpha1.AuthSecretTargetRef{
+			kedav1alpha1.AuthSecretTargetRef(kedav1alpha1.AuthTargetRef{
+				Parameter: "ca",
+				Name:      kedaEPPGuideAuthentication,
+				Key:       "ca.crt",
+			}),
+		},
+	}), "TriggerAuthentication must contain only the intended CA Secret reference")
 }
 
 func waitForKEDAEPPGuideScaledObjectReady() *kedav1alpha1.ScaledObject {
 	GinkgoHelper()
 
-	deadline := time.Now().Add(time.Duration(cfg.EventuallyExtendedSec) * time.Second)
+	deadline := time.Now().Add(kedaEPPGuideStabilizationTimeout)
 	for time.Now().Before(deadline) {
 		scaledObject := &kedav1alpha1.ScaledObject{}
 		callContext, cancelCall := kedaEPPGuideCallContext()
@@ -287,13 +310,13 @@ func waitForKEDAEPPGuideScaledObjectReady() *kedav1alpha1.ScaledObject {
 		cancelCall()
 		if err == nil {
 			ready := scaledObject.Status.Conditions.GetReadyCondition()
-			if ready.Status == metav1.ConditionTrue && scaledObject.Status.HpaName != "" {
+			if ready.Status == metav1.ConditionTrue {
 				return scaledObject
 			}
 		} else if !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
-		time.Sleep(time.Duration(cfg.PollIntervalSec) * time.Second)
+		time.Sleep(kedaEPPGuidePollInterval)
 	}
 
 	Fail(fmt.Sprintf("ScaledObject %s/%s did not reach Ready=True", cfg.LLMDNamespace, kedaEPPGuideScaledObject))
@@ -308,36 +331,36 @@ func waitForKEDAEPPGuideHPA(scaledObject *kedav1alpha1.ScaledObject) *autoscalin
 		callContext, cancelCall := kedaEPPGuideCallContext()
 		current, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(
 			callContext,
-			scaledObject.Status.HpaName,
+			kedaEPPGuideHPAName,
 			metav1.GetOptions{},
 		)
 		cancelCall()
 		g.Expect(err).NotTo(HaveOccurred())
 
-		owned := false
+		controllerOwners := make([]metav1.OwnerReference, 0, 1)
 		for _, owner := range current.OwnerReferences {
-			if owner.UID == scaledObject.UID &&
-				owner.APIVersion == "keda.sh/v1alpha1" &&
-				owner.Kind == "ScaledObject" &&
-				owner.Name == scaledObject.Name &&
-				owner.Controller != nil && *owner.Controller {
-				owned = true
-				break
+			if owner.Controller != nil && *owner.Controller {
+				controllerOwners = append(controllerOwners, owner)
 			}
 		}
-		g.Expect(owned).To(BeTrue(), "generated HPA should be owned by the current ScaledObject UID")
+		g.Expect(controllerOwners).To(HaveLen(1), "generated HPA must have exactly one controller owner")
+		owner := controllerOwners[0]
+		g.Expect(owner.APIVersion).To(Equal("keda.sh/v1alpha1"))
+		g.Expect(owner.Kind).To(Equal("ScaledObject"))
+		g.Expect(owner.Name).To(Equal(kedaEPPGuideScaledObject))
+		g.Expect(owner.UID).To(Equal(scaledObject.UID), "generated HPA must be owned by the current ScaledObject UID")
 		hpa = current
-	}).Should(Succeed())
+	}, kedaEPPGuideMetricObservationTimeout, kedaEPPGuidePollInterval).Should(Succeed())
 	return hpa
 }
 
-func waitForKEDAEPPGuideBaseline(hpaName string) {
+func waitForKEDAEPPGuideBaseline() {
 	GinkgoHelper()
 
 	stable := 0
 	Eventually(func(g Gomega) {
 		hpaContext, cancelHPA := kedaEPPGuideCallContext()
-		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, hpaName, metav1.GetOptions{})
+		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, kedaEPPGuideHPAName, metav1.GetOptions{})
 		cancelHPA()
 		g.Expect(err).NotTo(HaveOccurred())
 		deploymentContext, cancelDeployment := kedaEPPGuideCallContext()
@@ -345,18 +368,20 @@ func waitForKEDAEPPGuideBaseline(hpaName string) {
 		cancelDeployment()
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(deployment.Spec.Replicas).NotTo(BeNil())
+		g.Expect(hpa.Status.DesiredReplicas).To(BeNumerically("<=", 2))
+		g.Expect(*deployment.Spec.Replicas).To(BeNumerically("<=", 2))
+		g.Expect(deployment.Status.Replicas).To(BeNumerically("<=", 2))
+		g.Expect(deployment.Status.ReadyReplicas).To(BeNumerically("<=", 2))
 
-		if hpa.Status.CurrentReplicas == 1 &&
-			hpa.Status.DesiredReplicas == 1 &&
+		if hpa.Status.DesiredReplicas == 1 &&
 			*deployment.Spec.Replicas == 1 &&
-			deployment.Status.Replicas == 1 &&
 			deployment.Status.ReadyReplicas == 1 {
 			stable++
 		} else {
 			stable = 0
 		}
 		g.Expect(stable).To(BeNumerically(">=", kedaEPPGuideStableCount))
-	}, time.Duration(cfg.EventuallyExtendedSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+	}, kedaEPPGuideStabilizationTimeout, kedaEPPGuidePollInterval).Should(Succeed())
 }
 
 func createKEDAEPPGuideRequestPod() string {
@@ -390,7 +415,7 @@ func createKEDAEPPGuideRequestPod() string {
 				Args: []string{
 					fmt.Sprintf(
 						`exec curl --fail --silent --show-error --connect-timeout 10 --max-time %d -H 'Content-Type: application/json' --data-binary "$PAYLOAD" "$TARGET_URL"`,
-						kedaEPPGuideRequestLimit,
+						int(kedaEPPGuideRequestLifetime/time.Second),
 					),
 				},
 				Env: []corev1.EnvVar{
@@ -431,25 +456,7 @@ func waitForKEDAEPPGuidePodsDeleted(names []string) {
 			cancelCall()
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "guide pod %s should be deleted, got %v", name, err)
 		}
-	}, time.Duration(cfg.EventuallyMediumSec)*time.Second, time.Duration(cfg.PollIntervalQuickSec)*time.Second).Should(Succeed())
-}
-
-func assertKEDAEPPGuideServiceMonitor() {
-	GinkgoHelper()
-
-	serviceMonitor := &promoperator.ServiceMonitor{}
-	Eventually(func(g Gomega) {
-		callContext, cancelCall := kedaEPPGuideCallContext()
-		err := crClient.Get(callContext, client.ObjectKey{
-			Namespace: cfg.LLMDNamespace,
-			Name:      kedaEPPGuideServiceMonitor,
-		}, serviceMonitor)
-		cancelCall()
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(serviceMonitor.Spec.Endpoints).To(HaveLen(1))
-		g.Expect(serviceMonitor.Spec.Endpoints[0].Port).To(Equal("http-metrics"))
-		g.Expect(serviceMonitor.Spec.Endpoints[0].Path).To(Equal("/metrics"))
-	}, time.Duration(cfg.EventuallyMediumSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+	}, kedaEPPGuideRequestStartupTimeout, kedaEPPGuideQuickPollInterval).Should(Succeed())
 }
 
 func assertKEDAEPPGuideSecureTrust() {
@@ -475,63 +482,27 @@ func assertKEDAEPPGuideSecureTrust() {
 	operatorContainer := operator.Spec.Template.Spec.Containers[0]
 	Expect(operatorContainer.Args).To(ContainElement("--ca-dir=/custom/ca"))
 
-	foundMount := false
+	var caMount *corev1.VolumeMount
 	for _, mount := range operatorContainer.VolumeMounts {
-		if mount.Name == "llmd-prometheus-ca" && mount.MountPath == "/custom/ca" && mount.ReadOnly {
-			foundMount = true
+		if mount.Name == "llmd-prometheus-ca" {
+			mount := mount
+			caMount = &mount
 		}
 	}
-	Expect(foundMount).To(BeTrue(), "KEDA operator must mount the public Prometheus CA read-only")
-}
+	Expect(caMount).NotTo(BeNil(), "KEDA operator must mount the public Prometheus CA")
+	Expect(caMount.MountPath).To(Equal("/custom/ca"))
+	Expect(caMount.ReadOnly).To(BeTrue(), "KEDA operator public CA mount must be read-only")
 
-func waitForKEDAEPPGuideDirectMetric(triggerName string, expected float64) {
-	GinkgoHelper()
-
-	Eventually(func(g Gomega) {
-		output, err := runKEDAEPPGuideCurlProbe(
-			"direct-metrics",
-			[]string{
-				"--fail", "--silent", "--show-error", "--connect-timeout", "10", "--max-time", "30",
-				fmt.Sprintf("http://%s.%s.svc.cluster.local:9090/metrics", cfg.EPPServiceName, cfg.LLMDNamespace),
-			},
-			false,
-		)
-		g.Expect(err).NotTo(HaveOccurred())
-		aggregate, matches, err := kedaEPPGuideDirectMetricValue(output, triggerName)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(matches).To(BeNumerically(">=", 1), "direct EPP metric %s must expose at least one matching per-model series", triggerName)
-		g.Expect(aggregate).To(BeNumerically("==", expected))
-	}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
-}
-
-func kedaEPPGuideDirectMetricValue(output, triggerName string) (float64, int, error) {
-	metricName := map[string]string{
-		kedaEPPGuideQueueTrigger: "llm_d_epp_flow_control_queue_size",
-		kedaEPPGuideRunTrigger:   "llm_d_epp_request_running",
-	}[triggerName]
-	if metricName == "" {
-		return 0, 0, fmt.Errorf("unknown guide trigger %q", triggerName)
+	var caVolume *corev1.Volume
+	for _, volume := range operator.Spec.Template.Spec.Volumes {
+		if volume.Name == caMount.Name {
+			volume := volume
+			caVolume = &volume
+		}
 	}
-
-	matches := 0
-	aggregate := float64(0)
-	for _, line := range strings.Split(output, "\n") {
-		if !strings.HasPrefix(line, metricName+"{") ||
-			!strings.Contains(line, `model_name="Qwen/Qwen3-32B"`) {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) != 2 {
-			return 0, matches, fmt.Errorf("unexpected direct metric line %q", line)
-		}
-		parsed, err := strconv.ParseFloat(fields[1], 64)
-		if err != nil {
-			return 0, matches, fmt.Errorf("parse direct metric value %q: %w", fields[1], err)
-		}
-		matches++
-		aggregate += parsed
-	}
-	return aggregate, matches, nil
+	Expect(caVolume).NotTo(BeNil(), "KEDA operator CA mount must have a matching volume")
+	Expect(caVolume.Secret).NotTo(BeNil(), "KEDA operator CA volume must be Secret-backed")
+	Expect(caVolume.Secret.SecretName).To(Equal("llmd-prometheus-ca"))
 }
 
 type kedaEPPGuidePrometheusQueryResponse struct {
@@ -551,7 +522,7 @@ func waitForKEDAEPPGuidePrometheusValue(query string, expected float64) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(cardinality).To(Equal(1), "PromQL must return exactly one result rather than treating absence as zero")
 		g.Expect(value).To(BeNumerically("==", expected))
-	}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+	}, kedaEPPGuideMetricObservationTimeout, kedaEPPGuidePollInterval).Should(Succeed())
 }
 
 func kedaEPPGuidePrometheusValue(query string) (float64, int, error) {
@@ -638,7 +609,7 @@ func waitForKEDAEPPGuidePrometheusTarget() {
 			}
 		}
 		g.Expect(matched).To(Equal(1), "Prometheus must discover exactly one EPP target")
-	}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+	}, kedaEPPGuideMetricObservationTimeout, kedaEPPGuidePollInterval).Should(Succeed())
 }
 
 func runKEDAEPPGuideCurlProbe(nameSuffix string, args []string, mountPrometheusCA bool) (string, error) {
@@ -709,7 +680,7 @@ func runKEDAEPPGuideCurlProbe(nameSuffix string, args []string, mountPrometheusC
 			}
 			return string(logs), nil
 		}
-		time.Sleep(time.Duration(cfg.PollIntervalQuickSec) * time.Second)
+		time.Sleep(kedaEPPGuideQuickPollInterval)
 	}
 	return "", fmt.Errorf("%s probe %s did not complete within %s", nameSuffix, created.Name, kedaEPPGuideProbeTimeout)
 }
@@ -732,7 +703,7 @@ func waitForKEDAEPPGuideRequestPods(names []string) {
 			g.Expect(pod.Status.ContainerStatuses).To(HaveLen(1))
 			g.Expect(pod.Status.ContainerStatuses[0].State.Running).NotTo(BeNil(), "request pod %s curl should be running", name)
 		}
-	}, time.Duration(cfg.EventuallyMediumSec)*time.Second, time.Duration(cfg.PollIntervalQuickSec)*time.Second).Should(Succeed())
+	}, kedaEPPGuideRequestStartupTimeout, kedaEPPGuideQuickPollInterval).Should(Succeed())
 }
 
 func kedaEPPGuideExternalMetric(metricName string) (float64, error) {
@@ -766,19 +737,18 @@ func kedaEPPGuideExternalMetric(metricName string) (float64, error) {
 	return quantity.AsApproximateFloat64(), nil
 }
 
-func waitForKEDAEPPGuidePhaseA(hpaName, runningMetricName, queueMetricName string, requestPods []string) {
+func waitForKEDAEPPGuidePhaseA(runningMetricName, queueMetricName string, requestPods []string) {
 	GinkgoHelper()
 
-	deadline := time.Now().Add(time.Duration(cfg.EventuallyExtendedSec) * time.Second)
+	deadline := time.Now().Add(kedaEPPGuideStabilizationTimeout)
 	stable := 0
 	sample := 0
 
 	for time.Now().Before(deadline) {
 		sample++
-		assertKEDAEPPGuideRequestsActive(requestPods)
 
 		hpaContext, cancelHPA := kedaEPPGuideCallContext()
-		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, hpaName, metav1.GetOptions{})
+		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, kedaEPPGuideHPAName, metav1.GetOptions{})
 		cancelHPA()
 		Expect(err).NotTo(HaveOccurred())
 		deploymentContext, cancelDeployment := kedaEPPGuideCallContext()
@@ -788,10 +758,9 @@ func waitForKEDAEPPGuidePhaseA(hpaName, runningMetricName, queueMetricName strin
 		Expect(deployment.Spec.Replicas).NotTo(BeNil())
 
 		values := map[string]int32{
-			"hpaCurrent":       hpa.Status.CurrentReplicas,
 			"hpaDesired":       hpa.Status.DesiredReplicas,
 			"deploymentSpec":   *deployment.Spec.Replicas,
-			"deploymentStatus": deployment.Status.Replicas,
+			"deploymentActual": deployment.Status.Replicas,
 			"deploymentReady":  deployment.Status.ReadyReplicas,
 		}
 		for name, value := range values {
@@ -802,15 +771,15 @@ func waitForKEDAEPPGuidePhaseA(hpaName, runningMetricName, queueMetricName strin
 
 		runningValue, runningErr := kedaEPPGuideExternalMetric(runningMetricName)
 		queueValue, queueErr := kedaEPPGuideExternalMetric(queueMetricName)
+		requestsActive := kedaEPPGuideRequestsActive(requestPods)
 		exactPhaseA := runningErr == nil &&
 			queueErr == nil &&
 			runningValue == 1 &&
 			queueValue == 1 &&
-			hpa.Status.CurrentReplicas == 1 &&
 			hpa.Status.DesiredReplicas == 1 &&
 			*deployment.Spec.Replicas == 1 &&
-			deployment.Status.Replicas == 1 &&
-			deployment.Status.ReadyReplicas == 1
+			deployment.Status.ReadyReplicas == 1 &&
+			requestsActive
 		if exactPhaseA {
 			stable++
 		} else {
@@ -818,7 +787,7 @@ func waitForKEDAEPPGuidePhaseA(hpaName, runningMetricName, queueMetricName strin
 		}
 
 		GinkgoWriter.Printf(
-			"guide phase A sample=%d hpa=%d/%d deployment=%d/%d/%d rawRunning=%v runningErr=%v rawQueue=%v queueErr=%v stable=%d\n",
+			"guide phase A sample=%d hpa=%d/%d deployment=%d/%d/%d rawRunning=%v runningErr=%v rawQueue=%v queueErr=%v requestsActive=%v stable=%d\n",
 			sample,
 			hpa.Status.CurrentReplicas,
 			hpa.Status.DesiredReplicas,
@@ -829,13 +798,14 @@ func waitForKEDAEPPGuidePhaseA(hpaName, runningMetricName, queueMetricName strin
 			runningErr,
 			queueValue,
 			queueErr,
+			requestsActive,
 			stable,
 		)
 
 		if stable >= kedaEPPGuideStableCount {
 			return
 		}
-		time.Sleep(time.Duration(cfg.PollIntervalQuickSec) * time.Second)
+		time.Sleep(kedaEPPGuideQuickPollInterval)
 	}
 
 	Fail("guide Phase A did not produce stable one-running/one-queued exact-one state")
@@ -853,22 +823,20 @@ func nestedMetricValue(object map[string]any) (string, bool, error) {
 	return stringValue, true, nil
 }
 
-func waitForKEDAEPPGuideScaleUp(hpaName, runningMetricName, queueMetricName string, requestPods []string) {
+func waitForKEDAEPPGuideScaleUp(runningMetricName, queueMetricName string, requestPods []string) {
 	GinkgoHelper()
 	Expect(requestPods).To(HaveLen(3), "Phase B must retain exactly three bounded request pods")
 
-	deadline := time.Now().Add(time.Duration(cfg.ScaleUpTimeout) * time.Second)
-	desiredTransitionSeen := false
+	deadline := time.Now().Add(kedaEPPGuideScaleTransitionTimeout)
 	phaseBMetricsSeen := false
 	stable := 0
 	sample := 0
 
 	for time.Now().Before(deadline) {
 		sample++
-		assertKEDAEPPGuideRequestsActive(requestPods)
 
 		hpaContext, cancelHPA := kedaEPPGuideCallContext()
-		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, hpaName, metav1.GetOptions{})
+		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Get(hpaContext, kedaEPPGuideHPAName, metav1.GetOptions{})
 		cancelHPA()
 		Expect(err).NotTo(HaveOccurred())
 		deploymentContext, cancelDeployment := kedaEPPGuideCallContext()
@@ -878,10 +846,9 @@ func waitForKEDAEPPGuideScaleUp(hpaName, runningMetricName, queueMetricName stri
 		Expect(deployment.Spec.Replicas).NotTo(BeNil())
 
 		values := map[string]int32{
-			"hpaCurrent":       hpa.Status.CurrentReplicas,
 			"hpaDesired":       hpa.Status.DesiredReplicas,
 			"deploymentSpec":   *deployment.Spec.Replicas,
-			"deploymentStatus": deployment.Status.Replicas,
+			"deploymentActual": deployment.Status.Replicas,
 			"deploymentReady":  deployment.Status.ReadyReplicas,
 		}
 		for name, value := range values {
@@ -898,25 +865,16 @@ func waitForKEDAEPPGuideScaleUp(hpaName, runningMetricName, queueMetricName stri
 		if queueErr == nil && queueValue > 2 {
 			Fail(fmt.Sprintf("bounded guide stimulus observed rawQueue=%v (>2)", queueValue))
 		}
-		if runningErr == nil && queueErr == nil && runningValue == 1 && queueValue == 2 {
+		requestsActive := kedaEPPGuideRequestsActive(requestPods)
+		phaseBMetrics := runningErr == nil && queueErr == nil && runningValue == 1 && queueValue == 2 && requestsActive
+		if phaseBMetrics {
 			phaseBMetricsSeen = true
 		}
 
-		if !desiredTransitionSeen && hpa.Status.DesiredReplicas != 1 {
-			if hpa.Status.DesiredReplicas != 2 {
-				Fail(fmt.Sprintf(
-					"first HPA desired transition was 1 -> %d, want exactly 1 -> 2",
-					hpa.Status.DesiredReplicas,
-				))
-			}
-			desiredTransitionSeen = true
-		}
-
-		exactTwo := hpa.Status.CurrentReplicas == 2 &&
-			hpa.Status.DesiredReplicas == 2 &&
+		exactTwo := hpa.Status.DesiredReplicas == 2 &&
 			*deployment.Spec.Replicas == 2 &&
-			deployment.Status.Replicas == 2 &&
-			deployment.Status.ReadyReplicas == 2
+			deployment.Status.ReadyReplicas == 2 &&
+			requestsActive
 		if exactTwo {
 			stable++
 		} else {
@@ -924,7 +882,7 @@ func waitForKEDAEPPGuideScaleUp(hpaName, runningMetricName, queueMetricName stri
 		}
 
 		GinkgoWriter.Printf(
-			"guide scale sample=%d hpa=%d/%d deployment=%d/%d/%d rawRunning=%v runningErr=%v rawQueue=%v queueErr=%v phaseBMetrics=%v transition=%v stable=%d\n",
+			"guide scale sample=%d hpa=%d/%d deployment=%d/%d/%d rawRunning=%v runningErr=%v rawQueue=%v queueErr=%v requestsActive=%v phaseBMetrics=%v stable=%d\n",
 			sample,
 			hpa.Status.CurrentReplicas,
 			hpa.Status.DesiredReplicas,
@@ -935,22 +893,19 @@ func waitForKEDAEPPGuideScaleUp(hpaName, runningMetricName, queueMetricName stri
 			runningErr,
 			queueValue,
 			queueErr,
+			requestsActive,
 			phaseBMetricsSeen,
-			desiredTransitionSeen,
 			stable,
 		)
 
-		if desiredTransitionSeen && phaseBMetricsSeen && stable >= kedaEPPGuideStableCount {
-			Expect(requestPods).To(HaveLen(3), "Phase B success must retain exactly three bounded request pods")
-			assertKEDAEPPGuideRequestsActive(requestPods)
+		if phaseBMetricsSeen && stable >= kedaEPPGuideStableCount {
 			return
 		}
-		time.Sleep(time.Duration(cfg.PollIntervalQuickSec) * time.Second)
+		time.Sleep(kedaEPPGuideQuickPollInterval)
 	}
 
 	Fail(fmt.Sprintf(
-		"bounded guide stimulus did not produce stable exact-two state (desiredTransitionSeen=%v phaseBMetricsSeen=%v)",
-		desiredTransitionSeen,
+		"bounded guide stimulus did not produce stable exact-two state (phaseBMetricsSeen=%v)",
 		phaseBMetricsSeen,
 	))
 }
@@ -967,15 +922,19 @@ func assertKEDAEPPGuideHPAScalingRules(name string, rules *autoscalingv2.HPAScal
 	Expect(rules).NotTo(BeNil(), "canonical HPA %s rules must be present", name)
 	Expect(rules.StabilizationWindowSeconds).NotTo(BeNil(), "canonical HPA %s stabilization must be explicit", name)
 	Expect(*rules.StabilizationWindowSeconds).To(Equal(stabilizationWindow), "canonical HPA %s stabilization drifted", name)
+	Expect(rules.SelectPolicy).NotTo(BeNil(), "effective HPA %s select policy must be explicit", name)
+	Expect(*rules.SelectPolicy).To(Equal(autoscalingv2.MaxChangePolicySelect), "effective HPA %s select policy drifted", name)
 	Expect(rules.Policies).To(HaveLen(1), "canonical HPA %s must retain one policy", name)
 	Expect(rules.Policies[0].Type).To(Equal(autoscalingv2.PercentScalingPolicy), "canonical HPA %s policy type drifted", name)
 	Expect(rules.Policies[0].Value).To(Equal(int32(100)), "canonical HPA %s policy value drifted", name)
 	Expect(rules.Policies[0].PeriodSeconds).To(Equal(int32(15)), "canonical HPA %s policy period drifted", name)
+	Expect(rules.Tolerance).To(BeNil(), "canonical HPA %s must not set a per-direction tolerance", name)
 }
 
-func assertKEDAEPPGuideRequestsActive(names []string) {
+func kedaEPPGuideRequestsActive(names []string) bool {
 	GinkgoHelper()
 
+	allActive := true
 	for _, name := range names {
 		callContext, cancelCall := kedaEPPGuideCallContext()
 		pod, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).Get(callContext, name, metav1.GetOptions{})
@@ -984,66 +943,13 @@ func assertKEDAEPPGuideRequestsActive(names []string) {
 		if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
 			Fail(fmt.Sprintf("bounded request pod %s exited before scale evidence (phase=%s)", name, pod.Status.Phase))
 		}
+		if pod.Status.Phase != corev1.PodRunning ||
+			len(pod.Status.ContainerStatuses) != 1 ||
+			pod.Status.ContainerStatuses[0].State.Running == nil {
+			allActive = false
+		}
 	}
-}
-
-func kedaEPPGuideEventuallyBudget(timeoutSeconds, apiCallsPerAttempt int) time.Duration {
-	return time.Duration(timeoutSeconds)*time.Second +
-		time.Duration(apiCallsPerAttempt)*kedaEPPGuideAPITimeout
-}
-
-// A probe attempt can spend one API deadline creating the Pod, the probe
-// deadline waiting for it, one final Get deadline, one log-read deadline, and
-// one best-effort delete deadline. Eventually may start that full attempt just
-// before its own deadline, so both bounds are additive.
-func kedaEPPGuideProbeAttemptBudget() time.Duration {
-	return kedaEPPGuideProbeTimeout + 4*kedaEPPGuideAPITimeout
-}
-
-func kedaEPPGuideProbeObservationBudget() time.Duration {
-	return time.Duration(cfg.EventuallyLongSec)*time.Second + kedaEPPGuideProbeAttemptBudget()
-}
-
-func kedaEPPGuideWarmupObservationBudget() time.Duration {
-	return kedaEPPGuideAPITimeout + // create the warmup request
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // request Pod startup
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // ServiceMonitor
-		3*kedaEPPGuideAPITimeout + // two CA Secrets and the KEDA operator Deployment
-		5*kedaEPPGuideProbeObservationBudget() // two direct metrics, target, two PromQL queries
-}
-
-func kedaEPPGuideDeterministicObservationBudget() time.Duration {
-	return kedaEPPGuideAPITimeout + // first request create
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // first request Pod startup
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyLongSec, 1) + // running external metric
-		kedaEPPGuideAPITimeout + // second request create
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyExtendedSec, 6) + // Phase A: two Pods, HPA, Deployment, two metrics
-		kedaEPPGuideAPITimeout + // third request create
-		kedaEPPGuideEventuallyBudget(cfg.ScaleUpTimeout, 7) // Phase B: three Pods, HPA, Deployment, two metrics
-}
-
-// This is the complete successful-spec observation bound. It includes every
-// bounded wait in BeforeAll and the It body, materially extending API calls,
-// both stage-boundary log checks, and explicit/deferred stimulus cleanup. The
-// suite preflight and failure diagnostics are reserved outside this bound by
-// the Ginkgo/Go/CI timeout hierarchy in the Make target and workflow.
-func kedaEPPGuideCompleteSpecBudget() time.Duration {
-	operatorLogBudget := time.Duration(1+kedaEPPGuideMaxLogStreams) * kedaEPPGuideAPITimeout
-	return kedaEPPGuideEventuallyBudget(cfg.PodReadyTimeout, 1) + // simulator Ready in BeforeAll
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // ScaledObject created
-		kedaEPPGuideWarmupObservationBudget() +
-		kedaEPPGuideAPITimeout + // delete warmup request
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyMediumSec, 1) + // warmup deletion observed
-		2*kedaEPPGuideProbeObservationBudget() + // both PromQL series reset
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyExtendedSec, 1) + // ScaledObject Ready
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyStandardSec, 1) + // generated HPA
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyLongSec, 2) + // both external metrics reset
-		kedaEPPGuideEventuallyBudget(cfg.EventuallyExtendedSec, 2) + // stable one-replica baseline
-		operatorLogBudget +
-		kedaEPPGuideDeterministicObservationBudget() +
-		3*kedaEPPGuideAPITimeout + // explicit request deletion
-		operatorLogBudget +
-		4*kedaEPPGuideAPITimeout // deferred three-request and simulator deletion
+	return allActive
 }
 
 func kedaEPPGuideCallContext() (context.Context, context.CancelFunc) {
@@ -1090,7 +996,7 @@ type kedaEPPGuideOperatorLog struct {
 }
 
 func readKEDAEPPGuideOperatorLogs() ([]kedaEPPGuideOperatorLog, error) {
-	listContext, cancelList := context.WithTimeout(ctx, 10*time.Second)
+	listContext, cancelList := context.WithTimeout(ctx, kedaEPPGuideAPITimeout)
 	pods, err := k8sClient.CoreV1().Pods(cfg.KEDANamespace).List(listContext, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=keda-operator",
 	})
@@ -1108,7 +1014,7 @@ func readKEDAEPPGuideOperatorLogs() ([]kedaEPPGuideOperatorLog, error) {
 			if len(operatorLogs) >= kedaEPPGuideMaxLogStreams {
 				return operatorLogs, nil
 			}
-			logContext, cancelLogs := context.WithTimeout(ctx, 10*time.Second)
+			logContext, cancelLogs := context.WithTimeout(ctx, kedaEPPGuideAPITimeout)
 			logs, err := k8sClient.CoreV1().Pods(cfg.KEDANamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 				Container:    container.Name,
 				SinceSeconds: ptr.To(kedaEPPGuideLogSinceSecs),

--- a/test/e2e/keda_epp_guide_test.go
+++ b/test/e2e/keda_epp_guide_test.go
@@ -48,7 +48,7 @@ const (
 )
 
 var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, func() {
-	var requestPods []string
+	requestPods := make([]string, 0, 3)
 
 	deleteRequests := func() {
 		deleteKEDAEPPGuidePods(requestPods)
@@ -165,7 +165,7 @@ var _ = Describe("KEDA EPP guide contract", Label("keda-epp-guide"), Ordered, fu
 		By("ending warmup and proving it cannot contaminate the deterministic phases")
 		deleteKEDAEPPGuidePods(requestPods)
 		waitForKEDAEPPGuidePodsDeleted(requestPods)
-		requestPods = nil
+		requestPods = requestPods[:0]
 		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideRunQuery, 0)
 		waitForKEDAEPPGuidePrometheusValue(kedaEPPGuideQueueQuery, 0)
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -72,6 +72,7 @@ var _ = BeforeSuite(func() {
 	GinkgoWriter.Printf("=== E2E Test Configuration ===\n")
 	GinkgoWriter.Printf("Environment: %s\n", cfg.Environment)
 	GinkgoWriter.Printf("WVA Namespace: %s\n", cfg.WVANamespace)
+	GinkgoWriter.Printf("Deploy WVA: %v\n", cfg.DeployWVA)
 	GinkgoWriter.Printf("LLMD Namespace: %s\n", cfg.LLMDNamespace)
 	GinkgoWriter.Printf("Use Simulator: %v\n", cfg.UseSimulator)
 	GinkgoWriter.Printf("Scale-to-Zero Enabled: %v\n", cfg.ScaleToZeroEnabled)
@@ -118,23 +119,27 @@ var _ = BeforeSuite(func() {
 
 	ctx, cancel = context.WithCancel(context.Background()) //nolint:fatcontext // shared across BeforeSuite/AfterSuite
 
-	By("Verifying WVA controller is running")
-	Eventually(func(g Gomega) {
-		pods, err := k8sClient.CoreV1().Pods(cfg.WVANamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: "control-plane=controller-manager",
-		})
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(pods.Items).NotTo(BeEmpty(), "WVA controller pod not found")
+	if cfg.DeployWVA {
+		By("Verifying WVA controller is running")
+		Eventually(func(g Gomega) {
+			pods, err := k8sClient.CoreV1().Pods(cfg.WVANamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "control-plane=controller-manager",
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pods.Items).NotTo(BeEmpty(), "WVA controller pod not found")
 
-		// Check at least one pod is running
-		runningPods := 0
-		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodRunning {
-				runningPods++
+			// Check at least one pod is running
+			runningPods := 0
+			for _, pod := range pods.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					runningPods++
+				}
 			}
-		}
-		g.Expect(runningPods).To(BeNumerically(">", 0), "No running WVA controller pods")
-	}).Should(Succeed(), "WVA controller should be running")
+			g.Expect(runningPods).To(BeNumerically(">", 0), "No running WVA controller pods")
+		}).Should(Succeed(), "WVA controller should be running")
+	} else {
+		GinkgoWriter.Println("Skipping WVA controller readiness (DEPLOY_WVA=false)")
+	}
 
 	By("Verifying llm-d infrastructure")
 	// Verify Gateway CRDs exist
@@ -173,7 +178,11 @@ var _ = ReportAfterEach(func(report SpecReport) {
 	}
 
 	GinkgoWriter.Printf("\n=== Failure diagnostics: %s ===\n", report.FullText())
-	utils.DumpControllerLogs(context.Background(), k8sClient, cfg.WVANamespace, GinkgoWriter)
+	if cfg.DeployWVA {
+		utils.DumpControllerLogs(context.Background(), k8sClient, cfg.WVANamespace, GinkgoWriter)
+	} else {
+		dumpKEDAEPPGuideOperatorLogs()
+	}
 	utils.DumpManagedScalers(context.Background(), k8sClient, GinkgoWriter)
 })
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -181,7 +181,7 @@ var _ = ReportAfterEach(func(report SpecReport) {
 	if cfg.DeployWVA {
 		utils.DumpControllerLogs(context.Background(), k8sClient, cfg.WVANamespace, GinkgoWriter)
 	} else {
-		dumpKEDAEPPGuideOperatorLogs()
+		dumpKEDAEPPGuideDiagnostics()
 	}
 	utils.DumpManagedScalers(context.Background(), k8sClient, GinkgoWriter)
 })


### PR DESCRIPTION
## Motivation

This PR adds the WVA-owned Kind qualification path for the llm-d KEDA+EPP queue guide.

The intended ownership split is:

* WVA owns the deterministic Kind setup, lifecycle, conformance spec, diagnostics, and CI lane
* llm-d remains the source of truth for the user-facing guide and owns real-model / real-GPU nightly qualification

The Kind path is intentionally CPU-only. It uses a deterministic inference simulator with the canonical optimized-baseline decode Deployment identity so that the Prometheus → KEDA → HPA control path can be exercised without requiring real GPUs or KV-cache behavior.

## Changes

### Disposable Kind setup

Add:

```bash
make test-e2e-keda-epp-guide-with-setup
```

This target owns the complete disposable lifecycle:

1. creates a fresh single-node CPU-only Kind cluster;
2. resolves the current official llm-d `main` once to an immutable commit SHA;
3. materializes that exact revision for the complete run;
4. installs low-resource Prometheus, KEDA, and EPP infrastructure;
5. deploys the deterministic simulator under the canonical decode Deployment identity;
6. applies the canonical KEDA `TriggerAuthentication` and `ScaledObject`;
7. runs only the `keda-epp-guide` Ginkgo spec;
8. tears down the isolated Kind cluster on exit.

`LLMD_SOURCE_SHA=<full SHA>` remains available as an explicit opt-in pin for reproducibility, debugging, compatibility investigation, or temporary stabilization. `LLMD_SOURCE` may provide a local checkout for materialization, but its checked-out branch or `HEAD` never selects the canonical revision.

### Canonical guide composition

The EPP install uses the current llm-d inputs in this exact order:

1. canonical router base;
2. canonical optimized-baseline values;
3. canonical monitoring values;
4. canonical KEDA+EPP queue-guide values;
5. one narrow WVA-owned Kind override.

The WVA override provides only the deterministic / disposable-Kind differences needed for this environment, including bounded resources and `maxConcurrency: 1`.

The canonical Kustomize resources are materialized from the selected llm-d revision rather than maintained as an independent WVA copy. A temporary overlay changes only the environment-specific namespace and Prometheus endpoint; normalized comparison rejects other canonical drift.

### Secure KEDA / Prometheus path

The Kind setup keeps Prometheus HTTPS verification enabled.

A generated Prometheus CA is:

* used to issue the Prometheus serving certificate;
* exposed to the workload namespace through the canonical `keda-prometheus-auth` Secret;
* mounted into the KEDA operator as a public-CA-only trust directory.

The Prometheus private key remains only in the monitoring namespace. No `unsafeSsl`, `insecureSkipVerify`, or equivalent TLS bypass is used.

### Deterministic contract

The isolated spec verifies the canonical:

* `ScaledObject` target, replica bounds, generated HPA name, and HPA behavior;
* `TriggerAuthentication` relationship;
* queue trigger:
  `llm_d_epp_flow_control_queue_size`;
* running-request trigger:
  `llm_d_epp_request_running`;
* exact PromQL selectors, thresholds, and `AverageValue` metric type;
* Prometheus target health and exact source-query liveness;
* KEDA external metric freshness and phase-specific values;
* generated HPA ownership, target, selectors, metrics, and behavior;
* independent HPA decision, Deployment actuation, and ReadyReplicas convergence.

Because the EPP per-model metric series are lazy, the spec first sends one bounded warmup request, proves both source series exist through Prometheus, removes the warmup, and requires the downstream KEDA running metric to reset to zero before the deterministic scaling phases.

The deterministic scaling phase then proves:

1. one running request / one queued request remains stable at exactly one replica;
2. adding one more queued request produces the exact running-request and queue stimulus required for scale-up;
3. the HPA desires two replicas and the Deployment is actuated to two replicas;
4. ReadyReplicas converges stably to two;
5. no sampled HPA or Deployment replica value exceeds two.

## CI

Add a dedicated `keda-epp-guide` job to `.github/workflows/ci-pr-checks.yaml`.

The job invokes the same:

```bash
make test-e2e-keda-epp-guide-with-setup
```

entry point used for local execution.

This gives WVA its own deterministic Kind drift signal while real-GPU qualification remains upstream in llm-d.

## Relationship to llm-d GPU qualification

The metric contract and lazy-series ordering are aligned with the real-GPU KEDA+EPP queue path in llm-d #2192 / #2208.

This PR does **not** duplicate that qualification.

Out of scope here:

* real models or GPUs;
* KV-event generation or KV-routing quality;
* sustained/performance load;
* scale-down qualification;
* post-scale inference;
* OpenShift / Thanos qualification;
* stable-guide promotion;
* generic cross-repository synchronization machinery.

Those remain upstream or follow-up concerns.

## Validation

Local/static validation includes:

* `git diff --check`;
* Bash syntax and ShellCheck;
* Go formatting, compile-only E2E validation, vet, and lint;
* workflow/YAML validation;
* canonical render and normalized-equivalence validation;
* exact five-layer Helm ordering;
* source-policy tests for current-main resolution, explicit SHA pins, local-source safety, and fail-closed missing revisions.

A clean fresh-Kind semantic execution passed:

```text
Ran 1 of 73 Specs
SUCCESS! -- 1 Passed | 0 Failed | 72 Skipped
```

The run verified:

* secure Prometheus/KEDA CA trust with no TLS verification bypass;
* lazy-series warmup through Prometheus and downstream KEDA running-metric reset;
* Prometheus source-query liveness and KEDA external-metric liveness;
* exact canonical ScaledObject / TriggerAuthentication contract;
* generated HPA identity, ownership, metric translation, and behavior;
* stable one-running / one-queued Phase A;
* exact running-request and queue scale stimulus in Phase B;
* HPA desired replicas reaching `2`;
* Deployment spec reaching `2`;
* stable ReadyReplicas at `2`;
* no sampled HPA or Deployment replica value above `2`;
* request and fresh-cluster cleanup.

The repository-default Kind image currently uses Kubernetes v1.32. KEDA 2.20 does not list Kubernetes v1.32 in its tested compatibility matrix, although KEDA's deployment prerequisites allow Kubernetes 1.30 and newer. The local pass therefore demonstrates this contract on the repository-default environment but is not presented as evidence of official KEDA compatibility for that pairing.

## Scope

This PR completes the WVA side of the agreed split: the **Kind setup + deterministic spec + CI lane**.

Real-GPU/nightly qualification remains in llm-d.
