### PR TITLE
fix(coordinator): use the minimum GPU ResourceQuota and ignore scoped quotas

### DIFF
--- a/internal/coordinator/plugins/gpurebalance/plugin.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin.go
@@ -225,25 +225,45 @@ func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns str
 }
 
 func (p *Plugin) namespaceGPUQuota(ctx context.Context, ns string) (int64, error) {
-	// TODO: a namespace can have multiple ResourceQuotas; the effective GPU limit
-	// is the minimum across all of them, not the first one found. Returning the
-	// first match can overestimate the budget and allow over-scheduling.
-
-	// TODO: ResourceQuotas can carry a spec.scopeSelector that restricts which
-	// pods they apply to (e.g. only BestEffort or Terminating pods). This code
-	// ignores scope selectors and treats any quota with a GPU field as the full
-	// namespace budget, which may overstate the applicable limit.
+	log := ctrl.LoggerFrom(ctx).WithName("gpu-rebalance")
 
 	list := &corev1.ResourceQuotaList{}
 	if err := p.client.List(ctx, list, client.InNamespace(ns)); err != nil {
 		return 0, err
 	}
+
+	var (
+		quota int64
+		found bool
+	)
 	for i := range list.Items {
-		if q, ok := list.Items[i].Spec.Hard[corev1.ResourceName(gpuQuotaResource)]; ok {
-			return q.Value(), nil
+		rq := &list.Items[i]
+		q, ok := rq.Spec.Hard[corev1.ResourceName(gpuQuotaResource)]
+		if !ok {
+			continue
+		}
+
+		// A scoped ResourceQuota governs only the subset of pods its scopes match
+		// (for example BestEffort, Terminating, or a particular PriorityClass), so
+		// its hard limit is not the namespace-wide budget. Skip it rather than
+		// mistaking a partial limit for the full ceiling.
+		if len(rq.Spec.Scopes) > 0 || rq.Spec.ScopeSelector != nil {
+			log.Info("Ignoring scoped ResourceQuota when computing the GPU budget",
+				"namespace", ns, "resourceQuota", rq.Name)
+			continue
+		}
+
+		// A pod must satisfy every ResourceQuota that applies to it, so when more
+		// than one carries a GPU limit the effective ceiling is the smallest.
+		if v := q.Value(); !found || v < quota {
+			quota, found = v, true
 		}
 	}
-	return 0, nil
+
+	if !found {
+		return 0, nil
+	}
+	return quota, nil
 }
 
 func (p *Plugin) queryQueue(ctx context.Context, inferencePool string) (float64, error) {

--- a/internal/coordinator/plugins/gpurebalance/plugin_test.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin_test.go
@@ -120,6 +120,28 @@ func makeGPUQuota(name, ns string, gpus int64) *corev1.ResourceQuota {
 	}
 }
 
+// makeScopedGPUQuota builds a ResourceQuota carrying a GPU limit that only
+// applies to the subset of pods selected by scope.
+func makeScopedGPUQuota(name, ns string, gpus int64, scope corev1.ResourceQuotaScope) *corev1.ResourceQuota {
+	rq := makeGPUQuota(name, ns, gpus)
+	rq.Spec.Scopes = []corev1.ResourceQuotaScope{scope}
+	return rq
+}
+
+// makeScopeSelectorGPUQuota builds a ResourceQuota carrying a GPU limit that
+// only applies to pods matching a scopeSelector.
+func makeScopeSelectorGPUQuota(name, ns string, gpus int64, priorityClass string) *corev1.ResourceQuota {
+	rq := makeGPUQuota(name, ns, gpus)
+	rq.Spec.ScopeSelector = &corev1.ScopeSelector{
+		MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+			ScopeName: corev1.ResourceQuotaScopePriorityClass,
+			Operator:  corev1.ScopeSelectorOpIn,
+			Values:    []string{priorityClass},
+		}},
+	}
+	return rq
+}
+
 func newPlugin(t *testing.T, queues map[string]float64, errs map[string]error, objs ...client.Object) (*Plugin, client.Client) {
 	t.Helper()
 	scheme := newTestScheme(t)
@@ -714,5 +736,96 @@ func TestSetMaxReplicas_GivesUpAfterMaxRetries(t *testing.T) {
 	}
 	if got := getMaxReplicas(t, c, hpa); got != 5 {
 		t.Errorf("maxReplicas = %d, want 5 (unchanged)", got)
+	}
+}
+
+// TestNamespaceGPUQuota_MultipleQuotasUsesMinimum verifies that when a namespace
+// carries more than one GPU-bearing ResourceQuota the effective budget is the
+// smallest hard limit, since a pod must satisfy every applicable quota.
+func TestNamespaceGPUQuota_MultipleQuotasUsesMinimum(t *testing.T) {
+	// Names are chosen so that the larger quota sorts first in List order, which
+	// is what the previous first-match behaviour would have returned.
+	p, _ := newPlugin(t, nil, nil,
+		makeGPUQuota("a-large", "ns", 32),
+		makeGPUQuota("b-small", "ns", 8),
+	)
+
+	got, err := p.namespaceGPUQuota(context.Background(), "ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 8 {
+		t.Errorf("namespaceGPUQuota = %d, want 8 (minimum across quotas)", got)
+	}
+}
+
+// TestNamespaceGPUQuota_IgnoresScopedQuota verifies that a ResourceQuota
+// restricted by spec.scopes is not treated as the namespace-wide GPU budget.
+func TestNamespaceGPUQuota_IgnoresScopedQuota(t *testing.T) {
+	p, _ := newPlugin(t, nil, nil,
+		makeScopedGPUQuota("a-scoped", "ns", 4, corev1.ResourceQuotaScopeBestEffort),
+		makeGPUQuota("b-namespace-wide", "ns", 16),
+	)
+
+	got, err := p.namespaceGPUQuota(context.Background(), "ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 16 {
+		t.Errorf("namespaceGPUQuota = %d, want 16 (scoped quota must not lower the budget)", got)
+	}
+}
+
+// TestNamespaceGPUQuota_IgnoresScopeSelectorQuota is the spec.scopeSelector
+// counterpart of the spec.scopes case.
+func TestNamespaceGPUQuota_IgnoresScopeSelectorQuota(t *testing.T) {
+	p, _ := newPlugin(t, nil, nil,
+		makeScopeSelectorGPUQuota("a-scoped", "ns", 2, "high-priority"),
+		makeGPUQuota("b-namespace-wide", "ns", 12),
+	)
+
+	got, err := p.namespaceGPUQuota(context.Background(), "ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 12 {
+		t.Errorf("namespaceGPUQuota = %d, want 12 (scopeSelector quota must not lower the budget)", got)
+	}
+}
+
+// TestNamespaceGPUQuota_OnlyScopedQuotaYieldsNoBudget verifies that when every
+// GPU-bearing quota is scoped there is no namespace-wide budget to report, which
+// makes Tick skip the namespace rather than rebalance against a partial limit.
+func TestNamespaceGPUQuota_OnlyScopedQuotaYieldsNoBudget(t *testing.T) {
+	p, _ := newPlugin(t, nil, nil,
+		makeScopedGPUQuota("scoped", "ns", 4, corev1.ResourceQuotaScopeBestEffort),
+	)
+
+	got, err := p.namespaceGPUQuota(context.Background(), "ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("namespaceGPUQuota = %d, want 0 (only scoped quotas present)", got)
+	}
+}
+
+// TestNamespaceGPUQuota_IgnoresQuotasWithoutGPUField verifies that quotas which
+// do not constrain GPUs are not considered when computing the minimum.
+func TestNamespaceGPUQuota_IgnoresQuotasWithoutGPUField(t *testing.T) {
+	cpuOnly := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "a-cpu-only", Namespace: "ns"},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI)},
+		},
+	}
+	p, _ := newPlugin(t, nil, nil, cpuOnly, makeGPUQuota("b-gpu", "ns", 6))
+
+	got, err := p.namespaceGPUQuota(context.Background(), "ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 6 {
+		t.Errorf("namespaceGPUQuota = %d, want 6", got)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the two problems reported in #1460, both of which were already flagged by TODOs in `namespaceGPUQuota` (`internal/coordinator/plugins/gpurebalance/plugin.go`).

**1. Multiple quotas — the effective limit is the minimum.** The previous code returned the GPU `hard` value of the *first* ResourceQuota carrying `requests.nvidia.com/gpu`. `List` order is by name and unrelated to which quota actually binds, so the returned budget could exceed the real ceiling. A pod must satisfy every applicable quota, so the effective limit is the smallest.

**2. Scope selectors were ignored.** A ResourceQuota restricted by `spec.scopes` or `spec.scopeSelector` (BestEffort, Terminating, a PriorityClass) only governs the subset of pods it matches. Treating such a quota as the namespace-wide budget misreads a partial limit as the whole ceiling. Scoped quotas are now skipped with a log line rather than counted.

When every GPU-bearing quota in a namespace is scoped, no budget is reported (`0`), so `Tick` skips the namespace — matching the existing no-quota behaviour — rather than rebalancing against a partial limit.

On the open question raised in the issue: this keeps the existing semantics of reading `Spec.Hard` (the total ceiling) rather than `Hard − Status.Used`, since that is a separate behavioural change. Happy to follow up if the intent was headroom.

## Acceptance criteria

- [x] With two GPU-bearing ResourceQuotas in a namespace, the plugin uses the minimum `hard` value.
- [x] A GPU quota carrying a scope selector that does not match inference pods is not counted as the namespace budget.
- [x] Unit coverage for both cases (multi-quota minimum; scoped quota excluded).

## Testing

Five unit tests added to `plugin_test.go`, following the existing `newPlugin`/fake-client pattern: multi-quota minimum, `spec.scopes` exclusion, `spec.scopeSelector` exclusion, only-scoped-quotas yields no budget, and quotas without a GPU field are ignored.

Against the previous behaviour they fail as follows — the quota names are chosen so the larger value sorts first in `List` order, which is what first-match returned:

```
--- FAIL: TestNamespaceGPUQuota_MultipleQuotasUsesMinimum
    namespaceGPUQuota = 32, want 8 (minimum across quotas)
--- FAIL: TestNamespaceGPUQuota_IgnoresScopedQuota
    namespaceGPUQuota = 4, want 16 (scoped quota must not lower the budget)
--- FAIL: TestNamespaceGPUQuota_IgnoresScopeSelectorQuota
    namespaceGPUQuota = 2, want 12 (scopeSelector quota must not lower the budget)
--- FAIL: TestNamespaceGPUQuota_OnlyScopedQuotaYieldsNoBudget
    namespaceGPUQuota = 4, want 0 (only scoped quotas present)
```

`go build ./...`, `go vet`, `gofmt`, and the full `gpurebalance` package suite are clean.

## Related issue number

Closes #1460

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, fix, and tests were verified against the source and the existing test suite before submitting.