### PR TITLE
fix(saturation): replace stale interfaces package references with domain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
+	github.com/go-logr/zapr v1.3.0
 	github.com/go-openapi/jsonpointer v0.21.2 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -506,10 +506,10 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 // It mirrors the analyzer selection in optimize's switch statement.
 func modeLabelForAnalyzer(analyzerName string) string {
 	switch analyzerName {
-	case interfaces.QueueingModelAnalyzerName:
-		return interfaces.QueueingModelAnalyzerName
-	case interfaces.SaturationAnalyzerName:
-		return interfaces.SaturationAnalyzerName
+	case domain.QueueingModelAnalyzerName:
+		return domain.QueueingModelAnalyzerName
+	case domain.SaturationAnalyzerName:
+		return domain.SaturationAnalyzerName
 	default:
 		return "saturation-only"
 	}

--- a/internal/engines/saturation/mode_label_test.go
+++ b/internal/engines/saturation/mode_label_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
 // TestModeLabelForAnalyzer ensures the "Optimization completed successfully" log
@@ -17,8 +17,8 @@ func TestModeLabelForAnalyzer(t *testing.T) {
 		analyzerName string
 		wantMode     string
 	}{
-		{"queueing model analyzer", interfaces.QueueingModelAnalyzerName, interfaces.QueueingModelAnalyzerName},
-		{"V2 saturation analyzer", interfaces.SaturationAnalyzerName, interfaces.SaturationAnalyzerName},
+		{"queueing model analyzer", domain.QueueingModelAnalyzerName, domain.QueueingModelAnalyzerName},
+		{"V2 saturation analyzer", domain.SaturationAnalyzerName, domain.SaturationAnalyzerName},
 		{"unset analyzer name falls back to V1 saturation-only", "", "saturation-only"},
 		{"unrecognized analyzer name falls back to V1 saturation-only", "not-a-real-analyzer", "saturation-only"},
 	}


### PR DESCRIPTION
Fixes #1482

## Proposed Changes

- :bug: Point `modeLabelForAnalyzer` (`engine.go`) and `mode_label_test.go` at
  `internal/domain` instead of the removed `internal/interfaces`. #1334 merged
  from a branch predating the rename in #1449, so these lines kept the old
  qualifier while the surrounding code already used `domain`. Restores
  `go build ./...`.
- :broom: Drop the `// indirect` marker from `github.com/go-logr/zapr`, which
  `engine_v2_log_test.go` has imported directly since #1318. This is what
  `go mod tidy` produces once it can run again, so it is required for `main`
  to be tidy-clean.

### Pre-review Checklist

- [x] **E2E tests** for any new behavior — n/a, no behavior change; the existing `TestModeLabelForAnalyzer` now compiles and passes
- [x] **Docs PR** for any user-facing impact — n/a
- [x] **Proposal PR** for any new enhancement or change to existing behavior — n/a

**Release Note**

```release-note

```
