### PR TITLE
feat(saturation): gate the scale-down veto on per-analyzer liveness

### DIFF
--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -261,13 +261,38 @@ analyzer produces a fresh capacity-bearing result, it becomes live again on
 the next cycle. Liveness is tracked per model, not just per analyzer name,
 so one model's freshness never masks another's staleness.
 
-This liveness filter applies uniformly to every analyzer, including
+An analyzer reporting no usable capacity (`no-data`) does not become
+non-live immediately — it becomes non-live only once its last informative
+result ages out of the staleness window. This distinguishes three cases: an
+analyzer that never had good data (e.g. a mislabelled metric at startup)
+never sets its timestamp and is non-live from the start; a transient
+no-data blip on an analyzer with a recent good result stays live and still
+participates in the vote (the intended "uncertain, err toward not scaling
+down" behavior); and an analyzer whose good data has aged past the window
+becomes non-live. A mislabelled or broken metrics query is not treated as
+an *error* — it still returns a well-formed result, just one with no usable
+capacity — so this reason-based check, not an engine-level error signal, is
+what actually detects a durably-broken analyzer.
+
+Within the multi-analyzer engine path (`runAnalyzersAndScore`), this
+liveness filter applies uniformly to every registered analyzer, including
 saturation's own token-capacity signal — there is no name-based exemption
 inside the scale-down gate. (Saturation's separate role as the shared
 metrics-collection layer — cache size, replica cost, etc., feeding every
 analyzer and the cost optimizer — is unaffected; that collection either
 succeeds for everyone or, if it fails, every analyzer ends up non-live and
-the safety floor below applies.)
+the safety floor below applies.) The queueing-model optimize path
+(`optimizeQueueingModel`) is a separate, older code path that does not yet
+run through this liveness tracking; its `NamedAnalyzerResult` sets `Live:
+true` statically so it keeps scaling down as before. It will pick up real
+liveness tracking when it becomes a first-class multi-analyzer participant.
+
+Liveness reflects whether an analyzer has a current *capacity* (supply-side)
+signal — it does not attempt to detect a broken *demand* signal. A
+falsely-low demand value only biases toward scale-down, never toward a
+spurious veto, so it is out of scope for this gate; demand robustness is
+handled upstream by other mechanisms (metric sanity checks on calibration
+inputs, request-rate / local-demand fallbacks).
 
 **Safety floor.** If every analyzer in the slice is non-live for a role,
 `needsScaleDownForRole` returns false rather than falling through to "no

--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -288,11 +288,23 @@ true` statically so it keeps scaling down as before. It will pick up real
 liveness tracking when it becomes a first-class multi-analyzer participant.
 
 Liveness reflects whether an analyzer has a current *capacity* (supply-side)
-signal — it does not attempt to detect a broken *demand* signal. A
-falsely-low demand value only biases toward scale-down, never toward a
-spurious veto, so it is out of scope for this gate; demand robustness is
-handled upstream by other mechanisms (metric sanity checks on calibration
-inputs, request-rate / local-demand fallbacks).
+signal — it does not gate on the *demand* signal. A falsely-low demand value
+only biases toward scale-down, never toward a spurious veto, so it never
+affects the veto gate; demand robustness is handled upstream by other
+mechanisms (metric sanity checks on calibration inputs, request-rate /
+local-demand fallbacks).
+
+**Demand-liveness telemetry (warn-only).** As an observability aid, the engine
+separately watches for the throughput analyzer having a live capacity signal
+while reporting no demand (`TotalDemand == 0`) for at least the staleness
+window. This usually means the request-arrival query is misconfigured or EPP
+is not reporting arrivals — supply is being measured but no load is observed,
+so scale-up will never trigger. When detected, the engine logs a warning; it
+never sets `Live`, never touches `RoleSpare`, and never gates any scaling
+decision. The signal is a timestamp gap rather than a boolean so a cold-start
+scrape lag (supply resolving a cycle or two before the first arrival scrape)
+does not false-positive: the gap only reaches the staleness window after
+demand has genuinely been absent for that long.
 
 **Safety floor.** If every analyzer in the slice is non-live for a role,
 `needsScaleDownForRole` returns false rather than falling through to "no

--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -67,8 +67,8 @@ over it via shared free functions in `internal/engines/pipeline/`.
 │       pick(role) → variant; joint Δ_util commit          │
 │       applyAllocation → decrement Remaining              │
 │   • Scale-down: scaleDownRoleIterated                    │
-│       needsScaleDownForRole → veto gate (ALL must agree) │
-│       safeRemovalReplicasForRole → min across analyzers  │
+│       needsScaleDownForRole → veto gate (ALL live agree) │
+│       safeRemovalReplicasForRole → min across live       │
 │       applyDeallocationForRole → decrement RoleSpare     │
 └──────────────────────────┬───────────────────────────────┘
                            │
@@ -84,7 +84,7 @@ over it via shared free functions in `internal/engines/pipeline/`.
 | **`VariantCapacity`** | Per-variant primitives: `ReplicaCount`, `PendingReplicas`, `PerReplicaCapacity` (analyzer-specific units), `Cost`, `AcceleratorName`, `Role`, `TotalDemand`. |
 | **`AnalyzerResult`** | Per-(model, analyzer) output: `VariantCapacities[]`, model-level `Total*`, `RoleCapacities[role]` (P/D only), `RequiredCapacity` / `SpareCapacity` (engine-written by post-step; analyzers must not populate these). |
 | **`RoleCapacity`** | Per-role aggregate within an `AnalyzerResult`: `TotalSupply`, `TotalDemand`, `TotalAnticipatedSupply`, `RequiredCapacity` / `SpareCapacity` (engine-written). Used for P/D disaggregated models only. |
-| **`NamedAnalyzerResult`** | Optimizer-side wrapper: `{Name, Result, Score, Remaining, Spare, RoleSpare}`. Working `Remaining`/`Spare`/`RoleSpare` are decremented by helpers during allocation; `Result` is never mutated. |
+| **`NamedAnalyzerResult`** | Optimizer-side wrapper: `{Name, Result, Score, Remaining, Spare, RoleSpare, Live}`. Working `Remaining`/`Spare`/`RoleSpare` are decremented by helpers during allocation; `Result` is never mutated. `Live` is set by the engine each cycle and gates scale-down participation (see "How results combine"). |
 | **Linearity invariant** | Adding *n* replicas of variant *v* reduces analyzer *i*'s working `Remaining` by exactly *n × PRC_i[v]*. Holds at model scope (non-disaggregated) and at role scope (disaggregated). |
 
 ### Responsibility table
@@ -96,6 +96,7 @@ over it via shared free functions in `internal/engines/pipeline/`.
 | Per-role `RoleCapacities[role].Total*` | Analyzer (via aggregation helpers) | Engine post-step |
 | `RequiredCapacity`, `SpareCapacity` (model + role scope) | **Engine post-step only** — analyzer-written values are overwritten | Optimizer |
 | `NamedAnalyzerResult.Remaining`, `Spare`, `RoleSpare` | Optimizer helpers (`applyAllocation`, `applyDeallocationForRole`) | Optimizer allocation loop |
+| `NamedAnalyzerResult.Live` | Engine (`runAnalyzersAndScore`, each cycle) | Scale-down veto gate (`needsScaleDownForRole`, `safeRemovalReplicasForRole`) |
 
 ---
 
@@ -240,12 +241,47 @@ analyzer-written values are discarded.
 
 ## How results combine
 
-**Scale-down gate** (`needsScaleDownForRole`): ALL non-disabled analyzers in
-the slice must have `Spare > 0` for a role to scale down. One analyzer with
+**Scale-down gate** (`needsScaleDownForRole`): ALL **live** analyzers in the
+slice must have `Spare > 0` for a role to scale down. One live analyzer with
 `RequiredCapacity > 0` (i.e., `Spare == 0`) blocks scale-down for that role.
+`safeRemovalReplicasForRole` (the safe-removal-count computation) applies the
+same live-only filter.
+
+**Liveness.** An analyzer is live for the current cycle iff it produced a
+non-error, capacity-bearing result within the staleness window (a fixed
+multiple of the optimization interval, `analyzerLivenessStaleCycles` in
+`internal/engines/saturation/engine_v2.go`). A non-live analyzer — one that
+has never produced a usable result, is currently erroring, or whose last
+usable result has aged past the staleness window — is excluded from the
+scale-down vote entirely: it neither vetoes nor constrains the safe-removal
+minimum. This prevents a registered-but-uninformative analyzer (no metrics
+yet, an error state, or a stale result) from silently blocking scale-down
+for every model it's registered against. Recovery is automatic: once the
+analyzer produces a fresh capacity-bearing result, it becomes live again on
+the next cycle. Liveness is tracked per model, not just per analyzer name,
+so one model's freshness never masks another's staleness.
+
+This liveness filter applies uniformly to every analyzer, including
+saturation's own token-capacity signal — there is no name-based exemption
+inside the scale-down gate. (Saturation's separate role as the shared
+metrics-collection layer — cache size, replica cost, etc., feeding every
+analyzer and the cost optimizer — is unaffected; that collection either
+succeeds for everyone or, if it fails, every analyzer ends up non-live and
+the safety floor below applies.)
+
+**Safety floor.** If every analyzer in the slice is non-live for a role,
+`needsScaleDownForRole` returns false rather than falling through to "no
+vetoes, so scale down" — with zero live analyzers there is no current basis
+to scale down. This also makes leader failover safe: a freshly-elected
+leader starts with no liveness history, so scale-down for every role is
+withheld until at least one analyzer produces a fresh result (typically
+within a cycle or two).
 
 **Scale-up gate** (`anyRoleNeedsScaleUp`): ANY analyzer having `Remaining > 0`
-triggers scale-up for the corresponding role.
+triggers scale-up for the corresponding role. The liveness gate does not
+apply to scale-up — a non-live analyzer contributes `Remaining == 0`
+(from `RequiredCapacity == 0`), which is already harmless to the max-across-
+analyzers formula.
 
 The saturation entry in the slice is also the keeper of per-variant metadata
 (`Cost`, `AcceleratorName`, `Role`) that the optimizer reads from
@@ -335,10 +371,11 @@ synthetic role for non-disaggregated):
 
 ```
 for each role (sorted for determinism):
-  needsScaleDownForRole(s, role)           → gate: ALL analyzers have RoleSpare > 0
+  needsScaleDownForRole(s, role)           → gate: ALL live analyzers have RoleSpare > 0
+                                              (no live analyzer → false; see "How results combine")
   sortVariantsForScaleDown(s, vcs)         → cost-desc; tie-break: Score-weighted PRC asc
   scaleDownVariantSet(...)
-    safeRemovalReplicasForRole(s, v, role) → min_i floor(RoleSpare[i][role] / PRC_i[v])
+    safeRemovalReplicasForRole(s, v, role) → min over live i of floor(RoleSpare[i][role] / PRC_i[v])
     applyDeallocationForRole(s, v, role, n)→ decrement RoleSpare on all entries
 ```
 

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/aggregation"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 )
 
 // SaturationAnalyzer implements the domain.Analyzer interface using a
@@ -810,7 +811,7 @@ func k2SourceLabel(replicas []ReplicaCapacity) string {
 	if label, ok := k2Labels[sorted[medIdx].K2Priority]; ok {
 		return label
 	}
-	return "error"
+	return pipeline.ReasonError
 }
 
 // median returns the median value from a sorted slice of int64 values.

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -1,5 +1,7 @@
 package saturation_v2
 
+import "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+
 // learnedFromLive indicates a capacity record was derived from live metrics.
 const learnedFromLive = "live"
 
@@ -23,7 +25,10 @@ var k2Labels = map[k2Source]string{
 
 const (
 	satReasonP0Store = "P0-store" // capacity from store or compatible-variant record; no live replicas
-	satReasonNoData  = "no-data"  // no live replicas and no store record
+	// satReasonNoData marks a variant with no live replicas and no store record.
+	// It aliases the shared pipeline sentinel so this producer and the engine's
+	// liveness gate (pipeline.ResultIsInformative) cannot drift apart.
+	satReasonNoData = pipeline.ReasonNoData
 )
 
 // ReplicaCapacity holds the per-replica capacity breakdown computed by

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -27,6 +27,32 @@ func rolesOf(vcs []domain.VariantCapacity) []string {
 	return slices.Sorted(maps.Keys(set))
 }
 
+// Sentinel VariantCapacity.Reason values that indicate a variant carries no
+// usable capacity signal (see domain.VariantCapacity.Reason doc). Analyzers
+// that skip a variant entirely on failure (e.g. throughput's ITL-model
+// resolution) never emit these — the variant is simply absent from
+// VariantCapacities, which resultIsInformative also treats as uninformative.
+const (
+	analyzerReasonNoData = "no-data"
+	analyzerReasonError  = "error"
+)
+
+// ResultIsInformative reports whether nr carries a usable capacity signal:
+// a non-nil Result with at least one VariantCapacity whose Reason is not a
+// no-data/error sentinel. Used by the engine to decide whether to refresh
+// the analyzer's last-good-analysis timestamp for the liveness gate.
+func ResultIsInformative(nr NamedAnalyzerResult) bool {
+	if nr.Result == nil {
+		return false
+	}
+	for _, vc := range nr.Result.VariantCapacities {
+		if vc.Reason != analyzerReasonNoData && vc.Reason != analyzerReasonError {
+			return true
+		}
+	}
+	return false
+}
+
 // applyAllocation subtracts the capacity provided by n replicas of variant v
 // from each analyzer's Remaining counter. Clamps to 0. The slice is the working
 // allocation state; Result.RequiredCapacity is never mutated.

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -230,12 +230,17 @@ func variantsForRole(vcs []domain.VariantCapacity, role string) []domain.Variant
 
 // safeRemovalReplicasForRole returns the number of replicas of variant v that
 // can safely be removed — the minimum of floor(RoleSpare[role]_i / PRC_i[v])
-// across analyzers that have variant v and a non-zero PRC. Returns 0 if any
-// contributing analyzer has RoleSpare[role] ≤ 0 or RoleSpare is nil.
+// across live analyzers that have variant v and a non-zero PRC. Non-live
+// analyzers (no metrics, error state, never analyzed, or stale) are skipped
+// and do not constrain the minimum. Returns 0 if any contributing analyzer
+// has RoleSpare[role] ≤ 0 or RoleSpare is nil.
 func safeRemovalReplicasForRole(s []NamedAnalyzerResult, v, role string) int {
 	smallest := math.MaxInt
 	found := false
 	for _, e := range s {
+		if !e.Live {
+			continue // non-live analyzers do not constrain the safe-removal minimum
+		}
 		if e.Result == nil || e.RoleSpare == nil {
 			continue
 		}
@@ -273,22 +278,25 @@ func applyDeallocationForRole(s []NamedAnalyzerResult, v, role string, n int) {
 	}
 }
 
-// needsScaleDownForRole reports whether every analyzer agrees this role has
-// spare capacity (all-down gate, scoped to one role). Returns false if any
-// analyzer's RoleSpare[role] ≤ 0 or RoleSpare is nil.
+// needsScaleDownForRole reports whether every live analyzer agrees this role
+// has spare capacity (all-down gate, scoped to one role). Non-live analyzers
+// (no metrics, error state, never analyzed, or stale) do not veto — this
+// applies uniformly, including saturation's token-capacity result; there is
+// no name-based exemption. Returns false if any live analyzer's
+// RoleSpare[role] ≤ 0 or RoleSpare is nil. Safety floor: if no live analyzer
+// remains, there is no current basis to scale down, so this returns false.
 func needsScaleDownForRole(s []NamedAnalyzerResult, role string) bool {
-	if len(s) == 0 {
-		return false
-	}
+	liveCount := 0
 	for _, e := range s {
-		if e.Result == nil || e.RoleSpare == nil {
+		if !e.Live {
+			continue // non-live analyzers do not veto (no metrics / error / never analyzed)
+		}
+		if e.Result == nil || e.RoleSpare == nil || e.RoleSpare[role] <= 0 {
 			return false
 		}
-		if e.RoleSpare[role] <= 0 {
-			return false
-		}
+		liveCount++
 	}
-	return true
+	return liveCount > 0
 }
 
 // RolePickFn is the role-generic optimizer variant selector for the unified

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -31,10 +31,19 @@ func rolesOf(vcs []domain.VariantCapacity) []string {
 // usable capacity signal (see domain.VariantCapacity.Reason doc). Analyzers
 // that skip a variant entirely on failure (e.g. throughput's ITL-model
 // resolution) never emit these — the variant is simply absent from
-// VariantCapacities, which resultIsInformative also treats as uninformative.
+// VariantCapacities, which ResultIsInformative also treats as uninformative.
+//
+// These are the single source of truth for the no-data/error sentinels:
+// producer packages (e.g. saturation_v2) reference them rather than
+// re-declaring the literals, so ResultIsInformative and the producers cannot
+// drift apart.
 const (
-	analyzerReasonNoData = "no-data"
-	analyzerReasonError  = "error"
+	// ReasonNoData marks a variant for which the analyzer had no usable input
+	// (no live replicas and no store record).
+	ReasonNoData = "no-data"
+	// ReasonError marks a variant whose capacity could not be resolved due to
+	// an internal analyzer error.
+	ReasonError = "error"
 )
 
 // ResultIsInformative reports whether nr carries a usable capacity signal:
@@ -46,7 +55,7 @@ func ResultIsInformative(nr NamedAnalyzerResult) bool {
 		return false
 	}
 	for _, vc := range nr.Result.VariantCapacities {
-		if vc.Reason != analyzerReasonNoData && vc.Reason != analyzerReasonError {
+		if vc.Reason != ReasonNoData && vc.Reason != ReasonError {
 			return true
 		}
 	}

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -262,6 +262,10 @@ func safeRemovalReplicasForRole(s []NamedAnalyzerResult, v, role string) int {
 
 // applyDeallocationForRole decrements each analyzer's RoleSpare[role] by
 // n × PRC_i[v]. Clamps to 0. Never mutates Result.
+// Intentionally not Live-gated: non-live entries are already excluded from
+// the veto (needsScaleDownForRole) and the safe-removal minimum
+// (safeRemovalReplicasForRole), so mutating their RoleSpare here is harmless
+// — nothing reads it back.
 func applyDeallocationForRole(s []NamedAnalyzerResult, v, role string, n int) {
 	for i := range s {
 		if s[i].Result == nil || s[i].RoleSpare == nil {

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -75,6 +75,37 @@ var _ = Describe("analyzer helpers", func() {
 			Expect(saturationEntry(s)).To(BeNil())
 		})
 	})
+
+	Describe("ResultIsInformative", func() {
+		It("returns false for a nil Result", func() {
+			Expect(ResultIsInformative(NamedAnalyzerResult{Result: nil})).To(BeFalse())
+		})
+
+		It("returns false when every VariantCapacity is no-data or error", func() {
+			nr := NamedAnalyzerResult{Result: &domain.AnalyzerResult{
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "a", Reason: "no-data"},
+					{VariantName: "b", Reason: "error"},
+				},
+			}}
+			Expect(ResultIsInformative(nr)).To(BeFalse())
+		})
+
+		It("returns false for an empty VariantCapacities slice (e.g. throughput with no resolvable ITL model)", func() {
+			nr := NamedAnalyzerResult{Result: &domain.AnalyzerResult{}}
+			Expect(ResultIsInformative(nr)).To(BeFalse())
+		})
+
+		It("returns true when at least one VariantCapacity carries a usable reason", func() {
+			nr := NamedAnalyzerResult{Result: &domain.AnalyzerResult{
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "a", Reason: "no-data"},
+					{VariantName: "b", Reason: "T1-ols"},
+				},
+			}}
+			Expect(ResultIsInformative(nr)).To(BeTrue())
+		})
+	})
 })
 
 // makeNamedPD builds a NamedAnalyzerResult with RoleCapacities for P/D tests.

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 // makeNamed builds a NamedAnalyzerResult with the given RC, SC, and per-variant
-// (variantName, perReplicaCapacity) pairs.
+// (variantName, perReplicaCapacity) pairs. Live defaults to true — tests
+// exercising the liveness gate (needsScaleDownForRole, safeRemovalReplicasForRole)
+// override it explicitly on the entries they want treated as non-live.
 func makeNamed(name string, rc, sc float64, vcs ...any) NamedAnalyzerResult {
 	var caps []domain.VariantCapacity
 	for i := 0; i+1 < len(vcs); i += 2 {
@@ -28,6 +30,7 @@ func makeNamed(name string, rc, sc float64, vcs ...any) NamedAnalyzerResult {
 		},
 		Remaining: rc,
 		Spare:     sc,
+		Live:      true,
 	}
 }
 
@@ -110,6 +113,7 @@ var _ = Describe("analyzer helpers", func() {
 
 // makeNamedPD builds a NamedAnalyzerResult with RoleCapacities for P/D tests.
 // RoleSpare is initialized from pSC/dSC (as initDisaggregatedRemaining would do).
+// Live defaults to true; override explicitly for non-live-analyzer scenarios.
 func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float64, vPPRC float64, vDPRC float64) NamedAnalyzerResult {
 	return NamedAnalyzerResult{
 		Name: name,
@@ -125,6 +129,7 @@ func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float
 		},
 		Remaining: pRC, // P-scope after initDisaggregatedRemaining
 		RoleSpare: map[string]float64{"prefill": pSC, "decode": dSC},
+		Live:      true,
 	}
 }
 
@@ -190,6 +195,14 @@ var _ = Describe("paired helpers", func() {
 			e.RoleSpare = nil
 			Expect(safeRemovalReplicasForRole([]NamedAnalyzerResult{e}, "v", "prefill")).To(Equal(0))
 		})
+
+		It("skips a non-live analyzer instead of letting its tiny spare drag the min to 0", func() {
+			live := makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000) // floor(20000/10000)=2
+			nonLive := makeNamedPD("throughput", 0, 0, 5000, 5000, 10000, 30000, 10000, 10000)
+			nonLive.Live = false // would compute floor(5000/10000)=0 if counted
+			s := []NamedAnalyzerResult{live, nonLive}
+			Expect(safeRemovalReplicasForRole(s, "pf", "prefill")).To(Equal(2))
+		})
 	})
 
 	Describe("applyDeallocationForRole", func() {
@@ -226,6 +239,53 @@ var _ = Describe("paired helpers", func() {
 			e := makeNamed("sat", 0, 100, "v", 10.0)
 			e.RoleSpare = nil
 			Expect(needsScaleDownForRole([]NamedAnalyzerResult{e}, "prefill")).To(BeFalse())
+		})
+
+		It("never-analyzed analyzer does not veto: a non-live analyzer with no spare is skipped", func() {
+			live := makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000)
+			neverAnalyzed := makeNamedPD("throughput", 0, 0, 0, 0, 0, 0, 10000, 10000)
+			neverAnalyzed.Live = false
+			neverAnalyzed.RoleSpare = nil
+			s := []NamedAnalyzerResult{live, neverAnalyzed}
+			Expect(needsScaleDownForRole(s, "prefill")).To(BeTrue())
+			Expect(needsScaleDownForRole(s, "decode")).To(BeTrue())
+		})
+
+		It("stale analyzer does not veto: a non-live analyzer with zero spare is skipped", func() {
+			// Staleness itself is computed at the engine level (see engine_v2_liveness_test.go);
+			// here Live=false stands in for "last good analysis is older than the threshold".
+			live := makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000)
+			stale := makeNamedPD("throughput", 0, 0, 0, 0, 0, 0, 10000, 10000)
+			stale.Live = false
+			s := []NamedAnalyzerResult{live, stale}
+			Expect(needsScaleDownForRole(s, "prefill")).To(BeTrue())
+			Expect(needsScaleDownForRole(s, "decode")).To(BeTrue())
+		})
+
+		It("safety floor: returns false when no live analyzer remains", func() {
+			a := makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000)
+			a.Live = false
+			b := makeNamedPD("throughput", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000)
+			b.Live = false
+			s := []NamedAnalyzerResult{a, b}
+			Expect(needsScaleDownForRole(s, "prefill")).To(BeFalse())
+			Expect(needsScaleDownForRole(s, "decode")).To(BeFalse())
+		})
+
+		It("a live analyzer with no spare still vetoes (real veto preserved)", func() {
+			live := makeNamedPD("sat", 0, 0, 0, 30000, 10000, 30000, 10000, 10000)
+			Expect(live.Live).To(BeTrue())
+			s := []NamedAnalyzerResult{live}
+			Expect(needsScaleDownForRole(s, "prefill")).To(BeFalse())
+		})
+
+		It("applies uniformly to saturation: a non-live saturation result does not veto", func() {
+			satNonLive := makeNamedPD(domain.SaturationAnalyzerName, 0, 0, 0, 0, 0, 0, 10000, 10000)
+			satNonLive.Live = false
+			live := makeNamedPD("throughput", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000)
+			s := []NamedAnalyzerResult{satNonLive, live}
+			Expect(needsScaleDownForRole(s, "prefill")).To(BeTrue())
+			Expect(needsScaleDownForRole(s, "decode")).To(BeTrue())
 		})
 	})
 

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -20,6 +20,7 @@ func withSatEntry(r *domain.AnalyzerResult, req ModelScalingRequest) ModelScalin
 			Result:    r,
 			Remaining: r.RequiredCapacity,
 			Spare:     r.SpareCapacity,
+			Live:      true,
 		}}
 	}
 	return req
@@ -744,6 +745,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
+					Live:      true,
 				}}
 			}
 			return req
@@ -836,6 +838,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
+					Live:      true,
 				}}
 			}
 			return req
@@ -884,6 +887,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
+					Live:      true,
 				}}
 			}
 			return req

--- a/internal/engines/pipeline/optimizer_interfaces.go
+++ b/internal/engines/pipeline/optimizer_interfaces.go
@@ -27,6 +27,13 @@ type NamedAnalyzerResult struct {
 	RoleSpare         map[string]float64 // per-role mutable spare; set by initRoleState; nil for non-disaggregated
 	ScaleUpThreshold  float64            // resolved scale-up threshold used to compute RC
 	ScaleDownBoundary float64            // resolved scale-down boundary used to compute SC
+
+	// Live indicates the analyzer produced a non-error, informative result within the
+	// staleness window. Set by the engine each cycle. Non-live analyzers are excluded
+	// from the scale-down veto so a registered-but-uninformative analyzer (no metrics,
+	// error state, never analyzed) cannot block scale-down. Recovery is automatic: a
+	// fresh informative result makes it live again on the next cycle.
+	Live bool
 }
 
 // ModelScalingRequest bundles the analyzer result with variant state for one model.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -178,6 +178,10 @@ type Engine struct {
 	// serves all models — a global-by-name map would leak one model's freshness
 	// into another's. In-memory only; reset on process restart / leader failover
 	// (safe: non-live → no scale-down until refreshed).
+	// Unguarded, like vaEventTracker: safe today because PollingExecutor runs
+	// optimize cycles sequentially in one goroutine and models within a cycle
+	// are processed serially. Parallelizing model processing would need to
+	// synchronize this map — the top-level per-model insert would race first.
 	lastGoodAnalysis map[string]map[string]time.Time
 
 	// analyzers is the engine's analyzer registry, mutated only during setup

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -882,6 +882,18 @@ func (e *Engine) optimizeV2(
 ) []domain.VariantDecision {
 	logger := ctrl.LoggerFrom(ctx)
 
+	// Prune liveness state for departed models. Any model still present in
+	// modelGroups is active this cycle (config-not-loaded or transient-failure
+	// models are enumerated but skipped below — they have not departed); keys
+	// absent from modelGroups belong to models whose VariantAutoscalings are
+	// gone, so their lastGoodAnalysis entries are evicted here. Keyed identically
+	// to updateLivenessAndSetLive (utils.GetNamespacedKey(namespace, modelID)).
+	activeKeys := make(map[string]bool, len(modelGroups))
+	for _, modelVAs := range modelGroups {
+		activeKeys[utils.GetNamespacedKey(modelVAs[0].Namespace, modelVAs[0].Spec.ModelID)] = true
+	}
+	e.pruneLastGoodAnalysis(activeKeys)
+
 	// Stage 1: Collect ModelScalingRequests for all models
 	requests := make([]pipeline.ModelScalingRequest, 0, len(modelGroups))
 	// modelReplicaMetrics collects per-model replica metrics for KV token enrichment

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -169,6 +169,17 @@ type Engine struct {
 	// capacityStore is shared with the V2 analyzer for caching capacity knowledge.
 	capacityStore *saturation_v2.CapacityKnowledgeStore
 
+	// lastGoodAnalysis records, per model (keyed by utils.GetNamespacedKey(namespace,
+	// modelID)) and analyzer name, the AnalyzedAt of the most recent informative
+	// (non-error, capacity-bearing) result. Used to gate the scale-down veto: an
+	// analyzer whose last good analysis for a model is absent or staler than
+	// analyzerLivenessStaleCycles cycles does not participate in that model's vote.
+	// Keyed per model (not just per analyzer name) because one Engine instance
+	// serves all models — a global-by-name map would leak one model's freshness
+	// into another's. In-memory only; reset on process restart / leader failover
+	// (safe: non-live → no scale-down until refreshed).
+	lastGoodAnalysis map[string]map[string]time.Time
+
 	// analyzers is the engine's analyzer registry, mutated only during setup
 	// (NewEngine + RegisterAnalyzer). After StartOptimizeLoop it is frozen —
 	// further RegisterAnalyzer calls return an error. The optimize goroutine reads
@@ -248,6 +259,7 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 		saturationV2Analyzer:    satV2,
 		queueingModelAnalyzer:   queueingmodel.NewQueueingModelAnalyzer(),
 		capacityStore:           capacityStore,
+		lastGoodAnalysis:        make(map[string]map[string]time.Time),
 		optimizer:               scalingOptimizer,
 		metricsEmitter:          metrics.NewMetricsEmitter(),
 		v1AnalyzerFactory:       defaultV1AnalyzerFactory,

--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -83,6 +83,12 @@ func (e *Engine) optimizeQueueingModel(
 				Score:     1.0, // QM path: single analyzer, no per-entry score config
 				Remaining: result.RequiredCapacity,
 				Spare:     result.SpareCapacity,
+				// Live is statically true: the queueing-model path is not yet a
+				// per-analyzer-liveness participant (it doesn't run through
+				// updateLivenessAndSetLive), so it must not be caught by the
+				// liveness safety floor. Its own liveness tracking will be added
+				// when it becomes a first-class multi-analyzer participant.
+				Live: true,
 			}},
 			VariantStates: data.variantStates,
 		})

--- a/internal/engines/saturation/engine_queueing_model_test.go
+++ b/internal/engines/saturation/engine_queueing_model_test.go
@@ -1,0 +1,64 @@
+package saturation
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+)
+
+// withQMEntry builds a ModelScalingRequest whose single AnalyzerResults entry
+// mirrors the shape optimizeQueueingModel constructs in engine_queueing_model.go
+// (Name: SaturationAnalyzerName, Live: true statically), without going through
+// the full prepareModelData collection pipeline.
+func withQMEntry(r *domain.AnalyzerResult, req pipeline.ModelScalingRequest) pipeline.ModelScalingRequest {
+	req.AnalyzerResults = []pipeline.NamedAnalyzerResult{{
+		Name:      domain.SaturationAnalyzerName,
+		Result:    r,
+		Score:     1.0,
+		Remaining: r.RequiredCapacity,
+		Spare:     r.SpareCapacity,
+		Live:      true,
+	}}
+	return req
+}
+
+// This mirrors the QM path's request shape rather than calling optimizeQueueingModel
+// end-to-end (which requires a full prepareModelData collection fixture — a fake
+// k8s client and metrics source). It documents and pins the optimizer-side invariant
+// ("a QM-shaped Live:true result scales down") but does not, on its own, catch a
+// future regression where the Live: true statement is removed from
+// engine_queueing_model.go — that would require the heavier end-to-end fixture.
+var _ = Describe("Queueing model path stays live under the liveness gate", func() {
+
+	It("still scales down a QM result with spare capacity (regression guard for static Live: true)", func() {
+		optimizer := pipeline.NewCostAwareOptimizer()
+		r := &domain.AnalyzerResult{
+			ModelID:       "model-1",
+			Namespace:     "default",
+			SpareCapacity: 25000,
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "v1", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+			},
+		}
+		requests := []pipeline.ModelScalingRequest{
+			withQMEntry(r, pipeline.ModelScalingRequest{
+				ModelID:   "model-1",
+				Namespace: "default",
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "v1", CurrentReplicas: 3},
+				},
+			}),
+		}
+
+		decisions := optimizer.Optimize(context.Background(), requests, nil)
+		dm := decisionsByVariant(decisions)
+
+		// Spare=25000, PRC=10000 → floor(25000/10000)=2 removable; would be 0
+		// (no scale-down at all) if the QM entry were left at the Live zero-value.
+		Expect(dm["v1"].TargetReplicas).To(Equal(1))
+	})
+})

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/accelerator"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/throughput"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
@@ -164,7 +165,7 @@ func (e *Engine) runAnalyzersAndScore(
 			ScaleDownBoundary: down,
 		})
 	}
-	e.updateLivenessAndSetLive(namespace, modelID, namedResults)
+	e.updateLivenessAndSetLive(ctx, namespace, modelID, namedResults)
 
 	for _, nr := range namedResults {
 		logAnalyzerResult(ctx, modelID, namespace, nr)
@@ -176,8 +177,10 @@ func (e *Engine) runAnalyzersAndScore(
 // every informative result's AnalyzedAt, then sets nr.Live on each entry in
 // place based on whether its last good analysis (if any) is within the
 // staleness window. Applies uniformly to every analyzer, including
-// saturation — no name-based exemption.
+// saturation — no name-based exemption. After the liveness pass it runs the
+// warn-only demand-liveness detector (see detectDemandLiveness).
 func (e *Engine) updateLivenessAndSetLive(
+	ctx context.Context,
 	namespace, modelID string,
 	namedResults []pipeline.NamedAnalyzerResult,
 ) {
@@ -206,6 +209,126 @@ func (e *Engine) updateLivenessAndSetLive(
 		}
 		lastGood, ok := perAnalyzer[nr.Name]
 		nr.Live = ok && now.Sub(lastGood) <= threshold
+	}
+
+	e.detectDemandLiveness(ctx, modelID, namespace, namedResults, perAnalyzer, now, threshold)
+}
+
+// demandLatchSuffix is appended to an analyzer name to form the synthetic inner
+// key under which a demand latch is stored in lastGoodAnalysis. The NUL byte
+// guarantees the key cannot collide with any real analyzer name (analyzer names
+// are printable identifiers), so the Live/veto path — which only reads the map
+// via keyed lookups on real analyzer names (perAnalyzer[nr.Name]) and never
+// ranges over it in the decision path — can never observe this key and can
+// never have an nr.Live flipped by it.
+//
+// DEFERRED (future, per-pod demand): when demand becomes per-replica, the demand
+// latch key extends with a pod component (analyzerName + demandLatchSuffix +
+// "\x00" + podID) and a per-replica latch is tracked alongside the model-level
+// one. Not built now — 0.9 demand is model-level only.
+const demandLatchSuffix = "\x00demand"
+
+// detectDemandLiveness emits a warn-only observability signal when the
+// throughput analyzer has a live capacity/supply signal but has reported no
+// demand (Result.TotalDemand > 0) for at least the staleness window. It never
+// sets nr.Live, never touches RoleSpare, and never gates any decision.
+//
+// Why warn-only, and why a veto here would be wrong:
+//   - Zero demand is a legitimate state, not necessarily a fault. With no
+//     served-rate floor, arrival→0 correctly drives TotalDemand→0, which only
+//     permits scale-down and never forces a scale action. A missing or zero
+//     arrival signal can therefore never cause a spurious scale-up or a spurious
+//     veto, so vetoing on "demand looks absent" would defeat the very scale-down
+//     the liveness gate exists to enable.
+//   - The veto path is already covered by the supply/capacity liveness gate: an
+//     analyzer with no capacity signal is excluded from the scale-down vote via
+//     nr.Live. This detector is strictly additive telemetry pointing a human at
+//     a likely-broken arrival query.
+//
+// The detector pairs two latches in the same per-model map:
+//   - Supply latch: perAnalyzer[throughput.AnalyzerName], the analyzer's
+//     last-informative timestamp (maintained by the liveness loop above; the
+//     throughput analyzer resolves per-replica capacity regardless of arrival).
+//   - Demand latch: perAnalyzer[throughput.AnalyzerName+demandLatchSuffix],
+//     stamped with AnalyzedAt each cycle TotalDemand > 0.
+//
+// The signal is a timestamp gap, not a boolean, so a cold-start EPP scrape lag
+// (supply comes up a cycle or two before the first arrival scrape) does not
+// false-positive: on the first cycle the demand latch is seeded to the current
+// supply timestamp, so the gap starts at zero and only reaches the staleness
+// window after demand has genuinely been absent for that long.
+func (e *Engine) detectDemandLiveness(
+	ctx context.Context,
+	modelID, namespace string,
+	namedResults []pipeline.NamedAnalyzerResult,
+	perAnalyzer map[string]time.Time,
+	now time.Time,
+	threshold time.Duration,
+) {
+	var tp *pipeline.NamedAnalyzerResult
+	for i := range namedResults {
+		if namedResults[i].Name == throughput.AnalyzerName {
+			tp = &namedResults[i]
+			break
+		}
+	}
+	if tp == nil {
+		return // throughput not participating this cycle
+	}
+
+	demandKey := throughput.AnalyzerName + demandLatchSuffix
+
+	// Stamp the demand latch whenever demand is observed.
+	if tp.Result != nil && tp.Result.TotalDemand > 0 {
+		perAnalyzer[demandKey] = tp.Result.AnalyzedAt
+	}
+
+	// Only meaningful while supply is live now; otherwise the supply liveness
+	// gate already covers the situation and there is nothing to seed or compare.
+	supplyTS, hasSupply := perAnalyzer[throughput.AnalyzerName]
+	if !hasSupply || now.Sub(supplyTS) > threshold {
+		return
+	}
+
+	// Seed the demand latch to the current supply timestamp the first time we
+	// see live supply, so a fresh model / cold start starts with a zero gap.
+	demandTS, hasDemand := perAnalyzer[demandKey]
+	if !hasDemand {
+		perAnalyzer[demandKey] = supplyTS
+		return
+	}
+
+	if supplyTS.Sub(demandTS) >= threshold {
+		logger := ctrl.LoggerFrom(ctx)
+		logger.Info("throughput analyzer has a live capacity signal but has reported no demand "+
+			"for at least the staleness window; the request-arrival query is likely misconfigured "+
+			"or EPP is not reporting arrivals — scale-up will not trigger until arrivals are observed",
+			"modelID", modelID,
+			"namespace", namespace,
+			"analyzer", throughput.AnalyzerName,
+			"noDemandFor", supplyTS.Sub(demandTS).String(),
+		)
+	}
+}
+
+// pruneLastGoodAnalysis evicts liveness state for models that are no longer
+// active. activeKeys is the set of currently-active model keys (as produced by
+// utils.GetNamespacedKey(namespace, modelID)); any outer key in
+// e.lastGoodAnalysis absent from activeKeys belongs to a departed model (its
+// VariantAutoscalings are gone) and is deleted, bounding the map to live models
+// rather than letting it grow unboundedly across the controller's lifetime.
+//
+// Guards against an empty active set: a cycle that enumerates no models (e.g.
+// saturation config not loaded yet) must not wipe accumulated state, so pruning
+// is skipped when activeKeys is empty.
+func (e *Engine) pruneLastGoodAnalysis(activeKeys map[string]bool) {
+	if len(activeKeys) == 0 || e.lastGoodAnalysis == nil {
+		return
+	}
+	for modelKey := range e.lastGoodAnalysis {
+		if !activeKeys[modelKey] {
+			delete(e.lastGoodAnalysis, modelKey)
+		}
 	}
 }
 

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -3,6 +3,7 @@ package saturation
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -71,6 +72,13 @@ func (e *Engine) runV2AnalysisOnly(
 	// them at this point would always report 0 and be misleading.
 	return result, nil
 }
+
+// analyzerLivenessStaleCycles is the number of optimization cycles an
+// analyzer's last informative result may age before it is treated as stale
+// (non-live) for the scale-down veto gate. Fixed for now; revisit as a
+// per-deployment config field if operators need to tune it.
+// TODO: make configurable if needed.
+const analyzerLivenessStaleCycles = 3
 
 // runAnalyzersAndScore runs the V2 saturation analyzer, applies the universal
 // threshold post-step to every analyzer's result (using per-analyzer config
@@ -156,10 +164,49 @@ func (e *Engine) runAnalyzersAndScore(
 			ScaleDownBoundary: down,
 		})
 	}
+	e.updateLivenessAndSetLive(namespace, modelID, namedResults)
+
 	for _, nr := range namedResults {
 		logAnalyzerResult(ctx, modelID, namespace, nr)
 	}
 	return namedResults, nil
+}
+
+// updateLivenessAndSetLive refreshes e.lastGoodAnalysis for this model with
+// every informative result's AnalyzedAt, then sets nr.Live on each entry in
+// place based on whether its last good analysis (if any) is within the
+// staleness window. Applies uniformly to every analyzer, including
+// saturation — no name-based exemption.
+func (e *Engine) updateLivenessAndSetLive(
+	namespace, modelID string,
+	namedResults []pipeline.NamedAnalyzerResult,
+) {
+	if e.lastGoodAnalysis == nil {
+		e.lastGoodAnalysis = make(map[string]map[string]time.Time)
+	}
+	modelKey := utils.GetNamespacedKey(namespace, modelID)
+	if e.lastGoodAnalysis[modelKey] == nil {
+		e.lastGoodAnalysis[modelKey] = make(map[string]time.Time)
+	}
+	perAnalyzer := e.lastGoodAnalysis[modelKey]
+
+	// Config is nil in unit tests that construct a minimal Engine directly
+	// (bypassing NewEngine, which panics on a nil Config in production).
+	interval := 30 * time.Second
+	if e.Config != nil {
+		interval = e.Config.OptimizationInterval()
+	}
+	now := time.Now()
+	threshold := analyzerLivenessStaleCycles * interval
+
+	for i := range namedResults {
+		nr := &namedResults[i]
+		if pipeline.ResultIsInformative(*nr) {
+			perAnalyzer[nr.Name] = nr.Result.AnalyzedAt
+		}
+		lastGood, ok := perAnalyzer[nr.Name]
+		nr.Live = ok && now.Sub(lastGood) <= threshold
+	}
 }
 
 // scoreForAnalyzer returns the AnalyzerScoreConfig.Score for the named analyzer,

--- a/internal/engines/saturation/engine_v2_demand_liveness_test.go
+++ b/internal/engines/saturation/engine_v2_demand_liveness_test.go
@@ -1,0 +1,157 @@
+package saturation
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/throughput"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+)
+
+// demandLivenessEngine builds a minimal Engine with a saturation entry plus an
+// enabled throughput entry, suitable for driving runAnalyzersAndScore. Config
+// is left nil so the liveness/demand threshold falls back to the 30s default
+// (analyzerLivenessStaleCycles=3 → 90s window).
+func demandLivenessEngine(sat, tp domain.Analyzer) *Engine {
+	return &Engine{
+		saturationV2Analyzer: sat,
+		analyzersSnapshot: []analyzerEntry{
+			{name: domain.SaturationAnalyzerName, analyzer: sat},
+			{name: throughput.AnalyzerName, analyzer: tp},
+		},
+		started: true,
+	}
+}
+
+// informativeSat is a saturation analyzer whose result is informative (a
+// non-sentinel Reason), so the saturation entry is always live and never the
+// subject of the demand detector.
+func informativeSat() domain.Analyzer {
+	return &fakeAnalyzerWithResult{
+		analyzerName: domain.SaturationAnalyzerName,
+		result: &domain.AnalyzerResult{
+			AnalyzedAt:        time.Now(),
+			VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+		},
+	}
+}
+
+// throughputAnalyzer builds a throughput fake with a fresh, informative supply
+// signal and the given model-level demand.
+func throughputAnalyzer(totalDemand float64) domain.Analyzer {
+	return &fakeAnalyzerWithResult{
+		analyzerName: throughput.AnalyzerName,
+		result: &domain.AnalyzerResult{
+			AnalyzedAt:        time.Now(),
+			TotalDemand:       totalDemand,
+			VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+		},
+	}
+}
+
+// enabledThroughputCfg opts the throughput analyzer into the scaling decision so
+// runAnalyzersAndScore includes it (Enabled nil ⇒ present, participates).
+var enabledThroughputCfg = config.SaturationScalingConfig{
+	ScaleUpThreshold:  0.85,
+	ScaleDownBoundary: 0.70,
+	Analyzers:         []config.AnalyzerScoreConfig{{Name: throughput.AnalyzerName}},
+}
+
+// demandWarnings returns the demand-liveness warning entries emitted by the
+// detector, isolating them from the routine per-analyzer INFO lines.
+func demandWarnings(logs *observer.ObservedLogs) []observer.LoggedEntry {
+	var out []observer.LoggedEntry
+	for _, e := range logs.All() {
+		if strings.Contains(e.Message, "reported no demand") {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Case 1: supply informative + demand > 0 every cycle → demand latch keeps
+// pace, no warning.
+func TestDetectDemandLiveness_HealthyNoWarn(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+	e := demandLivenessEngine(informativeSat(), throughputAnalyzer(1000))
+
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	assert.True(t, namedByName(results)[throughput.AnalyzerName].Live, "fresh throughput supply must be live")
+	assert.Empty(t, demandWarnings(logs), "demand keeping pace must not warn")
+}
+
+// Case 2: supply informative but demand absent for longer than the staleness
+// window → warn fired. Crucially the detector must not affect the decision:
+// throughput stays live (its supply is fresh), proving the warning is pure
+// telemetry and did not veto anything.
+func TestDetectDemandLiveness_SupplyLiveDemandStaleWarns(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+	e := demandLivenessEngine(informativeSat(), throughputAnalyzer(0))
+
+	// Pre-seed the demand latch older than the 90s staleness window so a single
+	// cycle with fresh supply but zero demand crosses the threshold.
+	modelKey := utils.GetNamespacedKey("ns", "m")
+	demandKey := throughput.AnalyzerName + demandLatchSuffix
+	e.lastGoodAnalysis = map[string]map[string]time.Time{
+		modelKey: {demandKey: time.Now().Add(-95 * time.Second)},
+	}
+
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	warns := demandWarnings(logs)
+	require.Len(t, warns, 1, "live supply with stale demand must warn exactly once")
+	assert.Equal(t, throughput.AnalyzerName, warns[0].ContextMap()["analyzer"])
+
+	assert.True(t, namedByName(results)[throughput.AnalyzerName].Live,
+		"demand warning must not flip throughput Live — it is telemetry only")
+}
+
+// Case 3: cold start — supply live for the first cycle, demand zero that cycle
+// only → no warn, because the demand latch is seeded to the current supply
+// timestamp so the gap is still 0 (< threshold).
+func TestDetectDemandLiveness_ColdStartNoWarn(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+	e := demandLivenessEngine(informativeSat(), throughputAnalyzer(0)) // fresh engine, no pre-seed
+
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, demandWarnings(logs), "cold start (demand absent one cycle) must not warn")
+	assert.True(t, namedByName(results)[throughput.AnalyzerName].Live)
+}
+
+// The synthetic demand key must never make an analyzer live: the Live/veto path
+// reads lastGoodAnalysis only via keyed lookups on real analyzer names, never
+// the synthetic demand key. A model whose only entry is the demand key, with a
+// non-informative supply result, stays non-live.
+func TestDetectDemandLiveness_SyntheticKeyNeverFlipsLive(t *testing.T) {
+	e := &Engine{started: true}
+	modelKey := utils.GetNamespacedKey("ns", "m")
+	demandKey := throughput.AnalyzerName + demandLatchSuffix
+	e.lastGoodAnalysis = map[string]map[string]time.Time{
+		modelKey: {demandKey: time.Now()},
+	}
+
+	results := []pipeline.NamedAnalyzerResult{{
+		Name: throughput.AnalyzerName,
+		Result: &domain.AnalyzerResult{
+			AnalyzedAt:        time.Now(),
+			VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: pipeline.ReasonNoData}},
+		},
+	}}
+	e.updateLivenessAndSetLive(context.Background(), "ns", "m", results)
+
+	assert.False(t, results[0].Live, "synthetic demand key must never make an analyzer live")
+}

--- a/internal/engines/saturation/engine_v2_liveness_test.go
+++ b/internal/engines/saturation/engine_v2_liveness_test.go
@@ -1,0 +1,119 @@
+package saturation
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+var _ = Describe("analyzer liveness gate (engine level)", func() {
+
+	// liveEngine builds a minimal Engine with a single saturation analyzer
+	// entry, suitable for calling runAnalyzersAndScore directly. Config is
+	// left nil so the liveness threshold falls back to the 30s default
+	// (analyzerLivenessStaleCycles=3 → 90s window).
+	liveEngine := func(sat domain.Analyzer) *Engine {
+		return &Engine{
+			saturationV2Analyzer: sat,
+			analyzersSnapshot:    []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: sat}},
+			started:              true,
+		}
+	}
+
+	cfg := config.SaturationScalingConfig{ScaleUpThreshold: 0.85, ScaleDownBoundary: 0.70}
+
+	It("recovers: a non-live analyzer becomes live again once it produces a fresh informative result", func() {
+		noData := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Now(),
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "no-data"}},
+			},
+		}
+		e := liveEngine(noData)
+
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
+
+		informative := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Now(),
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+			},
+		}
+		e.saturationV2Analyzer = informative
+		e.analyzersSnapshot = []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: informative}}
+
+		results, err = e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeTrue())
+	})
+
+	It("staleness boundary: just inside the threshold is live, just past it is not", func() {
+		// The threshold is 90s (3 × default 30s interval). AnalyzedAt is captured
+		// here, before runAnalyzersAndScore captures its own "now" a moment later,
+		// so testing the exact millisecond boundary would be flaky — use a small
+		// margin on each side instead.
+		atThreshold := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Now().Add(-89 * time.Second),
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+			},
+		}
+		e := liveEngine(atThreshold)
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeTrue())
+
+		pastThreshold := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Now().Add(-95 * time.Second),
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+			},
+		}
+		e2 := liveEngine(pastThreshold)
+		results, err = e2.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
+	})
+
+	It("scopes liveness per model: one model's fresh result does not make another model's stale entry live", func() {
+		stale := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Now().Add(-95 * time.Second),
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+			},
+		}
+		e := liveEngine(stale)
+
+		// model-b, fresh: refreshes lastGoodAnalysis for model-b only.
+		fresh := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Now(),
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+			},
+		}
+		e.saturationV2Analyzer = fresh
+		e.analyzersSnapshot = []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: fresh}}
+		_, err := e.runAnalyzersAndScore(context.Background(), "model-b", "ns", nil, cfg, nil, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// model-a's stale result must still be non-live — not contaminated by model-b's freshness.
+		e.saturationV2Analyzer = stale
+		e.analyzersSnapshot = []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: stale}}
+		results, err := e.runAnalyzersAndScore(context.Background(), "model-a", "ns", nil, cfg, nil, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
+	})
+})

--- a/internal/engines/saturation/engine_v2_liveness_test.go
+++ b/internal/engines/saturation/engine_v2_liveness_test.go
@@ -86,17 +86,25 @@ var _ = Describe("analyzer liveness gate (engine level)", func() {
 		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
 	})
 
-	It("scopes liveness per model: one model's fresh result does not make another model's stale entry live", func() {
-		stale := &fakeAnalyzerWithResult{
+	It("scopes liveness per model: one model's fresh result does not make another model's never-analyzed entry live", func() {
+		// model-a's own call below must be non-informative (Reason: "no-data"), so it never
+		// writes its own timestamp. If it were informative (even with an old AnalyzedAt), that
+		// write alone would force Live=false regardless of whether the map is keyed correctly
+		// per (name, model, namespace) or buggily by name only — the two keyings would be
+		// indistinguishable, and the test would guard nothing. With a non-informative model-a
+		// result, correct per-tuple keying leaves model-a's entry absent (never written) →
+		// Live=false; a name-only-keyed map would instead read back model-b's fresh write under
+		// the shared "saturation" key → Live=true — so this discriminates the two keyings.
+		neverAnalyzed := &fakeAnalyzerWithResult{
 			analyzerName: domain.SaturationAnalyzerName,
 			result: &domain.AnalyzerResult{
-				AnalyzedAt:        time.Now().Add(-95 * time.Second),
-				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+				AnalyzedAt:        time.Now(),
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "no-data"}},
 			},
 		}
-		e := liveEngine(stale)
+		e := liveEngine(neverAnalyzed)
 
-		// model-b, fresh: refreshes lastGoodAnalysis for model-b only.
+		// model-b, fresh and informative: refreshes lastGoodAnalysis for model-b only.
 		fresh := &fakeAnalyzerWithResult{
 			analyzerName: domain.SaturationAnalyzerName,
 			result: &domain.AnalyzerResult{
@@ -109,9 +117,10 @@ var _ = Describe("analyzer liveness gate (engine level)", func() {
 		_, err := e.runAnalyzersAndScore(context.Background(), "model-b", "ns", nil, cfg, nil, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		// model-a's stale result must still be non-live — not contaminated by model-b's freshness.
-		e.saturationV2Analyzer = stale
-		e.analyzersSnapshot = []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: stale}}
+		// model-a's never-analyzed, non-informative result must still be non-live — not
+		// contaminated by model-b's freshness.
+		e.saturationV2Analyzer = neverAnalyzed
+		e.analyzersSnapshot = []analyzerEntry{{name: domain.SaturationAnalyzerName, analyzer: neverAnalyzed}}
 		results, err := e.runAnalyzersAndScore(context.Background(), "model-a", "ns", nil, cfg, nil, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())

--- a/internal/engines/saturation/engine_v2_prune_test.go
+++ b/internal/engines/saturation/engine_v2_prune_test.go
@@ -1,0 +1,54 @@
+package saturation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+)
+
+// TestPruneLastGoodAnalysis locks the two guards the prune relies on (empty
+// active set is a no-op; a nil map does not panic) plus the core contract:
+// departed model keys are evicted while active ones keep their inner entries.
+func TestPruneLastGoodAnalysis(t *testing.T) {
+	keyA := utils.GetNamespacedKey("ns", "model-a")
+	keyB := utils.GetNamespacedKey("ns", "model-b")
+	ts := time.Now()
+
+	newState := func() map[string]map[string]time.Time {
+		return map[string]map[string]time.Time{
+			keyA: {"saturation": ts},
+			keyB: {"saturation": ts},
+		}
+	}
+
+	t.Run("evicts departed keeps active", func(t *testing.T) {
+		e := &Engine{lastGoodAnalysis: newState()}
+		e.pruneLastGoodAnalysis(map[string]bool{keyA: true})
+
+		require.Contains(t, e.lastGoodAnalysis, keyA, "active model must be kept")
+		assert.NotContains(t, e.lastGoodAnalysis, keyB, "departed model must be evicted")
+		assert.Equal(t, ts, e.lastGoodAnalysis[keyA]["saturation"],
+			"surviving model's inner analyzer entries must be left intact")
+	})
+
+	t.Run("empty active set is a no-op", func(t *testing.T) {
+		e := &Engine{lastGoodAnalysis: newState()}
+		e.pruneLastGoodAnalysis(map[string]bool{})
+
+		assert.Contains(t, e.lastGoodAnalysis, keyA,
+			"a zero-model cycle must not wipe accumulated state")
+		assert.Contains(t, e.lastGoodAnalysis, keyB,
+			"a zero-model cycle must not wipe accumulated state")
+	})
+
+	t.Run("nil map does not panic", func(t *testing.T) {
+		e := &Engine{}
+		assert.NotPanics(t, func() {
+			e.pruneLastGoodAnalysis(map[string]bool{keyA: true})
+		})
+	})
+}

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -23,6 +23,7 @@ func withSatEntryV2(r *domain.AnalyzerResult, req pipeline.ModelScalingRequest) 
 			Result:    r,
 			Remaining: r.RequiredCapacity,
 			Spare:     r.SpareCapacity,
+			Live:      true,
 		}}
 	}
 	return req


### PR DESCRIPTION
Gate the scale-down veto on per-analyzer liveness so an uninformative analyzer (never had metrics, error state, or stale) cannot block scale-down.

- Track per-analyzer liveness via the last informative analysis time.
- Exclude non-live analyzers from the scale-down veto and the safe-removal minimum; this applies uniformly, with no name-based exemption.
- Keep the queueing-model path always-live under the new gate.
- Safety floor: if no live analyzer remains, do not scale down.
- Document the liveness gate in the multi-analyzer pipeline guide.

```release-note
Scale-down decisions now ignore analyzers with no recent informative result (never reported, errored, or stale): an uninformative analyzer can no longer veto a scale-down. If no analyzer is live for a model, scale-down is withheld as a safety measure.
```
