### PR TITLE
fix(saturation): update stale internal/interfaces refs

### DIFF
--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -506,10 +506,10 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 // It mirrors the analyzer selection in optimize's switch statement.
 func modeLabelForAnalyzer(analyzerName string) string {
 	switch analyzerName {
-	case interfaces.QueueingModelAnalyzerName:
-		return interfaces.QueueingModelAnalyzerName
-	case interfaces.SaturationAnalyzerName:
-		return interfaces.SaturationAnalyzerName
+	case domain.QueueingModelAnalyzerName:
+		return domain.QueueingModelAnalyzerName
+	case domain.SaturationAnalyzerName:
+		return domain.SaturationAnalyzerName
 	default:
 		return "saturation-only"
 	}

--- a/internal/engines/saturation/mode_label_test.go
+++ b/internal/engines/saturation/mode_label_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // TestModeLabelForAnalyzer ensures the "Optimization completed successfully" log
@@ -17,8 +17,8 @@ func TestModeLabelForAnalyzer(t *testing.T) {
 		analyzerName string
 		wantMode     string
 	}{
-		{"queueing model analyzer", interfaces.QueueingModelAnalyzerName, interfaces.QueueingModelAnalyzerName},
-		{"V2 saturation analyzer", interfaces.SaturationAnalyzerName, interfaces.SaturationAnalyzerName},
+		{"queueing model analyzer", domain.QueueingModelAnalyzerName, domain.QueueingModelAnalyzerName},
+		{"V2 saturation analyzer", domain.SaturationAnalyzerName, domain.SaturationAnalyzerName},
 		{"unset analyzer name falls back to V1 saturation-only", "", "saturation-only"},
 		{"unrecognized analyzer name falls back to V1 saturation-only", "not-a-real-analyzer", "saturation-only"},
 	}


### PR DESCRIPTION
Fixes stale internal/interfaces references in the saturation engine left behind by the interfaces → domain rename (#1449), which currently breaks main's build.
