### PR TITLE
feat(throughput): compute decode demand from model-level arrival rate

### DIFF
--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -189,6 +189,7 @@ Key `AnalyzerInput` fields:
 | `VariantStates` | `[]VariantReplicaState` | Current/desired/pending replica counts per variant |
 | `Config` | `AnalyzerConfig` | Resolved config (cast to your config type as needed) |
 | `SchedulerQueue` | `*SchedulerQueueMetrics` | Scheduler queue metrics; nil when flow control is off |
+| `ArrivalRate` | float64 | Model-level request arrival rate (req/s), no per-pod labels; zero when EPP absent or no traffic yet |
 
 ### Output invariants
 

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -368,7 +368,7 @@ On leader failover the incoming leader starts with an empty analyzer. During war
 │    demand: EPP primary → engine fallback → k*-local      │
 │                                                          │
 │  model-level:                                            │
-│    + queue demand from QueueSize / (factor×ITL)          │
+│    demand: ArrivalRate×avgOL + queue demand              │
 │    TotalSupply, TotalDemand, TotalAnticipatedSupply       │
 │    RequiredCapacity = 0, SpareCapacity = 0 (engine fills) │
 └──────┬───────────────────────────────────────────────────┘
@@ -448,57 +448,82 @@ per-analyzer constant pending alignment with the EPP system-wide k_sat (see open
 
 ## Demand Estimation
 
-### Priority Chain
+### Model-Level Decode Demand
 
-Demand is resolved in priority order per variant. The cascade falls through to the next
-source whenever the current source yields zero.
+TA's decode demand is a **model-level** quantity (TA-demand §3.3/§3.5), not a sum of per-variant
+contributions:
 
-**1. EPP primary**  
-When any replica has `ArrivalRate > 0`:
 ```
-λ_dec = Σ ArrivalRate_r × AvgOutputTokens_r
+avgOL               = mean(shape.AvgOutputTokens) over decode/both variants
+                      (tracked WorkloadShape — see Warm-Up Safety below)
+arrivalDecodeDemand = AnalyzerInput.ArrivalRate × avgOL
 ```
-Each replica contributes its own arrival rate × output length. This avoids averaging-the-averages
-when replicas have different throughput.
 
-If EPP is present but all `AvgOutputTokens == 0` (warm-up: scheduler is dispatching
-requests but no generation tokens have completed yet), this path yields zero and the
-cascade falls through. `isEPP` remains true so the engine is aware EPP is deployed.
+`AnalyzerInput.ArrivalRate` is collected from a single model-level
+`sum by (namespace) (rate(inference_extension_scheduler_attempts_total{...}))` query with no
+`pod`/`port`/`instance` labels — unlike the per-pod `ReplicaMetrics.ArrivalRate`
+(`QuerySchedulerDispatchRate`), it cannot partially mis-attribute: it either matches the model
+filter (correct) or returns zero (filter/EPP absent). No witness metric is needed.
 
-**2. Engine-rate fallback**  
-When EPP is absent **or** EPP is present but yielded zero (warm-up), and `RequestRate > 0`:
-```
-λ_dec = Σ RequestRate_r × AvgOutputTokens_r
-```
-Same structure as primary but using the engine-side completion rate. The engine rate counts
-only served (completed) requests and undercounts arriving demand under load.
+`ReplicaMetrics.ArrivalRate` (per-pod) is **retained** — `queueingmodel` and
+`internal/utils/allocation` still depend on it — but no longer drives TA's `TotalDemand`. The
+per-instance EPP↔vLLM key merge that previously fed it into TA's demand (and could orphan and
+drop it when ports differed) is no longer on TA's critical path.
 
-**3. k\*-based local** (scale-up only)  
-When EPP and the engine rate both yield zero (EPP absent or warm-up; engine rate also zero), demand
-is derived from the current KV utilization:
-```
-λ_local = Σ_r  k_r* × KV_max_r / KVreq / ITL(k_r*)
-```
-Each replica's in-flight request count `N_r = k_r* × KV_max / KVreq` is divided by `ITL(k_r*)`
-to approximate its current throughput. This path is scale-up only (no EPP → demand may be
-underestimated; TA publishes the raw `TotalDemand` and the engine post-step determines SC).
+### Warm-Up Safety
+
+`avgOL` is computed from each variant's **tracked** `WorkloadShape.AvgOutputTokens`
+(`state.shapeTracker.Current()`), never a fresh average over the current cycle's live
+`ReplicaMetrics`. This matters during EPP warm-up: a replica can report `ArrivalRate > 0` (EPP
+dispatching) but `AvgOutputTokens == 0` this cycle (no completions yet). Averaging live data
+would zero `avgOL` and, with it, `TotalDemand` — reintroducing the exact spurious-scale-down bug
+that the per-variant EPP-warm-up fix (`computeDemand` falling through to `computeLocalDemand`
+when `AvgOutputTokens == 0`, see below) was written to prevent. The tracked shape is robust to
+a single zero-OL cycle.
+
+### Per-Variant Demand (Introspection Only)
+
+Each variant still resolves its own demand via the same three-tier priority chain as before —
+the cascade falls through to the next source whenever the current source yields zero — but the
+result now only populates `VariantCapacity.TotalDemand` / `Utilization` (surfaced via
+`VariantState()`); it no longer feeds model-level `TotalDemand`.
+
+**1. EPP primary** — when any replica has `ArrivalRate > 0`:
+`λ_dec = Σ ArrivalRate_r × AvgOutputTokens_r`. If EPP is present but all `AvgOutputTokens == 0`
+(warm-up), this yields zero and the cascade falls through; `isEPP` still reflects EPP presence.
+
+**2. Engine-rate fallback** — when EPP is absent or yielded zero, and `RequestRate > 0`:
+`λ_dec = Σ RequestRate_r × AvgOutputTokens_r`. Counts only served (completed) requests.
+
+**3. k\*-based local** (scale-up only) — when both above yield zero:
+`λ_local = Σ_r k_r* × KV_max_r / KVreq / ITL(k_r*)`.
+
+**Deferred:** with demand model-level, `AnalyzerInput.ArrivalRate` is the sole driver of
+`TotalDemand`'s arrival component. When EPP is absent model-wide, `ArrivalRate` is legitimately
+0 (no signal — not "zero traffic"), and unlike before this cascade's k\*-local fallback no
+longer backfills model-level `TotalDemand` in that case; it remains per-variant only. This is a
+deliberate simplification, not a bug — revisit when `k_knee` (TA-supply.md §5.5, arrival-driven
+operating knee) is implemented.
 
 ### Scheduler Queue Demand
 
-After all per-variant contributions are summed, scheduler queue demand is added to model-level
-`totalDemand` (non-prefill roles only):
+The scheduler queue term is combined **alongside** the arrival decode term at model level —
+not folded into it, not double-counted:
 
 ```
 avgDecodeITLSat  = mean(ITL(k_sat)) over decode/both variants
 queueDemand      = QueueSize / (DefaultQueueDrainFactor × avgDecodeITLSat)
+TotalDemand      = arrivalDecodeDemand + queueDemand
 ```
 
 `DefaultQueueDrainFactor = 2.0` bounds per-request queueing time to
 ≤ 2 × ITL(k_sat) × avgOL. The output-length factor cancels in the derivation, so the result
 is independent of OL.
 
-Queue demand appears in model-level `TotalDemand` but is **not attributed to any specific
-variant** — `Σ VariantCapacity.TotalDemand ≤ result.TotalDemand` when a queue is present.
+Both `arrivalDecodeDemand` and `queueDemand` are split across active non-prefill roles by the
+same helper (`distributeDemandByRole`) and folded into `RoleCapacities[*].TotalDemand` — see
+Role-Aware Aggregation. Neither is attributed back to individual variants:
+`Σ VariantCapacity.TotalDemand` no longer sums to `result.TotalDemand`; the per-role sum does.
 
 **Note:** `SchedulerQueueMetrics` is passed via `AnalyzerInput.SchedulerQueue`. The TA handles
 nil correctly (queue demand = 0 when absent). The engine currently always passes nil due to a
@@ -517,9 +542,11 @@ TotalSupply            = aggregation.SumTotalSupply(VariantCapacities)
                        = Σ_v ReplicaCount_v × PerReplicaCapacity_v
 TotalAnticipatedSupply = aggregation.SumTotalAnticipatedSupply(VariantCapacities)
                        = Σ_v (ReplicaCount_v + PendingReplicas_v) × PerReplicaCapacity_v
-TotalDemand            = aggregation.SumTotalDemand(VariantCapacities)
+TotalDemand            = (AnalyzerInput.ArrivalRate × avgOL)
                        + QueueSize / (DefaultQueueDrainFactor × ITL(k_sat))
 ```
+`TotalDemand` no longer derives from `aggregation.SumTotalDemand(VariantCapacities)` — see
+Demand Estimation above.
 
 `PendingReplicas` (booting replicas not yet in service) are included in anticipated supply
 to suppress redundant scale-up requests while pods are starting.
@@ -594,12 +621,16 @@ use the same decode-rate framework.
 
 - TA publishes `TotalSupply`, `TotalAnticipatedSupply`, and `TotalDemand` per role.
   `RequiredCapacity` and `SpareCapacity` are left zero — the engine post-step fills them.
-- **Prefill role:** `TotalDemand` is negligible after the OL guard in `computeLocalDemand`
-  (EPP and vLLM demand multiply by `AvgOutputTokens ≈ 0` for prefill pods; k*-based local demand
-  is also gated on `AvgOutputTokens > DefaultMinDecodeOLForLocalDemand`). The engine post-step
-  therefore produces RC ≈ 0 for the prefill role naturally.
-- **Queue demand attribution:** queue demand is decode-rate-denominated and split evenly across
-  active non-prefill roles (`distributeQueueDemandByRole`).
+- **Prefill role:** `RoleCapacities["prefill"].TotalDemand` is 0 by construction —
+  `distributeDemandByRole` excludes the prefill role from both the model-level arrival decode
+  term and the queue term (both decode-rate-denominated), so neither contributes a prefill
+  share. (Per-variant `VariantCapacity.TotalDemand` for a prefill variant is separately
+  negligible via the OL guard in `computeLocalDemand`, but that value no longer feeds
+  `RoleCapacities` — see Demand Estimation.) The engine post-step therefore produces RC ≈ 0 for
+  the prefill role naturally.
+- **Demand attribution:** both the model-level arrival decode term and the scheduler queue term
+  are decode-rate-denominated and split evenly across active non-prefill roles by the same
+  helper (`distributeDemandByRole`).
 - `RoleCapacities` is nil when all variants have role `""` or `"both"` (non-disaggregated model).
 
 ## Constants and Tuning

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -454,8 +454,9 @@ TA's decode demand is a **model-level** quantity (TA-demand §3.3/§3.5), not a 
 contributions:
 
 ```
-avgOL               = mean(shape.AvgOutputTokens) over decode/both variants
-                      (tracked WorkloadShape — see Warm-Up Safety below)
+avgOL               = Σ_v (nKV_v × shape_v.AvgOutputTokens) / Σ_v nKV_v
+                      over non-prefill variants v (tracked WorkloadShape,
+                      weighted by each variant's replica count — see below)
 arrivalDecodeDemand = AnalyzerInput.ArrivalRate × avgOL
 ```
 
@@ -470,7 +471,7 @@ filter (correct) or returns zero (filter/EPP absent). No witness metric is neede
 per-instance EPP↔vLLM key merge that previously fed it into TA's demand (and could orphan and
 drop it when ports differed) is no longer on TA's critical path.
 
-### Warm-Up Safety
+### Warm-Up Safety and Weighting
 
 `avgOL` is computed from each variant's **tracked** `WorkloadShape.AvgOutputTokens`
 (`state.shapeTracker.Current()`), never a fresh average over the current cycle's live
@@ -480,6 +481,13 @@ would zero `avgOL` and, with it, `TotalDemand` — reintroducing the exact spuri
 that the per-variant EPP-warm-up fix (`computeDemand` falling through to `computeLocalDemand`
 when `AvgOutputTokens == 0`, see below) was written to prevent. The tracked shape is robust to
 a single zero-OL cycle.
+
+Combining each variant's tracked OL into one model-level `avgOL` must be **weighted by replica
+count** (`nKV`), not an unweighted mean-of-variant-means — otherwise a variant with one replica
+and a variant with ten replicas would contribute equally to `avgOL`, diverging from the true
+per-replica/request-weighted model-level average whenever non-prefill variants have different OL
+profiles and/or different replica counts. With a single non-prefill variant the distinction is
+invisible; it only matters with 2+ (e.g. canary/blue-green, multiple GPU tiers).
 
 ### Per-Variant Demand (Introspection Only)
 

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -450,7 +450,7 @@ per-analyzer constant pending alignment with the EPP system-wide k_sat (see open
 
 ### Model-Level Decode Demand
 
-TA's decode demand is a **model-level** quantity (TA-demand §3.3/§3.5), not a sum of per-variant
+TA's decode demand is a **model-level** quantity, not a sum of per-variant
 contributions:
 
 ```
@@ -510,7 +510,7 @@ result now only populates `VariantCapacity.TotalDemand` / `Utilization` (surface
 `TotalDemand`'s arrival component. When EPP is absent model-wide, `ArrivalRate` is legitimately
 0 (no signal — not "zero traffic"), and unlike before this cascade's k\*-local fallback no
 longer backfills model-level `TotalDemand` in that case; it remains per-variant only. This is a
-deliberate simplification, not a bug — revisit when `k_knee` (TA-supply.md §5.5, arrival-driven
+deliberate simplification, not a bug — revisit when `k_knee` (an arrival-driven
 operating knee) is implemented.
 
 ### Scheduler Queue Demand

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -12,7 +12,7 @@ import (
 
 // Query name constants for throughput analyzer metrics.
 //
-// Only three queries are registered here — those that are genuinely new and not
+// Only four queries are registered here — those that are genuinely new and not
 // provided by other analyzer registrations. The remaining TA inputs are already
 // collected and exposed via domain.ReplicaMetrics; the TA reads those fields
 // directly instead of re-registering duplicate PromQL templates.
@@ -25,7 +25,8 @@ import (
 //	IL      (avg input tokens)        → AvgInputTokens         (QueryAvgInputTokens        / RegisterSaturationQueries)
 //	H%      (prefix cache hit rate)   → PrefixCacheHitRate     (QueryPrefixCacheHitRate    / RegisterSaturationQueries)
 //	λ_req   (per-pod arrival rate)    → ArrivalRate            (QuerySchedulerDispatchRate / RegisterQueueingModelQueries)
-//	         λ_dec = Σ_{r∈V}(ArrivalRate_r × AvgOutputTokens_r) per variant V, computed in analyzer
+//	Λ_req   (model-level arrival)     → AnalyzerInput.ArrivalRate (QueryModelArrivalRate   / RegisterThroughputAnalyzerQueries, this file)
+//	         λ_dec = Λ_req × avgOL, combined with the queue-drain term (model level, see Commit 2)
 const (
 	// QueryGenerationTokenRate is the query name for the observed generation
 	// (decode) token rate per pod (tokens/sec).
@@ -67,15 +68,28 @@ const (
 	// It undercounts when requests are queued in the scheduler. Use
 	// ArrivalRate (via QuerySchedulerDispatchRate) as the primary demand source.
 	QueryRequestRate = "request_rate"
+
+	// QueryModelArrivalRate is the query name for the model-level request arrival
+	// rate (requests/sec), summed across the whole model with no per-pod labels to
+	// reconcile — unlike QuerySchedulerDispatchRate (RegisterQueueingModelQueries),
+	// which groups by pod_name/port and belongs to QM. This is a TA-exclusive query
+	// on the same underlying source metric; it is registered here, not in
+	// queueing_model.go, because no other analyzer consumes it.
+	//
+	// No model_name fallback: inference_extension_scheduler_attempts_total has
+	// never carried a model_name label on any EPP version examined (only
+	// target_model_name) — unlike the flow-control queue metric, which does.
+	QueryModelArrivalRate = "model_arrival_rate"
 )
 
-// RegisterThroughputAnalyzerQueries registers the three TA-exclusive queries.
+// RegisterThroughputAnalyzerQueries registers the four TA-exclusive queries.
 // It must be called once at engine startup alongside other analyzer registrations.
 //
 // Registered queries:
 //   - QueryGenerationTokenRate — μ_dec^obs: observed decode token rate per pod
 //   - QueryKvUsageInstant      — k*: instantaneous KV cache utilization per pod
 //   - QueryRequestRate     — fallback λ_req: completion rate per pod when EPP absent
+//   - QueryModelArrivalRate    — Λ_req: model-level request arrival rate
 //
 // Additional TA inputs are read from domain.ReplicaMetrics fields populated by
 // RegisterSaturationQueries (TotalKvCapacityTokens, AvgOutputTokens, AvgInputTokens,
@@ -141,6 +155,20 @@ func RegisterThroughputAnalyzerQueries(sourceRegistry *source.SourceRegistry) {
 		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "vLLM request completion rate per pod (req/s); fallback for λ_dec when EPP metrics are unavailable",
+	})
+
+	// Model-level request arrival rate (requests/sec), summed across the whole
+	// model. Same status="success" filter as QuerySchedulerDispatchRate, but
+	// grouped only by namespace — no pod_name/port labels, so none of that
+	// query's per-instance attribution fragility. Engine-agnostic (sourced from
+	// EPP, not vLLM/SGLang), so — like QuerySchedulerDispatchRate — it is not
+	// duplicated in registerSGLangThroughputAnalyzerQueries.
+	registry.MustRegister(source.QueryTemplate{
+		Name:        QueryModelArrivalRate,
+		Type:        source.QueryTypePromQL,
+		Template:    `sum by (namespace) (rate(inference_extension_scheduler_attempts_total{status="success",namespace="{{.namespace}}",target_model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Model-level request arrival rate (requests/sec) from scheduler, summed across the whole model with no per-pod labels to reconcile",
 	})
 
 	registerSGLangThroughputAnalyzerQueries(registry)

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -1091,6 +1091,51 @@ func (c *ReplicaMetricsCollector) CollectSchedulerQueueMetrics(
 	}
 }
 
+// CollectModelArrivalRate collects the model-level request arrival rate (req/s)
+// from the llm-d inference scheduler. Unlike the per-instance scheduler dispatch
+// rate (QuerySchedulerDispatchRate), this query sums the same source metric
+// across the whole model with no pod_name/port labels to reconcile against
+// vLLM's per-instance metrics. Returns 0 (not an error) when the metric is
+// unavailable.
+func (c *ReplicaMetricsCollector) CollectModelArrivalRate(
+	ctx context.Context,
+	modelID, namespace string,
+) float64 {
+	logger := ctrl.LoggerFrom(ctx)
+
+	params := map[string]string{
+		source.ParamNamespace: namespace,
+		source.ParamModelID:   modelID,
+	}
+
+	results, err := c.source.Refresh(ctx, source.RefreshSpec{
+		Queries: []string{registration.QueryModelArrivalRate},
+		Params:  params,
+	})
+	if err != nil {
+		logger.V(logging.DEBUG).Info("Model arrival rate unavailable",
+			"modelID", modelID, "namespace", namespace, "error", err)
+		return 0
+	}
+
+	result := results[registration.QueryModelArrivalRate]
+	if result == nil || result.HasError() {
+		return 0
+	}
+
+	var arrivalRate float64
+	for _, value := range result.Values {
+		if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 {
+			arrivalRate += value.Value
+		}
+	}
+
+	logger.V(logging.DEBUG).Info("Collected model arrival rate",
+		"modelID", modelID, "namespace", namespace, "arrivalRate", arrivalRate)
+
+	return arrivalRate
+}
+
 // getScaleTargetNames extracts scale target names from the scale target map.
 func getScaleTargetNames(scaleTargets map[string]scaletarget.ScaleTargetAccessor) []string {
 	names := make([]string, 0, len(scaleTargets))

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -1113,13 +1113,28 @@ func (c *ReplicaMetricsCollector) CollectModelArrivalRate(
 		Params:  params,
 	})
 	if err != nil {
+		// Categorize rather than swallow: a broken or misconfigured arrival query and
+		// genuine zero traffic both surface here as a zero rate, but only the former is a
+		// fault. Record the categorized reason as a collection error so an operator can
+		// tell the two apart (a nonzero arrival_rate error counter means a query problem,
+		// not idle traffic). Demand still falls back to 0 — zero only ever permits
+		// scale-down, gated by the multi-analyzer live-consensus veto.
+		reason := prometheus.CategorizePrometheusError(err)
+		metrics.IncMetricsCollectionErrors(constants.QueryTypeArrivalRate, reason)
 		logger.V(logging.DEBUG).Info("Model arrival rate unavailable",
-			"modelID", modelID, "namespace", namespace, "error", err)
+			"modelID", modelID, "namespace", namespace, "reason", reason, "error", err)
 		return 0
 	}
 
 	result := results[registration.QueryModelArrivalRate]
-	if result == nil || result.HasError() {
+	if result == nil {
+		return 0
+	}
+	if result.HasError() {
+		reason := prometheus.CategorizePrometheusError(result.Error)
+		metrics.IncMetricsCollectionErrors(constants.QueryTypeArrivalRate, reason)
+		logger.V(logging.DEBUG).Info("Model arrival rate result carried an error",
+			"modelID", modelID, "namespace", namespace, "reason", reason)
 		return 0
 	}
 

--- a/internal/collector/replica_metrics_test.go
+++ b/internal/collector/replica_metrics_test.go
@@ -662,6 +662,72 @@ func TestCollectReplicaMetrics_ThroughputKeyMerge(t *testing.T) {
 	}
 }
 
+// TestCollectReplicaMetrics_ArrivalRatePerPodRetained is a regression guard for
+// PR C (model-level TA demand): that PR adds a model-level arrival-rate query for
+// the throughput analyzer but must not touch the existing per-pod
+// scheduler_dispatch_rate collection — queueingmodel and internal/utils/allocation
+// still read ReplicaMetrics.ArrivalRate per-pod. This pins that the per-pod value
+// keeps flowing through CollectReplicaMetrics unchanged.
+func TestCollectReplicaMetrics_ArrivalRatePerPodRetained(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// KV-cache side: keyed by pod+instance (buildInstanceKey derives "pod-known:8000").
+	kvLabels := map[string]string{
+		"pod":                               "pod-known",
+		"instance":                          "10.0.0.1:8000",
+		constants.VariantLabelPrometheusKey: "va-1",
+	}
+	// Scheduler side: keyed by pod_name+port directly ("pod-known:8000" — same key).
+	schedulerLabels := map[string]string{
+		"pod_name": "pod-known",
+		"port":     "8000",
+	}
+	ts := time.Now()
+
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			return map[string]*source.MetricResult{
+				"kv_cache_usage": {
+					Values: []source.MetricValue{{Labels: kvLabels, Value: 0.5, Timestamp: ts}},
+				},
+				"scheduler_dispatch_rate": {
+					Values: []source.MetricValue{{Labels: schedulerLabels, Value: 3.5, Timestamp: ts}},
+				},
+			}, nil
+		},
+	}
+
+	collector := NewReplicaMetricsCollector(mockSource, k8sClient, nil, nil)
+	results, err := collector.CollectReplicaMetrics(
+		context.Background(),
+		"test-model",
+		"test-ns",
+		make(map[string]scaletarget.ScaleTargetAccessor),
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil,
+		make(map[string]float64),
+	)
+	if err != nil {
+		t.Fatalf("CollectReplicaMetrics: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 ReplicaMetrics entry (key merge), got %d", len(results))
+	}
+	if results[0].ArrivalRate != 3.5 {
+		t.Errorf("ArrivalRate is %v, want 3.5 — per-pod scheduler_dispatch_rate merge must still populate it "+
+			"(queueingmodel and internal/utils/allocation depend on this field)", results[0].ArrivalRate)
+	}
+}
+
 // TestCollectReplicaMetrics_SGLangCacheConfig verifies the SGLang cache-config
 // pass: SGLang exposes total KV-cache token capacity directly via
 // sglang:max_total_num_tokens (queried as sglang/cache_config_info), and the

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -324,6 +324,7 @@ const (
 	QueryTypeQueueLength  = "queue_length"
 	QueryTypeRequestCount = "request_count"
 	QueryTypeCacheConfig  = "cache_config"
+	QueryTypeArrivalRate  = "arrival_rate"
 )
 
 // Values for the LabelUnit Prometheus label, describing how to interpret the

--- a/internal/domain/analyzer.go
+++ b/internal/domain/analyzer.go
@@ -45,6 +45,13 @@ type AnalyzerInput struct {
 	// roles or variants is each analyzer's choice.
 	// Nil when flow control is disabled or metrics are unavailable.
 	SchedulerQueue *SchedulerQueueMetrics
+
+	// ArrivalRate is the model-level request arrival rate (requests/sec) from the
+	// llm-d inference scheduler, summed across the whole model with no per-pod
+	// labels to reconcile. Zero when the metric is unavailable (EPP absent or no
+	// traffic yet). Any analyzer with a demand model may convert this into its
+	// own unit (e.g. tokens/sec for the throughput analyzer).
+	ArrivalRate float64
 }
 
 // SchedulerQueueMetrics holds model-level queue metrics from the llm-d

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -173,9 +173,9 @@ func (a *ThroughputAnalyzer) Observe(
 //   - Tier 2 (constrained OLS): window not ready — fit A with B = DefaultBaselineITLSec
 //     using all replica (k*, ITL_obs) points: A = Σ((ITL_i−B)·k_i) / Σ(k_i²).
 //
-// Model-level decode demand is Λ_req × avgOL (TA-demand §3.3/§3.5): the
+// Model-level decode demand is Λ_req × avgOL: the
 // model-level arrival rate (input.ArrivalRate, a single sum(rate(...)) query
-// with no per-pod labels — decision #1) times avgOL, the RequestRate-weighted
+// with no per-pod labels — an all-or-nothing model-level signal) times avgOL, the RequestRate-weighted
 // average output length across all healthy replicas of the model. This is the
 // sole driver of TotalDemand's arrival component; it does not depend on
 // per-variant EPP attribution.
@@ -235,7 +235,7 @@ func (a *ThroughputAnalyzer) Analyze(
 
 	// EPP presence is now derived from the model-level arrival rate rather than
 	// per-replica ArrivalRate: a model-level sum(rate(...)) is all-or-nothing
-	// (decision #1), so a single check here is equivalent and simpler.
+	// by design, so a single check here is equivalent and simpler.
 	//
 	// The per-replica ReplicaMetrics.RequestRate is deliberately NOT consulted here as
 	// a "broken arrival" cross-check (e.g. warn when arrival == 0 while ΣRequestRate > 0).
@@ -330,9 +330,9 @@ func (a *ThroughputAnalyzer) Analyze(
 		// input.ReplicaMetrics, which would zero out avgOL during EPP warm-up
 		// (ArrivalRate>0, no completions yet) and reintroduce the spurious-
 		// scale-down bug regression-tested by "EPP warm-up" below. Weighted by
-		// nKV (replica count) across variants — per review finding F1
-		// (2026-07-27), an unweighted mean-of-means would let every non-prefill
-		// variant contribute equally regardless of its share of replicas/traffic,
+		// nKV (replica count) across variants: an unweighted mean-of-means would
+		// let every non-prefill variant contribute equally regardless of its
+		// share of replicas/traffic,
 		// diverging from the plan's specified RequestRate-weighted model-level
 		// average whenever 2+ non-prefill variants have different OL profiles.
 		if state.role != domain.RolePrefill {
@@ -387,7 +387,7 @@ func (a *ThroughputAnalyzer) Analyze(
 	totalSupply := aggregation.SumTotalSupply(variantCapacities)
 	totalAnticipatedSupply := aggregation.SumTotalAnticipatedSupply(variantCapacities)
 
-	// Decode demand is a model-level quantity (TA-demand §3.3/§3.5): Λ_req × avgOL,
+	// Decode demand is a model-level quantity: Λ_req × avgOL,
 	// computed once from the model-level arrival rate rather than summed from each
 	// variant's computeDemand result. This replaces the retired per-variant EPP
 	// arrival contribution to TotalDemand (per-variant VariantCapacity.TotalDemand
@@ -396,7 +396,7 @@ func (a *ThroughputAnalyzer) Analyze(
 	// shape.AvgOutputTokens across non-prefill variants (totalDecodeOL /
 	// totalDecodeKV, accumulated in the loop above) — weighted, not a plain
 	// mean-of-variant-means, so a variant with more replicas contributes
-	// proportionally more (review finding F1). Zero when no non-prefill variant
+	// proportionally more. Zero when no non-prefill variant
 	// currently has a resolved ITL model, matching avgDecodeITLSat's guard below.
 	var totalDemand, arrivalDecodeDemand float64
 	var arrivalDemandByRole map[string]float64
@@ -593,7 +593,7 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 // so the caller can use computeLocalDemand when both paths yield zero. The returned
 // λ_dec only feeds this variant's own VariantCapacity.TotalDemand/Utilization
 // (introspection) — Analyze's model-level TotalDemand uses input.ArrivalRate ×
-// avgOL instead (decision #1), and derives anyEPP from that model-level rate
+// avgOL instead (the all-or-nothing model-level design), and derives anyEPP from that model-level rate
 // rather than from this function's isEPP return.
 func computeDemand(metrics []domain.ReplicaMetrics) (float64, bool) {
 	var lambdaDec float64

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -236,6 +236,16 @@ func (a *ThroughputAnalyzer) Analyze(
 	// EPP presence is now derived from the model-level arrival rate rather than
 	// per-replica ArrivalRate: a model-level sum(rate(...)) is all-or-nothing
 	// (decision #1), so a single check here is equivalent and simpler.
+	//
+	// The per-replica ReplicaMetrics.RequestRate is deliberately NOT consulted here as
+	// a "broken arrival" cross-check (e.g. warn when arrival == 0 while ΣRequestRate > 0).
+	// RequestRate is a request completion rate, not an arrival rate: a draining engine
+	// keeps RequestRate > 0 after arrivals have legitimately fallen to zero, so that
+	// condition is a normal ramp-down state, not a fault — cross-checking it would warn
+	// constantly during scale-down. A genuine broken-arrival signal is temporal — supply
+	// live but demand never observed across a full staleness window — and is surfaced as
+	// an observability-only warning in the engine liveness path, not in this per-cycle
+	// demand math.
 	anyEPP := input.ArrivalRate > 0
 
 	a.mu.Lock()
@@ -400,6 +410,12 @@ func (a *ThroughputAnalyzer) Analyze(
 	// division-by-zero.
 	if nDecodeVariants > 0 {
 		avgOL := totalDecodeOL / float64(totalDecodeKV)
+		// Arrival rate is the demand signal. When it is zero — EPP absent, or present
+		// but not yet scraped — arrivalDecodeDemand is legitimately zero and so is
+		// TotalDemand. Zero demand only ever permits scale-down (still governed by the
+		// multi-analyzer all-live-agree gate); it never forces a scale action and never
+		// drives scale-up. So a zero/absent arrival signal is safe here and is
+		// intentionally NOT floored to a served-rate proxy.
 		arrivalDecodeDemand = input.ArrivalRate * avgOL
 		totalDemand = arrivalDecodeDemand
 		arrivalDemandByRole = distributeDemandByRole(arrivalDecodeDemand, variantCapacities)

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -245,6 +245,7 @@ func (a *ThroughputAnalyzer) Analyze(
 		anyGPSMismatch    bool
 		totalDecodeITLSat float64
 		totalDecodeOL     float64
+		totalDecodeKV     int // Σ nKV over non-prefill variants — avgOL replica-count weight
 		nDecodeVariants   int
 	)
 	variantCapacities := make([]domain.VariantCapacity, 0, len(byVariant))
@@ -313,15 +314,21 @@ func (a *ThroughputAnalyzer) Analyze(
 		pending := pendingByVariant[variantName]
 		// Track ITL(k_sat) and avgOL across non-prefill variants: ITL(k_sat) for
 		// queue demand estimation, avgOL for the model-level arrival decode term.
-		// Uses the tracked/smoothed shape.AvgOutputTokens (from state.shapeTracker,
-		// robust to a single warm-up cycle reporting AvgOutputTokens==0) rather than
-		// a fresh average over live input.ReplicaMetrics, which would zero out
-		// avgOL during EPP warm-up (ArrivalRate>0, no completions yet) and
-		// reintroduce the spurious-scale-down bug regression-tested by "EPP
-		// warm-up" below.
+		// avgOL uses each variant's tracked/smoothed shape.AvgOutputTokens (from
+		// state.shapeTracker, robust to a single warm-up cycle reporting
+		// AvgOutputTokens==0) rather than a fresh average over live
+		// input.ReplicaMetrics, which would zero out avgOL during EPP warm-up
+		// (ArrivalRate>0, no completions yet) and reintroduce the spurious-
+		// scale-down bug regression-tested by "EPP warm-up" below. Weighted by
+		// nKV (replica count) across variants — per review finding F1
+		// (2026-07-27), an unweighted mean-of-means would let every non-prefill
+		// variant contribute equally regardless of its share of replicas/traffic,
+		// diverging from the plan's specified RequestRate-weighted model-level
+		// average whenever 2+ non-prefill variants have different OL profiles.
 		if state.role != domain.RolePrefill {
 			totalDecodeITLSat += itlSat
-			totalDecodeOL += shape.AvgOutputTokens
+			totalDecodeOL += float64(nKV) * shape.AvgOutputTokens
+			totalDecodeKV += nKV
 			nDecodeVariants++
 		}
 
@@ -375,10 +382,12 @@ func (a *ThroughputAnalyzer) Analyze(
 	// variant's computeDemand result. This replaces the retired per-variant EPP
 	// arrival contribution to TotalDemand (per-variant VariantCapacity.TotalDemand
 	// above is unaffected — it still reflects computeDemand/computeLocalDemand for
-	// per-variant introspection). avgOL is the mean tracked shape.AvgOutputTokens
-	// across non-prefill variants (totalDecodeOL / nDecodeVariants, accumulated in
-	// the loop above); zero when no non-prefill variant currently has a resolved
-	// ITL model, matching avgDecodeITLSat's guard below.
+	// per-variant introspection). avgOL is the nKV-weighted mean of tracked
+	// shape.AvgOutputTokens across non-prefill variants (totalDecodeOL /
+	// totalDecodeKV, accumulated in the loop above) — weighted, not a plain
+	// mean-of-variant-means, so a variant with more replicas contributes
+	// proportionally more (review finding F1). Zero when no non-prefill variant
+	// currently has a resolved ITL model, matching avgDecodeITLSat's guard below.
 	var totalDemand, arrivalDecodeDemand float64
 	var arrivalDemandByRole map[string]float64
 	// Scheduler queue demand is decode-rate-denominated and not variant-attributed.
@@ -387,9 +396,10 @@ func (a *ThroughputAnalyzer) Analyze(
 	var queueDemandByRole map[string]float64
 	// nDecodeVariants > 0 is guaranteed here: the loop above only increments it for
 	// variants that produced supply > 0 (itlSat > 0), so dividing by nDecodeVariants
-	// is safe from division-by-zero.
+	// or totalDecodeKV (both guaranteed >= 1 in that case) is safe from
+	// division-by-zero.
 	if nDecodeVariants > 0 {
-		avgOL := totalDecodeOL / float64(nDecodeVariants)
+		avgOL := totalDecodeOL / float64(totalDecodeKV)
 		arrivalDecodeDemand = input.ArrivalRate * avgOL
 		totalDemand = arrivalDecodeDemand
 		arrivalDemandByRole = distributeDemandByRole(arrivalDecodeDemand, variantCapacities)

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -173,7 +173,16 @@ func (a *ThroughputAnalyzer) Observe(
 //   - Tier 2 (constrained OLS): window not ready — fit A with B = DefaultBaselineITLSec
 //     using all replica (k*, ITL_obs) points: A = Σ((ITL_i−B)·k_i) / Σ(k_i²).
 //
-// Demand per variant is estimated in priority order:
+// Model-level decode demand is Λ_req × avgOL (TA-demand §3.3/§3.5): the
+// model-level arrival rate (input.ArrivalRate, a single sum(rate(...)) query
+// with no per-pod labels — decision #1) times avgOL, the RequestRate-weighted
+// average output length across all healthy replicas of the model. This is the
+// sole driver of TotalDemand's arrival component; it does not depend on
+// per-variant EPP attribution.
+//
+// Per-variant demand (populating VariantCapacity.TotalDemand/Utilization, for
+// introspection/VariantState() only — not summed into TotalDemand) is still
+// estimated in priority order:
 //  1. EPP primary: Σ ArrivalRate × AvgOutputTokens (when ArrivalRate > 0 on any replica).
 //  2. Engine-rate fallback: RequestRate × avgOL (when EPP absent but the engine completion rate is nonzero).
 //  3. k*-based local: Σ k_r* × KV_max_r / KVreq / ITL(k_r*) (scale-up only; no EPP needed).
@@ -185,8 +194,8 @@ func (a *ThroughputAnalyzer) Observe(
 // returned AnalyzerResult; RequiredCapacity and SpareCapacity are left zero.
 // The engine's universal threshold post-step writes RC/SC after Analyze returns.
 // PendingReplicas are included in TotalAnticipatedSupply to suppress redundant
-// scale-up while pods are starting. Scheduler queue demand is split across
-// non-prefill roles via distributeQueueDemandByRole.
+// scale-up while pods are starting. Both the arrival decode term and scheduler
+// queue demand are split across non-prefill roles via distributeDemandByRole.
 //
 // For P/D disaggregated models, RoleCapacities carries per-role Total* fields
 // (TotalSupply, TotalAnticipatedSupply, TotalDemand); RC/SC per role are also
@@ -224,13 +233,19 @@ func (a *ThroughputAnalyzer) Analyze(
 
 	byVariant := groupByVariant(input.ReplicaMetrics)
 
+	// EPP presence is now derived from the model-level arrival rate rather than
+	// per-replica ArrivalRate: a model-level sum(rate(...)) is all-or-nothing
+	// (decision #1), so a single check here is equivalent and simpler.
+	anyEPP := input.ArrivalRate > 0
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	var (
-		anyEPP, anyGPSMismatch bool
-		totalDecodeITLSat      float64
-		nDecodeVariants        int
+		anyGPSMismatch    bool
+		totalDecodeITLSat float64
+		totalDecodeOL     float64
+		nDecodeVariants   int
 	)
 	variantCapacities := make([]domain.VariantCapacity, 0, len(byVariant))
 
@@ -276,7 +291,11 @@ func (a *ThroughputAnalyzer) Analyze(
 			continue
 		}
 
-		demand, isEPP := computeDemand(variantMetrics)
+		// isEPP is no longer used here — anyEPP is now derived model-level from
+		// input.ArrivalRate above — but computeDemand's own per-variant demand
+		// value is kept for VariantCapacity.TotalDemand/Utilization display and
+		// as the computeLocalDemand fallback trigger below (deferred, see plan).
+		demand, _ := computeDemand(variantMetrics)
 		// k*-based local demand: when EPP and the engine completion rate are both absent, or when
 		// EPP is present but yields zero usable demand (warm-up, no completions yet),
 		// derive demand from observed KV utilization so a busy replica is not
@@ -292,12 +311,17 @@ func (a *ThroughputAnalyzer) Analyze(
 		state.lastDemand = demand
 
 		pending := pendingByVariant[variantName]
-		if isEPP {
-			anyEPP = true
-		}
-		// Track ITL(k_sat) across non-prefill variants for queue demand estimation.
+		// Track ITL(k_sat) and avgOL across non-prefill variants: ITL(k_sat) for
+		// queue demand estimation, avgOL for the model-level arrival decode term.
+		// Uses the tracked/smoothed shape.AvgOutputTokens (from state.shapeTracker,
+		// robust to a single warm-up cycle reporting AvgOutputTokens==0) rather than
+		// a fresh average over live input.ReplicaMetrics, which would zero out
+		// avgOL during EPP warm-up (ArrivalRate>0, no completions yet) and
+		// reintroduce the spurious-scale-down bug regression-tested by "EPP
+		// warm-up" below.
 		if state.role != domain.RolePrefill {
 			totalDecodeITLSat += itlSat
+			totalDecodeOL += shape.AvgOutputTokens
 			nDecodeVariants++
 		}
 
@@ -341,24 +365,39 @@ func (a *ThroughputAnalyzer) Analyze(
 		})
 	}
 
-	// Model-level totals computed from the per-variant slice.
+	// Model-level supply totals computed from the per-variant slice.
 	// TotalAnticipatedSupply is published so the engine's post-step can compute RC/SC.
 	totalSupply := aggregation.SumTotalSupply(variantCapacities)
 	totalAnticipatedSupply := aggregation.SumTotalAnticipatedSupply(variantCapacities)
-	totalDemand := aggregation.SumTotalDemand(variantCapacities)
 
+	// Decode demand is a model-level quantity (TA-demand §3.3/§3.5): Λ_req × avgOL,
+	// computed once from the model-level arrival rate rather than summed from each
+	// variant's computeDemand result. This replaces the retired per-variant EPP
+	// arrival contribution to TotalDemand (per-variant VariantCapacity.TotalDemand
+	// above is unaffected — it still reflects computeDemand/computeLocalDemand for
+	// per-variant introspection). avgOL is the mean tracked shape.AvgOutputTokens
+	// across non-prefill variants (totalDecodeOL / nDecodeVariants, accumulated in
+	// the loop above); zero when no non-prefill variant currently has a resolved
+	// ITL model, matching avgDecodeITLSat's guard below.
+	var totalDemand, arrivalDecodeDemand float64
+	var arrivalDemandByRole map[string]float64
 	// Scheduler queue demand is decode-rate-denominated and not variant-attributed.
 	// Add to model-level demand and distribute across active non-prefill roles so
 	// per-role TotalDemand satisfies the linearity invariant.
 	var queueDemandByRole map[string]float64
 	// nDecodeVariants > 0 is guaranteed here: the loop above only increments it for
-	// variants that produced supply > 0 (itlSat > 0), so totalDecodeITLSat / nDecodeVariants
+	// variants that produced supply > 0 (itlSat > 0), so dividing by nDecodeVariants
 	// is safe from division-by-zero.
 	if nDecodeVariants > 0 {
+		avgOL := totalDecodeOL / float64(nDecodeVariants)
+		arrivalDecodeDemand = input.ArrivalRate * avgOL
+		totalDemand = arrivalDecodeDemand
+		arrivalDemandByRole = distributeDemandByRole(arrivalDecodeDemand, variantCapacities)
+
 		avgDecodeITLSat := totalDecodeITLSat / float64(nDecodeVariants)
 		queueDemand := estimateQueueDemand(input.SchedulerQueue, avgDecodeITLSat, DefaultQueueDrainFactor)
 		totalDemand += queueDemand
-		queueDemandByRole = distributeQueueDemandByRole(queueDemand, variantCapacities)
+		queueDemandByRole = distributeDemandByRole(queueDemand, variantCapacities)
 	}
 
 	// TA publishes raw Total* fields; RequiredCapacity and SpareCapacity are left
@@ -382,7 +421,7 @@ func (a *ThroughputAnalyzer) Analyze(
 		TotalAnticipatedSupply: totalAnticipatedSupply,
 		TotalDemand:            totalDemand,
 		Utilization:            safeDivide(totalDemand, totalSupply),
-		RoleCapacities:         aggregateRoleCapacities(variantCapacities, queueDemandByRole),
+		RoleCapacities:         aggregateRoleCapacities(variantCapacities, arrivalDemandByRole, queueDemandByRole),
 	}, nil
 }
 
@@ -525,8 +564,11 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 // Returns (λ_dec, isEPP). isEPP is true when at least one replica reports ArrivalRate > 0.
 // When EPP is present but yields zero usable demand (warm-up: ArrivalRate > 0 but
 // AvgOutputTokens == 0), the function falls through to the engine request-rate proxy
-// so the caller can use computeLocalDemand when both paths yield zero. isEPP still
-// reflects "EPP present" so the anyEPP tracking in Analyze is unaffected.
+// so the caller can use computeLocalDemand when both paths yield zero. The returned
+// λ_dec only feeds this variant's own VariantCapacity.TotalDemand/Utilization
+// (introspection) — Analyze's model-level TotalDemand uses input.ArrivalRate ×
+// avgOL instead (decision #1), and derives anyEPP from that model-level rate
+// rather than from this function's isEPP return.
 func computeDemand(metrics []domain.ReplicaMetrics) (float64, bool) {
 	var lambdaDec float64
 	var isEPP bool
@@ -775,11 +817,14 @@ func checkVariantGPSMismatch(
 	return mismatch
 }
 
-// distributeQueueDemandByRole splits queueDemand evenly across active non-prefill
-// roles derived from vcs. Queue demand is decode-rate-denominated so prefill roles
-// are excluded. Returns nil when queueDemand is zero or no non-prefill roles exist.
-func distributeQueueDemandByRole(queueDemand float64, vcs []domain.VariantCapacity) map[string]float64 {
-	if queueDemand == 0 {
+// distributeDemandByRole splits a model-level decode-rate-denominated demand
+// quantity evenly across active non-prefill roles derived from vcs. Used for
+// both the model-level arrival decode term (Λ_req × avgOL) and the scheduler
+// queue-drain term — both are decode-rate-denominated and role-agnostic at the
+// point they are computed, so prefill roles are excluded. Returns nil when
+// demand is zero or no non-prefill roles exist.
+func distributeDemandByRole(demand float64, vcs []domain.VariantCapacity) map[string]float64 {
+	if demand == 0 {
 		return nil
 	}
 	roles := make(map[string]struct{})
@@ -795,7 +840,7 @@ func distributeQueueDemandByRole(queueDemand float64, vcs []domain.VariantCapaci
 	if len(roles) == 0 {
 		return nil
 	}
-	share := queueDemand / float64(len(roles))
+	share := demand / float64(len(roles))
 	result := make(map[string]float64, len(roles))
 	for role := range roles {
 		result[role] = share
@@ -804,11 +849,16 @@ func distributeQueueDemandByRole(queueDemand float64, vcs []domain.VariantCapaci
 }
 
 // aggregateRoleCapacities groups variant capacities by P/D role and computes
-// per-role raw Total* fields. queueDemandByRole adds queue demand to each role's
-// TotalDemand (nil is safe — treated as zero). Returns nil for non-disaggregated
-// models (all variants role "" or "both"). RequiredCapacity and SpareCapacity are
-// left zero — the engine's universal threshold post-step writes them.
-func aggregateRoleCapacities(vcs []domain.VariantCapacity, queueDemandByRole map[string]float64) map[string]domain.RoleCapacity {
+// per-role raw Total* fields. TotalDemand per role is arrivalDemandByRole[role] +
+// queueDemandByRole[role] (either map nil is safe — treated as zero); it no
+// longer sums each role's per-variant computeDemand results (AggregateByRole's
+// TotalDemand is unused here), since the model-level arrival decode term
+// replaced that path — see Analyze's arrivalDecodeDemand. TotalSupply and
+// TotalAnticipatedSupply are still summed per-variant, unaffected by the demand
+// change. Returns nil for non-disaggregated models (all variants role "" or
+// "both"). RequiredCapacity and SpareCapacity are left zero — the engine's
+// universal threshold post-step writes them.
+func aggregateRoleCapacities(vcs []domain.VariantCapacity, arrivalDemandByRole, queueDemandByRole map[string]float64) map[string]domain.RoleCapacity {
 	byRole := aggregation.AggregateByRole(vcs)
 	// Non-disaggregated: only a "both" bucket (or nothing) — no per-role breakdown.
 	if _, hasBoth := byRole[domain.RoleBoth]; len(byRole) == 0 || (len(byRole) == 1 && hasBoth) {
@@ -821,7 +871,7 @@ func aggregateRoleCapacities(vcs []domain.VariantCapacity, queueDemandByRole map
 			Role:                   role,
 			TotalSupply:            t.TotalSupply,
 			TotalAnticipatedSupply: t.TotalAnticipatedSupply,
-			TotalDemand:            t.TotalDemand + queueDemandByRole[role],
+			TotalDemand:            arrivalDemandByRole[role] + queueDemandByRole[role],
 		}
 	}
 	return result

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -307,6 +307,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica(15)},
+				ArrivalRate:    15, // model-level, mirrors the single replica's per-pod rate
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -325,6 +326,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica(5)},
+				ArrivalRate:    5, // model-level, mirrors the single replica's per-pod rate
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -357,6 +359,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica(5)},
+				ArrivalRate:    5, // model-level, mirrors the single replica's per-pod rate
 			}
 			result, _ := analyzer.Analyze(ctx, input)
 			Expect(result.VariantCapacities).To(HaveLen(1))
@@ -470,6 +473,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: []domain.ReplicaMetrics{tier2Replica(0.75, 15)},
+				ArrivalRate:    15, // model-level, mirrors the single replica's per-pod rate
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -734,6 +738,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: replicas,
+				ArrivalRate:    45, // model-level, sum of the 3 replicas' per-pod rates
 				// No pending replicas — anticipated == current supply
 			}
 			result, err := analyzer.Analyze(ctx, input)
@@ -821,6 +826,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					{VariantName: "v-decode", Role: "decode"},
 					{VariantName: "v-prefill", Role: "prefill"},
 				},
+				ArrivalRate: 30, // model-level, sum of both variants' per-pod rates
 			}
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
@@ -873,11 +879,11 @@ var _ = Describe("ThroughputAnalyzer", func() {
 	})
 
 	Describe("Analyze — k*-based local demand (no EPP)", func() {
-		// Two replicas at k*=0.95 with no EPP and no vLLM rate.
+		// Two replicas at k*=0.95 with no EPP and no vLLM rate, and no model-level
+		// input.ArrivalRate (EPP absent model-wide too).
 		// λ_local = Σ (k_r × KV_max_r / KVreq) / ITL(k_r)
 		// For each replica: N = 0.95×1024000/4600 ≈ 211.4; ITL(0.95) = 0.073×0.95+0.006 = 0.07535
-		// λ_local ≈ 2 × 211.4/0.07535 ≈ 5612 tok/s
-		// μ_sat (per replica) ≈ 2782; totalAnticipated = 2 × 2782 = 5564 < 5612 → RC > 0
+		// λ_local ≈ 211.4/0.07535 ≈ 2806 tok/s per replica (still computed per-variant).
 		const (
 			il     = 5000.0
 			ol     = 200.0
@@ -888,7 +894,15 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		)
 		kValues := []float64{0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65}
 
-		It("emits RequiredCapacity from k* when EPP is absent", func() {
+		It("still populates per-variant demand from k*, but no longer drives model-level TotalDemand when EPP is absent", func() {
+			// DEFERRED (plan §Deferred, "computeDemand per-replica A→B→k*local
+			// fallback"): with demand model-level, Λ_req (input.ArrivalRate) is the
+			// sole driver of TotalDemand's arrival component. When EPP is absent
+			// model-wide, input.ArrivalRate is legitimately 0 (no signal, not "zero
+			// traffic") and — unlike before this PR — the per-variant k*-local
+			// fallback no longer backfills the model-level total; it remains
+			// per-variant only (VariantCapacity.TotalDemand / VariantState()), for
+			// introspection. Revisit when k_knee is implemented.
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 
 			replicas := []domain.ReplicaMetrics{
@@ -904,13 +918,18 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			}
 			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
+				// ArrivalRate: 0 (default) — EPP absent model-wide, no queue either.
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TA leaves RC/SC zero; engine post-step computes them. Assert the raw
-			// supply/demand inequality that the engine interprets as RC>0.
-			Expect(result.TotalDemand).To(BeNumerically(">", result.TotalAnticipatedSupply))
+			Expect(result.VariantCapacities).To(HaveLen(1))
+			// Per-variant demand still reflects the k*-local fallback (unchanged,
+			// deferred code path) — this is what VariantState()/introspection sees.
+			Expect(result.VariantCapacities[0].TotalDemand).To(BeNumerically(">", 0),
+				"per-variant k*-local demand must still be computed for introspection")
+			// Model-level: no EPP and no queue → TotalDemand is 0 by design (not a
+			// regression — see DEFERRED note above), so RC/SC both stay zero.
+			Expect(result.TotalDemand).To(Equal(0.0))
 			Expect(result.RequiredCapacity).To(Equal(0.0))
-			// No EPP → SpareCapacity must be zero regardless.
 			Expect(result.SpareCapacity).To(Equal(0.0))
 		})
 
@@ -994,12 +1013,14 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
 				ReplicaMetrics: []domain.ReplicaMetrics{replica},
+				ArrivalRate:    5.0, // model-level, mirrors the single replica's per-pod rate
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// Local demand must be > 0 (k*=0.85 is busy) so Utilization > 0 and
-			// the engine does NOT emit SC (no spurious scale-down).
+			// Model-level demand must be > 0: avgOL comes from the tracked/smoothed
+			// shape (200, seeded by injectWindowObs), not this cycle's live
+			// AvgOutputTokens==0, so warm-up does not zero out avgOL (see analyzer.go).
 			Expect(result.TotalDemand).To(BeNumerically(">", 0),
-				"warm-up replica must have non-zero demand via local k* fallback")
+				"warm-up replica must have non-zero demand via tracked-shape avgOL")
 			Expect(result.RequiredCapacity).To(Equal(0.0))
 			Expect(result.SpareCapacity).To(Equal(0.0))
 		})
@@ -1023,9 +1044,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
 				ReplicaMetrics: []domain.ReplicaMetrics{replica},
+				ArrivalRate:    10.0, // model-level, mirrors the single replica's per-pod rate
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// EPP demand = 10×200 = 2000 tok/s; TotalDemand must reflect that.
+			// Model-level demand = 10×200 = 2000 tok/s; TotalDemand must reflect that.
 			Expect(result.TotalDemand).To(BeNumerically("~", 2000.0, 1.0))
 			Expect(result.RequiredCapacity).To(Equal(0.0))
 			Expect(result.SpareCapacity).To(Equal(0.0))
@@ -1034,10 +1056,10 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 	Describe("Analyze — scheduler queue demand", func() {
 		// OLS-ready window, single replica at k*=0.50 with no EPP and no vLLM rate.
-		// λ_local = 0.50×1024000/4600 / ITL(0.50) ≈ 111.3/0.0425 ≈ 2618 tok/s
-		// μ_sat ≈ 2782 → λ_local < μ_sat: no RC without queue.
-		// Add QueueSize=200: λ_queue = 200 / (2.0×ITL(k_sat)) = 200/(2.0×0.06805) ≈ 1469 tok/s
-		// totalDemand = 2618+1469 = 4087 > 2782 → RC ≈ 1305 > 0.
+		// EPP absent → model-level TotalDemand's arrival term is 0 (k*-local
+		// remains per-variant only, deferred — see "k*-based local demand (no EPP)"
+		// above); the queue term is the only contributor to model-level demand here.
+		// μ_sat ≈ 2782 per replica.
 		const (
 			il     = 5000.0
 			ol     = 200.0
@@ -1055,13 +1077,19 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// ArrivalRate=0: no EPP
 		}
 
-		It("adds queue demand and emits RequiredCapacity when queue is large", func() {
+		It("queue demand alone (no EPP, no k*-local) emits RequiredCapacity when queue is large", func() {
+			// DEFERRED (plan §Deferred): with EPP absent (ArrivalRate=0 here, both
+			// per-pod and model-level), the k*-local fallback (λ_local≈2618 tok/s)
+			// no longer reaches model-level TotalDemand — only the scheduler queue
+			// term does. QueueSize=450: λ_queue = 450/(2.0×ITL(k_sat)) =
+			// 450/(2.0×0.06805) ≈ 3306 tok/s > μ_sat≈2782 → RC > 0 from queue alone.
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", il, ol, prefix, kvMax, B, kValues)
 
 			withQueue := domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace,
 				ReplicaMetrics: []domain.ReplicaMetrics{baseReplica},
-				SchedulerQueue: &domain.SchedulerQueueMetrics{QueueSize: 200},
+				SchedulerQueue: &domain.SchedulerQueueMetrics{QueueSize: 450},
+				// ArrivalRate: 0 (default) — EPP absent model-wide.
 			}
 			result, err := analyzer.Analyze(ctx, withQueue)
 			Expect(err).NotTo(HaveOccurred())
@@ -1117,6 +1145,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			}
 			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
+				ArrivalRate: 16, // model-level, sum of both variants' per-pod rates
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// Model-level: totalDemand=3200 < totalAnticipated≈5564 → no scale-up needed.
@@ -1145,6 +1174,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			}
 			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
+				ArrivalRate: 30, // model-level, sum of both variants' per-pod rates
 			})
 			Expect(err).NotTo(HaveOccurred())
 			// TA leaves RC/SC zero; engine post-step computes them. Assert the raw
@@ -1209,7 +1239,12 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				aggregation.SumTotalAnticipatedSupply(result.VariantCapacities), 1e-9))
 		})
 
-		It("TotalDemand equals aggregation.SumTotalDemand(VariantCapacities) plus queue demand", func() {
+		It("TotalDemand equals input.ArrivalRate×avgOL plus queue demand", func() {
+			// Commit 2 retires the old invariant (TotalDemand = SumTotalDemand
+			// (VariantCapacities) + queue demand): the model-level arrival term
+			// (input.ArrivalRate × avgOL) replaced the per-variant-summed
+			// contribution as TotalDemand's base. This verifies the new invariant
+			// with the same "queue demand added on top" structure as before.
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", ilA, olA, prefixA, kvMaxA, bA, kValuesA)
 			replicas := []domain.ReplicaMetrics{
 				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
@@ -1217,18 +1252,20 @@ var _ = Describe("ThroughputAnalyzer", func() {
 					PrefixCacheHitRate: prefixA, TotalKvCapacityTokens: kvMaxA, ArrivalRate: 5},
 			}
 			const queueSize = int64(10)
+			const modelArrivalRate = 7.0 // model-level; independent of the replica's per-pod ArrivalRate
 			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: replicas,
 				SchedulerQueue: &domain.SchedulerQueueMetrics{QueueSize: queueSize},
+				ArrivalRate:    modelArrivalRate,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			variantDemand := aggregation.SumTotalDemand(result.VariantCapacities)
-			// TotalDemand = variant demand + queue demand; queue demand > 0 when queue is non-empty.
-			Expect(result.TotalDemand).To(BeNumerically(">=", variantDemand))
-			// Verify queue demand was added: TotalDemand - variantDemand should be positive.
-			Expect(result.TotalDemand - variantDemand).To(BeNumerically(">", 0))
+			// avgOL is the tracked shape's AvgOutputTokens (olA), seeded by injectWindowObs.
+			arrivalDecodeDemand := modelArrivalRate * olA
+			Expect(result.TotalDemand).To(BeNumerically(">=", arrivalDecodeDemand))
+			// Verify queue demand was added on top: TotalDemand - arrivalDecodeDemand > 0.
+			Expect(result.TotalDemand - arrivalDecodeDemand).To(BeNumerically(">", 0))
 		})
 
 		It("RoleCapacities[role].TotalAnticipatedSupply matches per-role aggregation", func() {
@@ -1301,6 +1338,130 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// prefill TotalDemand unchanged (queue demand skips prefill role).
 			Expect(resultWithQ.RoleCapacities["prefill"].TotalDemand).To(
 				BeNumerically("~", resultNoQ.RoleCapacities["prefill"].TotalDemand, 1e-9))
+		})
+	})
+
+	Describe("Analyze — model-level demand invariants (plan §Tests 1-4)", func() {
+		const (
+			ilM    = 5000.0
+			olM    = 200.0 // L: model-level avgOL, tracked via injectWindowObs
+			prefix = 0.1
+			kvMax  = int64(1024000)
+			A      = 0.073
+			B      = 0.006
+		)
+		kValues := []float64{0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65}
+
+		It("TotalDemand's decode component equals R×L, independent of per-pod ArrivalRate", func() {
+			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", ilM, olM, prefix, kvMax, B, kValues)
+
+			const modelArrivalRate = 8.0 // R
+			replica := domain.ReplicaMetrics{
+				VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
+				AvgITL: A*0.50 + B, AvgInputTokens: ilM, AvgOutputTokens: olM,
+				PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
+				ArrivalRate: 999, // deliberately unrelated to R — must not affect TotalDemand
+			}
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+				ModelID: modelID, Namespace: namespace,
+				ReplicaMetrics: []domain.ReplicaMetrics{replica},
+				ArrivalRate:    modelArrivalRate,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// No queue: TotalDemand == R×L exactly.
+			Expect(result.TotalDemand).To(BeNumerically("~", modelArrivalRate*olM, 1e-6))
+		})
+
+		It("still produces demand when per-pod ArrivalRate is 0 everywhere but model-level ArrivalRate is set (orphan-merge regression backstop)", func() {
+			// Regression backstop for the benchmark symptom this PR fixes: a fragile
+			// EPP↔vLLM per-instance key merge could orphan every replica's per-pod
+			// ArrivalRate (all zero) while EPP is actually deployed and dispatching.
+			// TA must not go blind in that case now that demand is model-level.
+			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", ilM, olM, prefix, kvMax, B, kValues)
+
+			replicas := []domain.ReplicaMetrics{
+				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
+					AvgITL: A*0.50 + B, AvgInputTokens: ilM, AvgOutputTokens: olM,
+					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
+					ArrivalRate: 0, // orphaned: per-pod merge failed for every replica
+				},
+				{VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
+					AvgITL: A*0.50 + B, AvgInputTokens: ilM, AvgOutputTokens: olM,
+					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
+					ArrivalRate: 0,
+				},
+			}
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
+				ArrivalRate: 12, // model-level query is unaffected by the per-instance merge
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.TotalDemand).To(BeNumerically(">", 0),
+				"model-level ArrivalRate must still drive demand despite all-zero per-pod ArrivalRate")
+		})
+
+		It("combines the model-level arrival term and queue term exactly once, role-distributed with no double-count", func() {
+			injectWindowObs(analyzer, ctx, modelID, namespace, "v-decode", ilM, olM, prefix, kvMax, B, kValues)
+			injectWindowObs(analyzer, ctx, modelID, namespace, "v-prefill", ilM, olM, prefix, kvMax, B, kValues)
+
+			const modelArrivalRate = 6.0
+			replicas := []domain.ReplicaMetrics{
+				{VariantName: "v-decode", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
+					AvgITL: A*0.50 + B, AvgInputTokens: ilM, AvgOutputTokens: olM,
+					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax},
+				{VariantName: "v-prefill", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
+					AvgITL: A*0.50 + B, AvgInputTokens: ilM, AvgOutputTokens: olM,
+					PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax},
+			}
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: replicas,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "v-decode", Role: "decode"},
+					{VariantName: "v-prefill", Role: "prefill"},
+				},
+				ArrivalRate:    modelArrivalRate,
+				SchedulerQueue: &domain.SchedulerQueueMetrics{QueueSize: 100},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// avgOL is olM (only v-decode counts — v-prefill is excluded from the
+			// non-prefill accumulator), so the arrival term is exactly R×L.
+			arrivalDecodeDemand := modelArrivalRate * olM
+			queueDemand := result.TotalDemand - arrivalDecodeDemand
+			Expect(queueDemand).To(BeNumerically(">", 0), "queue term must be added on top, not folded in")
+
+			// No double-count: role sums reconstruct the model-level total exactly.
+			Expect(result.RoleCapacities).NotTo(BeNil())
+			roleSum := 0.0
+			for _, rc := range result.RoleCapacities {
+				roleSum += rc.TotalDemand
+			}
+			Expect(roleSum).To(BeNumerically("~", result.TotalDemand, 1e-6),
+				"sum of per-role TotalDemand must equal model-level TotalDemand exactly once")
+		})
+
+		It("arrival→0 reduces demand to zero even when the engine is still completing requests (no served-rate floor)", func() {
+			// Decision #4: a draining engine keeps RequestRate > 0 for a while after
+			// arrivals stop; that must not be used as a demand floor, or scale-down
+			// would be wrongly blocked.
+			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", ilM, olM, prefix, kvMax, B, kValues)
+
+			replica := domain.ReplicaMetrics{
+				VariantName: "v1", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
+				AvgITL: A*0.50 + B, AvgInputTokens: ilM, AvgOutputTokens: olM,
+				PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
+				ArrivalRate: 0,  // no new arrivals this window
+				RequestRate: 20, // still draining in-flight/queued work from before
+			}
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+				ModelID: modelID, Namespace: namespace,
+				ReplicaMetrics: []domain.ReplicaMetrics{replica},
+				ArrivalRate:    0, // model-level: no arrivals now
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.TotalDemand).To(Equal(0.0),
+				"model-level demand must not be held up by a still-nonzero RequestRate")
 		})
 	})
 
@@ -1626,6 +1787,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				ModelID:        modelID,
 				Namespace:      namespace,
 				ReplicaMetrics: []domain.ReplicaMetrics{replicaG(kStar, 20, gps)},
+				ArrivalRate:    20, // model-level, mirrors the single replica's per-pod rate
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.SpareCapacity).To(Equal(0.0))

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -1463,6 +1463,36 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(result.TotalDemand).To(Equal(0.0),
 				"model-level demand must not be held up by a still-nonzero RequestRate")
 		})
+
+		It("weights avgOL by replica count across non-prefill variants, not an equal-per-variant mean (review finding F1)", func() {
+			// v-light: 1 replica, OL=100. v-heavy: 3 replicas, OL=300.
+			// Weighted (correct):   avgOL = (1×100 + 3×300) / (1+3) = 1000/4 = 250
+			// Unweighted (wrong):   avgOL = (100 + 300) / 2 = 200
+			// These must diverge — pins that the fix is weighted, not a mean-of-means.
+			injectWindowObs(analyzer, ctx, modelID, namespace, "v-light", ilM, 100, prefix, kvMax, B, kValues)
+			injectWindowObs(analyzer, ctx, modelID, namespace, "v-heavy", ilM, 300, prefix, kvMax, B, kValues)
+
+			lightReplica := domain.ReplicaMetrics{
+				VariantName: "v-light", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
+				AvgITL: A*0.50 + B, AvgInputTokens: ilM, AvgOutputTokens: 100,
+				PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
+			}
+			heavyReplica := domain.ReplicaMetrics{
+				VariantName: "v-heavy", KvCacheUsage: 0.50, KvUsageInstant: 0.50,
+				AvgITL: A*0.50 + B, AvgInputTokens: ilM, AvgOutputTokens: 300,
+				PrefixCacheHitRate: prefix, TotalKvCapacityTokens: kvMax,
+			}
+			replicas := []domain.ReplicaMetrics{lightReplica, heavyReplica, heavyReplica, heavyReplica}
+
+			const modelArrivalRate = 10.0
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+				ModelID: modelID, Namespace: namespace, ReplicaMetrics: replicas,
+				ArrivalRate: modelArrivalRate,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.TotalDemand).To(BeNumerically("~", modelArrivalRate*250.0, 1e-6),
+				"avgOL must be replica-count-weighted (250), not an equal-per-variant mean (200)")
+		})
 	})
 
 	Describe("averageShapeMetrics — RequestRate-weighted averaging", func() {

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -895,8 +895,8 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		kValues := []float64{0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65}
 
 		It("still populates per-variant demand from k*, but no longer drives model-level TotalDemand when EPP is absent", func() {
-			// DEFERRED (plan §Deferred, "computeDemand per-replica A→B→k*local
-			// fallback"): with demand model-level, Λ_req (input.ArrivalRate) is the
+			// DEFERRED behavior (the computeDemand per-replica A→B→k*local
+			// fallback): with demand model-level, Λ_req (input.ArrivalRate) is the
 			// sole driver of TotalDemand's arrival component. When EPP is absent
 			// model-wide, input.ArrivalRate is legitimately 0 (no signal, not "zero
 			// traffic") and — unlike before this PR — the per-variant k*-local
@@ -1078,7 +1078,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		}
 
 		It("queue demand alone (no EPP, no k*-local) emits RequiredCapacity when queue is large", func() {
-			// DEFERRED (plan §Deferred): with EPP absent (ArrivalRate=0 here, both
+			// DEFERRED behavior: with EPP absent (ArrivalRate=0 here, both
 			// per-pod and model-level), the k*-local fallback (λ_local≈2618 tok/s)
 			// no longer reaches model-level TotalDemand — only the scheduler queue
 			// term does. QueueSize=450: λ_queue = 450/(2.0×ITL(k_sat)) =
@@ -1341,7 +1341,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		})
 	})
 
-	Describe("Analyze — model-level demand invariants (plan §Tests 1-4)", func() {
+	Describe("Analyze — model-level demand invariants", func() {
 		const (
 			ilM    = 5000.0
 			olM    = 200.0 // L: model-level avgOL, tracked via injectWindowObs
@@ -1442,7 +1442,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		})
 
 		It("arrival→0 reduces demand to zero even when the engine is still completing requests (no served-rate floor)", func() {
-			// Decision #4: a draining engine keeps RequestRate > 0 for a while after
+			// No served-rate floor: a draining engine keeps RequestRate > 0 for a while after
 			// arrivals stop; that must not be used as a demand floor, or scale-down
 			// would be wrongly blocked.
 			injectWindowObs(analyzer, ctx, modelID, namespace, "v1", ilM, olM, prefix, kvMax, B, kValues)
@@ -1464,7 +1464,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 				"model-level demand must not be held up by a still-nonzero RequestRate")
 		})
 
-		It("weights avgOL by replica count across non-prefill variants, not an equal-per-variant mean (review finding F1)", func() {
+		It("weights avgOL by replica count across non-prefill variants, not an equal-per-variant mean", func() {
 			// v-light: 1 replica, OL=100. v-heavy: 3 replicas, OL=300.
 			// Weighted (correct):   avgOL = (1×100 + 3×300) / (1+3) = 1000/4 = 250
 			// Unweighted (wrong):   avgOL = (100 + 300) / 2 = 200

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -908,7 +908,7 @@ func (e *Engine) optimizeV2(
 
 		req, err := e.collectV2ModelRequest(ctx, modelID, namespace,
 			data.replicaMetrics, saturationConfig, data.variantStates,
-			data.scaleTargets, data.variantAutoscalings, data.schedulerQueue)
+			data.scaleTargets, data.variantAutoscalings, data.schedulerQueue, data.arrivalRate)
 		if err != nil {
 			msg := "V2 analysis failed"
 			logger.Error(err, msg, "modelID", modelID)
@@ -1363,6 +1363,7 @@ type modelData struct {
 	variantCosts        map[string]float64
 	variantStates       []domain.VariantReplicaState
 	schedulerQueue      *domain.SchedulerQueueMetrics
+	arrivalRate         float64
 }
 
 // prepareModelData collects metrics and builds lookup maps for a model's VAs.
@@ -1437,6 +1438,7 @@ func (e *Engine) prepareModelData(
 
 	variantStates := e.BuildVariantStates(ctx, modelVAs, scaleTargets, k8sClient)
 	schedulerQueue := e.ReplicaMetricsCollector.CollectSchedulerQueueMetrics(ctx, modelID)
+	arrivalRate := e.ReplicaMetricsCollector.CollectModelArrivalRate(ctx, modelID, namespace)
 
 	return &modelData{
 		modelID:             modelID,
@@ -1447,6 +1449,7 @@ func (e *Engine) prepareModelData(
 		variantCosts:        variantCosts,
 		variantStates:       variantStates,
 		schedulerQueue:      schedulerQueue,
+		arrivalRate:         arrivalRate,
 	}, nil
 }
 

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -29,6 +29,7 @@ func (e *Engine) runV2AnalysisOnly(
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	schedulerQueue *domain.SchedulerQueueMetrics,
+	arrivalRate float64,
 ) (*domain.AnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -57,6 +58,7 @@ func (e *Engine) runV2AnalysisOnly(
 		VariantStates:  variantStates,
 		Config:         &config,
 		SchedulerQueue: schedulerQueue,
+		ArrivalRate:    arrivalRate,
 	}
 
 	// 3. Run V2 analyzer
@@ -91,12 +93,13 @@ func (e *Engine) runAnalyzersAndScore(
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	schedulerQueue *domain.SchedulerQueueMetrics,
+	arrivalRate float64,
 ) ([]pipeline.NamedAnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Run saturation analyzer (always needed for PerReplicaCapacity).
 	baseResult, err := e.runV2AnalysisOnly(ctx, modelID, namespace, replicaMetrics, config,
-		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
+		variantStates, scaleTargets, variantAutoscalings, schedulerQueue, arrivalRate)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +123,7 @@ func (e *Engine) runAnalyzersAndScore(
 		VariantStates:  variantStates,
 		Config:         &config,
 		SchedulerQueue: schedulerQueue,
+		ArrivalRate:    arrivalRate,
 	}
 
 	// Collect per-analyzer results. Saturation is first; each non-saturation
@@ -400,9 +404,10 @@ func (e *Engine) collectV2ModelRequest(
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	schedulerQueue *domain.SchedulerQueueMetrics,
+	arrivalRate float64,
 ) (*pipeline.ModelScalingRequest, error) {
 	namedResults, err := e.runAnalyzersAndScore(ctx, modelID, namespace, replicaMetrics, config,
-		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
+		variantStates, scaleTargets, variantAutoscalings, schedulerQueue, arrivalRate)
 	if err != nil {
 		return nil, fmt.Errorf("collecting V2 model request for %s/%s: %w", namespace, modelID, err)
 	}

--- a/internal/engines/saturation/engine_v2_demand_liveness_test.go
+++ b/internal/engines/saturation/engine_v2_demand_liveness_test.go
@@ -84,7 +84,7 @@ func TestDetectDemandLiveness_HealthyNoWarn(t *testing.T) {
 	ctx, logs := zapObserverCtx(t)
 	e := demandLivenessEngine(informativeSat(), throughputAnalyzer(1000))
 
-	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil)
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil, 0)
 	require.NoError(t, err)
 
 	assert.True(t, namedByName(results)[throughput.AnalyzerName].Live, "fresh throughput supply must be live")
@@ -107,7 +107,7 @@ func TestDetectDemandLiveness_SupplyLiveDemandStaleWarns(t *testing.T) {
 		modelKey: {demandKey: time.Now().Add(-95 * time.Second)},
 	}
 
-	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil)
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil, 0)
 	require.NoError(t, err)
 
 	warns := demandWarnings(logs)
@@ -125,7 +125,7 @@ func TestDetectDemandLiveness_ColdStartNoWarn(t *testing.T) {
 	ctx, logs := zapObserverCtx(t)
 	e := demandLivenessEngine(informativeSat(), throughputAnalyzer(0)) // fresh engine, no pre-seed
 
-	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil)
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil, 0)
 	require.NoError(t, err)
 
 	assert.Empty(t, demandWarnings(logs), "cold start (demand absent one cycle) must not warn")

--- a/internal/engines/saturation/engine_v2_liveness_test.go
+++ b/internal/engines/saturation/engine_v2_liveness_test.go
@@ -37,7 +37,7 @@ var _ = Describe("analyzer liveness gate (engine level)", func() {
 		}
 		e := liveEngine(noData)
 
-		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
 
@@ -51,7 +51,7 @@ var _ = Describe("analyzer liveness gate (engine level)", func() {
 		e.saturationV2Analyzer = informative
 		e.analyzersSnapshot = []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: informative}}
 
-		results, err = e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		results, err = e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeTrue())
 	})
@@ -69,7 +69,7 @@ var _ = Describe("analyzer liveness gate (engine level)", func() {
 			},
 		}
 		e := liveEngine(atThreshold)
-		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeTrue())
 
@@ -81,7 +81,7 @@ var _ = Describe("analyzer liveness gate (engine level)", func() {
 			},
 		}
 		e2 := liveEngine(pastThreshold)
-		results, err = e2.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		results, err = e2.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
 	})
@@ -114,14 +114,14 @@ var _ = Describe("analyzer liveness gate (engine level)", func() {
 		}
 		e.saturationV2Analyzer = fresh
 		e.analyzersSnapshot = []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: fresh}}
-		_, err := e.runAnalyzersAndScore(context.Background(), "model-b", "ns", nil, cfg, nil, nil, nil, nil)
+		_, err := e.runAnalyzersAndScore(context.Background(), "model-b", "ns", nil, cfg, nil, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 
 		// model-a's never-analyzed, non-informative result must still be non-live — not
 		// contaminated by model-b's freshness.
 		e.saturationV2Analyzer = neverAnalyzed
 		e.analyzersSnapshot = []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: neverAnalyzed}}
-		results, err := e.runAnalyzersAndScore(context.Background(), "model-a", "ns", nil, cfg, nil, nil, nil, nil)
+		results, err := e.runAnalyzersAndScore(context.Background(), "model-a", "ns", nil, cfg, nil, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
 	})

--- a/internal/engines/saturation/engine_v2_population_test.go
+++ b/internal/engines/saturation/engine_v2_population_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Engine config-population helpers", func() {
 				},
 			}
 
-			results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+			results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(results).To(HaveLen(2))
 
@@ -166,7 +166,7 @@ var _ = Describe("Engine config-population helpers", func() {
 				},
 			}
 
-			results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+			results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(results).To(HaveLen(2))
 
@@ -191,7 +191,7 @@ var _ = Describe("Engine config-population helpers", func() {
 					{Name: "spy"},
 				},
 			}
-			resultsGlobal, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfgGlobal, nil, nil, nil, nil)
+			resultsGlobal, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfgGlobal, nil, nil, nil, nil, 0)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Per-analyzer ScaleUpThreshold=1.10 → RC = 100/1.10 ≈ 90.9
@@ -203,7 +203,7 @@ var _ = Describe("Engine config-population helpers", func() {
 					{Name: "spy", ScaleUpThreshold: &overrideThreshold},
 				},
 			}
-			resultsOverride, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfgOverride, nil, nil, nil, nil)
+			resultsOverride, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfgOverride, nil, nil, nil, nil, 0)
 			Expect(err).NotTo(HaveOccurred())
 
 			rcGlobal := namedByName(resultsGlobal)["spy"].Remaining

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -380,7 +380,7 @@ var _ = Describe("runAnalyzersAndScore call ordering", func() {
 			},
 		}
 
-		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		// saturation + throughput + slo all appended
 		Expect(results).To(HaveLen(3))
@@ -417,7 +417,7 @@ var _ = Describe("runAnalyzersAndScore disabled-analyzer gate", func() {
 			},
 		}
 
-		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(results).To(HaveLen(1), "only saturation entry — disabled spy must not be appended")
 		Expect(results[0].Name).To(Equal(domain.SaturationAnalyzerName))
@@ -448,7 +448,7 @@ var _ = Describe("collectV2ModelRequest Disaggregated flag", func() {
 			{VariantName: "decode-v1", Role: "decode"},
 		}
 
-		req, err := e.collectV2ModelRequest(context.Background(), "m", "ns", nil, cfg, variantStates, nil, nil, nil)
+		req, err := e.collectV2ModelRequest(context.Background(), "m", "ns", nil, cfg, variantStates, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(req.Disaggregated).To(BeTrue())
 	})
@@ -474,7 +474,7 @@ var _ = Describe("collectV2ModelRequest Disaggregated flag", func() {
 			{VariantName: "v2", Role: ""},
 		}
 
-		req, err := e.collectV2ModelRequest(context.Background(), "m", "ns", nil, cfg, variantStates, nil, nil, nil)
+		req, err := e.collectV2ModelRequest(context.Background(), "m", "ns", nil, cfg, variantStates, nil, nil, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(req.Disaggregated).To(BeFalse())
 	})


### PR DESCRIPTION
Compute the throughput analyzer's decode demand from a model-level request arrival rate rather than a per-instance summation.

- Collector exposes a model-level request arrival rate for the analyzer.
- Decode demand is derived from the model-level arrival sum (Λ_req × avgOL) plus queue-drain, matching the per-model demand model.
- avgOL is weighted by replica (KV) count across non-prefill variants.
- Document the ArrivalRate input in the multi-analyzer pipeline guide.

```release-note
The throughput analyzer now derives decode demand from the model-level request arrival rate (arrival rate × average output length) rather than summing per-instance arrival rates, matching the model-level demand design.
```
