### PR TITLE
ci: gate merges via merge queue + main-health canary

### DIFF
--- a/.github/workflows/ci-main-health.yaml
+++ b/.github/workflows/ci-main-health.yaml
@@ -1,0 +1,59 @@
+name: CI - Main Health Canary
+
+# Post-merge safety net: runs the fast build/lint/tidy checks against main itself,
+# right after each merge. It does NOT prevent breakage (that is the merge queue's
+# job) — it surfaces a red main within minutes when a semantic conflict slips
+# through (e.g. two individually-green PRs that only break once combined), instead
+# of the breakage first appearing on the next contributor's unrelated PR.
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ci-main-health-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  main-health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Extract Go version from go.mod
+        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+
+      - name: Set up Go with cache
+        uses: actions/setup-go@v6
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: ./go.sum
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Verify go.mod / go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum \
+            || { echo "::error::main go.mod/go.sum are not tidy."; exit 1; }
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.8.0
+          args: ""
+
+      - name: Unit tests
+        run: make test

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -10,6 +10,11 @@ on:
     branches:
       - main
       - dev
+  # Run in the merge queue so the fast gating jobs (lint-and-test, kustomize-build)
+  # re-execute against the *merged* result — catching semantic conflicts that pass
+  # on each PR in isolation but break `main` once combined (e.g. a stale branch
+  # referencing a package another PR renamed/removed).
+  merge_group:
   workflow_dispatch:
     inputs:
       run_full_tests:
@@ -78,6 +83,12 @@ jobs:
 
       - name: Install dependencies
         run: go mod download
+
+      - name: Verify go.mod / go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum \
+            || { echo "::error::go.mod/go.sum are not tidy — run 'go mod tidy' and commit the result."; exit 1; }
 
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -174,7 +185,10 @@ jobs:
   e2e-tests-full:
     runs-on: ubuntu-latest
     needs: [lint-and-test, check-code-changes]
-    if: needs.check-code-changes.outputs.has_code_changes == 'true'
+    # PR-only: the full e2e suite (~14 min; 90-min timeout is just a safety cap)
+    # runs on the PR, not per queued merge. The queue gates on the fast jobs
+    # (lint-and-test, kustomize-build) instead, keeping queue throughput high.
+    if: github.event_name == 'pull_request' && needs.check-code-changes.outputs.has_code_changes == 'true'
     timeout-minutes: 90
     permissions:
       contents: read


### PR DESCRIPTION
## Proposed Changes

<!-- categorize with emoji -->
- :gift: Add a `merge_group` trigger to `ci-pr-checks.yaml` so the fast jobs (`lint-and-test`, `kustomize-build`) re-run against the **merged result** in the merge queue
- :gift: Add `ci-main-health.yaml` — a post-merge canary (build + vet + lint + tidy on push to `main`) as a detection backstop
- :broom: Verify `go mod tidy` is a no-op in `lint-and-test`
- :broom: Make `e2e-tests-full` PR-only (was implicitly eligible to run in the queue via `has_code_changes`)

### Why

Two PRs that each pass CI in isolation can still break `main` once combined — e.g. one PR renames/removes a package while another, branched earlier, still references the old name. Neither conflicts textually, so both merge, and the combination fails to build. Per-PR CI never tests the merged result.

A merge queue re-runs the fast checks against `main + PR` **before** landing, which catches this class. This PR wires the CI side (`merge_group` trigger; e2e stays PR-only since it doesn't add coverage for this failure mode and would slow the queue). The canary catches anything that bypasses the queue (e.g. an admin direct-push).

The preventive settings — enabling the merge queue and making `lint-and-test` + `kustomize-build` required status checks — are repo-admin actions applied separately (not code).

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A, CI-config only; validated with `actionlint` (0 issues)
- [ ] **Docs PR** for any user-facing impact — N/A for end users; a maintainer-facing guide is applied separately by the admin
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — N/A

**Release Note**

```release-note
NONE