### PR TITLE
Remove .yaml from default BENCHMARK_WORKLOAD=prefill_heavy Makefile variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ BENCHMARK_NAMESPACE  ?= # set via BENCHMARK_NAMESPACE=<namespace>
 BENCHMARK_GATEWAY_URL ?= http://infra-llmdbench-inference-gateway-istio.$(BENCHMARK_NAMESPACE).svc.cluster.local:80
 BENCHMARK_WORKSPACE  ?= $(CURDIR)
 BENCHMARK_HARNESS    ?= guidellm
-BENCHMARK_WORKLOAD   ?= prefill_heavy.yaml
+BENCHMARK_WORKLOAD   ?= prefill_heavy
 BENCHMARK_FORCE      ?= true
 BENCHMARK_MONITORING ?= true
 BENCHMARK_UV         ?= false


### PR DESCRIPTION
The .yaml suffix is added later in the workflow. To maintain compatibility with different harnesses, removing it from the default, guidellm-backed, BENCHMARK_WORKLOAD value.
