### PR TITLE
Feat/rescale beta observability and hysteresis

### DIFF
--- a/config/base/manager/saturation-scaling-configmap.yaml
+++ b/config/base/manager/saturation-scaling-configmap.yaml
@@ -45,3 +45,13 @@ data:
     # that namespace's quota budget. Has no effect without a same-scope GPU budget
     # (requires enableLimiter and a matching cluster/namespace budget).
     enableRescale: false
+    # Rescale hysteresis (Beta) — damps oscillation when demand hovers around the
+    # contention threshold. Both are budget-scope (read only from this `default`
+    # entry, same as enableRescale) and default 0, which preserves the plain
+    # whole-replica behavior. rescaleMinShareGapGPUs is a deadband in whole GPUs:
+    # a model is held at its current allocation when its target-vs-current gap is
+    # smaller than this. rescaleCooldownSeconds suppresses a repeat reclaim from a
+    # model until this many seconds after its last reclaim (fills are never cooled
+    # down). Recommended when enabling rescale in production: gap 1, cooldown ~60.
+    rescaleMinShareGapGPUs: 0
+    rescaleCooldownSeconds: 0

--- a/config/base/manager/saturation-scaling-configmap.yaml
+++ b/config/base/manager/saturation-scaling-configmap.yaml
@@ -50,7 +50,7 @@ data:
     # entry, same as enableRescale) and default 0, which preserves the plain
     # whole-replica behavior. rescaleMinShareGapGPUs is a deadband in whole GPUs:
     # a model is held at its current allocation when its target-vs-current gap is
-    # smaller than this. rescaleCooldownSeconds suppresses a repeat reclaim from a
+    # at or below this (inclusive). rescaleCooldownSeconds suppresses a repeat reclaim from a
     # model until this many seconds after its last reclaim (fills are never cooled
     # down). Recommended when enabling rescale in production: gap 1, cooldown ~60.
     rescaleMinShareGapGPUs: 0

--- a/deploy/configmap-saturation-scaling.yaml
+++ b/deploy/configmap-saturation-scaling.yaml
@@ -50,6 +50,16 @@ data:
     # governs the cluster budget; a namespace-local config's `default` governs
     # that namespace's quota budget. Has no effect without a same-scope GPU budget.
     enableRescale: false
+    # Rescale hysteresis (Beta) — damps oscillation when demand hovers around the
+    # contention threshold. Both are budget-scope (read only from this `default`
+    # entry, same as enableRescale) and default 0, which preserves the plain
+    # whole-replica behavior. rescaleMinShareGapGPUs is a deadband in whole GPUs:
+    # a model is held at its current allocation when its target-vs-current gap is
+    # smaller than this. rescaleCooldownSeconds suppresses a repeat reclaim from a
+    # model until this many seconds after its last reclaim (fills are never cooled
+    # down). Recommended when enabling rescale in production: gap 1, cooldown ~60.
+    rescaleMinShareGapGPUs: 0
+    rescaleCooldownSeconds: 0
 
   # Per-model overrides inherit the default's analyzer selection (V2) via
   # field-level merge, so they only need the thresholds they change. Under V2,

--- a/deploy/configmap-saturation-scaling.yaml
+++ b/deploy/configmap-saturation-scaling.yaml
@@ -55,7 +55,7 @@ data:
     # entry, same as enableRescale) and default 0, which preserves the plain
     # whole-replica behavior. rescaleMinShareGapGPUs is a deadband in whole GPUs:
     # a model is held at its current allocation when its target-vs-current gap is
-    # smaller than this. rescaleCooldownSeconds suppresses a repeat reclaim from a
+    # at or below this (inclusive). rescaleCooldownSeconds suppresses a repeat reclaim from a
     # model until this many seconds after its last reclaim (fills are never cooled
     # down). Recommended when enabling rescale in production: gap 1, cooldown ~60.
     rescaleMinShareGapGPUs: 0

--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -177,6 +177,11 @@ Design and staged rollout: [`docs/plans/engine/rescale-alpha.md`](../plans/engin
 (Alpha — redistribution) and [`docs/plans/engine/rescale-beta.md`](../plans/engine/rescale-beta.md)
 (Beta — observability + hysteresis).
 
+Rescale is multi-analyzer: the water-fill weight is the `Score`-weighted sum of each
+enabled analyzer's demand and the sizing uses the cross-analyzer bottleneck, so the
+[Multi-Analyzer](#multi-analyzer-registration) `score` weights apply to rescale too. With
+the default single (`saturation`) analyzer this is identical to the saturation-only signal.
+
 ### Parameters
 
 These are **budget-scope** settings, read only from the `default` entry (never a

--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -163,6 +163,51 @@ This proactive approach ensures adequate headroom and prevents request drops by 
 
 **For detailed implementation, see:** [Saturation Analyzer Documentation](user-guide/saturation-analyzer.md)
 
+## Priority-Weighted Rescale
+
+Under GPU contention (Σ demand > budget within a competition group), the V2
+GPU-constrained optimizer can **redistribute the whole group budget** by
+`priority × demand` — reclaiming GPUs from lower-priority (over-share) models so
+higher-priority work can run — instead of only handing out free GPUs. It is
+**opt-in and off by default**; when disabled or uncontended, behavior is unchanged.
+A competition group is keyed by `(accelerator type, budget scope)` where scope is the
+cluster budget or a namespace quota.
+
+Design and staged rollout: [`docs/plans/engine/rescale-alpha.md`](../plans/engine/rescale-alpha.md)
+(Alpha — redistribution) and [`docs/plans/engine/rescale-beta.md`](../plans/engine/rescale-beta.md)
+(Beta — observability + hysteresis).
+
+### Parameters
+
+These are **budget-scope** settings, read only from the `default` entry (never a
+per-model override): the value in the **global** config governs the cluster budget, and
+a **namespace-local** config's `default` governs that namespace's quota budget (never
+the global fallback). They have no effect without a same-scope GPU budget (`enableLimiter`
+plus a matching cluster/namespace budget).
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `enableRescale` | bool | Enable the priority-weighted rescale pass for this budget scope. | `false` |
+| `rescaleMinShareGapGPUs` | int | Hysteresis **deadband**, in whole GPUs. Holds a model at its current allocation when `0 < \|share − current\| ≤ gap` (inclusive, both directions), so small share drift around the contention threshold does not flap. `0` disables it. | `0` (recommended `1`) |
+| `rescaleCooldownSeconds` | int | Per-model **reclaim cool-down**, in seconds. Suppresses a repeat reclaim from a model until this long after its last reclaim. Fills are never cooled down; a stalled reclaim (shed nothing) never starts a cool-down. `0` disables it. | `0` (recommended `~60`) |
+
+### Observability
+
+Each `VariantAutoscaling` the rescale pass acts on gets a **`Rescaled`** status
+condition, attributed per variant by role:
+
+| Reason | Meaning |
+|--------|---------|
+| `Reclaim` | This variant is being scaled down to release GPUs to higher-priority work. |
+| `Fill` | This variant is being scaled up into freed budget. |
+| `Hold` | Within its share, or suppressed by the deadband / cool-down. |
+| `Stalled` | Its role owed a reclaim but could not shed a whole replica (blocked by `minReplicas` or the cheapest-at-1 protection). |
+
+The condition message carries `priority`, the water-fill `share`, `current` GPUs, and the
+budget `scope`. A stall additionally emits a `RescaleStalled` **Warning** event on that
+variant. When a variant stops being rescaled (its group became uncontended, or rescale was
+disabled), a previously-`True` `Rescaled` condition is set to `False`.
+
 ## Multi-Analyzer Registration
 
 The V2 engine carries an analyzer registry so external analyzers (e.g.

--- a/docs/plans/engine/rescale-alpha.md
+++ b/docs/plans/engine/rescale-alpha.md
@@ -26,10 +26,11 @@ allocation by arrival order once the budget is full.
   reclaims.
 
 **Deferred**
+- **Observability** (`Rescaled` status condition, surfacing a reclaim **stall** when a role can't
+  shed a whole replica) + **hysteresis** (min share-gap / cool-down) → **Beta** (delivered; see
+  `docs/plans/engine/rescale-beta.md`).
 - Physical∧quota **namespace partition** of the cluster budget → needs #1003.
 - **Multi-accelerator** models (variants spanning GPU types) → future scope.
-- **Observability** (`Rescaled` status condition, surfacing a reclaim **stall** when a role can't
-  shed a whole replica) + **hysteresis** (min share-gap / cool-down) → Beta.
 
 ## Flag semantics — scope-coupled to the budget
 

--- a/docs/plans/engine/rescale-beta.md
+++ b/docs/plans/engine/rescale-beta.md
@@ -74,22 +74,29 @@ live model set every cycle. Both knobs are inert at 0 — the deadband is inclus
 (`0 < |gap| ≤ knob`) but `absGap ≥ 1` while `knob == 0` never satisfies it, and the
 cool-down window can never trigger — so Alpha behaviour is preserved byte-for-byte.
 
-**Known limitation (deferred):** the deadband is evaluated on the *model-level* gap and,
-when it holds, skips the whole per-role loop. For a disaggregated (P/D) model whose total
-sits inside the band while its role split swings, a budget-neutral prefill↔decode
-rebalance is frozen for that cycle. This only bites at `gap ≥ 2` with a specific
-imbalanced-P/D shape (the recommended `gap: 1` never triggers it), so it is left as a
-future refinement (a per-role deadband) rather than fixed here.
+**Known limitations (deferred):**
+- The deadband is evaluated on the *model-level* gap and, when it holds, skips the whole
+  per-role loop. For a disaggregated (P/D) model whose total sits inside the band while its
+  role split swings, a budget-neutral prefill↔decode rebalance is frozen for that cycle.
+  This only bites at `gap ≥ 2` with a specific imbalanced-P/D shape (the recommended
+  `gap: 1` never triggers it), so it is left as a future refinement (a per-role deadband).
+- The condition/event message reports the model-level `share`/`current` GPUs. For a P/D
+  model whose roles rebalance to a near-zero net delta, a genuine role-level stall can
+  therefore surface with `share == current` in the text — accurate at the model level but
+  hiding the role imbalance that caused it. Surfacing role-level numbers is a future polish.
 
 ## Observability
 
 - `domain.RescaleDecisionInfo` (attached to every rescale decision; nil otherwise)
-  carries `Priority`, `TargetGPUs` (share), `CurrentGPUs`, `Scope`, `Action`
-  (`reclaim`/`fill`/`hold`), and `Stalled`. `Action` is derived from the work actually
-  performed (`modelRescaleAction`), not the model-level GPU totals, so a P/D model that
-  rebalances to a near-zero net delta — or stalls on one role — is not mislabeled `hold`.
+  carries model-level `Priority`, `TargetGPUs` (share), `CurrentGPUs`, `Scope`, plus a
+  **per-variant** `Action` (`reclaim`/`fill`/`hold`) and `Stalled`. Action/Stalled are
+  keyed off the variant's own role (`VariantDecision.Role`), not one shared model-level
+  summary, so a P/D model whose decode role stalls while its prefill role fills does not
+  blame the grown prefill variant with the decode reclaim/stall. A no-change variant
+  reflects its role's intent (a fill gated to 0 this cycle still reads `fill`; a reclaim
+  blocked at `minReplicas` still reads `reclaim`); a scaled-up variant is never `Stalled`.
 - `reclaimRole` returns the GPUs it could not shed; a whole-replica-sized shortfall
-  marks the model stalled.
+  marks that **role** stalled, attributed to that role's variants.
 - The engine's `applySaturationDecisions` calls `setRescaledCondition`, which sets the
   `Rescaled` condition (`variant.TypeRescaled`) with reason
   `Reclaim`/`Fill`/`Hold`/`Stalled` and a message

--- a/docs/plans/engine/rescale-beta.md
+++ b/docs/plans/engine/rescale-beta.md
@@ -44,7 +44,7 @@ for a namespace). Both default `0` (off).
 
 | Knob | Effect |
 |---|---|
-| `rescaleMinShareGapGPUs` | Deadband in whole GPUs. Hold the model when `|share − current| < gap`. |
+| `rescaleMinShareGapGPUs` | Deadband in whole GPUs. Hold the model when `0 < |share − current| ≤ gap` (inclusive, so `gap: 1` damps a single-GPU flap). |
 | `rescaleCooldownSeconds` | Per-model reclaim cool-down in seconds. Suppress a repeat reclaim within the window. |
 
 Recommended when enabling rescale in production: `gap: 1`, `cooldown: ~60`.
@@ -70,14 +70,24 @@ delta (before the per-role split):
 State: the cool-down clock (`time.Now()` for the cycle) and an engine-owned
 `map[modelKey]time.Time` last-reclaim store are handed to the optimizer each cycle. The
 store is touched only by the single optimize goroutine (lock-free) and is pruned to the
-live model set every cycle. Both knobs are inert at 0 — the deadband condition and the
+live model set every cycle. Both knobs are inert at 0 — the deadband is inclusive
+(`0 < |gap| ≤ knob`) but `absGap ≥ 1` while `knob == 0` never satisfies it, and the
 cool-down window can never trigger — so Alpha behaviour is preserved byte-for-byte.
+
+**Known limitation (deferred):** the deadband is evaluated on the *model-level* gap and,
+when it holds, skips the whole per-role loop. For a disaggregated (P/D) model whose total
+sits inside the band while its role split swings, a budget-neutral prefill↔decode
+rebalance is frozen for that cycle. This only bites at `gap ≥ 2` with a specific
+imbalanced-P/D shape (the recommended `gap: 1` never triggers it), so it is left as a
+future refinement (a per-role deadband) rather than fixed here.
 
 ## Observability
 
 - `domain.RescaleDecisionInfo` (attached to every rescale decision; nil otherwise)
   carries `Priority`, `TargetGPUs` (share), `CurrentGPUs`, `Scope`, `Action`
-  (`reclaim`/`fill`/`hold`), and `Stalled`.
+  (`reclaim`/`fill`/`hold`), and `Stalled`. `Action` is derived from the work actually
+  performed (`modelRescaleAction`), not the model-level GPU totals, so a P/D model that
+  rebalances to a near-zero net delta — or stalls on one role — is not mislabeled `hold`.
 - `reclaimRole` returns the GPUs it could not shed; a whole-replica-sized shortfall
   marks the model stalled.
 - The engine's `applySaturationDecisions` calls `setRescaledCondition`, which sets the
@@ -85,7 +95,9 @@ cool-down window can never trigger — so Alpha behaviour is preserved byte-for-
   `Reclaim`/`Fill`/`Hold`/`Stalled` and a message
   `priority=… share=…GPU current=…GPU scope=…`. A stall additionally emits the
   `RescaleStalled` Warning event (added to `recordEvent`'s dedup-bypass list so it
-  coexists with a scaling event) and a log line.
+  coexists with a scaling event) and a log line. When a VA is no longer rescaled (its
+  group became uncontended, or rescale was disabled), a previously-`True` `Rescaled`
+  condition is flipped to `False` so it does not linger as a stale "still reclaiming".
 
 ## Files
 

--- a/docs/plans/engine/rescale-beta.md
+++ b/docs/plans/engine/rescale-beta.md
@@ -106,6 +106,25 @@ cool-down window can never trigger — so Alpha behaviour is preserved byte-for-
   group became uncontended, or rescale was disabled), a previously-`True` `Rescaled`
   condition is flipped to `False` so it does not linger as a stale "still reclaiming".
 
+## Analyzer scope (multi-analyzer)
+
+Rescale consumes the same multi-analyzer signal as the rest of the V2 optimizer (the
+per-analyzer `req.AnalyzerResults` slice from #1246), so enabling a second analyzer
+(throughput / queueing) affects rescale, not just the additive fair-share path:
+
+- **Water-fill weight** (`priority × demand`): `demand` is `combinedDemandWeight` =
+  `Σₐ Scoreₐ × Resultₐ.TotalDemand` — the Score-weighted sum of each analyzer's raw total
+  demand, mirroring `fairShareValue`. Raw demand (a ratio) keeps a single analyzer
+  identical to Alpha; `Scoreₐ ≤ 0` normalizes to `1.0` (matching `scoreForAnalyzer`).
+- **Sizing demand-in-GPUs** (contention check, per-model `CapGPUs`, P/D role split):
+  `roleDemandGPUs` is the cross-analyzer **MAX** (bottleneck) of each analyzer's
+  total-demand-in-GPUs (converted in that analyzer's own replica-space), matching
+  `roleBottleneckReplicas`. A single analyzer reduces to the saturation value.
+- **Reclaim ordering** already used the combine (`sortVariantsForScaleDown` is
+  Score-weighted). **Fill ordering** stays cost-based (`sortByCostEfficiencyAsc`), and
+  **variant topology** (which variants, roles, `gpusPerReplica`, floors/caps) stays
+  saturation-sourced — both consistent with the pipeline's allocate path.
+
 ## Files
 
 | File | Change |

--- a/docs/plans/engine/rescale-beta.md
+++ b/docs/plans/engine/rescale-beta.md
@@ -1,0 +1,119 @@
+# Plan: Priority-Weighted Rescale — Beta stage
+
+Implements the **Beta** milestone of the rescale proposal
+(issue [#1447](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1447)),
+building on the **Alpha** redistribution (`docs/plans/engine/rescale-alpha.md`, PR #1452).
+
+## Goal
+
+Alpha made rescale correct but silent and un-damped. Beta adds the two things Alpha
+explicitly deferred:
+
+1. **Observability** — make each cycle's redistribution visible on the
+   `VariantAutoscaling`, and surface when a reclaim is *blocked*.
+2. **Hysteresis** — stop reclaim/fill from oscillating when demand hovers around the
+   contention threshold.
+
+Neither changes the Alpha water-fill math, the scope-coupling rules, or the paced
+free-capacity-gated convergence. With the new knobs at their defaults (0), behaviour is
+identical to Alpha.
+
+## Scope
+
+**In Beta**
+- `Rescaled` status condition, per model, carrying priority, the water-fill **share**
+  vs current GPUs, the budget scope, and the direction taken.
+- **Reclaim-stall** surfacing: a role that owed a reclaim but could not shed a whole
+  replica (blocked by `minReplicas` or the cheapest-at-1 protection) is flagged, sets
+  the `Stalled` condition reason, and emits a `RescaleStalled` **Warning** event.
+- **Deadband** hysteresis (`rescaleMinShareGapGPUs`) — hold a model when
+  `|share − current|` is below the gap, in both directions.
+- **Reclaim cool-down** (`rescaleCooldownSeconds`) — suppress a repeat reclaim from a
+  model until the configured time has elapsed since its last reclaim.
+
+**Still deferred (Stable)**
+- Physical∧quota **namespace partition** of the cluster budget → needs #1003.
+- **Multi-accelerator** models (variants spanning GPU types).
+
+## Config — hysteresis knobs (budget-scope)
+
+Two fields on `SaturationScalingConfig`, read only from the **`default`** entry, with
+the same budget-scope semantics as `enableRescale` (global governs the cluster budget;
+a namespace-local `default` governs that namespace's quota; never the global fallback
+for a namespace). Both default `0` (off).
+
+| Knob | Effect |
+|---|---|
+| `rescaleMinShareGapGPUs` | Deadband in whole GPUs. Hold the model when `|share − current| < gap`. |
+| `rescaleCooldownSeconds` | Per-model reclaim cool-down in seconds. Suppress a repeat reclaim within the window. |
+
+Recommended when enabling rescale in production: `gap: 1`, `cooldown: ~60`.
+
+Resolved per scope via `config.RescaleTuningCluster` /
+`config.RescaleTuningForNamespaceLocal`, mapped into `pipeline.RescaleFlags`
+(`ClusterTuning`, `ByNamespaceTuning`) by `resolveRescaleFlags`.
+
+## Hysteresis semantics
+
+Applied per model in `rescaleModelDecisions`, on the model-level `share` vs `current`
+delta (before the per-role split):
+
+- **Deadband** holds both directions: a sub-gap reclaim *and* a sub-gap fill are
+  suppressed, so tiny share drift does not actuate.
+- **Cool-down** holds only a would-be **reclaim**; fills are never cooled down, so
+  genuinely free GPUs still reach higher-priority work. The cool-down is stamped only
+  when a reclaim actually **shed** GPUs — a *stalled* reclaim (shed nothing) never
+  starts a cool-down, so the retry that could finally succeed is not blocked.
+- A held model produces no reclaim/fill (targets stay at current) and reports the
+  `hold` action.
+
+State: the cool-down clock (`time.Now()` for the cycle) and an engine-owned
+`map[modelKey]time.Time` last-reclaim store are handed to the optimizer each cycle. The
+store is touched only by the single optimize goroutine (lock-free) and is pruned to the
+live model set every cycle. Both knobs are inert at 0 — the deadband condition and the
+cool-down window can never trigger — so Alpha behaviour is preserved byte-for-byte.
+
+## Observability
+
+- `domain.RescaleDecisionInfo` (attached to every rescale decision; nil otherwise)
+  carries `Priority`, `TargetGPUs` (share), `CurrentGPUs`, `Scope`, `Action`
+  (`reclaim`/`fill`/`hold`), and `Stalled`.
+- `reclaimRole` returns the GPUs it could not shed; a whole-replica-sized shortfall
+  marks the model stalled.
+- The engine's `applySaturationDecisions` calls `setRescaledCondition`, which sets the
+  `Rescaled` condition (`variant.TypeRescaled`) with reason
+  `Reclaim`/`Fill`/`Hold`/`Stalled` and a message
+  `priority=… share=…GPU current=…GPU scope=…`. A stall additionally emits the
+  `RescaleStalled` Warning event (added to `recordEvent`'s dedup-bypass list so it
+  coexists with a scaling event) and a log line.
+
+## Files
+
+| File | Change |
+|---|---|
+| `internal/config/saturation_scaling.go` | `RescaleMinShareGapGPUs`, `RescaleCooldownSeconds` + `Validate` (>= 0) |
+| `internal/config/config.go` | `RescaleTuning` + `RescaleTuning{Cluster,ForNamespaceLocal}` accessors (bool accessors delegate) |
+| `internal/domain/saturation_analyzer.go` | `RescaleDecisionInfo` + `Rescale` field + action constants |
+| `internal/variant/types.go` | `TypeRescaled` + `ReasonRescale{Reclaim,Fill,Hold,Stalled}` |
+| `internal/constants/constants.go` | `K8SEventRescaleStalled` |
+| `internal/engines/pipeline/rescale.go` | per-scope tuning; deadband + cool-down; stall detection; info payload |
+| `internal/engines/pipeline/greedy_score_optimizer.go` | `RescaleNow` + `RescaleLastReclaim` per-cycle state |
+| `internal/engines/saturation/engine.go` | last-reclaim store; wire clock/store/tuning; `setRescaledCondition`; stall event |
+| `config/base/manager/saturation-scaling-configmap.yaml`, `deploy/configmap-saturation-scaling.yaml` | document the two knobs |
+
+## Tests
+- Config: knob yaml tags + zero defaults + negative-value validation; tuning accessors
+  (cluster + namespace-local, no global fallback).
+- Observability: info payload on reclaim/fill, namespace scope, the stall path, off ⇒
+  nil; condition/reason/message + stall Warning event.
+- Hysteresis: deadband holds a sub-gap reclaim; cool-down suppresses then allows across
+  cycles; no cool-down stamp on a stalled reclaim; **knobs=0 ⇒ decisions identical to
+  Alpha even with the clock wired**.
+
+## Commits (each: build + `go test` + golangci-lint via WSL, DCO-signed)
+1. **Config knobs** — the two fields + accessors + configmap docs. Behavior-neutral.
+2. **Observability** — `RescaleDecisionInfo` + `Rescaled` condition/reasons + stall
+   detection + event, with tests.
+3. **Hysteresis** — per-scope tuning + deadband + cool-down + engine state wiring, with
+   tests.
+4. **Docs** — this plan; alpha deferred-note update.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -419,30 +419,65 @@ func (c *Config) SaturationConfigForNamespace(namespace string) map[string]Satur
 	return copySaturationConfig(sourceConfig)
 }
 
-// RescaleEnabledForNamespaceLocal reports the EnableRescale flag from a namespace's
-// OWN saturation config `default` entry, and whether that namespace has its own
+// RescaleTuning is the scope-coupled rescale configuration read from a single
+// saturation config `default` entry: whether rescale is enabled at that budget
+// scope, plus the Beta hysteresis knobs. All fields come from the same "default"
+// entry, so they share the budget-scope semantics documented on EnableRescale.
+type RescaleTuning struct {
+	// Enabled mirrors EnableRescale for this scope.
+	Enabled bool
+	// MinShareGapGPUs is the hysteresis deadband in whole GPUs (0 = off).
+	MinShareGapGPUs int
+	// CooldownSeconds is the per-model reclaim cool-down in seconds (0 = off).
+	CooldownSeconds int
+}
+
+func rescaleTuningFrom(c SaturationScalingConfig) RescaleTuning {
+	return RescaleTuning{
+		Enabled:         c.EnableRescale,
+		MinShareGapGPUs: c.RescaleMinShareGapGPUs,
+		CooldownSeconds: c.RescaleCooldownSeconds,
+	}
+}
+
+// RescaleTuningCluster returns the rescale tuning from the global saturation config
+// `default` entry — the cluster-budget scope.
+func (c *Config) RescaleTuningCluster() RescaleTuning {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return rescaleTuningFrom(c.saturation.global["default"])
+}
+
+// RescaleTuningForNamespaceLocal returns the rescale tuning from a namespace's OWN
+// saturation config `default` entry, and whether that namespace has its own
 // (non-global) config. It intentionally does NOT fall back to the global config: the
-// scope-coupled rescale flag for a namespace quota is governed only by that
-// namespace's own config, so the cluster (global) flag never leaks onto it.
-func (c *Config) RescaleEnabledForNamespaceLocal(namespace string) (enabled bool, hasLocal bool) {
+// scope-coupled rescale flag and knobs for a namespace quota are governed only by
+// that namespace's own config, so the cluster (global) settings never leak onto it.
+func (c *Config) RescaleTuningForNamespaceLocal(namespace string) (RescaleTuning, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if namespace == "" {
-		return false, false
+		return RescaleTuning{}, false
 	}
 	nsCfg, ok := c.saturation.namespaceConfigs[namespace]
 	if !ok || len(nsCfg) == 0 {
-		return false, false
+		return RescaleTuning{}, false
 	}
-	return nsCfg["default"].EnableRescale, true
+	return rescaleTuningFrom(nsCfg["default"]), true
+}
+
+// RescaleEnabledForNamespaceLocal reports the EnableRescale flag from a namespace's
+// OWN saturation config `default` entry, and whether that namespace has its own
+// (non-global) config. Convenience wrapper over RescaleTuningForNamespaceLocal.
+func (c *Config) RescaleEnabledForNamespaceLocal(namespace string) (enabled bool, hasLocal bool) {
+	t, has := c.RescaleTuningForNamespaceLocal(namespace)
+	return t.Enabled, has
 }
 
 // RescaleEnabledCluster reports the EnableRescale flag from the global saturation
 // config `default` entry — the cluster-budget scope.
 func (c *Config) RescaleEnabledCluster() bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.saturation.global["default"].EnableRescale
+	return c.RescaleTuningCluster().Enabled
 }
 
 // copySaturationConfig creates a deep copy of the saturation config map.

--- a/internal/config/rescale_config_test.go
+++ b/internal/config/rescale_config_test.go
@@ -19,6 +19,36 @@ var _ = Describe("SaturationScalingConfig enableRescale", func() {
 		Entry("explicit false", "enableRescale: false\n", false),
 	)
 
+	// Locks the Beta hysteresis yaml tags and their zero defaults.
+	DescribeTable("hysteresis knob parsing",
+		func(doc string, wantGap, wantCooldown int) {
+			var cfg SaturationScalingConfig
+			Expect(yaml.Unmarshal([]byte(doc), &cfg)).To(Succeed())
+			Expect(cfg.RescaleMinShareGapGPUs).To(Equal(wantGap))
+			Expect(cfg.RescaleCooldownSeconds).To(Equal(wantCooldown))
+		},
+		Entry("absent defaults zero", "kvCacheThreshold: 0.8\n", 0, 0),
+		Entry("explicit values", "rescaleMinShareGapGPUs: 2\nrescaleCooldownSeconds: 90\n", 2, 90),
+	)
+
+	// Negative knob values are rejected by Validate.
+	DescribeTable("hysteresis knob validation",
+		func(gap, cooldown int, wantErr bool) {
+			cfg := SaturationScalingConfig{RescaleMinShareGapGPUs: gap, RescaleCooldownSeconds: cooldown}
+			cfg.ApplyDefaults()
+			err := cfg.Validate()
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry("both zero ok", 0, 0, false),
+		Entry("positive ok", 1, 60, false),
+		Entry("negative gap rejected", -1, 0, true),
+		Entry("negative cooldown rejected", 0, -1, true),
+	)
+
 	// enableRescale is budget-scoped: it is read only from the global/namespace
 	// `default` entry and must NOT be settable via a per-model override, so Merge()
 	// deliberately ignores it. This locks that exclusion against an accidental
@@ -63,5 +93,34 @@ var _ = Describe("rescale flag accessors", func() {
 		en, has := c.RescaleEnabledForNamespaceLocal("absent")
 		Expect(has).To(BeFalse())
 		Expect(en).To(BeFalse())
+	})
+
+	It("reads cluster hysteresis knobs from the global default", func() {
+		c.UpdateSaturationConfig(map[string]SaturationScalingConfig{
+			"default": {EnableRescale: true, RescaleMinShareGapGPUs: 2, RescaleCooldownSeconds: 90},
+		})
+		t := c.RescaleTuningCluster()
+		Expect(t.Enabled).To(BeTrue())
+		Expect(t.MinShareGapGPUs).To(Equal(2))
+		Expect(t.CooldownSeconds).To(Equal(90))
+	})
+
+	It("reads namespace-local hysteresis knobs without global fallback", func() {
+		c.UpdateSaturationConfig(map[string]SaturationScalingConfig{
+			"default": {EnableRescale: true, RescaleMinShareGapGPUs: 5, RescaleCooldownSeconds: 120},
+		})
+		c.UpdateSaturationConfigForNamespace("team", map[string]SaturationScalingConfig{
+			"default": {EnableRescale: true, RescaleMinShareGapGPUs: 1},
+		})
+		t, has := c.RescaleTuningForNamespaceLocal("team")
+		Expect(has).To(BeTrue())
+		Expect(t.Enabled).To(BeTrue())
+		Expect(t.MinShareGapGPUs).To(Equal(1), "namespace-local value, not the global 5")
+		Expect(t.CooldownSeconds).To(Equal(0), "unset namespace-local knob must not fall back to global")
+	})
+
+	It("reports no tuning for an unconfigured namespace", func() {
+		_, has := c.RescaleTuningForNamespaceLocal("absent")
+		Expect(has).To(BeFalse())
 	})
 })

--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -45,6 +45,26 @@ type SaturationScalingConfig struct {
 	// (see docs/plans/engine/rescale-alpha.md).
 	EnableRescale bool `yaml:"enableRescale,omitempty"`
 
+	// RescaleMinShareGapGPUs is the Beta hysteresis deadband, in whole GPUs: rescale
+	// holds a model at its current allocation this cycle when the target-vs-current
+	// GPU gap is smaller than this value, so a model whose water-fill share drifts by
+	// a GPU or two around the contention threshold does not flap up and down. Default
+	// 0 (whole-replica quantization is the only damping — the Alpha behavior).
+	//
+	// Same BUDGET-SCOPE semantics as EnableRescale: read only from the "default"
+	// entry; global governs the cluster budget, a namespace-local "default" governs
+	// that namespace's quota budget. No effect unless rescale is enabled at that scope.
+	RescaleMinShareGapGPUs int `yaml:"rescaleMinShareGapGPUs,omitempty"`
+
+	// RescaleCooldownSeconds is the Beta per-model reclaim cool-down, in seconds:
+	// after rescale reclaims GPUs from a model, it will not reclaim from that model
+	// again until this much time has elapsed (fills are never cooled down — genuinely
+	// free GPUs still flow to higher-priority work). Damps time-based oscillation.
+	// Default 0 (no cool-down — the Alpha behavior).
+	//
+	// Same BUDGET-SCOPE semantics as EnableRescale (see above).
+	RescaleCooldownSeconds int `yaml:"rescaleCooldownSeconds,omitempty"`
+
 	// AnalyzerName selects which saturation analyzer to use.
 	// "saturation" uses the V2 token-based analyzer.
 	// Empty string (default) uses the V1 percentage-based analyzer.
@@ -263,6 +283,12 @@ func (c *SaturationScalingConfig) Validate() error {
 	}
 	if c.Priority < 0 {
 		return fmt.Errorf("priority must be >= 0, got %.2f", c.Priority)
+	}
+	if c.RescaleMinShareGapGPUs < 0 {
+		return fmt.Errorf("rescaleMinShareGapGPUs must be >= 0, got %d", c.RescaleMinShareGapGPUs)
+	}
+	if c.RescaleCooldownSeconds < 0 {
+		return fmt.Errorf("rescaleCooldownSeconds must be >= 0, got %d", c.RescaleCooldownSeconds)
 	}
 
 	// KV cache threshold should be greater than spare trigger (otherwise contradictory)

--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -46,10 +46,11 @@ type SaturationScalingConfig struct {
 	EnableRescale bool `yaml:"enableRescale,omitempty"`
 
 	// RescaleMinShareGapGPUs is the Beta hysteresis deadband, in whole GPUs: rescale
-	// holds a model at its current allocation this cycle when the target-vs-current
-	// GPU gap is smaller than this value, so a model whose water-fill share drifts by
-	// a GPU or two around the contention threshold does not flap up and down. Default
-	// 0 (whole-replica quantization is the only damping — the Alpha behavior).
+	// holds a model at its current allocation this cycle when the target-vs-current GPU
+	// gap is at or below this value (inclusive), so a model whose water-fill share
+	// drifts by up to this many GPUs around the contention threshold does not flap up
+	// and down. The recommended starting value is 1 (damp single-GPU flaps). Default 0
+	// (whole-replica quantization is the only damping — the Alpha behavior).
 	//
 	// Same BUDGET-SCOPE semantics as EnableRescale: read only from the "default"
 	// entry; global governs the cluster budget, a namespace-local "default" governs

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -115,6 +115,7 @@ const (
 	K8SEventScaledToZero              = "ScaledToZero"
 	K8SEventOptimizationFailed        = "OptimizationFailed"
 	K8SEventUnattributedReadyPods     = "UnattributedReadyPods"
+	K8SEventRescaleStalled            = "RescaleStalled"
 	EnforcerPolicyTypeScaleToZero     = "scale_to_zero"
 	EnforcerPolicyTypeMinimumReplicas = "minimum_replicas"
 

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -218,6 +218,36 @@ type DecisionStep struct {
 	Timestamp metav1.Time
 }
 
+// RescaleDecisionInfo is the observability payload attached to a decision produced
+// by the priority-weighted rescale pass. It records the model-level view that drove
+// the per-variant decision — priority, the water-fill share (TargetGPUs) vs current
+// allocation, the budget scope, the direction taken, and whether a reclaim stalled
+// (a role could not shed a whole replica, so the model stays above its share). It is
+// nil on every non-rescale decision.
+type RescaleDecisionInfo struct {
+	// Priority is the model's priority multiplier used in the weight.
+	Priority float64
+	// TargetGPUs is the model's priority-weighted water-fill share, in whole GPUs.
+	TargetGPUs int
+	// CurrentGPUs is the model's current allocation on the group's accelerator type.
+	CurrentGPUs int
+	// Scope is the budget scope the model competes in: "cluster" or a namespace name.
+	Scope string
+	// Action is the rescale direction for this model this cycle: "reclaim", "fill",
+	// or "hold" (within its share, or suppressed by hysteresis).
+	Action string
+	// Stalled is true when a reclaim could not shed a whole replica it owed (blocked
+	// by minReplicas or the cheapest-at-1 protection), so the model remains over-share.
+	Stalled bool
+}
+
+// Rescale direction constants for RescaleDecisionInfo.Action.
+const (
+	RescaleActionReclaim = "reclaim"
+	RescaleActionFill    = "fill"
+	RescaleActionHold    = "hold"
+)
+
 // VariantDecision represents the scaling decision for a single variant.
 //
 // This type serves as shared state that flows through the decision pipeline.
@@ -286,6 +316,11 @@ type VariantDecision struct {
 	// DecisionSteps records each pipeline stage's contribution to the final decision.
 	// This replaces the single Reason field with structured multi-step tracking.
 	DecisionSteps []DecisionStep
+
+	// Rescale carries the priority-weighted rescale observability payload when this
+	// decision was produced by the rescale pass; nil otherwise. The engine surfaces
+	// it as the Rescaled status condition and a stall event.
+	Rescale *RescaleDecisionInfo
 
 	// decisionReason is the categorized reason used for Prometheus metric labels.
 	// Set via SetDecisionReason along with the detailed reason string.

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -219,11 +219,10 @@ type DecisionStep struct {
 }
 
 // RescaleDecisionInfo is the observability payload attached to a decision produced
-// by the priority-weighted rescale pass. It records the model-level view that drove
-// the per-variant decision — priority, the water-fill share (TargetGPUs) vs current
-// allocation, the budget scope, the direction taken, and whether a reclaim stalled
-// (a role could not shed a whole replica, so the model stays above its share). It is
-// nil on every non-rescale decision.
+// by the priority-weighted rescale pass. Priority, TargetGPUs (the water-fill share),
+// CurrentGPUs, and Scope are model-level context; Action and Stalled are per-variant,
+// derived from the variant's own role — so a P/D model's grown role is not blamed with
+// the shed role's reclaim or stall. It is nil on every non-rescale decision.
 type RescaleDecisionInfo struct {
 	// Priority is the model's priority multiplier used in the weight.
 	Priority float64
@@ -233,11 +232,12 @@ type RescaleDecisionInfo struct {
 	CurrentGPUs int
 	// Scope is the budget scope the model competes in: "cluster" or a namespace name.
 	Scope string
-	// Action is the rescale direction for this model this cycle: "reclaim", "fill",
-	// or "hold" (within its share, or suppressed by hysteresis).
+	// Action is this variant's rescale direction this cycle: "reclaim", "fill", or
+	// "hold" (no change, within share, or suppressed by hysteresis).
 	Action string
-	// Stalled is true when a reclaim could not shed a whole replica it owed (blocked
-	// by minReplicas or the cheapest-at-1 protection), so the model remains over-share.
+	// Stalled is true when this variant's role owed a reclaim but could not shed a whole
+	// replica (blocked by minReplicas or the cheapest-at-1 protection). It is never set
+	// on a variant that scaled up.
 	Stalled bool
 }
 

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"math"
 	"sort"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -23,10 +24,18 @@ import (
 //   - Disaggregated models use paired (n_P, n_D) allocation via the paired helpers
 //   - Scale-down uses scaleDownRoleIterated (role-iterated unified path)
 type GreedyByScoreOptimizer struct {
-	// Rescale carries the resolved, scope-coupled rescale enablement for the
-	// current cycle (set by the engine before Optimize). Zero value = off, which
-	// keeps the additive fair-share behaviour unchanged.
+	// Rescale carries the resolved, scope-coupled rescale enablement and hysteresis
+	// tuning for the current cycle (set by the engine before Optimize). Zero value =
+	// off, which keeps the additive fair-share behaviour unchanged.
 	Rescale RescaleFlags
+
+	// RescaleNow is this cycle's timestamp, used for the reclaim cool-down. The zero
+	// value (unset) disables cool-down, so pure-pipeline callers need not set it.
+	RescaleNow time.Time
+	// RescaleLastReclaim is the engine-owned per-model (namespace, ModelID) last-reclaim
+	// store the rescale pass reads and updates for the cool-down. A nil map disables
+	// cool-down (and makes the pass never write), so it is safe to leave unset.
+	RescaleLastReclaim map[string]time.Time
 }
 
 // NewGreedyByScoreOptimizer creates a new GreedyByScoreOptimizer.
@@ -111,7 +120,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 	// unchanged.
 	var rescaleDecisions []domain.VariantDecision
 	var handled map[string]bool
-	if o.Rescale.any() {
+	if o.Rescale.Any() {
 		rescaleDecisions, handled = o.applyRescale(ctx, requests, available, availableByNS)
 	}
 

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -392,7 +392,7 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	modelCurrent := 0
 	for _, role := range roles {
 		curByRole[role] = roleCurrentGPUs(req, accType, role)
-		demByRole[role] = roleDemandGPUs(satEntry, stateMap, accType, role)
+		demByRole[role] = roleDemandGPUs(req.AnalyzerResults, stateMap, accType, role)
 		floorByRole[role] = roleFloorGPUs(req, accType, role)
 		modelCurrent += curByRole[role]
 	}
@@ -681,7 +681,7 @@ func rescaleInputsForGroup(reqs []ModelScalingRequest, accType string, budget in
 			}
 		}
 
-		demandGPUs := modelDemandGPUs(satEntry, stateMap, accType)
+		demandGPUs := modelDemandGPUs(req.AnalyzerResults, stateMap, accType)
 		capGPUs := demandGPUs
 		if maxBounded {
 			capGPUs = min(capGPUs, maxGPUs)
@@ -693,7 +693,7 @@ func rescaleInputsForGroup(reqs []ModelScalingRequest, accType string, budget in
 		inputs = append(inputs, rescaleInput{
 			ID:        modelKey(req),
 			Priority:  req.Priority,
-			Demand:    satEntry.TotalDemand,
+			Demand:    combinedDemandWeight(req.AnalyzerResults),
 			FloorGPUs: floorGPUs,
 			CapGPUs:   capGPUs,
 		})
@@ -703,28 +703,52 @@ func rescaleInputsForGroup(reqs []ModelScalingRequest, accType string, budget in
 }
 
 // modelDemandGPUs is the model's demand-in-GPUs summed across its roles on accType
-// (a P/D model needs GPUs for both prefill and decode).
-func modelDemandGPUs(satEntry *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType string) int {
+// (a P/D model needs GPUs for both prefill and decode). Demand is combined across all
+// enabled analyzers (see roleDemandGPUs); the role topology is saturation-sourced.
+func modelDemandGPUs(results []NamedAnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType string) int {
+	satEntry := saturationEntry(results)
+	if satEntry == nil {
+		return 0
+	}
 	total := 0
 	for _, role := range modelRolesOnType(satEntry.VariantCapacities, accType) {
-		total += roleDemandGPUs(satEntry, stateMap, accType, role)
+		total += roleDemandGPUs(results, stateMap, accType, role)
 	}
 	return total
 }
 
-// roleDemandGPUs converts a role's token demand to a GPU count via the role's most
-// cost-efficient variant's per-replica capacity. The synthetic "both" role uses the
-// model-level TotalDemand; a P/D role uses its RoleCapacities demand.
-func roleDemandGPUs(satEntry *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType, role string) int {
-	demand := satEntry.TotalDemand
+// roleDemandGPUs is a role's demand-in-GPUs, combined across all enabled analyzers as
+// the cross-analyzer MAX (bottleneck) — matching roleBottleneckReplicas: the most
+// demanding analyzer sizes the role. Each analyzer's demand is converted to GPUs in its
+// own replica-space (its TotalDemand / its per-replica capacity), so the values are
+// commensurable. With a single analyzer this reduces to roleDemandGPUsForResult(sat).
+func roleDemandGPUs(results []NamedAnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType, role string) int {
+	maxGPUs := 0
+	for _, e := range results {
+		if e.Result == nil {
+			continue
+		}
+		if g := roleDemandGPUsForResult(e.Result, stateMap, accType, role); g > maxGPUs {
+			maxGPUs = g
+		}
+	}
+	return maxGPUs
+}
+
+// roleDemandGPUsForResult converts one analyzer's role demand to a GPU count via that
+// role's most cost-efficient variant's per-replica capacity (in the analyzer's own
+// units). The synthetic "both" role uses the model-level TotalDemand; a P/D role uses
+// its RoleCapacities demand. gpusPerReplica is physical (from state), analyzer-agnostic.
+func roleDemandGPUsForResult(result *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType, role string) int {
+	demand := result.TotalDemand
 	if role != domain.RoleBoth {
-		if rc, ok := satEntry.RoleCapacities[role]; ok {
+		if rc, ok := result.RoleCapacities[role]; ok {
 			demand = rc.TotalDemand
 		}
 	}
 	best := 0.0
 	bestGPUs := 1
-	for _, vc := range sortByCostEfficiencyAsc(variantsForRole(variantsOnType(satEntry.VariantCapacities, accType), role)) {
+	for _, vc := range sortByCostEfficiencyAsc(variantsForRole(variantsOnType(result.VariantCapacities, accType), role)) {
 		if vc.PerReplicaCapacity <= 0 {
 			continue
 		}
@@ -740,6 +764,27 @@ func roleDemandGPUs(satEntry *domain.AnalyzerResult, stateMap map[string]domain.
 		replicas = 0
 	}
 	return replicas * bestGPUs
+}
+
+// combinedDemandWeight is the model's demand for the water-fill weight, combined across
+// all enabled analyzers as the Score-weighted sum of their raw TotalDemand — mirroring
+// fairShareValue's priority combine. It enters computeRescaleTargets only inside the
+// priority x demand ratio, so mixing analyzer-specific units is tolerated (as in
+// fairShareValue). A single analyzer (Score normalized to 1) reduces to its TotalDemand,
+// preserving Alpha. Score <= 0 is normalized to 1.0, matching scoreForAnalyzer.
+func combinedDemandWeight(results []NamedAnalyzerResult) float64 {
+	weight := 0.0
+	for _, e := range results {
+		if e.Result == nil {
+			continue
+		}
+		score := e.Score
+		if score <= 0 {
+			score = 1.0
+		}
+		weight += score * e.Result.TotalDemand
+	}
+	return weight
 }
 
 // variantsOnType filters variants to those on accType.

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -404,12 +404,13 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	held := heldByHysteresis(o, modelKey(req), targetGPUs, modelCurrent, tuning)
 
 	stalled := false
+	totalShed, totalFilled, reclaimAttempted := 0, 0, false
 	if !held {
-		totalShed := 0
 		for _, role := range roles {
 			rt, rc := tgtByRole[role], curByRole[role]
 			switch {
 			case rt < rc:
+				reclaimAttempted = true
 				unshed := reclaimRole(ctx, req.AnalyzerResults, satEntry.VariantCapacities, role, stateMap, targets, rc-rt)
 				totalShed += (rc - rt) - unshed
 				// A whole-replica-sized shortfall means a role that owed a reclaim could
@@ -423,7 +424,9 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 				if want > *freeThisCycle {
 					want = *freeThisCycle
 				}
-				*freeThisCycle -= fillRole(satEntry.VariantCapacities, role, stateMap, targets, want)
+				spent := fillRole(satEntry.VariantCapacities, role, stateMap, targets, want)
+				*freeThisCycle -= spent
+				totalFilled += spent
 			}
 		}
 		// Stamp the cool-down only when a reclaim actually shed GPUs, so a stalled
@@ -434,16 +437,12 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 		}
 	}
 
-	action := rescaleAction(targetGPUs, modelCurrent)
-	if held {
-		action = domain.RescaleActionHold
-	}
 	info := &domain.RescaleDecisionInfo{
 		Priority:    req.Priority,
 		TargetGPUs:  targetGPUs,
 		CurrentGPUs: modelCurrent,
 		Scope:       scope,
-		Action:      action,
+		Action:      modelRescaleAction(held, reclaimAttempted, totalShed, totalFilled, targetGPUs, modelCurrent),
 		Stalled:     stalled,
 	}
 
@@ -460,9 +459,11 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 }
 
 // heldByHysteresis reports whether the Beta hysteresis holds a model at its current
-// allocation this cycle: the deadband (|target-current| below MinShareGapGPUs) holds
-// both directions; the reclaim cool-down holds only a would-be reclaim (target below
-// current) whose model was reclaimed too recently. Both are inert when their knob is 0.
+// allocation this cycle: the deadband (|target-current| at or below MinShareGapGPUs)
+// holds both directions; the reclaim cool-down holds only a would-be reclaim (target
+// below current) whose model was reclaimed too recently. Both are inert when their
+// knob is 0 (gap==0 returns early, and MinShareGapGPUs==0 can never satisfy the
+// inclusive test since absGap >= 1 here), preserving Alpha behaviour exactly.
 func heldByHysteresis(o *GreedyByScoreOptimizer, key string, targetGPUs, currentGPUs int, tuning RescaleTuning) bool {
 	gap := targetGPUs - currentGPUs
 	if gap == 0 {
@@ -472,7 +473,10 @@ func heldByHysteresis(o *GreedyByScoreOptimizer, key string, targetGPUs, current
 	if absGap < 0 {
 		absGap = -absGap
 	}
-	if tuning.MinShareGapGPUs > 0 && absGap < tuning.MinShareGapGPUs {
+	// Inclusive: a deadband of N holds a drift of up to N whole GPUs. Strict "<" would
+	// make the smallest useful value 2 (with 1 holding nothing, since absGap >= 1 here),
+	// so the documented recommendation of 1 would be inert.
+	if tuning.MinShareGapGPUs > 0 && absGap <= tuning.MinShareGapGPUs {
 		return true // deadband
 	}
 	if gap < 0 && o.inReclaimCooldown(key, tuning) {
@@ -493,6 +497,30 @@ func (o *GreedyByScoreOptimizer) inReclaimCooldown(key string, tuning RescaleTun
 		return false
 	}
 	return o.RescaleNow.Sub(last) < time.Duration(tuning.CooldownSeconds)*time.Second
+}
+
+// modelRescaleAction labels the rescale direction a model actually took this cycle,
+// from the work performed rather than the model-level GPU totals. This matters for a
+// disaggregated (P/D) model whose roles rebalance to a near-zero net delta: the totals
+// would read "hold" even though a role was reclaimed and/or filled — and, worse, a
+// stalled reclaim on such a model would produce a self-contradictory "hold" label under
+// a Stalled condition. Precedence: a hold wins; then any shed (a reclaim, possibly with
+// a paired fill — a rebalance); then a pure fill; then an attempted-but-unshed reclaim
+// (a stall); otherwise fall back to the intent (fill if under-share and merely fill-
+// gated this cycle, else hold).
+func modelRescaleAction(held, reclaimAttempted bool, totalShed, totalFilled, targetGPUs, currentGPUs int) string {
+	switch {
+	case held:
+		return domain.RescaleActionHold
+	case totalShed > 0:
+		return domain.RescaleActionReclaim
+	case totalFilled > 0:
+		return domain.RescaleActionFill
+	case reclaimAttempted:
+		return domain.RescaleActionReclaim
+	default:
+		return rescaleAction(targetGPUs, currentGPUs)
+	}
 }
 
 // rescaleAction classifies a model's rescale direction from its share vs current.

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"math"
 	"slices"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -22,15 +23,30 @@ func modelKey(req ModelScalingRequest) string {
 	return utils.GetNamespacedKey(req.Namespace, req.ModelID)
 }
 
-// RescaleFlags carries the resolved, scope-coupled rescale enablement for one
-// optimize cycle. Cluster governs the cluster budget group; ByNamespace[ns]
-// governs namespace ns's quota budget group. The zero value disables rescale.
-type RescaleFlags struct {
-	Cluster     bool
-	ByNamespace map[string]bool
+// RescaleTuning carries the Beta hysteresis knobs for one budget scope. The zero
+// value disables both mechanisms (Alpha behavior).
+type RescaleTuning struct {
+	// MinShareGapGPUs is the deadband: a model is held at its current allocation
+	// when |target-current| is smaller than this (0 = off).
+	MinShareGapGPUs int
+	// CooldownSeconds suppresses a repeat reclaim from a model until this many
+	// seconds after its last reclaim (0 = off).
+	CooldownSeconds int
 }
 
-func (f RescaleFlags) any() bool { return f.Cluster || len(f.ByNamespace) > 0 }
+// RescaleFlags carries the resolved, scope-coupled rescale enablement and hysteresis
+// tuning for one optimize cycle. Cluster governs the cluster budget group;
+// ByNamespace[ns] governs namespace ns's quota budget group, with matching per-scope
+// tuning in ClusterTuning / ByNamespaceTuning. The zero value disables rescale.
+type RescaleFlags struct {
+	Cluster           bool
+	ByNamespace       map[string]bool
+	ClusterTuning     RescaleTuning
+	ByNamespaceTuning map[string]RescaleTuning
+}
+
+// Any reports whether rescale is enabled at any scope this cycle.
+func (f RescaleFlags) Any() bool { return f.Cluster || len(f.ByNamespace) > 0 }
 
 // enabledForScope reports whether rescale is on at a group's budget scope:
 // the namespace flag for a namespace-quota group, else the cluster flag.
@@ -39,6 +55,14 @@ func (f RescaleFlags) enabledForScope(namespace string, namespaceScoped bool) bo
 		return f.ByNamespace[namespace]
 	}
 	return f.Cluster
+}
+
+// tuningForScope returns the hysteresis knobs for a group's budget scope.
+func (f RescaleFlags) tuningForScope(namespace string, namespaceScoped bool) RescaleTuning {
+	if namespaceScoped {
+		return f.ByNamespaceTuning[namespace]
+	}
+	return f.ClusterTuning
 }
 
 // rescaleInput is one model's contribution to the priority-weighted water-filling.
@@ -306,10 +330,11 @@ func (o *GreedyByScoreOptimizer) applyRescale(
 		if k.scope != "" {
 			scope = k.scope
 		}
+		tuning := o.Rescale.tuningForScope(k.scope, k.scope != "")
 
 		freeThisCycle := fillable
 		for _, req := range reqs {
-			d := o.rescaleModelDecisions(ctx, req, k.accType, scope, targets[modelKey(req)], &freeThisCycle)
+			d := o.rescaleModelDecisions(ctx, req, k.accType, scope, tuning, targets[modelKey(req)], &freeThisCycle)
 			decisions = append(decisions, d...)
 			handled[modelKey(req)] = true
 		}
@@ -338,13 +363,16 @@ func (o *GreedyByScoreOptimizer) applyRescale(
 // most-expensive-first, respecting minReplicas) or fill (add most-cost-efficient
 // first, gated on *freeThisCycle). Reclaim decisions are tagged DecisionReasonRescale.
 // scope is the model's budget scope ("cluster" or a namespace) for observability.
-// Every decision it returns carries a *domain.RescaleDecisionInfo summarising the
-// model's priority, share (targetGPUs) vs current, direction, and reclaim-stall state.
+// tuning applies the Beta hysteresis (deadband + reclaim cool-down): when it holds
+// the model, no reclaim/fill runs this cycle. Every decision it returns carries a
+// *domain.RescaleDecisionInfo summarising the model's priority, share (targetGPUs)
+// vs current, direction, and reclaim-stall state.
 func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	ctx context.Context,
 	req ModelScalingRequest,
 	accType string,
 	scope string,
+	tuning RescaleTuning,
 	targetGPUs int,
 	freeThisCycle *int,
 ) []domain.VariantDecision {
@@ -369,33 +397,53 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	}
 	tgtByRole := distributeGPUsByWeight(targetGPUs, roles, demByRole, curByRole, floorByRole)
 
+	// Hysteresis (Beta): hold the model at its current allocation when the
+	// target-vs-current gap is inside the deadband, or when a reclaim is still within
+	// its cool-down. Held models produce no reclaim/fill (targets stay = current) and
+	// report a "hold" action. Both checks are inert when their knob is 0 (Alpha).
+	held := heldByHysteresis(o, modelKey(req), targetGPUs, modelCurrent, tuning)
+
 	stalled := false
-	for _, role := range roles {
-		rt, rc := tgtByRole[role], curByRole[role]
-		switch {
-		case rt < rc:
-			unshed := reclaimRole(ctx, req.AnalyzerResults, satEntry.VariantCapacities, role, stateMap, targets, rc-rt)
-			// A whole-replica-sized shortfall means a role that owed a reclaim could
-			// not shed even one replica (blocked by minReplicas / cheapest-at-1); a
-			// smaller leftover is just sub-replica quantization, not a stall.
-			if gMin := roleMinGPUsPerReplica(satEntry.VariantCapacities, role, stateMap); gMin > 0 && unshed >= gMin {
-				stalled = true
+	if !held {
+		totalShed := 0
+		for _, role := range roles {
+			rt, rc := tgtByRole[role], curByRole[role]
+			switch {
+			case rt < rc:
+				unshed := reclaimRole(ctx, req.AnalyzerResults, satEntry.VariantCapacities, role, stateMap, targets, rc-rt)
+				totalShed += (rc - rt) - unshed
+				// A whole-replica-sized shortfall means a role that owed a reclaim could
+				// not shed even one replica (blocked by minReplicas / cheapest-at-1); a
+				// smaller leftover is just sub-replica quantization, not a stall.
+				if gMin := roleMinGPUsPerReplica(satEntry.VariantCapacities, role, stateMap); gMin > 0 && unshed >= gMin {
+					stalled = true
+				}
+			case rt > rc:
+				want := rt - rc
+				if want > *freeThisCycle {
+					want = *freeThisCycle
+				}
+				*freeThisCycle -= fillRole(satEntry.VariantCapacities, role, stateMap, targets, want)
 			}
-		case rt > rc:
-			want := rt - rc
-			if want > *freeThisCycle {
-				want = *freeThisCycle
-			}
-			*freeThisCycle -= fillRole(satEntry.VariantCapacities, role, stateMap, targets, want)
+		}
+		// Stamp the cool-down only when a reclaim actually shed GPUs, so a stalled
+		// reclaim (shed nothing) does not start a cool-down that would then block the
+		// retry that could finally succeed.
+		if totalShed > 0 && o.RescaleLastReclaim != nil {
+			o.RescaleLastReclaim[modelKey(req)] = o.RescaleNow
 		}
 	}
 
+	action := rescaleAction(targetGPUs, modelCurrent)
+	if held {
+		action = domain.RescaleActionHold
+	}
 	info := &domain.RescaleDecisionInfo{
 		Priority:    req.Priority,
 		TargetGPUs:  targetGPUs,
 		CurrentGPUs: modelCurrent,
 		Scope:       scope,
-		Action:      rescaleAction(targetGPUs, modelCurrent),
+		Action:      action,
 		Stalled:     stalled,
 	}
 
@@ -409,6 +457,42 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 		decisions[i].Rescale = info
 	}
 	return decisions
+}
+
+// heldByHysteresis reports whether the Beta hysteresis holds a model at its current
+// allocation this cycle: the deadband (|target-current| below MinShareGapGPUs) holds
+// both directions; the reclaim cool-down holds only a would-be reclaim (target below
+// current) whose model was reclaimed too recently. Both are inert when their knob is 0.
+func heldByHysteresis(o *GreedyByScoreOptimizer, key string, targetGPUs, currentGPUs int, tuning RescaleTuning) bool {
+	gap := targetGPUs - currentGPUs
+	if gap == 0 {
+		return false // already at its share; the model is a natural no-op, not "held"
+	}
+	absGap := gap
+	if absGap < 0 {
+		absGap = -absGap
+	}
+	if tuning.MinShareGapGPUs > 0 && absGap < tuning.MinShareGapGPUs {
+		return true // deadband
+	}
+	if gap < 0 && o.inReclaimCooldown(key, tuning) {
+		return true // reclaim cool-down
+	}
+	return false
+}
+
+// inReclaimCooldown reports whether model `key` was reclaimed less than
+// CooldownSeconds ago. It is false (cool-down off) when the knob is 0, no cool-down
+// clock/state was wired for this cycle, or the model has no recorded reclaim.
+func (o *GreedyByScoreOptimizer) inReclaimCooldown(key string, tuning RescaleTuning) bool {
+	if tuning.CooldownSeconds <= 0 || o.RescaleLastReclaim == nil || o.RescaleNow.IsZero() {
+		return false
+	}
+	last, ok := o.RescaleLastReclaim[key]
+	if !ok {
+		return false
+	}
+	return o.RescaleNow.Sub(last) < time.Duration(tuning.CooldownSeconds)*time.Second
 }
 
 // rescaleAction classifies a model's rescale direction from its share vs current.

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -364,9 +364,10 @@ func (o *GreedyByScoreOptimizer) applyRescale(
 // first, gated on *freeThisCycle). Reclaim decisions are tagged DecisionReasonRescale.
 // scope is the model's budget scope ("cluster" or a namespace) for observability.
 // tuning applies the Beta hysteresis (deadband + reclaim cool-down): when it holds
-// the model, no reclaim/fill runs this cycle. Every decision it returns carries a
-// *domain.RescaleDecisionInfo summarising the model's priority, share (targetGPUs)
-// vs current, direction, and reclaim-stall state.
+// the model, no reclaim/fill runs this cycle. Every decision carries its own
+// *domain.RescaleDecisionInfo: model-level priority/share (targetGPUs) vs current and
+// scope, but a per-variant Action and Stalled derived from that variant's role, so a
+// P/D model's grown role is never mislabeled with the shed role's reclaim/stall.
 func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	ctx context.Context,
 	req ModelScalingRequest,
@@ -403,30 +404,34 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	// report a "hold" action. Both checks are inert when their knob is 0 (Alpha).
 	held := heldByHysteresis(o, modelKey(req), targetGPUs, modelCurrent, tuning)
 
-	stalled := false
-	totalShed, totalFilled, reclaimAttempted := 0, 0, false
+	// Per-role outcome, so the observability payload attaches to each variant by ITS
+	// role rather than sharing one model-level summary — a P/D model whose decode role
+	// stalls while prefill fills must not blame the (grown) prefill variant with a
+	// shed-stall. roleIntent is the role's direction (reclaim/fill/hold); roleStalled
+	// marks a role that owed a reclaim but could not shed a whole replica.
+	roleIntent := make(map[string]string, len(roles))
+	roleStalled := make(map[string]bool, len(roles))
+	totalShed := 0
 	if !held {
 		for _, role := range roles {
 			rt, rc := tgtByRole[role], curByRole[role]
+			roleIntent[role] = rescaleAction(rt, rc)
 			switch {
 			case rt < rc:
-				reclaimAttempted = true
 				unshed := reclaimRole(ctx, req.AnalyzerResults, satEntry.VariantCapacities, role, stateMap, targets, rc-rt)
 				totalShed += (rc - rt) - unshed
 				// A whole-replica-sized shortfall means a role that owed a reclaim could
 				// not shed even one replica (blocked by minReplicas / cheapest-at-1); a
 				// smaller leftover is just sub-replica quantization, not a stall.
 				if gMin := roleMinGPUsPerReplica(satEntry.VariantCapacities, role, stateMap); gMin > 0 && unshed >= gMin {
-					stalled = true
+					roleStalled[role] = true
 				}
 			case rt > rc:
 				want := rt - rc
 				if want > *freeThisCycle {
 					want = *freeThisCycle
 				}
-				spent := fillRole(satEntry.VariantCapacities, role, stateMap, targets, want)
-				*freeThisCycle -= spent
-				totalFilled += spent
+				*freeThisCycle -= fillRole(satEntry.VariantCapacities, role, stateMap, targets, want)
 			}
 		}
 		// Stamp the cool-down only when a reclaim actually shed GPUs, so a stalled
@@ -437,23 +442,47 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 		}
 	}
 
-	info := &domain.RescaleDecisionInfo{
-		Priority:    req.Priority,
-		TargetGPUs:  targetGPUs,
-		CurrentGPUs: modelCurrent,
-		Scope:       scope,
-		Action:      modelRescaleAction(held, reclaimAttempted, totalShed, totalFilled, targetGPUs, modelCurrent),
-		Stalled:     stalled,
-	}
-
 	decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "rescale")
 	for i := range decisions {
-		if decisions[i].Action == domain.ActionScaleDown {
-			decisions[i].SetDecisionReason(domain.ActionScaleDown, domain.DecisionReasonRescale,
+		d := &decisions[i]
+		role := d.Role
+		if role == "" {
+			role = domain.RoleBoth
+		}
+
+		action := domain.RescaleActionHold
+		stalled := false
+		if !held {
+			// The variant's own action is authoritative when it moved; a no-change
+			// variant reflects its role's intent (a fill gated to 0 this cycle still
+			// reports "fill"; a reclaim blocked at minReplicas still reports "reclaim").
+			switch d.Action {
+			case domain.ActionScaleDown:
+				action = domain.RescaleActionReclaim
+			case domain.ActionScaleUp:
+				action = domain.RescaleActionFill
+			default:
+				if action = roleIntent[role]; action == "" {
+					action = domain.RescaleActionHold
+				}
+			}
+			// A variant being grown is never "stalled on shedding" — only attribute the
+			// role's stall to variants that did not scale up.
+			stalled = roleStalled[role] && d.Action != domain.ActionScaleUp
+		}
+
+		if d.Action == domain.ActionScaleDown {
+			d.SetDecisionReason(domain.ActionScaleDown, domain.DecisionReasonRescale,
 				string(domain.DecisionReasonRescale)+" (optimizer: rescale, reclaim)")
 		}
-		// Share the immutable model-level summary across the model's variant decisions.
-		decisions[i].Rescale = info
+		d.Rescale = &domain.RescaleDecisionInfo{
+			Priority:    req.Priority,
+			TargetGPUs:  targetGPUs,
+			CurrentGPUs: modelCurrent,
+			Scope:       scope,
+			Action:      action,
+			Stalled:     stalled,
+		}
 	}
 	return decisions
 }
@@ -499,31 +528,8 @@ func (o *GreedyByScoreOptimizer) inReclaimCooldown(key string, tuning RescaleTun
 	return o.RescaleNow.Sub(last) < time.Duration(tuning.CooldownSeconds)*time.Second
 }
 
-// modelRescaleAction labels the rescale direction a model actually took this cycle,
-// from the work performed rather than the model-level GPU totals. This matters for a
-// disaggregated (P/D) model whose roles rebalance to a near-zero net delta: the totals
-// would read "hold" even though a role was reclaimed and/or filled — and, worse, a
-// stalled reclaim on such a model would produce a self-contradictory "hold" label under
-// a Stalled condition. Precedence: a hold wins; then any shed (a reclaim, possibly with
-// a paired fill — a rebalance); then a pure fill; then an attempted-but-unshed reclaim
-// (a stall); otherwise fall back to the intent (fill if under-share and merely fill-
-// gated this cycle, else hold).
-func modelRescaleAction(held, reclaimAttempted bool, totalShed, totalFilled, targetGPUs, currentGPUs int) string {
-	switch {
-	case held:
-		return domain.RescaleActionHold
-	case totalShed > 0:
-		return domain.RescaleActionReclaim
-	case totalFilled > 0:
-		return domain.RescaleActionFill
-	case reclaimAttempted:
-		return domain.RescaleActionReclaim
-	default:
-		return rescaleAction(targetGPUs, currentGPUs)
-	}
-}
-
-// rescaleAction classifies a model's rescale direction from its share vs current.
+// rescaleAction classifies a rescale direction from a share (target) vs current, used
+// per role to label each variant's decision.
 func rescaleAction(targetGPUs, currentGPUs int) string {
 	switch {
 	case targetGPUs < currentGPUs:

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -302,9 +302,14 @@ func (o *GreedyByScoreOptimizer) applyRescale(
 			}
 		}
 
+		scope := "cluster"
+		if k.scope != "" {
+			scope = k.scope
+		}
+
 		freeThisCycle := fillable
 		for _, req := range reqs {
-			d := o.rescaleModelDecisions(ctx, req, k.accType, targets[modelKey(req)], &freeThisCycle)
+			d := o.rescaleModelDecisions(ctx, req, k.accType, scope, targets[modelKey(req)], &freeThisCycle)
 			decisions = append(decisions, d...)
 			handled[modelKey(req)] = true
 		}
@@ -332,10 +337,14 @@ func (o *GreedyByScoreOptimizer) applyRescale(
 // rescaleModelDecisions drives one model to targetGPUs on accType: reclaim (shed
 // most-expensive-first, respecting minReplicas) or fill (add most-cost-efficient
 // first, gated on *freeThisCycle). Reclaim decisions are tagged DecisionReasonRescale.
+// scope is the model's budget scope ("cluster" or a namespace) for observability.
+// Every decision it returns carries a *domain.RescaleDecisionInfo summarising the
+// model's priority, share (targetGPUs) vs current, direction, and reclaim-stall state.
 func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	ctx context.Context,
 	req ModelScalingRequest,
 	accType string,
+	scope string,
 	targetGPUs int,
 	freeThisCycle *int,
 ) []domain.VariantDecision {
@@ -351,18 +360,27 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	curByRole := make(map[string]int, len(roles))
 	demByRole := make(map[string]int, len(roles))
 	floorByRole := make(map[string]int, len(roles))
+	modelCurrent := 0
 	for _, role := range roles {
 		curByRole[role] = roleCurrentGPUs(req, accType, role)
 		demByRole[role] = roleDemandGPUs(satEntry, stateMap, accType, role)
 		floorByRole[role] = roleFloorGPUs(req, accType, role)
+		modelCurrent += curByRole[role]
 	}
 	tgtByRole := distributeGPUsByWeight(targetGPUs, roles, demByRole, curByRole, floorByRole)
 
+	stalled := false
 	for _, role := range roles {
 		rt, rc := tgtByRole[role], curByRole[role]
 		switch {
 		case rt < rc:
-			reclaimRole(ctx, req.AnalyzerResults, satEntry.VariantCapacities, role, stateMap, targets, rc-rt)
+			unshed := reclaimRole(ctx, req.AnalyzerResults, satEntry.VariantCapacities, role, stateMap, targets, rc-rt)
+			// A whole-replica-sized shortfall means a role that owed a reclaim could
+			// not shed even one replica (blocked by minReplicas / cheapest-at-1); a
+			// smaller leftover is just sub-replica quantization, not a stall.
+			if gMin := roleMinGPUsPerReplica(satEntry.VariantCapacities, role, stateMap); gMin > 0 && unshed >= gMin {
+				stalled = true
+			}
 		case rt > rc:
 			want := rt - rc
 			if want > *freeThisCycle {
@@ -372,18 +390,56 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 		}
 	}
 
+	info := &domain.RescaleDecisionInfo{
+		Priority:    req.Priority,
+		TargetGPUs:  targetGPUs,
+		CurrentGPUs: modelCurrent,
+		Scope:       scope,
+		Action:      rescaleAction(targetGPUs, modelCurrent),
+		Stalled:     stalled,
+	}
+
 	decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "rescale")
 	for i := range decisions {
 		if decisions[i].Action == domain.ActionScaleDown {
 			decisions[i].SetDecisionReason(domain.ActionScaleDown, domain.DecisionReasonRescale,
 				string(domain.DecisionReasonRescale)+" (optimizer: rescale, reclaim)")
 		}
+		// Share the immutable model-level summary across the model's variant decisions.
+		decisions[i].Rescale = info
 	}
 	return decisions
 }
 
+// rescaleAction classifies a model's rescale direction from its share vs current.
+func rescaleAction(targetGPUs, currentGPUs int) string {
+	switch {
+	case targetGPUs < currentGPUs:
+		return domain.RescaleActionReclaim
+	case targetGPUs > currentGPUs:
+		return domain.RescaleActionFill
+	default:
+		return domain.RescaleActionHold
+	}
+}
+
+// roleMinGPUsPerReplica is the smallest positive gpusPerReplica among a role's
+// variants on accType — the size of the smallest replica the role could shed.
+func roleMinGPUsPerReplica(variants []domain.VariantCapacity, role string, stateMap map[string]domain.VariantReplicaState) int {
+	minG := 0
+	for _, vc := range variantsForRole(variants, role) {
+		g := gpusPerReplicaFromState(stateMap, vc.VariantName)
+		if g > 0 && (minG == 0 || g < minG) {
+			minG = g
+		}
+	}
+	return minG
+}
+
 // reclaimRole sheds up to deltaGPUs worth of a role's replicas, most-expensive-first,
 // respecting minReplicas and the cheapest-at-1 protection, via scaleDownVariantSet.
+// It returns the GPUs it could NOT shed (the shortfall, >= 0): a value at least one
+// whole replica in size signals a reclaim stall.
 func reclaimRole(
 	ctx context.Context,
 	s []NamedAnalyzerResult,
@@ -392,7 +448,7 @@ func reclaimRole(
 	stateMap map[string]domain.VariantReplicaState,
 	targets map[string]int,
 	deltaGPUs int,
-) {
+) int {
 	remaining := deltaGPUs
 	sorted := sortVariantsForScaleDown(s, variantsForRole(variants, role))
 	scaleDownVariantSet(ctx, sorted, targets, stateMap,
@@ -407,6 +463,7 @@ func reclaimRole(
 			remaining -= n * gpusPerReplicaFromState(stateMap, vc.VariantName)
 		},
 	)
+	return remaining
 }
 
 // fillRole adds up to wantGPUs worth of a role's replicas, most-cost-efficient-first,

--- a/internal/engines/pipeline/rescale_optimize_test.go
+++ b/internal/engines/pipeline/rescale_optimize_test.go
@@ -791,6 +791,48 @@ var _ = Describe("GreedyByScoreOptimizer rescale observability (Beta)", func() {
 		Expect(dm["A-v"].TargetReplicas).To(Equal(3), "shed exactly one 2-GPU replica")
 	})
 
+	// Per-variant attribution: a P/D model whose decode role stalls (can't shed its
+	// protected last replica) while its prefill role fills must NOT blame the grown
+	// prefill variant with the decode reclaim/stall. Each variant's info reflects its
+	// own role. A shared model-level payload would mislabel prefill as fill+stalled.
+	It("attributes stall to the shed role, not the filled role, on a P/D model", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+
+		a := &domain.AnalyzerResult{
+			ModelID: "A", Namespace: "default", TotalDemand: 6000,
+			RoleCapacities: map[string]domain.RoleCapacity{
+				"prefill": {TotalDemand: 6000},
+				"decode":  {TotalDemand: 0},
+			},
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "A-prefill", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "prefill", ReplicaCount: 1},
+				{VariantName: "A-decode", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, Role: "decode", ReplicaCount: 1},
+			},
+		}
+		reqA := withSatEntry(a, ModelScalingRequest{
+			ModelID: "A", Namespace: "default", Priority: 1, Disaggregated: true,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "A-prefill", CurrentReplicas: 1, GPUsPerReplica: 1, Role: "prefill"},
+				{VariantName: "A-decode", CurrentReplicas: 1, GPUsPerReplica: 1, Role: "decode"},
+			},
+		})
+		// Budget 3 (free 1 + current 2), contended (demand 6 > 3): A's share is 3, split
+		// prefill 3 / decode 0. Decode owes a reclaim to 0 but is protected at 1 (stall);
+		// prefill fills 1->2 with the 1 free GPU.
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 3, Used: 2}}}}
+		dm := decisionMap(o.Optimize(context.Background(), []ModelScalingRequest{reqA}, cons))
+
+		pf, dc := dm["A-prefill"], dm["A-decode"]
+		Expect(pf.Action).To(Equal(domain.ActionScaleUp), "prefill grows into the free GPU")
+		Expect(pf.Rescale.Action).To(Equal(domain.RescaleActionFill))
+		Expect(pf.Rescale.Stalled).To(BeFalse(), "a grown variant is never stalled on shedding")
+
+		Expect(dc.TargetReplicas).To(Equal(1), "decode can't shed its protected last replica")
+		Expect(dc.Rescale.Action).To(Equal(domain.RescaleActionReclaim), "decode owed a reclaim")
+		Expect(dc.Rescale.Stalled).To(BeTrue(), "the stall belongs to the decode role")
+	})
+
 	// Rescale off ⇒ no info attached (nil), regardless of contention.
 	It("attaches no info when rescale is off", func() {
 		o := NewGreedyByScoreOptimizer()

--- a/internal/engines/pipeline/rescale_optimize_test.go
+++ b/internal/engines/pipeline/rescale_optimize_test.go
@@ -751,6 +751,46 @@ var _ = Describe("GreedyByScoreOptimizer rescale observability (Beta)", func() {
 		Expect(dm["A-v"].TargetReplicas).To(Equal(1), "A stays at its protected replica")
 	})
 
+	// Sub-replica leftover is NOT a stall (guards the `unshed >= gMin` threshold, not a
+	// naive `unshed > 0`). A100 at 2 GPUs/replica: A holds 4 replicas (8 GPUs), its
+	// water-fill share is 5 GPUs (an odd, sub-replica-aligned target), so reclaim owes 3
+	// GPUs, sheds one whole replica (2 GPUs) and leaves 1 GPU unshed — 1 < gMin 2, benign
+	// quantization, not a stall. (Priorities 1 and 0.6 make the split land at exactly 5/3.)
+	It("does not flag a sub-replica reclaim leftover as stalled", func() {
+		mk2 := func(id string, prio float64) ModelScalingRequest {
+			r := &domain.AnalyzerResult{
+				ModelID: id, Namespace: "default", TotalDemand: 8000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: id + "-v", AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, ReplicaCount: 4},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID: id, Namespace: "default", Priority: prio,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: id + "-v", CurrentReplicas: 4, GPUsPerReplica: 2},
+				},
+			})
+		}
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+		// A holds 8 GPUs, B holds 0; budget 8 (full) so B's fill is gated to 0.
+		reqs := []ModelScalingRequest{mk2("A", 1), func() ModelScalingRequest {
+			r := mk2("B", 0.6)
+			r.VariantStates[0].CurrentReplicas = 0
+			saturationEntry(r.AnalyzerResults).VariantCapacities[0].ReplicaCount = 0
+			return r
+		}()}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		ra := dm["A-v"].Rescale
+		Expect(ra).NotTo(BeNil())
+		Expect(ra.TargetGPUs).To(Equal(5), "water-fill share is an odd GPU count")
+		Expect(ra.Action).To(Equal(domain.RescaleActionReclaim))
+		Expect(ra.Stalled).To(BeFalse(), "1-GPU sub-replica leftover is quantization, not a stall")
+		Expect(dm["A-v"].TargetReplicas).To(Equal(3), "shed exactly one 2-GPU replica")
+	})
+
 	// Rescale off ⇒ no info attached (nil), regardless of contention.
 	It("attaches no info when rescale is off", func() {
 		o := NewGreedyByScoreOptimizer()
@@ -767,8 +807,8 @@ var _ = Describe("GreedyByScoreOptimizer rescale observability (Beta)", func() {
 
 var _ = Describe("GreedyByScoreOptimizer rescale hysteresis (Beta)", func() {
 	// Deadband: equal-priority A(5)/B(3) on a full budget of 8 water-fill to 4/4, so A
-	// owes a 1-GPU reclaim. A deadband of 2 GPUs holds A at 5 (gap 1 < 2); without it,
-	// A would reclaim to 4.
+	// owes a 1-GPU reclaim. The deadband is inclusive, so the *recommended* value of 1
+	// already holds a 1-GPU drift; without it, A would reclaim to 4.
 	It("holds a sub-deadband reclaim", func() {
 		reqs := func() []ModelScalingRequest {
 			return []ModelScalingRequest{
@@ -783,12 +823,48 @@ var _ = Describe("GreedyByScoreOptimizer rescale hysteresis (Beta)", func() {
 		plain.Rescale = RescaleFlags{Cluster: true}
 		Expect(decisionMap(plain.Optimize(context.Background(), reqs(), cons))["A-v"].TargetReplicas).To(Equal(4))
 
-		// With a 2-GPU deadband: the 1-GPU gap is held, A stays at 5.
+		// With the recommended 1-GPU deadband: the 1-GPU gap is held, A stays at 5.
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true, ClusterTuning: RescaleTuning{MinShareGapGPUs: 1}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs(), cons))
+		Expect(dm["A-v"].TargetReplicas).To(Equal(5), "held by the inclusive 1-GPU deadband")
+		Expect(dm["A-v"].Rescale.Action).To(Equal(domain.RescaleActionHold))
+	})
+
+	// The deadband is a MAXIMUM held drift: a gap strictly larger than it is NOT held.
+	// Same setup but A holds 6 (owes a 2-GPU reclaim to its share of 4); a 1-GPU deadband
+	// does not hold it, so A reclaims.
+	It("does not hold a drift larger than the deadband", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true, ClusterTuning: RescaleTuning{MinShareGapGPUs: 1}}
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 6),
+			rescaleReq("B", "default", 1, 8000, 2),
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+		Expect(dm["A-v"].TargetReplicas).To(Equal(4), "2-GPU gap exceeds the 1-GPU deadband -> reclaimed")
+	})
+
+	// The deadband holds the FILL side too (not just reclaims). Equal-priority A(5)/B(4)
+	// under contention water-fill to 6/5, so each owes a 1-GPU fill. With 2 GPUs free
+	// this cycle the fills are fundable, yet a 2-GPU deadband holds both — neither fills
+	// and the free GPUs stay unconsumed. (A cool-down would not do this — it never
+	// suppresses fills.)
+	It("holds a sub-deadband fill", func() {
 		o := NewGreedyByScoreOptimizer()
 		o.Rescale = RescaleFlags{Cluster: true, ClusterTuning: RescaleTuning{MinShareGapGPUs: 2}}
-		dm := decisionMap(o.Optimize(context.Background(), reqs(), cons))
-		Expect(dm["A-v"].TargetReplicas).To(Equal(5), "held by deadband")
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 5),
+			rescaleReq("B", "default", 1, 8000, 4),
+		}
+		// currentUsage 9, free 2 -> budget 11; shares 6/5, each a 1-GPU fill within the band.
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 11, Used: 9}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+		Expect(dm["A-v"].TargetReplicas).To(Equal(5), "1-GPU fill held by the 2-GPU deadband")
+		Expect(dm["B-v"].TargetReplicas).To(Equal(4), "1-GPU fill held by the 2-GPU deadband")
 		Expect(dm["A-v"].Rescale.Action).To(Equal(domain.RescaleActionHold))
+		Expect(dm["B-v"].Rescale.Action).To(Equal(domain.RescaleActionHold))
 	})
 
 	// Cool-down: A is reclaimed in cycle 1 (stamping the cool-down), held in cycle 2

--- a/internal/engines/pipeline/rescale_optimize_test.go
+++ b/internal/engines/pipeline/rescale_optimize_test.go
@@ -681,3 +681,85 @@ var _ = Describe("GreedyByScoreOptimizer rescale", func() {
 		Expect(dm["B-v"].TargetReplicas).To(BeNumerically(">=", 2), "not reclaimed below current in Conflict")
 	})
 })
+
+var _ = Describe("GreedyByScoreOptimizer rescale observability (Beta)", func() {
+	// Every decision from a rescale group carries a *RescaleDecisionInfo summary:
+	// the reclaimed model reports its priority, share vs current, scope, and direction.
+	It("attaches priority/share info to reclaim and fill decisions", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 8),
+			rescaleReq("B", "default", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		ra := dm["A-v"].Rescale
+		Expect(ra).NotTo(BeNil())
+		Expect(ra.Action).To(Equal(domain.RescaleActionReclaim))
+		Expect(ra.Priority).To(Equal(1.0))
+		Expect(ra.TargetGPUs).To(Equal(2), "water-fill share")
+		Expect(ra.CurrentGPUs).To(Equal(8))
+		Expect(ra.Scope).To(Equal("cluster"))
+		Expect(ra.Stalled).To(BeFalse())
+
+		rb := dm["B-v"].Rescale
+		Expect(rb).NotTo(BeNil())
+		Expect(rb.Action).To(Equal(domain.RescaleActionFill), "B is under its share")
+		Expect(rb.TargetGPUs).To(Equal(6))
+		Expect(rb.Scope).To(Equal("cluster"))
+	})
+
+	// A namespace-quota group reports the namespace as its scope.
+	It("reports the namespace as scope for a namespace-quota group", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{ByNamespace: map[string]bool{"team": true}}
+		reqs := []ModelScalingRequest{
+			nsModelReq("A", "team", "A-v", 1, 8000, 8),
+			nsModelReq("B", "team", "B-v", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{
+			Pools:          map[string]ResourcePool{"A100": {Limit: 8, Used: 8}},
+			NamespacePools: map[string]map[string]ResourcePool{"team": {"A100": {Limit: 8, Used: 8}}},
+		}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+		Expect(dm["A-v"].Rescale).NotTo(BeNil())
+		Expect(dm["A-v"].Rescale.Scope).To(Equal("team"))
+	})
+
+	// Stall: A holds a single, cheapest-at-1-protected replica whose water-fill share
+	// rounds to 0 (zero demand ⇒ zero weight). Reclaim owes one whole replica but the
+	// last replica is protected, so it cannot shed it — the info reports Stalled.
+	It("flags a reclaim that cannot shed a whole replica as stalled", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 0, 1),    // no demand ⇒ weight 0 ⇒ share 0, but holds 1 protected replica
+			rescaleReq("B", "default", 5, 8000, 3), // high priority, hungry
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 4, Used: 4}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+
+		ra := dm["A-v"].Rescale
+		Expect(ra).NotTo(BeNil())
+		Expect(ra.Action).To(Equal(domain.RescaleActionReclaim), "share 0 < current 1")
+		Expect(ra.TargetGPUs).To(Equal(0))
+		Expect(ra.CurrentGPUs).To(Equal(1))
+		Expect(ra.Stalled).To(BeTrue(), "cheapest-at-1 blocks shedding the last replica")
+		Expect(dm["A-v"].TargetReplicas).To(Equal(1), "A stays at its protected replica")
+	})
+
+	// Rescale off ⇒ no info attached (nil), regardless of contention.
+	It("attaches no info when rescale is off", func() {
+		o := NewGreedyByScoreOptimizer()
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 8),
+			rescaleReq("B", "default", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+		Expect(dm["A-v"].Rescale).To(BeNil())
+		Expect(dm["B-v"].Rescale).To(BeNil())
+	})
+})

--- a/internal/engines/pipeline/rescale_optimize_test.go
+++ b/internal/engines/pipeline/rescale_optimize_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"math"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -761,5 +762,98 @@ var _ = Describe("GreedyByScoreOptimizer rescale observability (Beta)", func() {
 		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
 		Expect(dm["A-v"].Rescale).To(BeNil())
 		Expect(dm["B-v"].Rescale).To(BeNil())
+	})
+})
+
+var _ = Describe("GreedyByScoreOptimizer rescale hysteresis (Beta)", func() {
+	// Deadband: equal-priority A(5)/B(3) on a full budget of 8 water-fill to 4/4, so A
+	// owes a 1-GPU reclaim. A deadband of 2 GPUs holds A at 5 (gap 1 < 2); without it,
+	// A would reclaim to 4.
+	It("holds a sub-deadband reclaim", func() {
+		reqs := func() []ModelScalingRequest {
+			return []ModelScalingRequest{
+				rescaleReq("A", "default", 1, 8000, 5),
+				rescaleReq("B", "default", 1, 8000, 3),
+			}
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+
+		// Without a deadband: A reclaims 5 -> 4.
+		plain := NewGreedyByScoreOptimizer()
+		plain.Rescale = RescaleFlags{Cluster: true}
+		Expect(decisionMap(plain.Optimize(context.Background(), reqs(), cons))["A-v"].TargetReplicas).To(Equal(4))
+
+		// With a 2-GPU deadband: the 1-GPU gap is held, A stays at 5.
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true, ClusterTuning: RescaleTuning{MinShareGapGPUs: 2}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs(), cons))
+		Expect(dm["A-v"].TargetReplicas).To(Equal(5), "held by deadband")
+		Expect(dm["A-v"].Rescale.Action).To(Equal(domain.RescaleActionHold))
+	})
+
+	// Cool-down: A is reclaimed in cycle 1 (stamping the cool-down), held in cycle 2
+	// (30s < 60s window), and reclaimed again in cycle 3 (90s > 60s). The model's
+	// current stays at 8 across cycles (paced convergence: the reclaim has not actuated).
+	It("suppresses a repeat reclaim within the cool-down, then allows it after", func() {
+		reqs := func() []ModelScalingRequest {
+			return []ModelScalingRequest{
+				rescaleReq("A", "default", 1, 8000, 8),
+				rescaleReq("B", "default", 3, 8000, 0),
+			}
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true, ClusterTuning: RescaleTuning{CooldownSeconds: 60}}
+		o.RescaleLastReclaim = map[string]time.Time{}
+		t0 := time.Unix(1_000_000, 0)
+
+		o.RescaleNow = t0
+		dm1 := decisionMap(o.Optimize(context.Background(), reqs(), cons))
+		Expect(dm1["A-v"].TargetReplicas).To(Equal(2), "cycle 1: A reclaims 8 -> 2")
+		Expect(dm1["A-v"].Rescale.Action).To(Equal(domain.RescaleActionReclaim))
+
+		o.RescaleNow = t0.Add(30 * time.Second)
+		dm2 := decisionMap(o.Optimize(context.Background(), reqs(), cons))
+		Expect(dm2["A-v"].TargetReplicas).To(Equal(8), "cycle 2: within cool-down, A held at 8")
+		Expect(dm2["A-v"].Rescale.Action).To(Equal(domain.RescaleActionHold))
+
+		o.RescaleNow = t0.Add(90 * time.Second)
+		dm3 := decisionMap(o.Optimize(context.Background(), reqs(), cons))
+		Expect(dm3["A-v"].TargetReplicas).To(Equal(2), "cycle 3: past cool-down, A reclaims again")
+	})
+
+	// A stalled reclaim sheds nothing, so it must NOT stamp the cool-down (otherwise the
+	// retry that could finally succeed would be blocked). Here A holds one protected
+	// replica it can never shed; the store stays empty.
+	It("does not start a cool-down for a reclaim that shed nothing", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true, ClusterTuning: RescaleTuning{CooldownSeconds: 60}}
+		o.RescaleLastReclaim = map[string]time.Time{}
+		o.RescaleNow = time.Unix(1_000_000, 0)
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 0, 1),    // share 0, holds 1 protected replica -> stall
+			rescaleReq("B", "default", 5, 8000, 3), // hungry, high priority
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 4, Used: 4}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+		Expect(dm["A-v"].Rescale.Stalled).To(BeTrue())
+		Expect(o.RescaleLastReclaim).To(BeEmpty(), "a stalled reclaim must not stamp the cool-down")
+	})
+
+	// Knobs at 0 with the cool-down clock/state wired must behave exactly like Alpha:
+	// A reclaims to its share, unaffected by the presence of the store.
+	It("is byte-identical to Alpha when knobs are 0 even with the clock wired", func() {
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true} // zero tuning
+		o.RescaleLastReclaim = map[string]time.Time{}
+		o.RescaleNow = time.Unix(1_000_000, 0)
+		reqs := []ModelScalingRequest{
+			rescaleReq("A", "default", 1, 8000, 8),
+			rescaleReq("B", "default", 3, 8000, 0),
+		}
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+		dm := decisionMap(o.Optimize(context.Background(), reqs, cons))
+		Expect(dm["A-v"].TargetReplicas).To(Equal(2), "Alpha reclaim unaffected by zero knobs")
 	})
 })

--- a/internal/engines/pipeline/rescale_optimize_test.go
+++ b/internal/engines/pipeline/rescale_optimize_test.go
@@ -975,3 +975,83 @@ var _ = Describe("GreedyByScoreOptimizer rescale hysteresis (Beta)", func() {
 		Expect(dm["A-v"].TargetReplicas).To(Equal(2), "Alpha reclaim unaffected by zero knobs")
 	})
 })
+
+var _ = Describe("GreedyByScoreOptimizer rescale multi-analyzer", func() {
+	// Builds a request whose demand comes from the saturation entry (1 GPU/replica)
+	// plus an optional second analyzer, so the tests can compare saturation-only vs a
+	// Score-weighted second signal.
+	mkReq := func(id string, prio, satDemand float64, current int, extra *NamedAnalyzerResult) ModelScalingRequest {
+		v := id + "-v"
+		sat := &domain.AnalyzerResult{
+			ModelID: id, Namespace: "default", TotalDemand: satDemand,
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: v, AcceleratorName: "A100", Cost: 5, PerReplicaCapacity: 1000, ReplicaCount: current},
+			},
+		}
+		results := []NamedAnalyzerResult{{Name: domain.SaturationAnalyzerName, Result: sat}}
+		if extra != nil {
+			results = append(results, *extra)
+		}
+		return ModelScalingRequest{
+			ModelID: id, Namespace: "default", Priority: prio,
+			AnalyzerResults: results,
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: v, CurrentReplicas: current, GPUsPerReplica: 1},
+			},
+		}
+	}
+	// A second analyzer for variant {id}-v on A100 with the given demand and Score.
+	extraFor := func(id string, demand, score float64) *NamedAnalyzerResult {
+		return &NamedAnalyzerResult{
+			Name: "throughput", Score: score,
+			Result: &domain.AnalyzerResult{
+				ModelID: id, Namespace: "default", TotalDemand: demand,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: id + "-v", AcceleratorName: "A100", PerReplicaCapacity: 1000},
+				},
+			},
+		}
+	}
+
+	// The Score-weighted second analyzer raises A's water-fill share. Equal-priority
+	// A(8)/B(0), budget 8, both saturation demand 8000 (8 GPUs) -> contended. Saturation
+	// only: equal weight -> split 4/4, A reclaims to 4. Adding analyzer(demand 16000,
+	// Score 3) to A gives weight 8000 + 3*16000 = 56000 vs B's 8000 (7:1) -> A keeps 7.
+	It("weights the water-fill by the combined Score-weighted demand", func() {
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 8}}}}
+
+		base := NewGreedyByScoreOptimizer()
+		base.Rescale = RescaleFlags{Cluster: true}
+		dmBase := decisionMap(base.Optimize(context.Background(),
+			[]ModelScalingRequest{mkReq("A", 1, 8000, 8, nil), mkReq("B", 1, 8000, 0, nil)}, cons))
+		Expect(dmBase["A-v"].TargetReplicas).To(Equal(4), "saturation-only: equal weight -> A=4")
+
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+		dm := decisionMap(o.Optimize(context.Background(),
+			[]ModelScalingRequest{mkReq("A", 1, 8000, 8, extraFor("A", 16000, 3)), mkReq("B", 1, 8000, 0, nil)}, cons))
+		Expect(dm["A-v"].TargetReplicas).To(Equal(7), "second analyzer raises A's share 7:1")
+		Expect(dm["A-v"].Rescale.TargetGPUs).To(Equal(7))
+	})
+
+	// The sizing MAX (bottleneck) can flip a group into contention. Low-priority A(4)
+	// and high-priority B(0), saturation demand 4000 (4 GPUs) each, budget 8. Saturation
+	// only: 4+4 = 8 does not exceed 8 -> uncontended, no rescale. A high-demand second
+	// analyzer on B (20 GPUs) makes Sum demand 4+20 exceed 8 -> rescale reclaims A.
+	It("triggers contention via the cross-analyzer bottleneck demand", func() {
+		cons := []*ResourceConstraints{{Pools: map[string]ResourcePool{"A100": {Limit: 8, Used: 4}}}}
+
+		base := NewGreedyByScoreOptimizer()
+		base.Rescale = RescaleFlags{Cluster: true}
+		dmBase := decisionMap(base.Optimize(context.Background(),
+			[]ModelScalingRequest{mkReq("A", 1, 4000, 4, nil), mkReq("B", 5, 4000, 0, nil)}, cons))
+		Expect(hasRescaleReason(dmBase)).To(BeFalse(), "saturation-only demand (4+4=8) does not exceed budget 8")
+
+		o := NewGreedyByScoreOptimizer()
+		o.Rescale = RescaleFlags{Cluster: true}
+		dm := decisionMap(o.Optimize(context.Background(),
+			[]ModelScalingRequest{mkReq("A", 1, 4000, 4, nil), mkReq("B", 5, 4000, 0, extraFor("B", 20000, 1))}, cons))
+		Expect(hasRescaleReason(dm)).To(BeTrue(), "B's 20-GPU bottleneck demand makes the group contended")
+		Expect(dm["A-v"].TargetReplicas).To(BeNumerically("<", 4), "low-priority A is reclaimed under contention")
+	})
+})

--- a/internal/engines/pipeline/rescale_test.go
+++ b/internal/engines/pipeline/rescale_test.go
@@ -131,7 +131,7 @@ var _ = Describe("distributeGPUsByWeight", func() {
 	})
 })
 
-var _ = Describe("roleDemandGPUs", func() {
+var _ = Describe("roleDemandGPUsForResult", func() {
 	It("rounds token demand up to whole replicas (ceil)", func() {
 		// 8500 tokens / 1000 per-replica capacity = 8.5 -> ceil = 9 replicas (9 GPUs).
 		// Guards against a regression to floor (which would under-count demand at 8).
@@ -145,6 +145,66 @@ var _ = Describe("roleDemandGPUs", func() {
 		stateMap := map[string]domain.VariantReplicaState{
 			"A-v": {VariantName: "A-v", GPUsPerReplica: 1},
 		}
-		Expect(roleDemandGPUs(sat, stateMap, "A100", domain.RoleBoth)).To(Equal(9))
+		Expect(roleDemandGPUsForResult(sat, stateMap, "A100", domain.RoleBoth)).To(Equal(9))
+	})
+})
+
+var _ = Describe("combinedDemandWeight (multi-analyzer)", func() {
+	res := func(demand float64) *domain.AnalyzerResult {
+		return &domain.AnalyzerResult{ModelID: "A", TotalDemand: demand}
+	}
+
+	It("treats an unset/zero Score as 1.0 (matches scoreForAnalyzer)", func() {
+		// withSatEntry-style fixtures leave Score 0; it must weight as 1.0, not zero out.
+		Expect(combinedDemandWeight([]NamedAnalyzerResult{{Result: res(4000)}})).To(Equal(4000.0))
+	})
+
+	It("is the Score-weighted sum of each analyzer's TotalDemand", func() {
+		w := combinedDemandWeight([]NamedAnalyzerResult{
+			{Result: res(4000), Score: 2},
+			{Result: res(8000), Score: 3},
+		})
+		Expect(w).To(Equal(2*4000.0 + 3*8000.0))
+	})
+
+	It("skips nil results", func() {
+		w := combinedDemandWeight([]NamedAnalyzerResult{
+			{Result: res(4000), Score: 1},
+			{Result: nil, Score: 5},
+		})
+		Expect(w).To(Equal(4000.0))
+	})
+})
+
+var _ = Describe("roleDemandGPUs (multi-analyzer)", func() {
+	stateMap := map[string]domain.VariantReplicaState{
+		"A-v": {VariantName: "A-v", GPUsPerReplica: 1},
+	}
+	res := func(demand, prc float64) *domain.AnalyzerResult {
+		return &domain.AnalyzerResult{
+			ModelID:     "A",
+			TotalDemand: demand,
+			VariantCapacities: []domain.VariantCapacity{
+				{VariantName: "A-v", AcceleratorName: "A100", PerReplicaCapacity: prc},
+			},
+		}
+	}
+
+	It("takes the cross-analyzer MAX (bottleneck) demand-in-GPUs", func() {
+		// sat: 4000/1000 = 4 GPUs; second analyzer: 8000/1000 = 8 GPUs -> max 8.
+		got := roleDemandGPUs([]NamedAnalyzerResult{
+			{Result: res(4000, 1000), Score: 1},
+			{Result: res(8000, 1000), Score: 3},
+		}, stateMap, "A100", domain.RoleBoth)
+		Expect(got).To(Equal(8))
+	})
+
+	It("ignores an analyzer whose variant has no per-replica capacity", func() {
+		// The zero-PRC entry contributes 0; only the saturation entry's 4 GPUs count.
+		got := roleDemandGPUs([]NamedAnalyzerResult{
+			{Result: res(4000, 1000), Score: 1},
+			{Result: res(9_000_000, 0), Score: 1}, // PRC 0 -> skipped
+		}, stateMap, "A100", domain.RoleBoth)
+		Expect(got).To(Equal(4))
 	})
 })

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1684,8 +1684,19 @@ func (e *Engine) applySaturationDecisions(
 		// current allocation, the budget scope, and the direction taken. A reclaim
 		// that could not shed a whole replica (stall) is additionally emitted as a
 		// Warning event so operators see redistribution is blocked without reading logs.
-		if hasDecision && decision.Rescale != nil {
+		// When the model is no longer rescaled this cycle (uncontended, or rescale
+		// disabled), flip a previously-True condition to False so it does not linger as
+		// a stale "still reclaiming" — matching the condition's this-cycle semantics.
+		switch {
+		case hasDecision && decision.Rescale != nil:
 			e.setRescaledCondition(ctx, &updateVa, decision.Rescale)
+		default:
+			if c := llmdVariantAutoscalingV1alpha1.GetCondition(&updateVa, llmdVariantAutoscalingV1alpha1.TypeRescaled); c != nil && c.Status == metav1.ConditionTrue {
+				llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
+					llmdVariantAutoscalingV1alpha1.TypeRescaled, metav1.ConditionFalse,
+					llmdVariantAutoscalingV1alpha1.ReasonRescaleHold,
+					"not part of a rescale group this cycle")
+			}
 		}
 
 		// Emit metrics for external autoscalers (Important: Actuator emits these)

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -141,6 +141,13 @@ type Engine struct {
 	// Key is namespace/name from utils.GetNamespacedKey.
 	vaEventTracker map[string]bool
 
+	// rescaleLastReclaim records, per model (namespace/ModelID key), when rescale last
+	// reclaimed GPUs from it — the state behind the rescale reclaim cool-down. It is
+	// read and written only from the single optimize goroutine (after StartOptimizeLoop),
+	// so it needs no lock; it is lazily created and pruned to the live model set each
+	// cycle. Empty/absent means no cool-down is in effect.
+	rescaleLastReclaim map[string]time.Time
+
 	Config *config.Config // Unified configuration (injected from main.go)
 
 	// ReplicaMetricsCollector is the collector for replica metrics using the source infrastructure
@@ -848,12 +855,17 @@ func (e *Engine) selectV2Optimizer(
 	return optimizer, constraints
 }
 
-// resolveRescaleFlags builds the scope-coupled rescale enablement for this cycle:
-// the cluster flag from the global saturation `default` config, plus a per-namespace
-// flag from each active namespace's OWN `default` config (never the global fallback,
-// so the cluster flag cannot enable rescale on a namespace quota).
+// resolveRescaleFlags builds the scope-coupled rescale enablement and hysteresis
+// tuning for this cycle: the cluster flag/knobs from the global saturation `default`
+// config, plus per-namespace flag/knobs from each active namespace's OWN `default`
+// config (never the global fallback, so the cluster settings cannot enable or tune
+// rescale on a namespace quota).
 func (e *Engine) resolveRescaleFlags(requests []pipeline.ModelScalingRequest) pipeline.RescaleFlags {
-	flags := pipeline.RescaleFlags{Cluster: e.Config.RescaleEnabledCluster()}
+	ct := e.Config.RescaleTuningCluster()
+	flags := pipeline.RescaleFlags{
+		Cluster:       ct.Enabled,
+		ClusterTuning: toPipelineTuning(ct),
+	}
 	seen := make(map[string]bool)
 	for _, req := range requests {
 		ns := req.Namespace
@@ -861,14 +873,41 @@ func (e *Engine) resolveRescaleFlags(requests []pipeline.ModelScalingRequest) pi
 			continue
 		}
 		seen[ns] = true
-		if enabled, hasLocal := e.Config.RescaleEnabledForNamespaceLocal(ns); hasLocal && enabled {
+		if t, hasLocal := e.Config.RescaleTuningForNamespaceLocal(ns); hasLocal && t.Enabled {
 			if flags.ByNamespace == nil {
 				flags.ByNamespace = make(map[string]bool)
+				flags.ByNamespaceTuning = make(map[string]pipeline.RescaleTuning)
 			}
 			flags.ByNamespace[ns] = true
+			flags.ByNamespaceTuning[ns] = toPipelineTuning(t)
 		}
 	}
 	return flags
+}
+
+// toPipelineTuning maps the config hysteresis knobs to the pipeline tuning type.
+func toPipelineTuning(t config.RescaleTuning) pipeline.RescaleTuning {
+	return pipeline.RescaleTuning{
+		MinShareGapGPUs: t.MinShareGapGPUs,
+		CooldownSeconds: t.CooldownSeconds,
+	}
+}
+
+// pruneRescaleCooldownStore drops cool-down stamps for models no longer present, so
+// the store stays bounded to the live model set. Called before each rescale cycle.
+func (e *Engine) pruneRescaleCooldownStore(requests []pipeline.ModelScalingRequest) {
+	if len(e.rescaleLastReclaim) == 0 {
+		return
+	}
+	live := make(map[string]struct{}, len(requests))
+	for _, req := range requests {
+		live[utils.GetNamespacedKey(req.Namespace, req.ModelID)] = struct{}{}
+	}
+	for k := range e.rescaleLastReclaim {
+		if _, ok := live[k]; !ok {
+			delete(e.rescaleLastReclaim, k)
+		}
+	}
 }
 
 // optimizeV2 runs the V2 token-based optimizer path (saturation-token-based).
@@ -942,10 +981,21 @@ func (e *Engine) optimizeV2(
 
 	// Stage 2: Compute GPU constraints and call optimizer
 	optimizer, constraints := e.selectV2Optimizer(ctx, requests)
-	// Scope-coupled rescale enablement (cluster + per-namespace) is resolved from
-	// config and handed to the GPU-aware optimizer for this cycle.
+	// Scope-coupled rescale enablement + hysteresis tuning (cluster + per-namespace)
+	// is resolved from config and handed to the GPU-aware optimizer for this cycle.
+	// When rescale is on, also wire the cool-down clock and the engine-owned per-model
+	// last-reclaim store (pruned to the live model set first) so the reclaim cool-down
+	// persists across cycles.
 	if g, ok := optimizer.(*pipeline.GreedyByScoreOptimizer); ok {
 		g.Rescale = e.resolveRescaleFlags(requests)
+		if g.Rescale.Any() {
+			if e.rescaleLastReclaim == nil {
+				e.rescaleLastReclaim = make(map[string]time.Time)
+			}
+			e.pruneRescaleCooldownStore(requests)
+			g.RescaleNow = time.Now()
+			g.RescaleLastReclaim = e.rescaleLastReclaim
+		}
 	}
 	allDecisions := optimizer.Optimize(ctx, requests, constraints)
 	logScalingDecisions(ctx, requests, allDecisions)

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -516,8 +516,9 @@ func modeLabelForAnalyzer(analyzerName string) string {
 }
 
 // recordEvent ensures only one event is recorded per VA in an optimization cycle.
-// Exception: K8SEventResourceConstrained events bypass deduplication and can be
-// recorded alongside other event types (e.g., ScaledUp + ResourceConstrained).
+// Exception: K8SEventResourceConstrained and K8SEventRescaleStalled bypass
+// deduplication and can be recorded alongside another event type (e.g., a scaling
+// event) — both are Warnings that describe a constraint on top of the scaling action.
 func (e *Engine) recordEvent(
 	va *llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	eventType, reason, message string,
@@ -526,8 +527,9 @@ func (e *Engine) recordEvent(
 		return
 	}
 
-	if reason == constants.K8SEventResourceConstrained {
-		// This is the only exception where a variant can have 2 K8S events in an optimize cycle: K8SEventScaledUp & K8SEventResourceConstrained
+	if reason == constants.K8SEventResourceConstrained || reason == constants.K8SEventRescaleStalled {
+		// The only exceptions where a variant can have 2 K8S events in an optimize
+		// cycle: a scaling event plus ResourceConstrained or RescaleStalled.
 		e.Recorder.Event(va, eventType, reason, message)
 		return
 	}
@@ -1627,6 +1629,15 @@ func (e *Engine) applySaturationDecisions(
 				"Optimization loop ran (no scaling change needed)")
 		}
 
+		// Surface the priority-weighted rescale outcome (Beta observability): the
+		// Rescaled condition records the model's priority, its water-fill share vs
+		// current allocation, the budget scope, and the direction taken. A reclaim
+		// that could not shed a whole replica (stall) is additionally emitted as a
+		// Warning event so operators see redistribution is blocked without reading logs.
+		if hasDecision && decision.Rescale != nil {
+			e.setRescaledCondition(ctx, &updateVa, decision.Rescale)
+		}
+
 		// Emit metrics for external autoscalers (Important: Actuator emits these)
 		// We should emit metrics even if no decision changed, to keep HPA alive
 		act := actuator.NewActuator(e.client)
@@ -1711,6 +1722,39 @@ func (e *Engine) applySaturationDecisions(
 				"target", targetReplicas,
 				"reason", reason)
 		}
+	}
+}
+
+// setRescaledCondition records the priority-weighted rescale outcome on a variant:
+// the Rescaled status condition (reason = Reclaim/Fill/Hold, or Stalled when a
+// reclaim could not shed a whole replica) with a message carrying the model's
+// priority, water-fill share, current allocation, and budget scope. A stall also
+// emits a Warning event and a log line so blocked redistribution is visible.
+func (e *Engine) setRescaledCondition(
+	ctx context.Context,
+	va *llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	info *domain.RescaleDecisionInfo,
+) {
+	reason := llmdVariantAutoscalingV1alpha1.ReasonRescaleHold
+	switch {
+	case info.Stalled:
+		reason = llmdVariantAutoscalingV1alpha1.ReasonRescaleStalled
+	case info.Action == domain.RescaleActionReclaim:
+		reason = llmdVariantAutoscalingV1alpha1.ReasonRescaleReclaim
+	case info.Action == domain.RescaleActionFill:
+		reason = llmdVariantAutoscalingV1alpha1.ReasonRescaleFill
+	}
+	msg := fmt.Sprintf("priority-weighted rescale (%s): priority=%g share=%dGPU current=%dGPU scope=%s",
+		info.Action, info.Priority, info.TargetGPUs, info.CurrentGPUs, info.Scope)
+	llmdVariantAutoscalingV1alpha1.SetCondition(va,
+		llmdVariantAutoscalingV1alpha1.TypeRescaled, metav1.ConditionTrue, reason, msg)
+
+	if info.Stalled {
+		e.recordEvent(va, corev1.EventTypeWarning, constants.K8SEventRescaleStalled,
+			"rescale could not shed a whole replica to reach the priority-weighted share: "+msg)
+		ctrl.LoggerFrom(ctx).Info("rescale reclaim stalled (role could not shed a whole replica)",
+			"variant", va.Name, "namespace", va.Namespace,
+			"share", info.TargetGPUs, "current", info.CurrentGPUs, "scope", info.Scope)
 	}
 }
 

--- a/internal/engines/saturation/engine_rescale_condition_test.go
+++ b/internal/engines/saturation/engine_rescale_condition_test.go
@@ -1,0 +1,98 @@
+package saturation
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
+)
+
+// newRescaleTestEngine builds a minimal engine with a fake recorder and a fresh
+// per-cycle event tracker, enough to exercise setRescaledCondition.
+func newRescaleTestEngine() (*Engine, *record.FakeRecorder) {
+	rec := record.NewFakeRecorder(10)
+	return &Engine{Recorder: rec, vaEventTracker: map[string]bool{}}, rec
+}
+
+func newRescaleTestVA() *llmdVariantAutoscalingV1alpha1.VariantAutoscaling {
+	return &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{Name: "va-a", Namespace: "default"},
+	}
+}
+
+// TestSetRescaledCondition_Reclaim sets the Rescaled condition with the Reclaim
+// reason and a message carrying priority/share/current/scope, and emits no event.
+func TestSetRescaledCondition_Reclaim(t *testing.T) {
+	e, rec := newRescaleTestEngine()
+	va := newRescaleTestVA()
+
+	e.setRescaledCondition(context.Background(), va, &domain.RescaleDecisionInfo{
+		Priority: 1, TargetGPUs: 2, CurrentGPUs: 8, Scope: "cluster",
+		Action: domain.RescaleActionReclaim,
+	})
+
+	cond := llmdVariantAutoscalingV1alpha1.GetCondition(va, llmdVariantAutoscalingV1alpha1.TypeRescaled)
+	if assert.NotNil(t, cond, "Rescaled condition must be set") {
+		assert.Equal(t, metav1.ConditionTrue, cond.Status)
+		assert.Equal(t, llmdVariantAutoscalingV1alpha1.ReasonRescaleReclaim, cond.Reason)
+		assert.Contains(t, cond.Message, "share=2GPU")
+		assert.Contains(t, cond.Message, "current=8GPU")
+		assert.Contains(t, cond.Message, "scope=cluster")
+	}
+
+	select {
+	case ev := <-rec.Events:
+		t.Errorf("no event expected for a clean reclaim, got %q", ev)
+	default:
+	}
+}
+
+// TestSetRescaledCondition_Fill uses the Fill reason for an under-share model.
+func TestSetRescaledCondition_Fill(t *testing.T) {
+	e, _ := newRescaleTestEngine()
+	va := newRescaleTestVA()
+
+	e.setRescaledCondition(context.Background(), va, &domain.RescaleDecisionInfo{
+		Priority: 3, TargetGPUs: 6, CurrentGPUs: 0, Scope: "team",
+		Action: domain.RescaleActionFill,
+	})
+
+	cond := llmdVariantAutoscalingV1alpha1.GetCondition(va, llmdVariantAutoscalingV1alpha1.TypeRescaled)
+	if assert.NotNil(t, cond) {
+		assert.Equal(t, llmdVariantAutoscalingV1alpha1.ReasonRescaleFill, cond.Reason)
+		assert.Contains(t, cond.Message, "scope=team")
+	}
+}
+
+// TestSetRescaledCondition_Stalled uses the Stalled reason (overriding the direction)
+// and emits a RescaleStalled Warning event.
+func TestSetRescaledCondition_Stalled(t *testing.T) {
+	e, rec := newRescaleTestEngine()
+	va := newRescaleTestVA()
+
+	e.setRescaledCondition(context.Background(), va, &domain.RescaleDecisionInfo{
+		Priority: 1, TargetGPUs: 0, CurrentGPUs: 1, Scope: "cluster",
+		Action: domain.RescaleActionReclaim, Stalled: true,
+	})
+
+	cond := llmdVariantAutoscalingV1alpha1.GetCondition(va, llmdVariantAutoscalingV1alpha1.TypeRescaled)
+	if assert.NotNil(t, cond) {
+		assert.Equal(t, llmdVariantAutoscalingV1alpha1.ReasonRescaleStalled, cond.Reason,
+			"Stalled reason overrides the reclaim direction")
+	}
+
+	select {
+	case ev := <-rec.Events:
+		assert.Contains(t, ev, constants.K8SEventRescaleStalled)
+		assert.True(t, strings.Contains(ev, "Warning"), "stall event must be a Warning: %q", ev)
+	default:
+		t.Error("expected a RescaleStalled Warning event, got none")
+	}
+}

--- a/internal/engines/saturation/engine_rescale_condition_test.go
+++ b/internal/engines/saturation/engine_rescale_condition_test.go
@@ -71,6 +71,30 @@ func TestSetRescaledCondition_Fill(t *testing.T) {
 	}
 }
 
+// TestSetRescaledCondition_Hold uses the Hold reason for a model held (deadband/cool-down)
+// or already at its share, and emits no event.
+func TestSetRescaledCondition_Hold(t *testing.T) {
+	e, rec := newRescaleTestEngine()
+	va := newRescaleTestVA()
+
+	e.setRescaledCondition(context.Background(), va, &domain.RescaleDecisionInfo{
+		Priority: 1, TargetGPUs: 4, CurrentGPUs: 4, Scope: "cluster",
+		Action: domain.RescaleActionHold,
+	})
+
+	cond := llmdVariantAutoscalingV1alpha1.GetCondition(va, llmdVariantAutoscalingV1alpha1.TypeRescaled)
+	if assert.NotNil(t, cond) {
+		assert.Equal(t, llmdVariantAutoscalingV1alpha1.ReasonRescaleHold, cond.Reason)
+		assert.Contains(t, cond.Message, "(hold)")
+	}
+
+	select {
+	case ev := <-rec.Events:
+		t.Errorf("no event expected for a hold, got %q", ev)
+	default:
+	}
+}
+
 // TestSetRescaledCondition_Stalled uses the Stalled reason (overriding the direction)
 // and emits a RescaleStalled Warning event.
 func TestSetRescaledCondition_Stalled(t *testing.T) {

--- a/internal/engines/saturation/engine_rescale_test.go
+++ b/internal/engines/saturation/engine_rescale_test.go
@@ -49,4 +49,28 @@ var _ = Describe("Engine.resolveRescaleFlags", func() {
 		Expect(flags.ByNamespace).ToNot(HaveKey("absent"))
 		Expect(flags.ByNamespace).ToNot(HaveKey(""))
 	})
+
+	It("propagates the cluster hysteresis knobs into the resolved tuning", func() {
+		c := config.NewTestConfig()
+		c.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{
+			"default": {EnableRescale: true, RescaleMinShareGapGPUs: 2, RescaleCooldownSeconds: 90},
+		})
+		flags := (&Engine{Config: c}).resolveRescaleFlags([]pipeline.ModelScalingRequest{req("any")})
+		Expect(flags.ClusterTuning.MinShareGapGPUs).To(Equal(2))
+		Expect(flags.ClusterTuning.CooldownSeconds).To(Equal(90))
+	})
+
+	It("propagates namespace-local hysteresis knobs without leaking the cluster ones", func() {
+		c := config.NewTestConfig()
+		c.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{
+			"default": {EnableRescale: true, RescaleMinShareGapGPUs: 5, RescaleCooldownSeconds: 120},
+		})
+		c.UpdateSaturationConfigForNamespace("team", map[string]config.SaturationScalingConfig{
+			"default": {EnableRescale: true, RescaleMinShareGapGPUs: 1},
+		})
+		flags := (&Engine{Config: c}).resolveRescaleFlags([]pipeline.ModelScalingRequest{req("team")})
+		Expect(flags.ByNamespaceTuning).To(HaveKey("team"))
+		Expect(flags.ByNamespaceTuning["team"].MinShareGapGPUs).To(Equal(1), "namespace-local value")
+		Expect(flags.ByNamespaceTuning["team"].CooldownSeconds).To(Equal(0), "no global fallback for the namespace knob")
+	})
 })

--- a/internal/variant/types.go
+++ b/internal/variant/types.go
@@ -111,6 +111,24 @@ const (
 	TypeMetricsAvailable = "MetricsAvailable"
 	// TypeOptimizationReady indicates whether the optimization engine can run successfully
 	TypeOptimizationReady = "OptimizationReady"
+	// TypeRescaled indicates the variant participated in a priority-weighted rescale
+	// group this cycle (set only when rescale acted on the model). See the Rescale*
+	// reason constants below.
+	TypeRescaled = "Rescaled"
+)
+
+// Condition Reasons for the Rescaled condition (priority-weighted rescale, #1447).
+const (
+	// ReasonRescaleReclaim indicates rescale reclaimed GPUs from this over-share model.
+	ReasonRescaleReclaim = "Reclaim"
+	// ReasonRescaleFill indicates rescale filled this under-share model with free GPUs.
+	ReasonRescaleFill = "Fill"
+	// ReasonRescaleHold indicates the model is within its share (or hysteresis held it),
+	// so rescale made no change this cycle.
+	ReasonRescaleHold = "Hold"
+	// ReasonRescaleStalled indicates a reclaim could not shed a whole replica (blocked
+	// by minReplicas or the cheapest-at-1 protection), so the model stays over its share.
+	ReasonRescaleStalled = "Stalled"
 )
 
 // Condition Reasons for MetricsAvailable


### PR DESCRIPTION
Implements the **Beta** milestone of priority-weighted rescale, on top of the merged Alpha (#1452). Alpha made the redistribution correct but silent and un-damped; Beta adds the two pieces Alpha explicitly deferred — **observability** and **hysteresis** — without touching the water-fill math, scope-coupling, or paced convergence. With the new knobs at their defaults (`0`), behavior is byte-identical to Alpha.

## Proposed Changes

<!--
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: **Observability** — a `Rescaled` VariantAutoscaling status condition (reasons `Reclaim` / `Fill` / `Hold` / `Stalled`) carrying the model's priority, water-fill **share** vs current GPUs, and budget scope; plus a `RescaleStalled` **Warning event** when a reclaim cannot shed a whole replica (blocked by `minReplicas` / cheapest-at-1). Action and stall are attributed **per variant by role**, so a P/D model's grown role is never blamed with the shed role's reclaim or stall. A previously-`True` condition is flipped to `False` once a VA stops being rescaled, so it never lingers stale.
- :gift: **Hysteresis** — two optional **budget-scope** ConfigMap knobs (read only from the `default` entry, same rule as `enableRescale`), both default `0`:
  - `rescaleMinShareGapGPUs` — inclusive deadband; holds a model when `0 < |share − current| ≤ gap` (so the recommended `1` damps a single-GPU flap), in both directions.
  - `rescaleCooldownSeconds` — per-model reclaim cool-down; suppresses a repeat reclaim within the window. Fills are never cooled down; a stalled reclaim (shed nothing) never starts a cool-down.
- :broom: Cool-down state is engine-owned, touched only by the single optimize goroutine (lock-free) and pruned to the live model set each cycle.

**Scope:** unchanged when off or uncontended; V2 GPU-constrained optimizer only. Still deferred to Stable: the physical∧quota namespace partition (#1003) and multi-accelerator models. Two minor P/D observability edge cases (deadband freezing a budget-neutral role rebalance at `gap ≥ 2`; a role-level stall message showing model-level `share`/`current`) are documented as future refinements in `docs/plans/engine/rescale-beta.md`.

**Testing:** unit + envtest coverage for the config knobs and accessors, the condition/reason/message and stall event, the inclusive deadband (`1` holds, `>gap` doesn't), the fill-side hold, the cool-down window (suppress-then-allow across cycles), the sub-replica non-stall (`unshed ≥ gMin` vs `> 0`), per-variant P/D attribution, and a **knobs=0 ⇒ decisions identical to Alpha** regression guard. `golangci-lint` clean.

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A: the pass is opt-in and off by default (identical to Alpha when disabled); covered by unit + envtest, consistent with how Alpha (#1452) landed.
- [x] **Docs PR** for any user-facing impact — in-repo: the operator-facing knobs, the `Rescaled` condition, and the `RescaleStalled` event are documented in `docs/developer-guide/saturation-scaling-config.md` (new *Priority-Weighted Rescale* section), both ConfigMaps carry inline comments, and `docs/plans/engine/rescale-beta.md` is the design record.
- [x] **Proposal PR** for any new enhancement or change to existing behavior — covered by the existing rescale proposal (Alpha, #1238/#1452) and `docs/plans/engine/rescale-beta.md`; this PR is the Beta milestone of #1447, not a new enhancement.

**Release Note**

```release-note
Priority-weighted rescale (Beta): the saturation ConfigMap gains two optional budget-scope knobs — `rescaleMinShareGapGPUs` (hysteresis deadband) and `rescaleCooldownSeconds` (per-model reclaim cool-down), both default 0. VariantAutoscaling resources now expose a `Rescaled` status condition (Reclaim/Fill/Hold/Stalled) and emit a `RescaleStalled` warning event when a reclaim cannot shed a whole replica. Off by default; behavior is unchanged unless rescale is enabled.
```

**Docs**

- `docs/developer-guide/saturation-scaling-config.md` — *Priority-Weighted Rescale* (knobs, condition, event)
- `docs/plans/engine/rescale-beta.md` — Beta design/plan
