### PR TITLE
fix(saturation): make analyzer effectiveEnabled opt-in and log non-registration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -97,11 +97,12 @@ func init() {
 
 // throughputAnalyzerEnabled reports whether any saturation config entry lists
 // the throughput analyzer with enabled != false. Startup-time gate: when no
-// entry enables throughput the analyzer is never registered, so it cannot
-// participate in scaling decisions and cannot veto scale-down.
+// entry enables throughput anywhere, the analyzer is never registered, so it
+// cannot participate in scaling decisions and cannot veto scale-down.
 //
-// This is a stopgap until the per-cycle consumption gate (effectiveEnabled
-// opt-in fix) lands. Runtime enablement after controller start requires a
+// This is independent of the per-cycle effectiveEnabled opt-in check in the
+// saturation engine, which governs participation per namespace/model once the
+// analyzer is registered. Runtime enablement after controller start requires a
 // restart because RegisterAnalyzer is frozen after StartOptimizeLoop.
 func throughputAnalyzerEnabled(cfg *config.Config) bool {
 	for _, sc := range cfg.SaturationConfig() {
@@ -535,6 +536,10 @@ func main() {
 				return err
 			}
 			setupLog.Info("ThroughputAnalyzer registered (enabled in saturation config)")
+		} else {
+			setupLog.Info("ThroughputAnalyzer NOT registered — no saturation config entry " +
+				"enables 'throughput'. Add it to the analyzers config and restart the " +
+				"controller to enable it.")
 		}
 		go engine.StartOptimizeLoop(ctx)
 		return nil

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/throughput"
+)
+
+func TestThroughputAnalyzerEnabled(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name     string
+		analyzer []config.AnalyzerScoreConfig
+		want     bool
+	}{
+		{
+			name:     "absent — no saturation config entries",
+			analyzer: nil,
+			want:     false,
+		},
+		{
+			name: "absent — other analyzers present, throughput missing",
+			analyzer: []config.AnalyzerScoreConfig{
+				{Name: "saturation"},
+			},
+			want: false,
+		},
+		{
+			name: "enabled — explicit Enabled:true",
+			analyzer: []config.AnalyzerScoreConfig{
+				{Name: throughput.AnalyzerName, Enabled: &trueVal},
+			},
+			want: true,
+		},
+		{
+			name: "enabled — present with Enabled nil (defaults true)",
+			analyzer: []config.AnalyzerScoreConfig{
+				{Name: throughput.AnalyzerName},
+			},
+			want: true,
+		},
+		{
+			name: "disabled — explicit Enabled:false",
+			analyzer: []config.AnalyzerScoreConfig{
+				{Name: throughput.AnalyzerName, Enabled: &falseVal},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewTestConfig()
+			cfg.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{
+				"default": {Analyzers: tt.analyzer},
+			})
+
+			got := throughputAnalyzerEnabled(cfg)
+			if got != tt.want {
+				t.Errorf("throughputAnalyzerEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -132,7 +132,7 @@ Analyzers are configured via `SaturationScalingConfig.Analyzers` (YAML key
 | Field | Type | Default | Purpose |
 |---|---|---|---|
 | `name` | string | required | Must match the name returned by `Analyzer.Name()` |
-| `enabled` | bool | true | Set false to disable without removing the analyzer |
+| `enabled` | bool | true (when the entry is present) | Set false to disable without removing the analyzer |
 | `score` | float64 | 1.0 | Weight in the fair-share priority formula |
 | `scaleUpThreshold` | float64 | global | Overrides the model-level `scaleUpThreshold` for this analyzer |
 | `scaleDownBoundary` | float64 | global | Overrides the model-level `scaleDownBoundary` for this analyzer |
@@ -152,6 +152,17 @@ analyzers:
 
 When `enabled` is false the analyzer is neither called nor included in the
 result slice, so it cannot veto scale-down decisions.
+
+**Participation is opt-in.** An analyzer registered in code
+(`Engine.RegisterAnalyzer`) participates in a cycle only when it has an
+explicit entry in `analyzers` with `enabled` `true` or unset. An analyzer with
+no entry at all does not run and is not included in the result slice,
+exactly as if `enabled: false` had been set. This prevents a
+registered-but-unconfigured analyzer from returning `SpareCapacity=0` and
+silently vetoing scale-down, since the per-role scale-down decision requires
+every analyzer in the slice to agree. Saturation is exempt from this gate —
+it is always run, independent of `analyzers` config, because the engine
+identifies it by name before this check applies.
 
 ---
 

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -23,10 +23,12 @@ operating point, and scales before demand exceeds that supply.
 > analyzer is not registered and never participates in scaling. The default config ships with
 > saturation only, so throughput is off by default.
 >
-> **Runtime toggling requires a restart.** Registration is frozen after `StartOptimizeLoop`.
-> Editing the configmap to add `throughput` takes effect only after a controller restart.
-> This is a stopgap; the per-cycle consumption gate (effectiveEnabled opt-in fix) is the
-> correct long-term home and will remove the need for a restart when it lands.
+> **Runtime toggling requires a restart.** Registration is frozen after `StartOptimizeLoop`;
+> editing the configmap to add `throughput` takes effect only after a controller restart.
+> This restart requirement is about registration, not participation: the per-cycle
+> `effectiveEnabled` gate (see the [multi-analyzer pipeline guide](multi-analyzer-pipeline.md))
+> governs whether an already-registered analyzer participates in a given cycle, and is
+> independent of this startup-time registration gate.
 
 ## Table of Contents
 

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -187,19 +187,24 @@ func resolveThresholds(analyzerName string, cfg config.SaturationScalingConfig) 
 	return cfg.ScaleUpThreshold, cfg.ScaleDownBoundary
 }
 
-// effectiveEnabled returns false only when the analyzer has an explicit
-// Enabled:false entry in cfg.Analyzers. Absent entries and nil Enabled
-// pointers default to true (consistent with ApplyDefaults).
+// effectiveEnabled reports whether the named analyzer should participate in this
+// cycle's scaling decision. An analyzer is opt-in: it participates only when it has
+// an explicit entry in cfg.Analyzers whose Enabled is true (or nil, i.e. present but
+// not yet defaulted). An analyzer registered in code but ABSENT from cfg.Analyzers
+// does NOT participate — this prevents a registered-but-unconfigured analyzer (e.g.
+// throughput) from returning SpareCapacity=0 and silently vetoing scale-down.
+// Saturation is exempt: it is guarded by the SaturationAnalyzerName check upstream
+// (engine_v2.go ~L136) before effectiveEnabled is ever called.
 func effectiveEnabled(analyzerName string, cfg config.SaturationScalingConfig) bool {
 	for _, aw := range cfg.Analyzers {
 		if aw.Name == analyzerName {
 			if aw.Enabled != nil {
 				return *aw.Enabled
 			}
-			return true
+			return true // present, not yet defaulted → participates
 		}
 	}
-	return true
+	return false // absent → opt-in: does not participate
 }
 
 // runRegisteredAnalyzer invokes a single non-saturation analyzer's Analyze

--- a/internal/engines/saturation/engine_v2_population_test.go
+++ b/internal/engines/saturation/engine_v2_population_test.go
@@ -67,6 +67,15 @@ var _ = Describe("Engine config-population helpers", func() {
 			Expect(effectiveEnabled("throughput", config.SaturationScalingConfig{})).To(BeFalse())
 		})
 
+		It("returns false when other analyzers are configured but the target is absent", func() {
+			cfg := config.SaturationScalingConfig{
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "other"},
+				},
+			}
+			Expect(effectiveEnabled("throughput", cfg)).To(BeFalse())
+		})
+
 		It("returns true when Enabled is nil for the matching entry", func() {
 			cfg := config.SaturationScalingConfig{
 				Analyzers: []config.AnalyzerScoreConfig{

--- a/internal/engines/saturation/engine_v2_population_test.go
+++ b/internal/engines/saturation/engine_v2_population_test.go
@@ -63,8 +63,8 @@ var _ = Describe("Engine config-population helpers", func() {
 	})
 
 	Describe("effectiveEnabled", func() {
-		It("returns true when the analyzer is absent from config", func() {
-			Expect(effectiveEnabled("throughput", config.SaturationScalingConfig{})).To(BeTrue())
+		It("returns false when the analyzer is absent from config (opt-in)", func() {
+			Expect(effectiveEnabled("throughput", config.SaturationScalingConfig{})).To(BeFalse())
 		})
 
 		It("returns true when Enabled is nil for the matching entry", func() {
@@ -151,7 +151,10 @@ var _ = Describe("Engine config-population helpers", func() {
 			cfg := config.SaturationScalingConfig{
 				ScaleUpThreshold:  0.85,
 				ScaleDownBoundary: 0.70,
-				// No Analyzers entries — both default to 1.0.
+				// spy has an entry (so it participates, opt-in) but no Score — defaults to 1.0.
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "spy"},
+				},
 			}
 
 			results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
@@ -175,6 +178,9 @@ var _ = Describe("Engine config-population helpers", func() {
 			cfgGlobal := config.SaturationScalingConfig{
 				ScaleUpThreshold:  0.85,
 				ScaleDownBoundary: 0.70,
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "spy"},
+				},
 			}
 			resultsGlobal, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfgGlobal, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -374,6 +374,10 @@ var _ = Describe("runAnalyzersAndScore call ordering", func() {
 		cfg := config.SaturationScalingConfig{
 			ScaleUpThreshold:  0.85,
 			ScaleDownBoundary: 0.70,
+			Analyzers: []config.AnalyzerScoreConfig{
+				{Name: "throughput"},
+				{Name: "slo"},
+			},
 		}
 
 		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)


### PR DESCRIPTION
Make analyzer participation opt-in and add a startup signal when the ThroughputAnalyzer is not registered.

- effectiveEnabled is now opt-in: an absent config entry resolves to false (previously defaulted to enabled), so an analyzer only participates when explicitly configured.
- Log at startup when the ThroughputAnalyzer is not registered, so a misconfiguration is visible rather than silent.
- Document the opt-in participation semantics in the developer guide.

```release-note
Analyzer participation is now opt-in: an analyzer runs only when explicitly enabled in its configuration. An absent config entry no longer defaults to enabled. A startup log line now reports when the ThroughputAnalyzer is not registered.
```
