### PR TITLE
docs(throughput-analyzer): fix stale developer-guide and query-comment references

### DIFF
--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -227,7 +227,6 @@ internal/engines/analyzers/throughput/
 ├── observation_window.go      ObservationWindow: rolling (k,ITL) pairs, Ready flag
 ├── sanity.go                  CheckModelMetrics: 6 SanityIssue types
 ├── itl_model.go               ITLModel{A,B}, FitITLModel (OLS), ITLAt(k)
-├── itl_knowledge_store.go     itlKnowledgeStore: tier-3 skeleton (not yet wired)
 └── analyzer.go                ThroughputAnalyzer: Observe() + full Analyze()
 ```
 
@@ -420,9 +419,10 @@ survives shape-change window resets. When no prior Tier-1 fit has occurred (`has
 false), B falls back to `DefaultBaselineITLSec` (0.006 s — H100 baseline at near-zero load).
 `lastFittedB` and `hasFittedB` are exposed in `ThroughputVariantState` for observability.
 
-**Tier 3 (not yet wired):** `itlKnowledgeStore` is present in the package for a future
-zero-replica fallback using the last successful tier-1 fit. It is not wired into the current
-`Analyze()` loop because that loop only iterates variants with active replica metrics.
+**Tier 3 (not implemented):** a zero-replica fallback — reusing the last successful Tier-1 fit
+when a variant has scaled to zero replicas — is not implemented. The current `Analyze()` loop
+only iterates variants with active replica metrics, so a scaled-to-zero variant has no ITL
+model to fall back to.
 
 ## Supply Estimation
 

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -105,7 +105,7 @@ and queueing model registrations.
 #### QueryGenerationTokenRate (`generation_token_rate`)
 
 ```promql
-sum by (pod) (rate(vllm:request_generation_tokens_sum{namespace="...",model_name="..."}[1m]))
+sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_sum{namespace="...",model_name="..."}[1m]))
 ```
 
 **What it measures:** Observed generation (decode) token rate per pod in tokens/sec.
@@ -122,7 +122,7 @@ replica. A deviation > 15% at k* ≥ 0.30 suppresses SpareCapacity for the cycle
 #### QueryKvUsageInstant (`kv_usage_instant`)
 
 ```promql
-max by (pod) (vllm:kv_cache_usage_perc{namespace="...",model_name="..."})
+max by (instance, pod, llm_d_ai_variant) (vllm:kv_cache_usage_perc{namespace="...",model_name="..."})
 ```
 
 **What it measures:** Instantaneous KV cache utilization fraction per pod (0.0–1.0).
@@ -138,20 +138,20 @@ Throughput Analyzer sees the current operating point k*, not a high-water mark f
 spike that has since subsided. Using the peak would overestimate load and cause premature
 scale-up. Both fields coexist on `ReplicaMetrics` for their respective purposes.
 
-**Why `max by (pod)` and not `avg by (pod)`:** `vllm:kv_cache_usage_perc` is a scalar gauge
-per vLLM process, so there is one Prometheus series per pod in normal deployment. The
-`max by (pod)` clause is purely deduplication: if the same pod is scraped by multiple targets
-(e.g., a PodMonitor and a ServiceMonitor), duplicate series with identical values appear under
-the same pod label. `max` collapses them. Since duplicates carry the same value, `max = avg`
-— the choice has no effect on correctness. This follows the convention used by every other
-per-pod query in this codebase.
+**Why `max by (instance, pod, llm_d_ai_variant)` and not `avg by (...)`:** `vllm:kv_cache_usage_perc`
+is a scalar gauge per vLLM process, so there is one Prometheus series per pod in normal
+deployment. The `max by (...)` clause is purely deduplication: if the same pod is scraped by
+multiple targets (e.g., a PodMonitor and a ServiceMonitor), duplicate series with identical
+values appear under the same pod label. `max` collapses them. Since duplicates carry the same
+value, `max = avg` — the choice has no effect on correctness. This follows the convention used
+by every other per-pod query in this codebase.
 
 ---
 
 #### QueryRequestRate (`request_rate`)
 
 ```promql
-sum by (pod) (rate(vllm:request_generation_tokens_count{namespace="...",model_name="..."}[1m]))
+sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_count{namespace="...",model_name="..."}[1m]))
 ```
 
 **What it measures:** Engine-side request completion rate per pod (req/s), derived from the
@@ -203,14 +203,14 @@ namespace filtering limitation of the scheduler metric.
 
 | Query / Field | Source | Aggregation | Window | Purpose in TA |
 |---|---|---|---|---|
-| `QueryGenerationTokenRate` | vLLM | `sum by (pod)` | 1m rate | μ_dec^obs per pod (observability) |
-| `QueryKvUsageInstant` | vLLM | `max by (pod)` | instant | k* (no max_over_time) |
-| `QueryRequestRate` | vLLM | `sum by (pod)` | 1m rate | Fallback λ_req; histogram weight |
+| `QueryGenerationTokenRate` | vLLM | `sum by (instance, pod, llm_d_ai_variant)` | 1m rate | μ_dec^obs per pod (observability) |
+| `QueryKvUsageInstant` | vLLM | `max by (instance, pod, llm_d_ai_variant)` | instant | k* (no max_over_time) |
+| `QueryRequestRate` | vLLM | `sum by (instance, pod, llm_d_ai_variant)` | 1m rate | Fallback λ_req; histogram weight |
 | `TotalKvCapacityTokens` | `KvCacheConfigInfo` labels | derived | static | KV_max = blocks × block_size |
-| `AvgITL` | `QueryAvgITL` | `max by (pod)` | 1m rate | ITL_obs for OLS calibration |
-| `AvgOutputTokens` | `QueryAvgOutputTokens` | `max by (pod)` | 5m rate | OL for KV_req and λ_dec |
-| `AvgInputTokens` | `QueryAvgInputTokens` | `max by (pod)` | 5m rate | IL for IL_eff = IL × (1−H％) |
-| `PrefixCacheHitRate` | `QueryPrefixCacheHitRate` | `max by (pod)` | 5m rate | H％ for IL_eff |
+| `AvgITL` | `QueryAvgITL` | `max by (instance, pod, llm_d_ai_variant)` | 1m rate | ITL_obs for OLS calibration |
+| `AvgOutputTokens` | `QueryAvgOutputTokens` | `max by (instance, pod, llm_d_ai_variant)` | 5m rate | OL for KV_req and λ_dec |
+| `AvgInputTokens` | `QueryAvgInputTokens` | `max by (instance, pod, llm_d_ai_variant)` | 5m rate | IL for IL_eff = IL × (1−H％) |
+| `PrefixCacheHitRate` | `QueryPrefixCacheHitRate` | `max by (instance, pod, llm_d_ai_variant)` | 5m rate | H％ for IL_eff |
 | `ArrivalRate` | `QuerySchedulerDispatchRate` | `sum by (pod_name, namespace)` | 1m rate | λ_req per pod (primary) |
 
 ## Architecture

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -435,7 +435,11 @@ N_dec_sat = DefaultKSat × KV_max / KVreq      # in-flight requests at k_sat
 μ_dec_sat = N_dec_sat / ITL(k_sat)            # decode tokens/sec at saturation operating point
 ```
 
-Per-variant totals: `totalSupply = Σ μ_dec_sat`, `perReplicaSupply = totalSupply / n`.
+Per-variant totals: `totalSupply = Σ μ_dec_sat`, `perReplicaSupply = totalSupply / n`, where
+`n` is the count of KV-capable replicas (`nKV`) — replicas actually reporting KV metrics, not
+a raw spec/status replica count. This `n` becomes `ReplicaCount_v` in the Scaling Signal
+formulas below, mirroring the saturation analyzer's `readyCount`; still-booting KV=0 replicas
+are excluded here and counted separately via `PendingReplicas_v` below instead.
 
 `DefaultKSat = 0.85` — the KV utilization at which μ_dec_sat is evaluated. This is a
 per-analyzer constant pending alignment with the EPP system-wide k_sat (see open items).

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -211,7 +211,7 @@ namespace filtering limitation of the scheduler metric.
 | `AvgOutputTokens` | `QueryAvgOutputTokens` | `max by (instance, pod, llm_d_ai_variant)` | 5m rate | OL for KV_req and λ_dec |
 | `AvgInputTokens` | `QueryAvgInputTokens` | `max by (instance, pod, llm_d_ai_variant)` | 5m rate | IL for IL_eff = IL × (1−H％) |
 | `PrefixCacheHitRate` | `QueryPrefixCacheHitRate` | `max by (instance, pod, llm_d_ai_variant)` | 5m rate | H％ for IL_eff |
-| `ArrivalRate` | `QuerySchedulerDispatchRate` | `sum by (pod_name, namespace)` | 1m rate | λ_req per pod (primary) |
+| `ArrivalRate` | `QuerySchedulerDispatchRate` | `sum by (pod_name, port, namespace)` | 1m rate | λ_req per pod (primary) |
 
 ## Architecture
 

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -45,11 +45,11 @@ const (
 	// 1-minute high-water mark that could overestimate load and trigger premature
 	// scale-up after a transient spike.
 	//
-	// max by (pod): deduplication only. vllm:kv_cache_usage_perc is a single scalar
-	// gauge per vLLM process; there is one series per pod in normal deployment. The
-	// max by (pod) collapses any duplicate series that arise when a pod is scraped by
-	// multiple targets (e.g., PodMonitor + ServiceMonitor). Since duplicates carry the
-	// same value, max = avg — the choice has no effect on correctness.
+	// max by (instance, pod, llm_d_ai_variant): deduplication only. vllm:kv_cache_usage_perc
+	// is a single scalar gauge per vLLM process; there is one series per pod in normal
+	// deployment. The max by (...) collapses any duplicate series that arise when a pod
+	// is scraped by multiple targets (e.g., PodMonitor + ServiceMonitor). Since duplicates
+	// carry the same value, max = avg — the choice has no effect on correctness.
 	// Source: vllm:kv_cache_usage_perc (gauge)
 	QueryKvUsageInstant = "kv_usage_instant"
 


### PR DESCRIPTION
Documentation-only cleanup of the throughput-analyzer developer guide and a collector query comment. No behavior change.

- Fix stale PromQL groupby labels in the query examples.
- Drop references to the removed itl_knowledge_store.
- Clarify that ReplicaCount is the KV-derived ready count.
- Add the missing `port` label to the ArrivalRate groupby.

> Note: `lint-and-test` will be red until #1477 merges — main's tip (aa86a2a9)
> does not compile (interfaces→domain rename fallout). This branch is based on
> the last compiling commit (55e24be9) and passes all gates locally.