### PR TITLE
Feat/rate anchored k2

### DIFF
--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -329,6 +329,45 @@ as replicas drift across it. Input and output thresholds are also separate now: 
 run an order of magnitude longer than generations, and bucketing input at the output
 thresholds put almost every real workload in one bucket.
 
+### The scale-down floor
+
+Capacity estimation alone cannot make a scale-down safe, because the decision is a
+counterfactual — would `N−1` replicas still cope? — and the token-space figures cannot
+answer it. Demand in resident tokens is measured at the current replica count and does
+not survive the removal being evaluated: residence rises, occupancy per replica rises
+with it, and past a point a queue appears from nothing. Arrivals are the one quantity
+the decision does not move, so the same question asked in rate space has an answer that
+holds.
+
+The constraint is on the aggregate service rate within a role, not on replicas within a
+variant:
+
+```
+sum over v in role of (N_v x mu_v)  >=  lambda_role / scaleDownBoundary
+```
+
+Per-variant would be wrong: shedding from one variant re-routes its traffic to a
+sibling, so a variant's own arrival rate is itself a function of the decision. Only the
+role's total stream is invariant. Heterogeneous accelerators fall out naturally, since
+`mu_v` is per bucket and the bucket key already carries accelerator and GPU count.
+
+The optimizer enforces it in `scaleDownVariantSet`, which is already role-scoped, and
+only bounds *how many* replicas may go — which variant gives one up is still the cost
+ordering's decision. One consequence worth expecting: when the expensive variant's
+replicas are individually large in service-rate terms, the floor can hold them and shed
+a cheap one instead. That is correct. Capacity you need cannot be removed merely
+because it is the capacity you would rather not pay for.
+
+If any variant holding replicas in a role has no calibrated `mu`, the role's available
+side is understated while its arrivals still count, which would hold replicas that are
+not needed. Partial knowledge is therefore treated as no knowledge and the constraint is
+skipped.
+
+For P/D, both roles see the same request stream and each gets its own constraint. A
+prefill replica completes few or no generations, so its service rate comes from prompts
+processed (`vllm:request_prompt_tokens_count`, `sglang:prompt_tokens_histogram_count`)
+rather than from the generation-tokens counter.
+
 ### Residual risks
 
 - **Mixed time bases.** Demand still uses `TokensInUse`, a 1-minute peak, while capacity uses

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -1,0 +1,187 @@
+# Rate-anchored compute capacity (k2) — plan
+
+## Problem
+
+The V2 saturation analyzer models a replica's capacity as `min(k1, k2)` in KV tokens:
+
+- `k1 = TotalKvCapacityTokens × kvCacheThreshold` — the memory bound.
+- `k2` — the compute bound, currently recorded as `tokensInUse` at the moment the
+  replica was seen queueing (`computeK2` priority 1), then averaged into a rolling
+  history keyed by `model|accelerator|gpuCount|outputBucket`.
+
+`k2` measures a **KV stock** while the constraint it stands for is a **rate**. On a
+prefill-heavy workload the two are unrelated: the engine exhausts prompt-token
+throughput and begins queueing while KV occupancy is still low. In the sustained
+1000/250 comparison run the WVA leg was queueing, dropping requests, and cycling
+replicas at **16.2% average KV utilization** — a regime the current model cannot
+express, because at 16% occupancy `demand/supply` reads as abundant headroom.
+
+Three consequences follow, all observed in that run:
+
+1. **The compute bound is silently discarded.** `tokensInUse` derives from
+   `kv_cache_usage` which is `max_over_time(...[1m])` — a peak. Whenever the peak
+   exceeds `kvCacheThreshold` (0.80), `k2 ≥ k1` and `min(k1, k2)` returns the
+   memory bound, so the compute signal never binds.
+2. **Supply is over-stated exactly when load is highest**, so utilization reads low
+   and `spareCapacity = totalSupply − totalDemand/scaleDownBoundary` grows.
+3. **Demand deflates faster than supply.** The queue term
+   (`QueueLength × (avgInput + avgOutput)`) is the dominant part of demand at peak
+   and collapses to zero the moment new replicas absorb the backlog, while `k2`
+   stays inflated via the historical average. The controller then sheds to one
+   replica and the cycle repeats.
+
+Tuning thresholds cannot fix this: six threshold/window/policy legs were run
+against that workload and none of them broke the cycling.
+
+## Approach
+
+Add a second, **rate-anchored** estimator for `k2`, selected by an internal flag,
+leaving the existing estimator in place and untouched when the flag is off.
+
+When a replica has a backlog, its completion rate *is* its service rate — this
+holds whichever resource binds (prefill compute, decode bandwidth, memory), which
+is what makes it the right anchor for a workload-agnostic capacity model:
+
+```
+μ  = max completion rate observed for this workload bucket while QueueLength > 0
+λ  = this replica's arrival rate (EPP dispatch rate)
+k2 = KvUsageInstant × TotalKvCapacityTokens × (μ / λ)
+```
+
+At `λ = μ` the replica is exactly saturated and `k2` equals its current occupancy,
+so utilization reads 100% **even at 16% KV**. At `λ = μ/2`, `k2` is twice the
+occupancy and utilization reads 50%. The result stays in KV tokens, so `min(k1, k2)`,
+`spareCapacity`, and every downstream consumer are unchanged.
+
+Properties that matter here:
+
+- **Blind to which resource binds.** No assumption that the workload is decode-heavy.
+- **Monotone in the right direction.** `μ` is a ceiling measured only under backlog;
+  heavier load cannot inflate it. The current estimator moves the wrong way.
+- **Does not need a live queue.** Once `μ` is known for a bucket it stays valid
+  until the workload shape changes, unlike an occupancy sample which is meaningful
+  only at the instant it was taken.
+- **Uses the instantaneous KV reading**, not the 1-minute peak. The peak stays where
+  it belongs — on the demand side, where erring high is deliberate.
+
+### Why not an ITL model
+
+`ITL(k) = A·k + B` (already fitted by the throughput analyzer) describes decode
+latency against KV occupancy. On prefill-heavy traffic ITL can stay flat while TTFT
+and the queue explode, so it does not capture this bottleneck. It remains the better
+model for decode-bound workloads; the rate anchor covers both.
+
+## Metrics
+
+Everything required already exists. Two of the three are registered only when the
+throughput analyzer is enabled, which this plan removes as a dependency.
+
+| Quantity | Query | Field | Today |
+|---|---|---|---|
+| λ arrival rate | `rate(inference_extension_scheduler_attempts_total{status="success"}[1m])` (EPP) | `ArrivalRate` | unconditional |
+| μ completion rate | `rate(vllm:request_generation_tokens_count[1m])` | `RequestRate` | throughput-analyzer only |
+| occupancy (no peak bias) | `vllm:kv_cache_usage_perc` (instant) | `KvUsageInstant` | throughput-analyzer only |
+| queue | `max_over_time(vllm:num_requests_waiting[1m])` | `QueueLength` | unconditional |
+| KV capacity | `vllm:cache_config_info` | `TotalKvCapacityTokens` | unconditional |
+
+No new PromQL. `QueryRequestRate` and `QueryKvUsageInstant` move to a shared
+registrar called unconditionally by the saturation engine; the throughput analyzer
+registers the same two only if absent, so either order works and neither panics.
+
+SGLang equivalents (`sglang:generation_tokens_histogram_count`, `sglang:token_usage`)
+are already defined and move with them.
+
+## Work items
+
+1. **Shared query registration** — `internal/collector/registration/rate_capacity.go`:
+   single definition of the two shared templates (vLLM + SGLang) and
+   `RegisterRateCapacityQueries`; `registerIfAbsent` / `registerForEngineIfAbsent`
+   helpers; `RegisterThroughputAnalyzerQueries` switched to the if-absent variants.
+   Called from `saturation.Engine` construction alongside `RegisterSaturationQueries`.
+2. **Switch** — `EnableRateAnchoredK2`, a build-time constant in
+   `saturation_v2/rate_capacity.go`. Deliberately not a ConfigMap setting: the
+   estimator is under evaluation against the incumbent and is not something to
+   toggle in a running cluster. With it false the service-rate store is never
+   allocated and every path in the file returns immediately.
+3. **Estimator** — `internal/engines/analyzers/saturation_v2/rate_capacity.go`:
+   per-bucket service-rate store (running max under backlog, staleness eviction),
+   bucket key extended with the **input** dimension, and `rateAnchoredK2()`.
+4. **Wiring** — `computeK2` consults the rate-anchored estimator first when the flag
+   is on, falling through to the existing chain when it declines to answer. New
+   `k2Source` value so the active estimator is visible in logs and metrics.
+5. **Tests** — store behaviour (backlog gating, max, decay, eviction), estimator
+   arithmetic and clamps, flag-off equivalence with the current path.
+
+## Lambda fallback chain
+
+`saturationRatio` takes the most direct signal available:
+
+1. **EPP arrival rate** (`k2SrcRateAnchored`) — the intended path. λ is measured
+   independently of the engine, so μ/λ holds whether or not the replica keeps up.
+2. **Backlog** (`k2SrcRateBacklog`) — a queueing replica is saturated by
+   observation, so the ratio is 1 and capacity is the current occupancy. Needs
+   neither λ nor a calibrated μ, which makes it the safety net for a fleet with no
+   EPP and no prior calibration — and it is exactly the prefill-heavy case the
+   occupancy estimator misreads as idle.
+3. **Completions as λ** (`k2SrcRateNoEPP`) — with no queue, everything arriving is
+   served within the scrape window, so completions are arrivals. Valid only in that
+   case, which is why it sits behind the backlog check.
+
+Only an idle, never-calibrated replica with no EPP declines, and there is nothing
+at risk in that state. Each source has its own `k2Source` label (`RATE-λ`,
+`RATE-q`, `RATE-c`) so the active path is visible per replica.
+
+## What the capacity store learns
+
+`capacityStore` feeds zero-replica estimation, cross-variant `FindCompatible`
+lookups and the fallback path — all of which need a **ceiling**, what a replica can
+do. The rate-anchored value is operating-point-relative, so it is persisted only
+when it is ceiling-like:
+
+- **λ ≥ μ** — the replica is at or past saturation, so `occupancy × μ/λ` is what it
+  actually held. Persisted.
+- **λ < μ** — the same expression is occupancy scaled by headroom. Correct for this
+  cycle's utilization, not a property of the variant. The store keeps the
+  occupancy-based estimate instead; persisting the headroom-scaled value would
+  under-state capacity for a variant that later scales from zero.
+
+`computeReplicaCapacity` therefore tracks `effectiveCapacity` (what this cycle
+scales on) separately from `storedCapacity` (what the store learns).
+
+## Guards
+
+- Require `KvUsageInstant > 0` and a usable ratio; otherwise decline and fall through.
+- Clamp `μ/λ` to `[0.05, 20]` so a mis-scraped rate cannot swing capacity wildly.
+- Never exceed `k1`: `min(k1, k2)` already handles this, but the estimator also
+  refuses to return a value below a floor fraction of `k1` to avoid a stalled
+  replica collapsing capacity to near zero.
+
+## Known limitations
+
+- **Requires EPP.** `ArrivalRate` comes from the EPP scheduler counter. Without it
+  the estimator declines and the existing chain applies unchanged.
+- **Needs backlog to calibrate.** A fleet that never queues never learns `μ` and
+  falls back to the memory bound — acceptable, since nothing is at risk there, but
+  it makes emitting `k2Source` mandatory rather than optional.
+- **P/D disaggregation.** `μ` from the generation-tokens histogram is decode-centric;
+  a prefill pool would need `rate(vllm:request_prompt_tokens_count[1m])` as its `μ`.
+  Not addressed here.
+- **Prompt-token throughput is still not collected.** Useful as a diagnostic to
+  confirm the prefill-bound reading of the sustained run; not required by the
+  estimator.
+
+## Validation
+
+1. **Offline** — replay the recorded metrics from the sustained 1000/250 run through
+   both estimators and compare `k2` against replica count and queue depth. The
+   prediction: the current estimator plateaus high after each queue drain, the
+   rate-anchored one tracks `λ/μ` and stays bound.
+2. **Cluster** — three legs, KEDA `scaleDown` restored to the shipped
+   `Percent 100 / 15s` so the drain cap cannot mask the result, controller restarted
+   between legs:
+   - sustained 1000/250, flag on — expect the two overshoot-correct cycles to
+     disappear;
+   - sustained 1000/250, flag off — baseline on the same cluster state;
+   - **300/300 steady, flag on — regression control.** A more conservative capacity
+     estimate is exactly what could turn "correctly holds at one replica" into
+     spurious scale-up. This leg must stay flat at 1 with zero errors.

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -75,8 +75,9 @@ from rates; the measurement records it in the units the rest of the engine speak
 
 - `SaturationEnterRatio` (0.95) means the detector fires just before arrivals cross
   the service rate, and a lambda hovering at mu does not toggle it between cycles.
-- The service rate is a running maximum with slow decay; the ceiling is a running
-  minimum with slow upward relaxation. Neither tracks a single cycle.
+- The service rate is a mean over backlogged samples with a five-minute time constant;
+  the ceiling is a running miniμm with slow upward relaxation. Neither tracks a single
+  cycle, and neither can move in only one direction.
 - `MinServiceRateSamples` keeps one slow interval from establishing a limit.
 - lambda is smoothed over a residence time, so a completion-derived rate and an
   arrival rate are compared on the same time base.
@@ -181,8 +182,11 @@ now — a state in which nothing is at risk.
 
 ## Known limitations
 
-- **Requires EPP.** `ArrivalRate` comes from the EPP scheduler counter. Without it
-  the estimator declines and the existing chain applies unchanged.
+- **EPP is no longer required.** μ comes from completions
+  (`vllm:request_generation_tokens_count`), the ceiling from occupancy under backlog, and `W`
+  from TTFT and ITL — all vLLM-side. The EPP dispatch rate now only distinguishes the
+  `RATE-now` label from `RATE-learned`. The earlier hard dependency is gone; worth correcting
+  in #1500 and #1501.
 - **Needs backlog to calibrate.** A fleet that never queues never learns `μ` and
   falls back to the memory bound — acceptable, since nothing is at risk there, but
   it makes emitting `k2Source` mandatory rather than optional.
@@ -203,12 +207,103 @@ spare capacity (the shed-to-one), while the rate path reads λ still at the ceil
 and holds capacity at the current load. That is the behaviour the cluster legs must
 confirm, and it is pinned by a test at the `computeReplicaCapacity` level.
 
+## Round 1 result — supply was the smaller half of the problem
+
+Measured 2026-07-31 on the sustained 1000/250 workload, two images from one commit:
+the flag moved the amplitude (5 replicas at peak vs 4, 67 errors vs 132, EPP queue 2.19 vs
+3.54) and left the collapse-to-one cycle intact.
+
+A ceiling alone cannot stop that cycle. Demand is resident tokens, `λ × W × tokensPerRequest`,
+so it falls when replicas are added: contention drops, residence `W` drops, and the queue
+term — the dominant part at the peak — disappears outright. Supply held flat against a
+shrinking demand reads as abundant spare capacity, and the fleet sheds the replicas that had
+just fixed the problem. At the run's numbers: five replicas at a ~320k bound is 1.6M of
+supply against ~258k of demand once the backlog cleared, so `SC = 1.6M — 258k/0.60 = 1.17M`
+- over three replicas' worth of "spare", acted on in one cycle.
+
+### The correction: capacity at the current operating point
+
+By Little's law a replica at its limit holds `μ × W × tokensPerRequest` tokens, so that
+product IS capacity in the units the engine already speaks, at whatever operating point `W`
+describes:
+
+```go
+capacity = min(ceiling, μ × W × tokensPerRequest)
+```
+
+Demand is `λ × W × tokensPerRequest`, so the ratio becomes `λ / (N × μ)` — it does not
+move when replicas are added, only λ per replica does. The alternative was to rewrite the
+demand term as `(λ/μ) × ceiling`, the same mathematics from the other side, but that changes
+a quantity the optimizer and the role-aggregation path share. This stays inside the flag.
+
+Three properties the implementation depends on:
+
+- **Nothing jumps when it engages.** At calibration λ = μ, so the product equals the
+  occupancy that set the ceiling.
+- **One direction only.** `W` comes from TTFT, which includes time queued, so a backlogged
+  replica reports an inflated `W`. The clamp at the ceiling is not a safety rail — it is what
+  makes the forμla correct while the queue contaminates `W`. After a drain the queue wait is
+  gone, `W` is true service residence, and the scaling is exact.
+- **Bucket-wide, not per-replica.** `FreezeWork` averages the previous cycle's samples across
+  the bucket's replicas and publishes one value at the top of `Analyze`, so the median in
+  `aggregateByVariant` stays a no-op. Averaging rather than folding each sample as it arrives
+  matters: every replica reports at the same timestamp, so folding would give the first
+  replica of the loop the entire weight and make capacity depend on iteration order — a
+  freshly started replica with a short residence could pull the bucket down and drive a
+  spurious scale-up. It costs one cycle of lag.
+
+Three related corrections came with it:
+
+- **Ceilings are recorded only under backlog.** Arrivals reaching the service rate still says
+  the replica is at its limit — that is how the limit is caught before a queue forms — but
+  with no queue, low occupancy means the replica is keeping up, not that its ceiling fell.
+  Recording it ratcheted capacity down on evidence of health.
+- **μ is the mean of backlogged samples, not their running maxiμm.** The ceiling is a running
+  miniμm, so it errs toward less capacity and more replicas; a running maxiμm for μ erred
+  the opposite way and only decayed back slowly. When prompts get heavier within a bucket the
+  true μ falls, and an estimate that can only ratchet up overstates capacity and under-scales.
+  Under backlog the server is never idle, so every sample is a valid reading, and their mean
+  is both the better estimate and the one that moves in either direction.
+- **The ceiling is measured from the instantaneous KV reading**, not `TokensInUse`
+  (`max_over_time(...[1m])`). A running miniμm fed a peak is biased high in the one
+  direction that costs replicas. `KvUsageInstant` is already collected; the older field
+  remains the fallback.
+
+### What this predicts for the round-1 workload
+
+The run completed 39 600 requests (mean λ 22 req/s) on 2.09 average replicas at 0.17% errors,
+so per-replica service rate is about **μ = 22/2.09 ≈ 10.5 req/s** — a throughput identity, not
+an estimate. At N=2 that is ρ ≈ 1.05: throughput fine, queue unbounded, which is exactly the
+measured 140-deep queue and 7.58 s TTFT p99. With `scaleUpThreshold = 0.75` the band is
+`N in [λ/(0.75 μ), λ/(0.60 μ)]`, so at the sustained λ = 24 the fleet settles at
+**3–4 replicas**, and shedding to one would require `λ < 0.6 μ ≈ 6.3 req/s`. The old fixed
+point of 2.09 was not "enough" — it was ρ ≈ 1, reported as 12.9% utilization because a request
+waiting in the queue holds no KV at all.
+
+### Residual risks
+
+- **Mixed time bases.** Demand still uses `TokensInUse`, a 1-minute peak, while capacity uses
+  1-minute average TTFT/ITL. The two `W`s do not cancel exactly and the ratio is biased high
+  — toward more replicas, so safe for this failure, but systematic. Changing the demand term
+  is outside the flag and was deliberately left alone.
+- **The band is only 1.25× wide.** With integer `N` and a noisy λ, a one-replica flap is
+  still possible. Stabilization is not obviated by this fix.
+- **A wrong μ cannot be rescued by any of this**, which is why the instrumentation below
+  blocks the next leg.
+
 ## Validation
 
+0. **Instrumentation, and it blocks everything else.** Round 1 shipped without emitting
+   `k2Source`, μ, λ or the learned ceiling, which is why its result had to be reconstructed
+   from replica timelines. Emit them per variant and role, along with replica demand split
+   into its occupancy, local-queue and rate components, before any further leg.
 1. **Offline** — replay the recorded metrics from the sustained 1000/250 run through
    both estimators and compare `k2` against replica count and queue depth. The
-   prediction: the current estimator plateaus high after each queue drain, the
-   rate-anchored one tracks `λ/μ` and stays bound.
+   prediction: only the operating-point capacity holds its replica count through a queue
+   drain; the occupancy estimator plateaus high after each one.
+
+   Success criteria, fixed in advance: **zero shed-to-one events while λ ≥ 20 req/s** is
+   primary. Average replica count is not, and is expected to rise toward 3–4.
 2. **Cluster** — three legs, KEDA `scaleDown` restored to the shipped
    `Percent 100 / 15s` so the drain cap cannot mask the result, controller restarted
    between legs:

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -122,6 +122,25 @@ are already defined and move with them.
 5. **Tests** — store behaviour (backlog gating, max, decay, eviction), estimator
    arithmetic and clamps, flag-off equivalence with the current path.
 
+## Arrival/completion delay
+
+A completion happens one residence time `W` after the arrival that caused it, so a
+completion-derived μ and an instantaneous λ sit on different time bases. During a
+ramp, completions still reflect the lighter load of `W` ago, and μ/λ reads as
+saturation on a replica that is coping. Occupancy has the same property — it is a
+stock that already integrates arrivals over `W`.
+
+λ is therefore smoothed per replica with an EWMA whose time constant is
+`W = AvgTTFT + AvgOutputTokens × AvgITL`, both already collected. The weight comes
+from the actual gap between samples, so an irregular optimize interval or a missed
+cycle does not distort the average; an average older than
+`ArrivalSmoothingResetFactor × W` is discarded rather than blended. Without latency
+data the rate passes through unsmoothed rather than being averaged by a made-up
+constant.
+
+The backlog path needs none of this: it compares no rates, so it is unaffected by
+the delay. That is a second reason to keep it ahead of the completions fallback.
+
 ## Lambda fallback chain
 
 `saturationRatio` takes the most direct signal available:

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -363,6 +363,12 @@ side is understated while its arrivals still count, which would hold replicas th
 not needed. Partial knowledge is therefore treated as no knowledge and the constraint is
 skipped.
 
+GPU rebalancing overrides the floor. A reclaim happens because another model needs the
+GPUs more, and a variant refusing to give one up because its own traffic wants it is
+precisely the argument prioritisation exists to settle. The floor is a safety net for a
+scale-down nobody asked for, not a veto over one that was — so `reclaimRole` passes
+`overrideRateFloor` and the routine optimizer passes `honorRateFloor`.
+
 For P/D, both roles see the same request stream and each gets its own constraint. A
 prefill replica completes few or no generations, so its service rate comes from prompts
 processed (`vllm:request_prompt_tokens_count`, `sglang:prompt_tokens_histogram_count`)

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -102,10 +102,23 @@ throughput analyzer is enabled, which this plan removes as a dependency.
 | queue | `max_over_time(vllm:num_requests_waiting[1m])` | `QueueLength` | unconditional |
 | KV capacity | `vllm:cache_config_info` | `TotalKvCapacityTokens` | unconditional |
 
-No new PromQL. `QueryRequestRate` moves to a shared registrar called unconditionally
-by the saturation engine (`QueryKvUsageInstant` moves with it, since the throughput
-analyzer needs it and the registrar is shared); the throughput analyzer registers
-them only if absent, so either order works and neither panics.
+One new query, and it is not optional: `QueryQueueLengthInstant`, the waiting-request
+count without `max_over_time`. `QueryQueueLength` is the same counter as a one-minute
+peak, which the demand path wants and a capacity gate cannot use — the peak latches for
+a minute after a queue drains, long enough to record a replica that is now keeping up
+as though it were at its limit. The gate and the measurement have to be read at the
+same instant, so both instantaneous readings are collected.
+
+`QueryRequestRate` moves to a shared registrar called unconditionally by the saturation
+engine (`QueryKvUsageInstant` moves with it, since the throughput analyzer needs it and
+the registrar is shared); the throughput analyzer registers them only if absent, so
+either order works and neither panics.
+
+This is the one part of the change that is not behind the flag: with the estimator off,
+the controller still issues the extra per-pod query each cycle and populates two fields
+nothing reads. The cost is one range query per model per interval, and the alternative —
+registering it from inside a flagged path — would mean the flag could not be flipped
+without a collector restart.
 
 SGLang equivalents (`sglang:generation_tokens_histogram_count`, `sglang:token_usage`)
 are already defined and move with them.

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -165,22 +165,32 @@ Only an idle, never-calibrated replica with no EPP declines, and there is nothin
 at risk in that state. Each source has its own `k2Source` label (`RATE-λ`,
 `RATE-q`, `RATE-c`) so the active path is visible per replica.
 
+## The estimator answers only at or past saturation
+
+Below saturation, `occupancy × μ/λ` is occupancy scaled by *headroom* — a statement
+about slack, not a capacity. It must not be returned, for two reasons:
+
+- **It is not a ceiling**, so it has no business in the capacity store.
+- **`aggregateByVariant` takes the MEDIAN of per-replica capacities.** An idle
+  replica's headroom-scaled number would sit under that median next to a backlogged
+  sibling's genuine ceiling as though the two were commensurable. With one replica
+  queueing twelve deep and one idle sibling, the median rose far enough to turn a
+  scale-up into a scale-down — reintroducing shed-to-one by a new route.
+
+So the estimator declines when `μ/λ > 1`. Nothing is lost: detecting saturation the
+occupancy path misses is the entire purpose, and where a replica genuinely has
+headroom the occupancy path's ceiling is the better answer. Because everything
+returned is now a measured ceiling, the capacity store can learn it unconditionally
+and no separate stored value is needed.
+
 ## What the capacity store learns
 
 `capacityStore` feeds zero-replica estimation, cross-variant `FindCompatible`
 lookups and the fallback path — all of which need a **ceiling**, what a replica can
-do. The rate-anchored value is operating-point-relative, so it is persisted only
-when it is ceiling-like:
-
-- **λ ≥ μ** — the replica is at or past saturation, so `occupancy × μ/λ` is what it
-  actually held. Persisted.
-- **λ < μ** — the same expression is occupancy scaled by headroom. Correct for this
-  cycle's utilization, not a property of the variant. The store keeps the
-  occupancy-based estimate instead; persisting the headroom-scaled value would
-  under-state capacity for a variant that later scales from zero.
-
-`computeReplicaCapacity` therefore tracks `effectiveCapacity` (what this cycle
-scales on) separately from `storedCapacity` (what the store learns).
+do. Since the estimator only answers at or past saturation, every value it produces
+is what the replica actually held under load, so the store learns it directly.
+`MinRateRatio` floors the ratio; there is no upper clamp, because a ratio above 1
+means headroom and the estimator declines instead.
 
 ## Guards
 

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -71,8 +71,12 @@ Properties that matter here:
 - **Does not need a live queue.** Once `μ` is known for a bucket it stays valid
   until the workload shape changes, unlike an occupancy sample which is meaningful
   only at the instant it was taken.
-- **Uses the instantaneous KV reading**, not the 1-minute peak. The peak stays where
-  it belongs — on the demand side, where erring high is deliberate.
+- **Scales by the same occupancy figure demand is built from** (`TokensInUse`).
+  Dividing a max-aggregated demand by an instant-aggregated capacity would inflate
+  utilization by the peak-to-instant spread, so a spiky replica would look more
+  saturated than a steady one at identical load. With both sides on the same
+  aggregation the occupancy term cancels and, with no queue, utilization reduces to
+  λ/μ — which is the whole intent.
 
 ### Why not an ITL model
 
@@ -90,13 +94,14 @@ throughput analyzer is enabled, which this plan removes as a dependency.
 |---|---|---|---|
 | λ arrival rate | `rate(inference_extension_scheduler_attempts_total{status="success"}[1m])` (EPP) | `ArrivalRate` | unconditional |
 | μ completion rate | `rate(vllm:request_generation_tokens_count[1m])` | `RequestRate` | throughput-analyzer only |
-| occupancy (no peak bias) | `vllm:kv_cache_usage_perc` (instant) | `KvUsageInstant` | throughput-analyzer only |
+| occupancy | `max_over_time(vllm:kv_cache_usage_perc[1m])` × capacity | `TokensInUse` | unconditional |
 | queue | `max_over_time(vllm:num_requests_waiting[1m])` | `QueueLength` | unconditional |
 | KV capacity | `vllm:cache_config_info` | `TotalKvCapacityTokens` | unconditional |
 
-No new PromQL. `QueryRequestRate` and `QueryKvUsageInstant` move to a shared
-registrar called unconditionally by the saturation engine; the throughput analyzer
-registers the same two only if absent, so either order works and neither panics.
+No new PromQL. `QueryRequestRate` moves to a shared registrar called unconditionally
+by the saturation engine (`QueryKvUsageInstant` moves with it, since the throughput
+analyzer needs it and the registrar is shared); the throughput analyzer registers
+them only if absent, so either order works and neither panics.
 
 SGLang equivalents (`sglang:generation_tokens_histogram_count`, `sglang:token_usage`)
 are already defined and move with them.
@@ -198,6 +203,16 @@ scales on) separately from `storedCapacity` (what the store learns).
 - **Prompt-token throughput is still not collected.** Useful as a diagnostic to
   confirm the prefill-bound reading of the sustained run; not required by the
   estimator.
+
+## Where the two estimators actually differ
+
+Under a deep backlog they agree: the occupancy path records `TokensInUse` as k2 and
+the rate path's backlog branch returns the same figure. The divergence is entirely
+in the **post-drain** state — queue empty, occupancy collapsed, arrivals unchanged.
+There the occupancy path answers from its inflated history and reports abundant
+spare capacity (the shed-to-one), while the rate path reads λ still at the ceiling
+and holds capacity at the current load. That is the behaviour the cluster legs must
+confirm, and it is pinned by a test at the `computeReplicaCapacity` level.
 
 ## Validation
 

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -35,48 +35,51 @@ against that workload and none of them broke the cycling.
 
 ## Approach
 
-Add a second, **rate-anchored** estimator for `k2`, selected by an internal flag,
-leaving the existing estimator in place and untouched when the flag is off.
+Add a second, **rate-anchored** estimator for `k2`, selected by an internal switch,
+leaving the existing estimator in place and untouched when it is off.
 
-When a replica *cannot keep up*, its completion rate is its service rate — this
-holds whichever resource binds (prefill compute, decode bandwidth, memory), which
-is what makes it the right anchor for a workload-agnostic capacity model:
+The design separates two questions that the occupancy-based estimator conflates:
 
 ```
-μ  = max completion rate for this bucket, observed only while the queue was
-     at least QueueLengthThreshold deep, over ≥ MinServiceRateSamples samples
-λ  = this replica's arrival rate (EPP dispatch rate)
-k2 = KvUsageInstant × TotalKvCapacityTokens × (μ / λ)
+detector:    rates decide WHEN a replica is at its limit
+measurement: tokens record WHAT that limit is
 ```
 
-**μ must be a ceiling, and that has to be established rather than assumed.** With
-no backlog, completions equal arrivals at any load — flow conservation — so an idle
-replica's completion rate carries no information about its limit. If μ were
-recorded from a momentary queue, `μ = λ` would later read as saturation on a
-replica that is merely keeping up comfortably at low occupancy, and the estimator
-would over-provision: the mirror image of the bug it replaces. Hence two gates: a
-queue depth of at least `QueueLengthThreshold` (default 5) to record at all, and
-`MinServiceRateSamples` (2) qualifying observations before a bucket answers.
+A replica is at its limit when it has a backlog at least `QueueLengthThreshold`
+deep, or when its arrival rate has reached the service rate measured while it *was*
+backlogged. At that moment its resident token count is a measurement of the limit.
+That measurement is stored **per workload bucket** — model, accelerator, role,
+request shape — as a running minimum, and every replica of the bucket reads the
+same value.
 
-At `λ = μ` the replica is exactly saturated and `k2` equals its current occupancy,
-so utilization reads 100% **even at 16% KV**. At `λ = μ/2`, `k2` is twice the
-occupancy and utilization reads 50%. The result stays in KV tokens, so `min(k1, k2)`,
-`spareCapacity`, and every downstream consumer are unchanged.
+Two properties follow, and both were learned the hard way from earlier versions of
+this code:
 
-Properties that matter here:
+- **The value is identical across replicas of a variant.** `aggregateByVariant`
+  takes the MEDIAN of per-replica capacities. A number that varied with each
+  replica's own load was not commensurable across siblings: an idle replica's
+  figure blended with a backlogged one's and lifted variant capacity enough to turn
+  a scale-up into a scale-down, reintroducing shed-to-one by a new route. A bucket
+  ceiling makes the median a no-op.
+- **The value does not move with this cycle's load.** A capacity recomputed from
+  the current arrival rate changed every cycle, which is an oscillation waiting to
+  happen. A stored ceiling changes only as the running minimum is lowered by a new
+  measurement or relaxed upward by age — both slow by construction.
 
-- **Blind to which resource binds.** No assumption that the workload is decode-heavy.
-- **Monotone in the right direction.** `μ` is a ceiling measured only under backlog;
-  heavier load cannot inflate it. The current estimator moves the wrong way.
-- **Does not need a live queue.** Once `μ` is known for a bucket it stays valid
-  until the workload shape changes, unlike an occupancy sample which is meaningful
-  only at the instant it was taken.
-- **Scales by the same occupancy figure demand is built from** (`TokensInUse`).
-  Dividing a max-aggregated demand by an instant-aggregated capacity would inflate
-  utilization by the peak-to-instant spread, so a spiky replica would look more
-  saturated than a steady one at identical load. With both sides on the same
-  aggregation the occupancy term cancels and, with no queue, utilization reduces to
-  λ/μ — which is the whole intent.
+Why a limit measured at 16% KV utilization is the whole point: on a prefill-heavy
+workload the engine exhausts prompt-token throughput long before memory, so the
+binding constraint is invisible to an occupancy-only model. The detector notices it
+from rates; the measurement records it in the units the rest of the engine speaks.
+
+### Damping, by construction
+
+- `SaturationEnterRatio` (0.95) means the detector fires just before arrivals cross
+  the service rate, and a lambda hovering at mu does not toggle it between cycles.
+- The service rate is a running maximum with slow decay; the ceiling is a running
+  minimum with slow upward relaxation. Neither tracks a single cycle.
+- `MinServiceRateSamples` keeps one slow interval from establishing a limit.
+- lambda is smoothed over a residence time, so a completion-derived rate and an
+  arrival rate are compared on the same time base.
 
 ### Why not an ITL model
 
@@ -165,32 +168,14 @@ Only an idle, never-calibrated replica with no EPP declines, and there is nothin
 at risk in that state. Each source has its own `k2Source` label (`RATE-λ`,
 `RATE-q`, `RATE-c`) so the active path is visible per replica.
 
-## The estimator answers only at or past saturation
-
-Below saturation, `occupancy × μ/λ` is occupancy scaled by *headroom* — a statement
-about slack, not a capacity. It must not be returned, for two reasons:
-
-- **It is not a ceiling**, so it has no business in the capacity store.
-- **`aggregateByVariant` takes the MEDIAN of per-replica capacities.** An idle
-  replica's headroom-scaled number would sit under that median next to a backlogged
-  sibling's genuine ceiling as though the two were commensurable. With one replica
-  queueing twelve deep and one idle sibling, the median rose far enough to turn a
-  scale-up into a scale-down — reintroducing shed-to-one by a new route.
-
-So the estimator declines when `μ/λ > 1`. Nothing is lost: detecting saturation the
-occupancy path misses is the entire purpose, and where a replica genuinely has
-headroom the occupancy path's ceiling is the better answer. Because everything
-returned is now a measured ceiling, the capacity store can learn it unconditionally
-and no separate stored value is needed.
-
 ## What the capacity store learns
 
 `capacityStore` feeds zero-replica estimation, cross-variant `FindCompatible`
 lookups and the fallback path — all of which need a **ceiling**, what a replica can
-do. Since the estimator only answers at or past saturation, every value it produces
-is what the replica actually held under load, so the store learns it directly.
-`MinRateRatio` floors the ratio; there is no upper clamp, because a ratio above 1
-means headroom and the estimator declines instead.
+do. Everything this estimator produces is a limit measured under load, so the store
+learns it directly. `MinRateAnchoredFraction` floors it so a stalled replica cannot
+teach the bucket a near-zero capacity; there is no upper clamp, because `min(k1, k2)`
+already prevents a compute bound from exceeding the memory bound.
 
 ## Guards
 

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -149,38 +149,32 @@ constant.
 The backlog path needs none of this: it compares no rates, so it is unaffected by
 the delay. That is a second reason to keep it ahead of the completions fallback.
 
-## Lambda fallback chain
+## Detector inputs, in order
 
-`saturationRatio` takes the most direct signal available:
+1. **Backlog** — a queue at least `QueueLengthThreshold` deep. Needs no rates at all,
+   which makes it the safety net for a fleet with no EPP and no prior calibration,
+   and it is exactly the prefill-heavy case the occupancy estimator misreads as idle.
+   A shallower queue does not qualify: arrival jitter produces one at any load.
+2. **Arrivals reaching the service rate** — λ from the EPP dispatch rate, smoothed
+   over a residence time, against the bucket's μ at `SaturationEnterRatio`. This
+   catches the limit before a queue forms.
+3. **Completions as λ** — without EPP, and only when there is no queue, completions
+   are arrivals. Invalid under backlog, which is why it sits behind that check.
 
-1. **EPP arrival rate** (`k2SrcRateAnchored`) — the intended path. λ is measured
-   independently of the engine, so μ/λ holds whether or not the replica keeps up.
-2. **Backlog** (`k2SrcRateBacklog`) — a queueing replica is saturated by
-   observation, so the ratio is 1 and capacity is the current occupancy. Needs
-   neither λ nor a calibrated μ, which makes it the safety net for a fleet with no
-   EPP and no prior calibration — and it is exactly the prefill-heavy case the
-   occupancy estimator misreads as idle.
-3. **Completions as λ** (`k2SrcRateNoEPP`) — with no queue, everything arriving is
-   served within the scrape window, so completions are arrivals. Valid only in that
-   case, which is why it sits behind the backlog check.
-
-Only an idle, never-calibrated replica with no EPP declines, and there is nothing
-at risk in that state. Each source has its own `k2Source` label (`RATE-λ`,
-`RATE-q`, `RATE-c`) so the active path is visible per replica.
-
-## What the capacity store learns
-
-`capacityStore` feeds zero-replica estimation, cross-variant `FindCompatible`
-lookups and the fallback path — all of which need a **ceiling**, what a replica can
-do. Everything this estimator produces is a limit measured under load, so the store
-learns it directly. `MinRateAnchoredFraction` floors it so a stalled replica cannot
-teach the bucket a near-zero capacity; there is no upper clamp, because `min(k1, k2)`
-already prevents a compute bound from exceeding the memory bound.
+The two `k2Source` labels do **not** identify which of these fired; they distinguish
+a limit measured this cycle (`RATE-now`) from one carried over from an earlier one
+(`RATE-learned`), which is what the offline replay needs to tell apart. A replica
+declines only when nothing has been learned for its bucket and it is not at its limit
+now — a state in which nothing is at risk.
 
 ## Guards
 
 - Require `KvUsageInstant > 0` and a usable ratio; otherwise decline and fall through.
-- Clamp `μ/λ` to `[0.05, 20]` so a mis-scraped rate cannot swing capacity wildly.
+- `MinRateRatio` floors the ratio a mis-scraped rate can produce; there is no upper
+  clamp, since `min(k1, k2)` already bounds the compute estimate by the memory one.
+- Both stores prune themselves on insert past `BucketPruneThreshold`, because nothing
+  in the engine drives eviction for the analyzer's other stores either — a store that
+  relied on being swept would grow unbounded the moment the flag was flipped.
 - Never exceed `k1`: `min(k1, k2)` already handles this, but the estimator also
   refuses to return a value below a floor fraction of `k1` to avoid a stalled
   replica collapsing capacity to near zero.

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -280,6 +280,42 @@ measured 140-deep queue and 7.58 s TTFT p99. With `scaleUpThreshold = 0.75` the 
 point of 2.09 was not "enough" — it was ρ ≈ 1, reported as 12.9% utilization because a request
 waiting in the queue holds no KV at all.
 
+### Reading the limit, and reading it early
+
+Two rules decide when a replica is at its limit, and they are read on one time base.
+`QueueLength` and `TokensInUse` are collected as `max_over_time(...[1m])`, so the peak
+latches for a minute; `QueryQueueLengthInstant` and `KvUsageInstant` are point samples.
+Pairing a latched gate with a point sample is what let a drained replica be recorded as
+its own limit, collapsing the ceiling to its floor. `limitEvidence` pairs them
+explicitly — instantaneous with instantaneous, or the one-minute peak of both.
+
+Only a replica that is both backlogged **and** completing work may define a ceiling,
+and lowering one takes `MinCeilingLowerCycles` consecutive cycles of agreement. A pod
+that has just become ready takes a routed burst before its cache fills; a stalled pod
+queues without completing anything. Either looks backlogged at almost zero occupancy,
+and since the ceiling is a minimum across the bucket, either would set capacity for
+every healthy sibling.
+
+Arrivals reaching the service rate is not a measurement of the limit — with no queue,
+low occupancy means the replica is keeping up — but it is a reliable signal that the
+limit has been reached. Capacity is then held at the current occupancy, so demand meets
+it and the fleet scales **before** a queue forms. That matters more than it looks: a
+replica takes about ninety seconds from decision to serving, so the backlog that builds
+during a scale-up is set by how early the decision was made, not by how fast the loop
+runs afterward.
+
+### The bucket key is a property of the variant
+
+The shape that keys a bucket is averaged across the variant's replicas. Replicas of one
+variant serve the same traffic, so their per-replica averages differ only by sampling
+noise — but that noise is enough to put two siblings either side of a threshold, where
+they learn independent ceilings and service rates. `aggregateByVariant` takes the MEDIAN
+of per-replica capacities, so those two figures get blended even though they measure
+different things, and a variant sitting near a threshold flips its estimate every cycle
+as replicas drift across it. Input and output thresholds are also separate now: prompts
+run an order of magnitude longer than generations, and bucketing input at the output
+thresholds put almost every real workload in one bucket.
+
 ### Residual risks
 
 - **Mixed time bases.** Demand still uses `TokensInUse`, a 1-minute peak, while capacity uses

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -329,6 +329,39 @@ as replicas drift across it. Input and output thresholds are also separate now: 
 run an order of magnitude longer than generations, and bucketing input at the output
 thresholds put almost every real workload in one bucket.
 
+### Residence must be service time
+
+The operating point is `mu x W x tokensPerRequest`, and `W` has to be the time a request
+spends *being served*. Reading it as `TTFT + outputTokens x ITL` does not give that:
+TTFT is measured from arrival at the engine, so it carries time queued.
+
+The validation runs made the consequence visible. `RATE-W` — the only label under which
+capacity is scaled below the learned ceiling, and so the only mechanism that can prevent
+the post-drain shed — fired **once in thirty-five minutes** on prefill-heavy traffic
+against **twenty-seven times** on symmetric traffic in the same build. Under backlog the
+inflated `W` pushes `mu x W x tokensPerRequest` past the ceiling, the clamp holds capacity
+there, and the ceiling on that workload is measured while a one or two replica fleet sits
+at near-full KV — so it lands at the memory bound, which is what the occupancy path
+already returns. ON and OFF producing the same numbers follows from that.
+
+The decode half was never contaminated: inter-token latency contains no queue wait. Only
+prefill is, and it can be measured directly, because during a cycle with nothing queued
+TTFT *is* prefill. Buckets learn it then and reuse it when the queue is deep, retaining it
+for the bucket's lifetime rather than the service-rate window — prefill is a property of
+model, hardware and prompt length, all of which are in the bucket key, and it can only be
+observed in the unqueued cycles a busy fleet does not have.
+
+Where vLLM publishes `request_inference_time_seconds` (time in the RUNNING phase, queue
+wait already excluded) that is preferred outright, since the derived prefill is sampled
+uncontended while real prefill grows under load. SGLang publishes no equivalent among its
+seventeen metrics, so it takes the derived path, which needs nothing not already
+collected.
+
+Worth knowing where the derived form is weakest: long prompts with short generations,
+where prefill dominates residence rather than being a couple of per cent of it. It
+understates residence there, therefore understates capacity, therefore asks for more
+replicas rather than fewer — the tolerable direction, and the case the vLLM metric covers.
+
 ### The scale-down floor
 
 Capacity estimation alone cannot make a scale-down safe, because the decision is a

--- a/docs/plans/engine/rate-anchored-k2.md
+++ b/docs/plans/engine/rate-anchored-k2.md
@@ -38,15 +38,25 @@ against that workload and none of them broke the cycling.
 Add a second, **rate-anchored** estimator for `k2`, selected by an internal flag,
 leaving the existing estimator in place and untouched when the flag is off.
 
-When a replica has a backlog, its completion rate *is* its service rate — this
+When a replica *cannot keep up*, its completion rate is its service rate — this
 holds whichever resource binds (prefill compute, decode bandwidth, memory), which
 is what makes it the right anchor for a workload-agnostic capacity model:
 
 ```
-μ  = max completion rate observed for this workload bucket while QueueLength > 0
+μ  = max completion rate for this bucket, observed only while the queue was
+     at least QueueLengthThreshold deep, over ≥ MinServiceRateSamples samples
 λ  = this replica's arrival rate (EPP dispatch rate)
 k2 = KvUsageInstant × TotalKvCapacityTokens × (μ / λ)
 ```
+
+**μ must be a ceiling, and that has to be established rather than assumed.** With
+no backlog, completions equal arrivals at any load — flow conservation — so an idle
+replica's completion rate carries no information about its limit. If μ were
+recorded from a momentary queue, `μ = λ` would later read as saturation on a
+replica that is merely keeping up comfortably at low occupancy, and the estimator
+would over-provision: the mirror image of the bug it replaces. Hence two gates: a
+queue depth of at least `QueueLengthThreshold` (default 5) to record at all, and
+`MinServiceRateSamples` (2) qualifying observations before a bucket answers.
 
 At `λ = μ` the replica is exactly saturated and `k2` equals its current occupancy,
 so utilization reads 100% **even at 16% KV**. At `λ = μ/2`, `k2` is twice the

--- a/internal/collector/engine_queries.go
+++ b/internal/collector/engine_queries.go
@@ -37,8 +37,14 @@ var engineSpecificReplicaQueries = []string{
 // agnosticReplicaQueries are the logical query names collected per replica whose
 // metric source is engine-independent (the EPP inference scheduler). They are
 // refreshed once and shared across engines.
+//
+// QueryInferenceTime sits here for a different reason: it is vLLM-only, and no engine
+// prefix is wanted for it. Listing it as engine-specific would oblige an SGLang form
+// that does not exist; left here, the bare query returns nothing on SGLang and the
+// analyzer derives the value instead.
 var agnosticReplicaQueries = []string{
 	registration.QuerySchedulerDispatchRate,
+	registration.QueryInferenceTime,
 }
 
 // buildEngineQueryList returns the physical query names to refresh for the given

--- a/internal/collector/engine_queries.go
+++ b/internal/collector/engine_queries.go
@@ -30,6 +30,7 @@ var engineSpecificReplicaQueries = []string{
 	registration.QueryGenerationTokenRate,
 	registration.QueryKvUsageInstant,
 	registration.QueryQueueLengthInstant,
+	registration.QueryPromptTokenRate,
 	registration.QueryRequestRate,
 }
 

--- a/internal/collector/engine_queries.go
+++ b/internal/collector/engine_queries.go
@@ -29,6 +29,7 @@ var engineSpecificReplicaQueries = []string{
 	registration.QueryAvgITL,
 	registration.QueryGenerationTokenRate,
 	registration.QueryKvUsageInstant,
+	registration.QueryQueueLengthInstant,
 	registration.QueryRequestRate,
 }
 

--- a/internal/collector/registration/engine.go
+++ b/internal/collector/registration/engine.go
@@ -32,6 +32,7 @@ var EngineSpecificQueries = []string{
 	QueryGenerationTokenRate,
 	QueryKvUsageInstant,
 	QueryQueueLengthInstant,
+	QueryPromptTokenRate,
 	QueryRequestRate,
 	QueryModelRequestCount,
 }

--- a/internal/collector/registration/engine.go
+++ b/internal/collector/registration/engine.go
@@ -31,6 +31,7 @@ var EngineSpecificQueries = []string{
 	QueryAvgITL,
 	QueryGenerationTokenRate,
 	QueryKvUsageInstant,
+	QueryQueueLengthInstant,
 	QueryRequestRate,
 	QueryModelRequestCount,
 }

--- a/internal/collector/registration/engine_test.go
+++ b/internal/collector/registration/engine_test.go
@@ -38,6 +38,7 @@ var _ = Describe("SGLang query registration", func() {
 		RegisterSaturationQueries(registry)
 		RegisterQueueingModelQueries(registry)
 		RegisterThroughputAnalyzerQueries(registry)
+		RegisterRateCapacityQueries(registry)
 		RegisterScaleToZeroQueries(registry)
 	})
 

--- a/internal/collector/registration/rate_capacity.go
+++ b/internal/collector/registration/rate_capacity.go
@@ -29,8 +29,10 @@ func RegisterRateCapacityQueries(sourceRegistry *source.SourceRegistry) {
 	registry := metricsSource.QueryList()
 
 	registerIfAbsent(registry, kvUsageInstantQuery())
+	registerIfAbsent(registry, queueLengthInstantQuery())
 	registerIfAbsent(registry, requestRateQuery())
 	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangKvUsageInstantQuery())
+	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangQueueLengthInstantQuery())
 	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangRequestRateQuery())
 }
 
@@ -65,6 +67,35 @@ func kvUsageInstantQuery() source.QueryTemplate {
 		Template:    `max by (instance, pod, llm_d_ai_variant) (vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Instantaneous KV cache utilization per pod (0.0–1.0); operating point for capacity estimation",
+	}
+}
+
+// queueLengthInstantQuery is the per-pod count of requests waiting right now.
+//
+// QueryQueueLength is the same counter under max_over_time(...[1m]), which the demand
+// path wants: erring high on how much work is outstanding is the safe direction. A
+// capacity estimator cannot use it, because the peak latches for a full minute after
+// a queue drains — long enough to record occupancy from a replica that is now keeping
+// up comfortably and call it the occupancy at which the replica could not keep up.
+// The gate and the measurement have to be read at the same instant.
+func queueLengthInstantQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name:        QueryQueueLengthInstant,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (vllm:num_requests_waiting{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Requests waiting per pod right now; the gate for capacity measurement",
+	}
+}
+
+// sglangQueueLengthInstantQuery is the SGLang form of queueLengthInstantQuery.
+func sglangQueueLengthInstantQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name:        QueryQueueLengthInstant,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (sglang:num_queue_reqs{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Requests waiting per pod right now; the gate for capacity measurement (SGLang)",
 	}
 }
 

--- a/internal/collector/registration/rate_capacity.go
+++ b/internal/collector/registration/rate_capacity.go
@@ -31,9 +31,11 @@ func RegisterRateCapacityQueries(sourceRegistry *source.SourceRegistry) {
 	registerIfAbsent(registry, kvUsageInstantQuery())
 	registerIfAbsent(registry, queueLengthInstantQuery())
 	registerIfAbsent(registry, requestRateQuery())
+	registerIfAbsent(registry, promptTokenRateQuery())
 	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangKvUsageInstantQuery())
 	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangQueueLengthInstantQuery())
 	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangRequestRateQuery())
+	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangPromptTokenRateQuery())
 }
 
 // registerIfAbsent registers tmpl unless a query of that name already exists.
@@ -111,6 +113,34 @@ func requestRateQuery() source.QueryTemplate {
 		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Request completion rate per pod (req/s); service rate under backlog, fallback for λ_dec without EPP",
+	}
+}
+
+// promptTokenRateQuery is the per-pod rate of prompts processed (req/s), from the
+// prompt-tokens histogram _count, which increments once per prefilled request.
+//
+// A prefill replica in a disaggregated deployment completes few or no generations,
+// so the generation-tokens counter that measures a decode replica's service rate
+// says nothing about it. Prompts processed is the same quantity for the prefill
+// role, and the counter is already collected for average input tokens.
+func promptTokenRateQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name:        QueryPromptTokenRate,
+		Type:        source.QueryTypePromQL,
+		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_prompt_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Prompts processed per pod (req/s); service rate of a prefill replica",
+	}
+}
+
+// sglangPromptTokenRateQuery is the SGLang form of promptTokenRateQuery.
+func sglangPromptTokenRateQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name:        QueryPromptTokenRate,
+		Type:        source.QueryTypePromQL,
+		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(sglang:prompt_tokens_histogram_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Prompts processed per pod (req/s); service rate of a prefill replica (SGLang)",
 	}
 }
 

--- a/internal/collector/registration/rate_capacity.go
+++ b/internal/collector/registration/rate_capacity.go
@@ -32,6 +32,7 @@ func RegisterRateCapacityQueries(sourceRegistry *source.SourceRegistry) {
 	registerIfAbsent(registry, queueLengthInstantQuery())
 	registerIfAbsent(registry, requestRateQuery())
 	registerIfAbsent(registry, promptTokenRateQuery())
+	registerIfAbsent(registry, inferenceTimeQuery())
 	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangKvUsageInstantQuery())
 	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangQueueLengthInstantQuery())
 	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangRequestRateQuery())
@@ -141,6 +142,27 @@ func sglangPromptTokenRateQuery() source.QueryTemplate {
 		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(sglang:prompt_tokens_histogram_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Prompts processed per pod (req/s); service rate of a prefill replica (SGLang)",
+	}
+}
+
+// inferenceTimeQuery is the average seconds a request spends in the RUNNING phase —
+// being served, with time queued excluded.
+//
+// This is the residence Little's law needs, measured rather than derived. It is
+// deliberately NOT in EngineSpecificQueries and has no SGLang form, because SGLang
+// publishes nothing equivalent: its seventeen metrics expose end-to-end latency, time
+// to first token and time per output token, all of which either include queue wait or
+// cover only part of the request. Left engine-agnostic, the bare query simply returns
+// nothing on an SGLang fleet and serviceResidence derives the figure instead.
+func inferenceTimeQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name: QueryInferenceTime,
+		Type: source.QueryTypePromQL,
+		Template: `max by (instance, pod, llm_d_ai_variant) (` +
+			`rate(vllm:request_inference_time_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / ` +
+			`rate(vllm:request_inference_time_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Seconds per request in the RUNNING phase, queue wait excluded (vLLM only)",
 	}
 }
 

--- a/internal/collector/registration/rate_capacity.go
+++ b/internal/collector/registration/rate_capacity.go
@@ -1,0 +1,106 @@
+// Package registration provides query registration for metrics sources.
+// This file holds the per-pod rate queries shared by the V2 saturation analyzer's
+// rate-anchored capacity estimator and the throughput analyzer.
+package registration
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+)
+
+// RegisterRateCapacityQueries registers the per-pod rate queries the V2 saturation
+// analyzer needs for rate-anchored capacity: the request completion rate (mu) and
+// the instantaneous KV utilization.
+//
+// Both were originally registered by RegisterThroughputAnalyzerQueries, which runs
+// only when the throughput analyzer is enabled. The rate-anchored capacity estimator
+// must not depend on that analyzer, so the definitions live here and both registrars
+// use the register-if-absent helpers below. Either may run first, and running both
+// is a no-op for the shared queries rather than a duplicate-registration panic.
+func RegisterRateCapacityQueries(sourceRegistry *source.SourceRegistry) {
+	metricsSource := sourceRegistry.Get("prometheus")
+	if metricsSource == nil {
+		ctrl.Log.V(logging.DEBUG).Info("Prometheus source not registered, skipping rate capacity query registration")
+		return
+	}
+	registry := metricsSource.QueryList()
+
+	registerIfAbsent(registry, kvUsageInstantQuery())
+	registerIfAbsent(registry, requestRateQuery())
+	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangKvUsageInstantQuery())
+	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangRequestRateQuery())
+}
+
+// registerIfAbsent registers tmpl unless a query of that name already exists.
+// Unlike MustRegister it does not panic on a second registration, which is what
+// allows two independent registrars to declare the same shared query.
+func registerIfAbsent(registry *source.QueryList, tmpl source.QueryTemplate) {
+	if registry.Get(tmpl.Name) != nil {
+		return
+	}
+	registry.MustRegister(tmpl)
+}
+
+// registerForEngineIfAbsent is registerIfAbsent for an engine-scoped query name.
+// engine is a parameter rather than a constant so a second engine can be added
+// without reshaping the call sites, matching registerForEngine.
+func registerForEngineIfAbsent(registry *source.QueryList, engine inferenceengine.Engine, tmpl source.QueryTemplate) { //nolint:unparam // mirrors registerForEngine; more engines are expected
+	tmpl.Name = EngineQuery(engine, tmpl.Name)
+	registerIfAbsent(registry, tmpl)
+}
+
+// kvUsageInstantQuery is the per-pod instantaneous KV cache utilization (0.0–1.0).
+//
+// Deliberately NOT max_over_time: the saturation analyzer's demand path wants the
+// 1-minute peak (erring high is the safe direction for demand), while a capacity
+// estimate anchored on a peak over-states what the replica can hold. Both readings
+// of the same underlying metric are needed, for opposite purposes.
+func kvUsageInstantQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name:        QueryKvUsageInstant,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Instantaneous KV cache utilization per pod (0.0–1.0); operating point for capacity estimation",
+	}
+}
+
+// requestRateQuery is the per-pod request completion rate (req/s), derived from the
+// generation-tokens histogram _count, which increments once per completed request.
+//
+// While a replica has a backlog its completion rate is its service rate, whichever
+// resource binds — that is what makes it usable as mu for capacity estimation.
+func requestRateQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name:        QueryRequestRate,
+		Type:        source.QueryTypePromQL,
+		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Request completion rate per pod (req/s); service rate under backlog, fallback for λ_dec without EPP",
+	}
+}
+
+// sglangKvUsageInstantQuery is the SGLang form of kvUsageInstantQuery.
+func sglangKvUsageInstantQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name:        QueryKvUsageInstant,
+		Type:        source.QueryTypePromQL,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (sglang:token_usage{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Instantaneous KV cache utilization per pod (0.0–1.0); operating point for capacity estimation (SGLang)",
+	}
+}
+
+// sglangRequestRateQuery is the SGLang form of requestRateQuery.
+func sglangRequestRateQuery() source.QueryTemplate {
+	return source.QueryTemplate{
+		Name:        QueryRequestRate,
+		Type:        source.QueryTypePromQL,
+		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(sglang:generation_tokens_histogram_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Description: "Request completion rate per pod (req/s); service rate under backlog, fallback for λ_dec without EPP (SGLang)",
+	}
+}

--- a/internal/collector/registration/rate_capacity_test.go
+++ b/internal/collector/registration/rate_capacity_test.go
@@ -22,7 +22,8 @@ var _ = Describe("RegisterRateCapacityQueries", func() {
 		registry *source.SourceRegistry
 	)
 
-	shared := []string{QueryKvUsageInstant, QueryQueueLengthInstant, QueryRequestRate}
+	shared := []string{QueryKvUsageInstant, QueryQueueLengthInstant, QueryRequestRate,
+		QueryPromptTokenRate, QueryInferenceTime}
 
 	withPrometheus := func() *source.QueryList {
 		metricsSource := prometheus.NewPrometheusSource(ctx, &mockPrometheusAPI{},
@@ -43,9 +44,14 @@ var _ = Describe("RegisterRateCapacityQueries", func() {
 		for _, name := range shared {
 			Expect(queryList.Get(name)).NotTo(BeNil(), name)
 		}
-		for _, name := range []string{QueryKvUsageInstant, QueryQueueLengthInstant, QueryRequestRate} {
+		for _, name := range []string{QueryKvUsageInstant, QueryQueueLengthInstant,
+			QueryRequestRate, QueryPromptTokenRate} {
 			Expect(queryList.Get(EngineQuery(inferenceengine.EngineSGLang, name))).NotTo(BeNil(), name)
 		}
+		// Deliberately vLLM-only: SGLang publishes nothing that measures time in the
+		// running phase, so the bare query returns nothing there and the analyzer
+		// derives the value instead.
+		Expect(IsEngineSpecific(QueryInferenceTime)).To(BeFalse())
 	})
 
 	It("tolerates the throughput analyzer registering first", func() {

--- a/internal/collector/registration/rate_capacity_test.go
+++ b/internal/collector/registration/rate_capacity_test.go
@@ -1,0 +1,83 @@
+package registration
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
+)
+
+// The rate-anchored capacity estimator and the throughput analyzer both need the
+// per-pod rate queries, and either registrar may run first. That is the whole reason
+// the shared definitions moved here and both switched to register-if-absent, so it is
+// worth pinning: a rebase that put one of them back on MustRegister would panic the
+// controller at startup, and nothing else in the suite would catch it.
+var _ = Describe("RegisterRateCapacityQueries", func() {
+	var (
+		ctx      context.Context
+		registry *source.SourceRegistry
+	)
+
+	shared := []string{QueryKvUsageInstant, QueryQueueLengthInstant, QueryRequestRate}
+
+	withPrometheus := func() *source.QueryList {
+		metricsSource := prometheus.NewPrometheusSource(ctx, &mockPrometheusAPI{},
+			prometheus.DefaultPrometheusSourceConfig())
+		Expect(registry.Register("prometheus", metricsSource)).To(Succeed())
+		return metricsSource.QueryList()
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		registry = source.NewSourceRegistry()
+	})
+
+	It("registers the queries the estimator depends on", func() {
+		queryList := withPrometheus()
+		RegisterRateCapacityQueries(registry)
+
+		for _, name := range shared {
+			Expect(queryList.Get(name)).NotTo(BeNil(), name)
+		}
+		for _, name := range []string{QueryKvUsageInstant, QueryQueueLengthInstant, QueryRequestRate} {
+			Expect(queryList.Get(EngineQuery(inferenceengine.EngineSGLang, name))).NotTo(BeNil(), name)
+		}
+	})
+
+	It("tolerates the throughput analyzer registering first", func() {
+		queryList := withPrometheus()
+		RegisterThroughputAnalyzerQueries(registry)
+
+		Expect(func() { RegisterRateCapacityQueries(registry) }).NotTo(Panic())
+		for _, name := range shared {
+			Expect(queryList.Get(name)).NotTo(BeNil(), name)
+		}
+	})
+
+	It("tolerates registering first itself", func() {
+		queryList := withPrometheus()
+		RegisterRateCapacityQueries(registry)
+
+		Expect(func() { RegisterThroughputAnalyzerQueries(registry) }).NotTo(Panic())
+		for _, name := range shared {
+			Expect(queryList.Get(name)).NotTo(BeNil(), name)
+		}
+	})
+
+	It("leaves the first registration in place rather than replacing it", func() {
+		queryList := withPrometheus()
+		RegisterRateCapacityQueries(registry)
+		before := queryList.Get(QueryRequestRate).Template
+
+		RegisterRateCapacityQueries(registry)
+		Expect(queryList.Get(QueryRequestRate).Template).To(Equal(before))
+	})
+
+	It("is a no-op when there is no prometheus source", func() {
+		Expect(func() { RegisterRateCapacityQueries(registry) }).NotTo(Panic())
+	})
+})

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -115,33 +115,11 @@ func RegisterThroughputAnalyzerQueries(sourceRegistry *source.SourceRegistry) {
 		Description: "Observed generation (decode) token rate per pod (tokens/sec), proxy for μ_dec^obs",
 	})
 
-	// Per-pod instantaneous KV cache utilization (0.0–1.0).
-	// Does NOT use max_over_time: the throughput analyzer needs the current
-	// operating point k*, not the worst-case peak used by the saturation analyzer.
-	// Preserves instance (IP:port for composite key), pod (for pod lookup),
-	// and llm_d_ai_variant (for direct pod-to-VA mapping).
-	registry.MustRegister(source.QueryTemplate{
-		Name:        QueryKvUsageInstant,
-		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
-		Params:      []string{source.ParamNamespace, source.ParamModelID},
-		Description: "Instantaneous KV cache utilization per pod (0.0–1.0), used as k* in the ITL model",
-	})
-
-	// Per-pod vLLM request completion rate (req/s).
-	// Derived from the generation tokens histogram _count (increments once per
-	// completed request). Used as a fallback for λ_dec when EPP/scheduler metrics
-	// are unavailable; per variant V, the analyzer falls back to:
-	//   λ_dec_fallback = Σ_{r∈V}(RequestRate_r × AvgOutputTokens_r)
-	// Preserves instance (IP:port for composite key), pod (for pod lookup),
-	// and llm_d_ai_variant (for direct pod-to-VA mapping).
-	registry.MustRegister(source.QueryTemplate{
-		Name:        QueryRequestRate,
-		Type:        source.QueryTypePromQL,
-		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
-		Params:      []string{source.ParamNamespace, source.ParamModelID},
-		Description: "vLLM request completion rate per pod (req/s); fallback for λ_dec when EPP metrics are unavailable",
-	})
+	// Shared with the V2 saturation analyzer's rate-anchored capacity estimator,
+	// which registers them unconditionally. Whichever registrar runs first wins;
+	// the second is a no-op. See registration/rate_capacity.go.
+	registerIfAbsent(registry, kvUsageInstantQuery())
+	registerIfAbsent(registry, requestRateQuery())
 
 	registerSGLangThroughputAnalyzerQueries(registry)
 }
@@ -159,21 +137,6 @@ func registerSGLangThroughputAnalyzerQueries(registry *source.QueryList) {
 		Description: "Observed generation (decode) token rate per pod (tokens/sec), proxy for μ_dec^obs (SGLang)",
 	})
 
-	// Per-pod instantaneous KV cache utilization (0.0-1.0), no max_over_time.
-	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
-		Name:        QueryKvUsageInstant,
-		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (sglang:token_usage{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
-		Params:      []string{source.ParamNamespace, source.ParamModelID},
-		Description: "Instantaneous KV cache utilization per pod (0.0-1.0), used as k* in the ITL model (SGLang)",
-	})
-
-	// Per-pod request completion rate (req/s) from the generation histogram count.
-	registerForEngine(registry, inferenceengine.EngineSGLang, source.QueryTemplate{
-		Name:        QueryRequestRate,
-		Type:        source.QueryTypePromQL,
-		Template:    `sum by (instance, pod, llm_d_ai_variant) (rate(sglang:generation_tokens_histogram_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
-		Params:      []string{source.ParamNamespace, source.ParamModelID},
-		Description: "Request completion rate per pod (req/s); fallback for λ_dec when EPP metrics are unavailable (SGLang)",
-	})
+	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangKvUsageInstantQuery())
+	registerForEngineIfAbsent(registry, inferenceengine.EngineSGLang, sglangRequestRateQuery())
 }

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -62,6 +62,10 @@ const (
 	// service rate of a prefill replica.
 	QueryPromptTokenRate = "prompt_token_rate"
 
+	// QueryInferenceTime is the query name for average time a request spends being
+	// served, excluding time queued. vLLM only — see inferenceTimeQuery.
+	QueryInferenceTime = "inference_time"
+
 	// QueryRequestRate is the query name for the engine-side request completion
 	// rate per pod (req/s), derived from the generation tokens histogram count.
 	// It is engine-agnostic: the vLLM variant reads

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -53,6 +53,11 @@ const (
 	// Source: vllm:kv_cache_usage_perc (gauge)
 	QueryKvUsageInstant = "kv_usage_instant"
 
+	// QueryQueueLengthInstant is the query name for the instantaneous count of
+	// requests waiting on a replica, as opposed to QueryQueueLength which is that
+	// count's peak over the last minute.
+	QueryQueueLengthInstant = "queue_length_instant"
+
 	// QueryRequestRate is the query name for the engine-side request completion
 	// rate per pod (req/s), derived from the generation tokens histogram count.
 	// It is engine-agnostic: the vLLM variant reads

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -58,6 +58,10 @@ const (
 	// count's peak over the last minute.
 	QueryQueueLengthInstant = "queue_length_instant"
 
+	// QueryPromptTokenRate is the query name for per-pod prompt-processing rate, the
+	// service rate of a prefill replica.
+	QueryPromptTokenRate = "prompt_token_rate"
+
 	// QueryRequestRate is the query name for the engine-side request completion
 	// rate per pod (req/s), derived from the generation tokens histogram count.
 	// It is engine-agnostic: the vLLM variant reads

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -421,6 +421,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		generationTokenRate float64
 		kvUsageInstant      float64
 		queueLengthInstant  float64
+		promptTokenRate     float64
 		hasQueueInstant     bool
 		requestRate         float64
 	}
@@ -839,6 +840,21 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 	}
 
+	// Process prompt-processing rate (req/s) — service rate of a prefill replica
+	if result := results[registration.QueryPromptTokenRate]; result != nil {
+		if !result.HasError() {
+			for _, value := range result.Values {
+				instanceKey, _, _ := c.buildInstanceKey(ctx, namespace, value.Labels)
+				if instanceKey == "" || podData[instanceKey] == nil {
+					continue
+				}
+				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 {
+					podData[instanceKey].promptTokenRate = value.Value
+				}
+			}
+		}
+	}
+
 	// Process engine request completion rate (req/s) — throughput analyzer fallback λ_req
 	if result := results[registration.QueryRequestRate]; result != nil {
 		if !result.HasError() {
@@ -1020,6 +1036,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			GenerationTokenRate:   data.generationTokenRate,
 			KvUsageInstant:        data.kvUsageInstant,
 			QueueLengthInstant:    data.queueLengthInstant,
+			PromptTokenRate:       data.promptTokenRate,
 			HasQueueLengthInstant: data.hasQueueInstant,
 			RequestRate:           data.requestRate,
 			Metadata: &domain.ReplicaMetricsMetadata{

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -422,6 +422,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		kvUsageInstant      float64
 		queueLengthInstant  float64
 		promptTokenRate     float64
+		inferenceTime       float64
 		hasQueueInstant     bool
 		requestRate         float64
 	}
@@ -840,6 +841,21 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 	}
 
+	// Process time-in-RUNNING per request (s) — residence with queue wait excluded
+	if result := results[registration.QueryInferenceTime]; result != nil {
+		if !result.HasError() {
+			for _, value := range result.Values {
+				instanceKey, _, _ := c.buildInstanceKey(ctx, namespace, value.Labels)
+				if instanceKey == "" || podData[instanceKey] == nil {
+					continue
+				}
+				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value > 0 {
+					podData[instanceKey].inferenceTime = value.Value
+				}
+			}
+		}
+	}
+
 	// Process prompt-processing rate (req/s) — service rate of a prefill replica
 	if result := results[registration.QueryPromptTokenRate]; result != nil {
 		if !result.HasError() {
@@ -1037,6 +1053,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			KvUsageInstant:        data.kvUsageInstant,
 			QueueLengthInstant:    data.queueLengthInstant,
 			PromptTokenRate:       data.promptTokenRate,
+			AvgInferenceTime:      data.inferenceTime,
 			HasQueueLengthInstant: data.hasQueueInstant,
 			RequestRate:           data.requestRate,
 			Metadata: &domain.ReplicaMetricsMetadata{

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -420,6 +420,8 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		// Throughput analyzer fields
 		generationTokenRate float64
 		kvUsageInstant      float64
+		queueLengthInstant  float64
+		hasQueueInstant     bool
 		requestRate         float64
 	}
 
@@ -818,6 +820,25 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 	}
 
+	// Process instantaneous waiting-request count — the gate for capacity measurement
+	if result := results[registration.QueryQueueLengthInstant]; result != nil {
+		if !result.HasError() {
+			for _, value := range result.Values {
+				instanceKey, _, _ := c.buildInstanceKey(ctx, namespace, value.Labels)
+				if instanceKey == "" {
+					continue
+				}
+				if podData[instanceKey] == nil {
+					continue // skip pods the KV/queue queries didn't see (scrape skew)
+				}
+				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 {
+					podData[instanceKey].queueLengthInstant = value.Value
+					podData[instanceKey].hasQueueInstant = true
+				}
+			}
+		}
+	}
+
 	// Process engine request completion rate (req/s) — throughput analyzer fallback λ_req
 	if result := results[registration.QueryRequestRate]; result != nil {
 		if !result.HasError() {
@@ -998,6 +1019,8 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			AvgITL:                data.avgITL,
 			GenerationTokenRate:   data.generationTokenRate,
 			KvUsageInstant:        data.kvUsageInstant,
+			QueueLengthInstant:    data.queueLengthInstant,
+			HasQueueLengthInstant: data.hasQueueInstant,
 			RequestRate:           data.requestRate,
 			Metadata: &domain.ReplicaMetricsMetadata{
 				CollectedAt:     collectedAt,

--- a/internal/domain/analyzer.go
+++ b/internal/domain/analyzer.go
@@ -154,9 +154,14 @@ type VariantCapacity struct {
 	Utilization float64
 
 	// ServiceRatePerReplica is the measured requests per second one replica of this
-	// variant sustains at its limit, and RequiredServiceRate is what this variant's
-	// share of arrivals demands at the scale-down boundary. Both are zero when the
-	// service rate has not been calibrated, which is the signal to ignore them.
+	// variant sustains at its limit, and ArrivalRate is what this variant is being
+	// asked to serve. Both are zero when the service rate has not been calibrated,
+	// which is the signal to ignore them.
+	//
+	// The threshold that turns them into a floor is applied by the optimizer, not
+	// here: the boundary the engine actually used is the per-analyzer resolved value
+	// from NamedAnalyzerResult, and an analyzer reading the global one from its own
+	// config would silently disagree with it wherever an override is configured.
 	//
 	// They exist because a scale-down decision is a counterfactual — "would N-1
 	// replicas still cope?" — and the token-space figures cannot answer it. Demand in
@@ -166,5 +171,5 @@ type VariantCapacity struct {
 	// nothing. Arrivals are the one quantity the decision does not move, so the same
 	// question in rate space has an answer that holds.
 	ServiceRatePerReplica float64
-	RequiredServiceRate   float64
+	ArrivalRate           float64
 }

--- a/internal/domain/analyzer.go
+++ b/internal/domain/analyzer.go
@@ -152,4 +152,19 @@ type VariantCapacity struct {
 
 	// Utilization is TotalDemand / TotalCapacity (0.0-1.0).
 	Utilization float64
+
+	// ServiceRatePerReplica is the measured requests per second one replica of this
+	// variant sustains at its limit, and RequiredServiceRate is what this variant's
+	// share of arrivals demands at the scale-down boundary. Both are zero when the
+	// service rate has not been calibrated, which is the signal to ignore them.
+	//
+	// They exist because a scale-down decision is a counterfactual — "would N-1
+	// replicas still cope?" — and the token-space figures cannot answer it. Demand in
+	// resident tokens is measured at the current replica count and does not survive
+	// the change being evaluated: remove a replica and residence rises, occupancy per
+	// replica rises more than proportionally, and past a point a queue appears out of
+	// nothing. Arrivals are the one quantity the decision does not move, so the same
+	// question in rate space has an answer that holds.
+	ServiceRatePerReplica float64
+	RequiredServiceRate   float64
 }

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -144,6 +144,13 @@ type ReplicaMetrics struct {
 	// Zero when metrics are unavailable.
 	KvUsageInstant float64
 
+	// QueueLengthInstant is how many requests are waiting on this replica right now,
+	// as opposed to QueueLength, which is that count's peak over the last minute.
+	// HasQueueLengthInstant distinguishes a genuine zero from a metric that was not
+	// collected, which matters because the two call for opposite behaviour.
+	QueueLengthInstant    float64
+	HasQueueLengthInstant bool
+
 	// RequestRate is the engine-side request completion rate on this replica (req/s).
 	// Engine-agnostic: derived per pod from rate(vllm:request_generation_tokens_count[1m])
 	// for vLLM and rate(sglang:generation_tokens_histogram_count[1m]) for SGLang.

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -151,6 +151,12 @@ type ReplicaMetrics struct {
 	QueueLengthInstant    float64
 	HasQueueLengthInstant bool
 
+	// PromptTokenRate is prompts processed per second on this replica. It is the
+	// service rate of a prefill replica, which the generation-tokens rate cannot
+	// measure: a prefill pod in a disaggregated deployment completes few or no
+	// generations.
+	PromptTokenRate float64
+
 	// RequestRate is the engine-side request completion rate on this replica (req/s).
 	// Engine-agnostic: derived per pod from rate(vllm:request_generation_tokens_count[1m])
 	// for vLLM and rate(sglang:generation_tokens_histogram_count[1m]) for SGLang.

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -157,6 +157,11 @@ type ReplicaMetrics struct {
 	// generations.
 	PromptTokenRate float64
 
+	// AvgInferenceTime is the average seconds a request spends being served on this
+	// replica, with time queued excluded. Published by vLLM; 0 on engines that do not
+	// expose it, where the analyzer derives the same quantity instead.
+	AvgInferenceTime float64
+
 	// RequestRate is the engine-side request completion rate on this replica (req/s).
 	// Engine-agnostic: derived per pod from rate(vllm:request_generation_tokens_count[1m])
 	// for vLLM and rate(sglang:generation_tokens_histogram_count[1m]) for SGLang.

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -31,6 +31,10 @@ type SaturationAnalyzer struct {
 	// estimator. Nil unless that estimator is enabled, which is what keeps the
 	// occupancy-based path byte-identical when the flag is off.
 	serviceRates *serviceRateStore
+	// arrivals smooths per-replica arrival rates over a residence time so they are
+	// comparable with the completion-derived service rate. Allocated with
+	// serviceRates.
+	arrivals *arrivalSmoother
 }
 
 // Option configures a SaturationAnalyzer at construction.
@@ -44,6 +48,7 @@ func withRateAnchoredK2(enabled bool) Option { //nolint:unparam // tests pass tr
 	return func(a *SaturationAnalyzer) {
 		if enabled {
 			a.serviceRates = newServiceRateStore()
+			a.arrivals = newArrivalSmoother()
 		}
 	}
 }
@@ -57,6 +62,7 @@ func NewSaturationAnalyzer(store *CapacityKnowledgeStore, opts ...Option) *Satur
 	}
 	if EnableRateAnchoredK2 {
 		a.serviceRates = newServiceRateStore()
+		a.arrivals = newArrivalSmoother()
 	}
 	for _, opt := range opts {
 		opt(a)

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -139,8 +139,12 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 	}
 
 	// The request shape that keys a workload bucket is a property of the variant, not
-	// of whichever replica happens to be reporting — see variantShape.
-	shapes := variantShapes(input.ReplicaMetrics)
+	// of whichever replica happens to be reporting — see variantShape. Only the
+	// rate-anchored estimator consumes it, so with that off this costs nothing.
+	var shapes map[string]variantShape
+	if a.serviceRates != nil {
+		shapes = variantShapes(input.ReplicaMetrics)
+	}
 
 	// Phase 1: Per-replica capacity computation
 	replicaCapacities := make([]ReplicaCapacity, 0, len(input.ReplicaMetrics))

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -223,7 +223,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	// headroom rather than being a ceiling, and the store feeds zero-replica
 	// estimation and cross-variant lookups that need a ceiling.
 	storedK2 := k2
-	if rateK2, rateSrc, ceiling, ok := a.rateAnchoredK2(rm, modelID, gpuCount, k1, config.QueueLengthThreshold, time.Now()); ok {
+	if rateK2, rateSrc, ceiling, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, k1, config.QueueLengthThreshold, time.Now()); ok {
 		k2, k2Priority = rateK2, rateSrc
 		if ceiling {
 			storedK2 = rateK2

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -217,7 +217,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	// headroom rather than being a ceiling, and the store feeds zero-replica
 	// estimation and cross-variant lookups that need a ceiling.
 	storedK2 := k2
-	if rateK2, rateSrc, ceiling, ok := a.rateAnchoredK2(rm, modelID, gpuCount, k1, time.Now()); ok {
+	if rateK2, rateSrc, ceiling, ok := a.rateAnchoredK2(rm, modelID, gpuCount, k1, config.QueueLengthThreshold, time.Now()); ok {
 		k2, k2Priority = rateK2, rateSrc
 		if ceiling {
 			storedK2 = rateK2

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -163,8 +163,7 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 	}
 
 	// Phase 2: Per-variant aggregation
-	variantCapacities := a.aggregateByVariant(replicaCapacities, input.ReplicaMetrics, input.VariantStates, input.ModelID, input.Namespace, satConfig.KvCacheThreshold,
-		satConfig.ScaleDownBoundary)
+	variantCapacities := a.aggregateByVariant(replicaCapacities, input.ReplicaMetrics, input.VariantStates, input.ModelID, input.Namespace, satConfig.KvCacheThreshold)
 
 	// Phase 3: Model-level aggregation via shared helpers (enforces linearity invariant).
 	totalSupply := aggregation.SumTotalSupply(variantCapacities)
@@ -443,7 +442,6 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 	variantStates []domain.VariantReplicaState,
 	modelID, namespace string,
 	kvCacheThreshold float64,
-	scaleDownBoundary float64,
 ) []domain.VariantCapacity {
 	// Group replicas by variant
 	byVariant := make(map[string][]ReplicaCapacity)
@@ -556,11 +554,8 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 				arrivals += completionRate(rm, vs.Role)
 			}
 		}
-		var requiredServiceRate float64
-		if serviceRatePerReplica > 0 && arrivals > 0 && scaleDownBoundary > 0 {
-			requiredServiceRate = arrivals / scaleDownBoundary
-		} else {
-			serviceRatePerReplica = 0
+		if serviceRatePerReplica <= 0 || arrivals <= 0 {
+			serviceRatePerReplica, arrivals = 0, 0
 		}
 
 		totalCapacity := float64(replicaCount) * perReplicaCapacity
@@ -572,7 +567,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 
 		result = append(result, domain.VariantCapacity{
 			ServiceRatePerReplica: serviceRatePerReplica,
-			RequiredServiceRate:   requiredServiceRate,
+			ArrivalRate:           arrivals,
 
 			VariantName:        vs.VariantName,
 			AcceleratorName:    accelerator,

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -132,10 +132,10 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 		rolesByVariant[vs.VariantName] = vs.Role
 	}
 
-	// Publish each bucket's operating point for this cycle before any replica reads
-	// it, so every replica of a bucket scales by the same number — see FreezeWork.
+	// Fold what last cycle observed and publish this cycle's operating point before
+	// any replica is looked at — see BeginCycle.
 	if a.serviceRates != nil {
-		a.serviceRates.FreezeWork(a.now())
+		a.serviceRates.BeginCycle(a.now())
 	}
 
 	// Phase 1: Per-replica capacity computation
@@ -251,7 +251,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	// why anything per-replica or per-cycle was unusable downstream.
 	var rateReference int64
 	if rateK2, ref, rateSrc, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, k1, config.QueueLengthThreshold, a.now()); ok {
-		k2, k2Priority, rateReference = rateK2, rateSrc, ref
+		k2, rateReference, k2Priority = rateK2, ref, rateSrc
 	}
 
 	effectiveCapacity := k1

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -26,15 +26,42 @@ type SaturationAnalyzer struct {
 	// TODO: check if we need to use other model parameters as key in the future.
 	computeCapacityHistory map[string]*rollingAverage
 	capacityStore          *CapacityKnowledgeStore
+
+	// serviceRates holds observed service rates for the rate-anchored k2
+	// estimator. Nil unless that estimator is enabled, which is what keeps the
+	// occupancy-based path byte-identical when the flag is off.
+	serviceRates *serviceRateStore
+}
+
+// Option configures a SaturationAnalyzer at construction.
+type Option func(*SaturationAnalyzer)
+
+// withRateAnchoredK2 selects the rate-anchored compute-capacity estimator. It is
+// unexported on purpose: the switch is EnableRateAnchoredK2, a build-time constant
+// in rate_capacity.go, not an operator-facing setting. Tests use this to exercise
+// the estimator while the constant is off.
+func withRateAnchoredK2(enabled bool) Option { //nolint:unparam // tests pass true; the parameter documents the switch
+	return func(a *SaturationAnalyzer) {
+		if enabled {
+			a.serviceRates = newServiceRateStore()
+		}
+	}
 }
 
 // NewSaturationAnalyzer creates a new V2 saturation analyzer backed by the
 // given capacity store.
-func NewSaturationAnalyzer(store *CapacityKnowledgeStore) *SaturationAnalyzer {
-	return &SaturationAnalyzer{
+func NewSaturationAnalyzer(store *CapacityKnowledgeStore, opts ...Option) *SaturationAnalyzer {
+	a := &SaturationAnalyzer{
 		computeCapacityHistory: make(map[string]*rollingAverage),
 		capacityStore:          store,
 	}
+	if EnableRateAnchoredK2 {
+		a.serviceRates = newServiceRateStore()
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
 // Name returns the analyzer identifier for logging and result metadata.
@@ -181,10 +208,29 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		engineParams,
 		k1,
 	)
+	// Rate-anchored estimate takes precedence when enabled and answerable. It runs
+	// after computeK2 so the occupancy history keeps being maintained, which keeps
+	// the two estimators comparable in the same run.
+	//
+	// storedK2 tracks what the capacity store should learn, which is not always what
+	// this cycle scales on: a below-saturation rate-anchored value is scaled by
+	// headroom rather than being a ceiling, and the store feeds zero-replica
+	// estimation and cross-variant lookups that need a ceiling.
+	storedK2 := k2
+	if rateK2, rateSrc, ceiling, ok := a.rateAnchoredK2(rm, modelID, gpuCount, k1, time.Now()); ok {
+		k2, k2Priority = rateK2, rateSrc
+		if ceiling {
+			storedK2 = rateK2
+		}
+	}
 
 	effectiveCapacity := k1
 	if k2 < k1 {
 		effectiveCapacity = k2
+	}
+	storedCapacity := k1
+	if storedK2 < k1 {
+		storedCapacity = storedK2
 	}
 
 	isSaturated := replicaDemand >= effectiveCapacity
@@ -201,7 +247,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		NumGpuBlocks:          rm.NumGpuBlocks,
 		BlockSize:             rm.BlockSize,
 		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
-		EffectiveCapacity:     effectiveCapacity,
+		EffectiveCapacity:     storedCapacity,
 		EngineParams:          existingParams,
 		LearnedFrom:           learnedFromLive,
 	})

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -163,7 +163,8 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 	}
 
 	// Phase 2: Per-variant aggregation
-	variantCapacities := a.aggregateByVariant(replicaCapacities, input.ReplicaMetrics, input.VariantStates, input.ModelID, input.Namespace, satConfig.KvCacheThreshold)
+	variantCapacities := a.aggregateByVariant(replicaCapacities, input.ReplicaMetrics, input.VariantStates, input.ModelID, input.Namespace, satConfig.KvCacheThreshold,
+		satConfig.ScaleDownBoundary)
 
 	// Phase 3: Model-level aggregation via shared helpers (enforces linearity invariant).
 	totalSupply := aggregation.SumTotalSupply(variantCapacities)
@@ -260,8 +261,12 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	// every replica of the variant and stable across cycles — see rateAnchoredK2 for
 	// why anything per-replica or per-cycle was unusable downstream.
 	var rateReference int64
+	// One timestamp for the whole replica: everything computed here belongs to the
+	// same cycle, and reading the clock twice would place the two halves in different
+	// ones.
+	now := a.now()
 	if rateK2, ref, rateSrc, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, shape, k1,
-		config.QueueLengthThreshold, a.now()); ok {
+		config.QueueLengthThreshold, now); ok {
 		k2, rateReference, k2Priority = rateK2, ref, rateSrc
 	}
 
@@ -302,6 +307,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	})
 
 	return &ReplicaCapacity{
+		ServiceRate:           a.serviceRate(modelID, role, gpuCount, rm.AcceleratorName, shape, now),
 		PodName:               rm.PodName,
 		VariantName:           rm.VariantName,
 		AcceleratorName:       rm.AcceleratorName,
@@ -437,6 +443,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 	variantStates []domain.VariantReplicaState,
 	modelID, namespace string,
 	kvCacheThreshold float64,
+	scaleDownBoundary float64,
 ) []domain.VariantCapacity {
 	// Group replicas by variant
 	byVariant := make(map[string][]ReplicaCapacity)
@@ -482,6 +489,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 		pendingCount := vs.PendingReplicas
 
 		var capacityLabel string
+		var serviceRatePerReplica float64
 		if len(replicas) > 0 {
 			// len(replicas) counts vLLM engine instances (DP ranks), not pods: a DP=8
 			// pod hosts 8 independently-capacitied instances. Using the pod count would
@@ -513,6 +521,8 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 				accelerator = replicas[0].AcceleratorName
 			}
 			capacityLabel = k2SourceLabel(replicas)
+			// Every replica of the bucket reports the same figure; take the first.
+			serviceRatePerReplica = replicas[0].ServiceRate
 		} else if rec := a.capacityStore.Get(namespace, modelID, vs.VariantName); rec != nil && rec.EffectiveCapacity > 0 {
 			// No ready replicas — use stored capacity, enhanced with k2 derivation
 			// for deployment-derived records when workload data is available.
@@ -526,6 +536,29 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			capacityLabel = satReasonNoData
 		}
 
+		// The rate-space pair the optimizer needs to evaluate a scale-down. Arrivals
+		// are summed over the variant's own replicas: they are what this variant is
+		// actually being asked to serve. Without EPP the dispatch rate is absent and
+		// completions stand in — a substitution that is only wrong under backlog,
+		// which is not a state anything is considering a scale-down in.
+		var arrivals float64
+		for _, rm := range inputMetrics {
+			if rm.VariantName != vs.VariantName {
+				continue
+			}
+			if rm.ArrivalRate > 0 {
+				arrivals += rm.ArrivalRate
+			} else {
+				arrivals += rm.RequestRate
+			}
+		}
+		var requiredServiceRate float64
+		if serviceRatePerReplica > 0 && arrivals > 0 && scaleDownBoundary > 0 {
+			requiredServiceRate = arrivals / scaleDownBoundary
+		} else {
+			serviceRatePerReplica = 0
+		}
+
 		totalCapacity := float64(replicaCount) * perReplicaCapacity
 
 		var utilization float64
@@ -534,6 +567,9 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 		}
 
 		result = append(result, domain.VariantCapacity{
+			ServiceRatePerReplica: serviceRatePerReplica,
+			RequiredServiceRate:   requiredServiceRate,
+
 			VariantName:        vs.VariantName,
 			AcceleratorName:    accelerator,
 			Cost:               cost,

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -549,7 +549,11 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			if rm.ArrivalRate > 0 {
 				arrivals += rm.ArrivalRate
 			} else {
-				arrivals += rm.RequestRate
+				// Same role-aware choice the service rate makes: a prefill replica
+				// completes few or no generations, so falling back to the generation
+				// rate would read its arrivals as zero and silently disable the floor
+				// for the role that needs it most.
+				arrivals += completionRate(rm, vs.Role)
 			}
 		}
 		var requiredServiceRate float64

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -138,6 +138,10 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 		a.serviceRates.BeginCycle(a.now())
 	}
 
+	// The request shape that keys a workload bucket is a property of the variant, not
+	// of whichever replica happens to be reporting — see variantShape.
+	shapes := variantShapes(input.ReplicaMetrics)
+
 	// Phase 1: Per-replica capacity computation
 	replicaCapacities := make([]ReplicaCapacity, 0, len(input.ReplicaMetrics))
 	for _, rm := range input.ReplicaMetrics {
@@ -147,7 +151,8 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 		default:
 		}
 		gpuCount := gpusByVariant[rm.VariantName]
-		rc := a.computeReplicaCapacity(rm, satConfig, input.ModelID, input.Namespace, gpuCount, rolesByVariant[rm.VariantName])
+		rc := a.computeReplicaCapacity(rm, satConfig, input.ModelID, input.Namespace, gpuCount,
+			rolesByVariant[rm.VariantName], shapes[rm.VariantName])
 		if rc != nil {
 			replicaCapacities = append(replicaCapacities, *rc)
 		}
@@ -211,6 +216,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	modelID, namespace string,
 	gpuCount int,
 	role string,
+	shape variantShape,
 ) *ReplicaCapacity {
 	if rm.TotalKvCapacityTokens <= 0 {
 		// TODO: implement proper demand estimation when vllm:cache_config_info is absent.
@@ -250,7 +256,8 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	// every replica of the variant and stable across cycles — see rateAnchoredK2 for
 	// why anything per-replica or per-cycle was unusable downstream.
 	var rateReference int64
-	if rateK2, ref, rateSrc, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, k1, config.QueueLengthThreshold, a.now()); ok {
+	if rateK2, ref, rateSrc, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, shape, k1,
+		config.QueueLengthThreshold, a.now()); ok {
 		k2, rateReference, k2Priority = rateK2, ref, rateSrc
 	}
 

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -36,6 +36,10 @@ type SaturationAnalyzer struct {
 	// comparable with the completion-derived service rate. Allocated with
 	// serviceRates.
 	arrivals *arrivalSmoother
+	// arrivalPeaks holds each variant's summed arrival rate at its maximum over a
+	// short window, so the floor cannot be weakened by the measurement artefact a
+	// scale-down itself produces. Allocated with serviceRates.
+	arrivalPeaks *peakWindow
 	// clock is time.Now in production. The rate-anchored estimator weights its
 	// averages by the real gap between cycles, so tests that drive several cycles in
 	// a row need to advance time to exercise it at all.
@@ -54,6 +58,7 @@ func withRateAnchoredK2(enabled bool) Option { //nolint:unparam // tests pass tr
 		if enabled {
 			a.serviceRates = newBucketStore()
 			a.arrivals = newArrivalSmoother()
+			a.arrivalPeaks = newPeakWindow()
 		}
 	}
 }
@@ -85,6 +90,7 @@ func NewSaturationAnalyzer(store *CapacityKnowledgeStore, opts ...Option) *Satur
 	if EnableRateAnchoredK2 {
 		a.serviceRates = newBucketStore()
 		a.arrivals = newArrivalSmoother()
+		a.arrivalPeaks = newPeakWindow()
 	}
 	for _, opt := range opts {
 		opt(a)
@@ -519,8 +525,17 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 				accelerator = replicas[0].AcceleratorName
 			}
 			capacityLabel = k2SourceLabel(replicas)
-			// Every replica of the bucket reports the same figure; take the first.
+			// The lowest figure across the variant's replicas, and zero if any replica
+			// has none. Taking whichever replica came first would have been
+			// order-dependent — ReplicaMetrics is built by ranging a map — and a
+			// replica reporting nothing means the variant is only partly measured,
+			// which the floor treats as not measured at all.
 			serviceRatePerReplica = replicas[0].ServiceRate
+			for _, rc := range replicas[1:] {
+				if rc.ServiceRate < serviceRatePerReplica {
+					serviceRatePerReplica = rc.ServiceRate
+				}
+			}
 		} else if rec := a.capacityStore.Get(namespace, modelID, vs.VariantName); rec != nil && rec.EffectiveCapacity > 0 {
 			// No ready replicas — use stored capacity, enhanced with k2 derivation
 			// for deployment-derived records when workload data is available.
@@ -553,6 +568,11 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 				// for the role that needs it most.
 				arrivals += completionRate(rm, vs.Role)
 			}
+		}
+		// Held at its recent maximum: see ArrivalPeakWindow for why the sum dips
+		// precisely when a scale-down is in progress.
+		if a.arrivalPeaks != nil && arrivals > 0 {
+			arrivals = a.arrivalPeaks.Observe(namespace+"|"+modelID+"|"+vs.VariantName, arrivals, a.now())
 		}
 		if serviceRatePerReplica <= 0 || arrivals <= 0 {
 			serviceRatePerReplica, arrivals = 0, 0

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -218,25 +218,17 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	// after computeK2 so the occupancy history keeps being maintained, which keeps
 	// the two estimators comparable in the same run.
 	//
-	// storedK2 tracks what the capacity store should learn, which is not always what
-	// this cycle scales on: a below-saturation rate-anchored value is scaled by
-	// headroom rather than being a ceiling, and the store feeds zero-replica
-	// estimation and cross-variant lookups that need a ceiling.
-	storedK2 := k2
-	if rateK2, rateSrc, ceiling, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, k1, config.QueueLengthThreshold, time.Now()); ok {
+	// It only answers at or past saturation, so whatever it returns is a measured
+	// ceiling — the same thing the capacity store wants to learn. No separate
+	// stored value is needed: see rateAnchoredK2 for why a headroom-scaled figure
+	// is withheld instead of being special-cased here.
+	if rateK2, rateSrc, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, k1, config.QueueLengthThreshold, time.Now()); ok {
 		k2, k2Priority = rateK2, rateSrc
-		if ceiling {
-			storedK2 = rateK2
-		}
 	}
 
 	effectiveCapacity := k1
 	if k2 < k1 {
 		effectiveCapacity = k2
-	}
-	storedCapacity := k1
-	if storedK2 < k1 {
-		storedCapacity = storedK2
 	}
 
 	isSaturated := replicaDemand >= effectiveCapacity
@@ -253,7 +245,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		NumGpuBlocks:          rm.NumGpuBlocks,
 		BlockSize:             rm.BlockSize,
 		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
-		EffectiveCapacity:     storedCapacity,
+		EffectiveCapacity:     effectiveCapacity,
 		EngineParams:          existingParams,
 		LearnedFrom:           learnedFromLive,
 	})

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -36,6 +36,10 @@ type SaturationAnalyzer struct {
 	// comparable with the completion-derived service rate. Allocated with
 	// serviceRates.
 	arrivals *arrivalSmoother
+	// clock is time.Now in production. The rate-anchored estimator weights its
+	// averages by the real gap between cycles, so tests that drive several cycles in
+	// a row need to advance time to exercise it at all.
+	clock func() time.Time
 }
 
 // Option configures a SaturationAnalyzer at construction.
@@ -54,12 +58,29 @@ func withRateAnchoredK2(enabled bool) Option { //nolint:unparam // tests pass tr
 	}
 }
 
+// withClock replaces time.Now for tests that need to drive successive cycles.
+func withClock(clock func() time.Time) Option {
+	return func(a *SaturationAnalyzer) {
+		a.clock = clock
+	}
+}
+
+// now reads the analyzer's clock, tolerating a zero value so an analyzer built
+// without the constructor still works.
+func (a *SaturationAnalyzer) now() time.Time {
+	if a.clock == nil {
+		return time.Now()
+	}
+	return a.clock()
+}
+
 // NewSaturationAnalyzer creates a new V2 saturation analyzer backed by the
 // given capacity store.
 func NewSaturationAnalyzer(store *CapacityKnowledgeStore, opts ...Option) *SaturationAnalyzer {
 	a := &SaturationAnalyzer{
 		computeCapacityHistory: make(map[string]*rollingAverage),
 		capacityStore:          store,
+		clock:                  time.Now,
 	}
 	if EnableRateAnchoredK2 {
 		a.serviceRates = newBucketStore()
@@ -109,6 +130,12 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input domain.AnalyzerI
 	for _, vs := range input.VariantStates {
 		gpusByVariant[vs.VariantName] = vs.GPUsPerReplica
 		rolesByVariant[vs.VariantName] = vs.Role
+	}
+
+	// Publish each bucket's operating point for this cycle before any replica reads
+	// it, so every replica of a bucket scales by the same number — see FreezeWork.
+	if a.serviceRates != nil {
+		a.serviceRates.FreezeWork(a.now())
 	}
 
 	// Phase 1: Per-replica capacity computation
@@ -222,13 +249,26 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	// What it returns is a per-bucket ceiling measured at the limit, identical for
 	// every replica of the variant and stable across cycles — see rateAnchoredK2 for
 	// why anything per-replica or per-cycle was unusable downstream.
-	if rateK2, rateSrc, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, k1, config.QueueLengthThreshold, time.Now()); ok {
-		k2, k2Priority = rateK2, rateSrc
+	var rateReference int64
+	if rateK2, ref, rateSrc, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, k1, config.QueueLengthThreshold, a.now()); ok {
+		k2, k2Priority, rateReference = rateK2, rateSrc, ref
 	}
 
 	effectiveCapacity := k1
 	if k2 < k1 {
 		effectiveCapacity = k2
+	}
+
+	// What the store keeps is not what this cycle scaled on. The rate-anchored
+	// capacity moves with contention by design, while the store feeds variants with
+	// no live replicas and cross-variant estimation — both of which need the
+	// load-independent measurement.
+	storedCapacity := effectiveCapacity
+	if rateReference > 0 {
+		storedCapacity = k1
+		if rateReference < k1 {
+			storedCapacity = rateReference
+		}
 	}
 
 	isSaturated := replicaDemand >= effectiveCapacity
@@ -245,7 +285,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		NumGpuBlocks:          rm.NumGpuBlocks,
 		BlockSize:             rm.BlockSize,
 		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
-		EffectiveCapacity:     effectiveCapacity,
+		EffectiveCapacity:     storedCapacity,
 		EngineParams:          existingParams,
 		LearnedFrom:           learnedFromLive,
 	})

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -27,10 +27,11 @@ type SaturationAnalyzer struct {
 	computeCapacityHistory map[string]*rollingAverage
 	capacityStore          *CapacityKnowledgeStore
 
-	// serviceRates holds observed service rates for the rate-anchored k2
-	// estimator. Nil unless that estimator is enabled, which is what keeps the
-	// occupancy-based path byte-identical when the flag is off.
-	serviceRates *serviceRateStore
+	// serviceRates holds what has been learned per workload bucket for the
+	// rate-anchored k2 estimator: the service rate under backlog and the token
+	// ceiling measured at the limit. Nil unless that estimator is enabled, which is
+	// what keeps the occupancy-based path byte-identical when the flag is off.
+	serviceRates *bucketStore
 	// arrivals smooths per-replica arrival rates over a residence time so they are
 	// comparable with the completion-derived service rate. Allocated with
 	// serviceRates.
@@ -47,7 +48,7 @@ type Option func(*SaturationAnalyzer)
 func withRateAnchoredK2(enabled bool) Option { //nolint:unparam // tests pass true; the parameter documents the switch
 	return func(a *SaturationAnalyzer) {
 		if enabled {
-			a.serviceRates = newServiceRateStore()
+			a.serviceRates = newBucketStore()
 			a.arrivals = newArrivalSmoother()
 		}
 	}
@@ -61,7 +62,7 @@ func NewSaturationAnalyzer(store *CapacityKnowledgeStore, opts ...Option) *Satur
 		capacityStore:          store,
 	}
 	if EnableRateAnchoredK2 {
-		a.serviceRates = newServiceRateStore()
+		a.serviceRates = newBucketStore()
 		a.arrivals = newArrivalSmoother()
 	}
 	for _, opt := range opts {
@@ -218,10 +219,9 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	// after computeK2 so the occupancy history keeps being maintained, which keeps
 	// the two estimators comparable in the same run.
 	//
-	// It only answers at or past saturation, so whatever it returns is a measured
-	// ceiling — the same thing the capacity store wants to learn. No separate
-	// stored value is needed: see rateAnchoredK2 for why a headroom-scaled figure
-	// is withheld instead of being special-cased here.
+	// What it returns is a per-bucket ceiling measured at the limit, identical for
+	// every replica of the variant and stable across cycles — see rateAnchoredK2 for
+	// why anything per-replica or per-cycle was unusable downstream.
 	if rateK2, rateSrc, ok := a.rateAnchoredK2(rm, modelID, role, gpuCount, k1, config.QueueLengthThreshold, time.Now()); ok {
 		k2, k2Priority = rateK2, rateSrc
 	}

--- a/internal/engines/analyzers/saturation_v2/constants.go
+++ b/internal/engines/analyzers/saturation_v2/constants.go
@@ -38,4 +38,12 @@ const (
 	// MediumOutputThreshold is the upper bound (exclusive) for the "medium"
 	// output-length bucket used for k2 history keying.
 	MediumOutputThreshold = 500
+
+	// ShortInputThreshold and MediumInputThreshold bucket prompt lengths. They are
+	// separate from the output thresholds because prompts are an order of magnitude
+	// longer: bucketing input at 100/500 would put almost every real workload in one
+	// bucket, so a 600-token prompt and a 4000-token one would calibrate each other's
+	// ceiling despite being different services on the same hardware.
+	ShortInputThreshold  = 500
+	MediumInputThreshold = 2000
 )

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -675,8 +675,9 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 
 	// Detector and measurement, read at the same instant — see limitEvidence.
 	backlogged, occupancy := limitEvidence(rm, queueThreshold)
-	if backlogged && rm.RequestRate > 0 {
-		a.serviceRates.ObserveRate(key, rm.RequestRate, now)
+	completions := completionRate(rm, role)
+	if backlogged && completions > 0 {
+		a.serviceRates.ObserveRate(key, completions, now)
 	}
 	atLimit := backlogged || a.arrivalsReachedServiceRate(rm, key, now)
 
@@ -808,6 +809,37 @@ func limitEvidence(rm domain.ReplicaMetrics, queueThreshold float64) (bool, floa
 		}
 	}
 	return float64(rm.QueueLength) >= queueThreshold, float64(rm.TokensInUse)
+}
+
+// serviceRate returns the bucket's calibrated service rate in requests per second,
+// or 0 when it has not been established. Unlike the capacity estimate this is not
+// clamped or scaled: it is the measured throughput of a replica that could not keep
+// up, which is exactly what a scale-down counterfactual needs.
+func (a *SaturationAnalyzer) serviceRate(modelID, role string, gpuCount int, accelerator string,
+	shape variantShape, now time.Time) float64 {
+	if a.serviceRates == nil {
+		return 0
+	}
+	rate, ok := a.serviceRates.Rate(serviceRateKey(modelID, accelerator, role, gpuCount, shape), now)
+	if !ok {
+		return 0
+	}
+	return rate
+}
+
+// completionRate is the rate at which this replica finishes the work its role is
+// responsible for: prompts processed for a prefill replica, generations completed
+// for a decode replica or an undisaggregated one.
+//
+// A prefill pod completes few or no generations, so measuring it with the
+// generation-tokens counter would either learn nothing or learn a service rate an
+// order of magnitude below the truth. Falls back to completions when the prompt rate
+// is unavailable, which is no worse than before it was collected.
+func completionRate(rm domain.ReplicaMetrics, role string) float64 {
+	if canonicalRole(role) == domain.RolePrefill && rm.PromptTokenRate > 0 {
+		return rm.PromptTokenRate
+	}
+	return rm.RequestRate
 }
 
 // tokensPerRequest is the KV footprint of one request of this bucket's shape.

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -72,6 +72,11 @@ const (
 	// Five minutes is responsive within a load stage without chasing a single scrape.
 	ServiceRateSmoothingWindow = 5 * time.Minute
 
+	// PrefillSmoothingWindow is the time constant over which a bucket learns how long
+	// prefill takes when nothing is waiting. Long, because the observations are sparse
+	// by construction: only unqueued cycles qualify.
+	PrefillSmoothingWindow = 10 * time.Minute
+
 	// WorkWindow is the window the bucket's operating point is held over, and it
 	// mirrors the demand side exactly: TokensInUse and QueueLength are collected as
 	// max_over_time(...[1m]), so the operating point is the MAXIMUM of what replicas
@@ -173,6 +178,12 @@ type bucketEntry struct {
 	ceilingHas    bool
 	pendingLower  float64 // a lower reading waiting to be confirmed by another cycle
 	pendingCycles int
+
+	prefill      float64 // time to first token with nothing queued, in seconds
+	prefillKnown bool
+	prefillSeen  time.Time
+	prefillSum   float64
+	prefillCount int
 
 	workSeen    time.Time
 	workSamples []workSample // one per cycle, held for WorkWindow
@@ -358,6 +369,46 @@ func (s *bucketStore) ObserveWork(key string, work float64, now time.Time) {
 	e.workCount++
 }
 
+// ObservePrefill records a time-to-first-token measured while nothing was waiting.
+//
+// Callers must only pass readings taken with an empty queue. That is the whole point:
+// TTFT is measured from arrival at the engine, so it carries queue wait, and under
+// backlog it is inflated several-fold. Sampled with no queue it is prefill alone.
+func (s *bucketStore) ObservePrefill(key string, ttft float64, now time.Time) {
+	if !(ttft > 0) || math.IsInf(ttft, 0) {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e := s.entry(key, now)
+	e.prefillSum += ttft
+	e.prefillCount++
+}
+
+// Prefill returns the bucket's uncontended prefill time, and false when none has been
+// observed or it has gone stale.
+func (s *bucketStore) Prefill(key string, now time.Time) (float64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.entries[key]
+	if !ok || !e.prefillKnown || e.prefill <= 0 {
+		return 0, false
+	}
+	// Retained for the bucket's lifetime rather than the service-rate window. Prefill
+	// time is a property of the model, the hardware and the prompt length, all of
+	// which are in the bucket key, so it does not drift the way a service rate does.
+	// And it can only be observed while nothing is queued — precisely the cycles a
+	// busy fleet does not have. Expiring it after thirty minutes would mean a
+	// sustained overload silently reverting to the queue-contaminated residence at
+	// the worst possible moment.
+	if now.Sub(e.prefillSeen) > HistoryEvictionTimeout {
+		return 0, false
+	}
+	return e.prefill, true
+}
+
 // FrozenWork returns the work-per-request every replica of the bucket scales by
 // this cycle, and false when none has been frozen yet.
 func (s *bucketStore) FrozenWork(key string, now time.Time) (float64, bool) {
@@ -412,6 +463,18 @@ func (s *bucketStore) BeginCycle(now time.Time) {
 		if e.ceilingHas {
 			e.applyCeiling(e.ceilingSum, now)
 			e.ceilingSum, e.ceilingHas = 0, false
+		}
+
+		if e.prefillCount > 0 {
+			sample := e.prefillSum / float64(e.prefillCount)
+			e.prefillSum, e.prefillCount = 0, 0
+			if e.prefillKnown {
+				e.prefill = ewmaStep(e.prefill, sample, now.Sub(e.prefillSeen).Seconds(),
+					PrefillSmoothingWindow.Seconds())
+			} else {
+				e.prefill, e.prefillKnown = sample, true
+			}
+			e.prefillSeen = now
 		}
 
 		if e.workCount > 0 {
@@ -533,6 +596,60 @@ func (s *arrivalSmoother) EvictStale(timeout time.Duration, now time.Time) int {
 		}
 	}
 	return removed
+}
+
+// queueIsEmpty reports whether nothing is waiting on this replica right now. The
+// instantaneous reading is required: QueueLength is a one-minute peak and latches, so
+// it would keep claiming a queue for a minute after the last one cleared.
+func queueIsEmpty(rm domain.ReplicaMetrics) bool {
+	return rm.HasQueueLengthInstant && rm.QueueLengthInstant == 0
+}
+
+// serviceResidence is how long a request occupies the replica while it is being
+// served — excluding time spent waiting to be scheduled.
+//
+// This is the quantity Little's law needs to turn a service rate into a token count.
+// The obvious reading, TTFT + outputTokens x ITL, is not it: TTFT is measured from
+// arrival at the engine, so under backlog it carries queue wait and inflates several
+// fold. Capacity computed from it then exceeds the learned ceiling, the clamp holds it
+// there, and on a queueing workload the estimator spends the entire run reporting the
+// ceiling — which is measured at near-full KV and lands at the memory bound. That is
+// visible in the validation runs as RATE-W firing once in thirty-five minutes on
+// prefill-heavy traffic against twenty-seven times on symmetric traffic.
+//
+// The decode half is already clean: inter-token latency contains no queue wait. Only
+// the prefill half is contaminated, and it can be measured directly — during cycles
+// with nothing queued, TTFT *is* prefill. So the bucket learns it then and reuses it
+// when the queue is deep.
+//
+// Falls back to the contaminated form when no unqueued cycle has been seen yet, which
+// is no worse than the previous behaviour and still bounded by the clamp. vLLM
+// publishes request_inference_time_seconds, which measures this directly and would be
+// authoritative where available; SGLang has no equivalent, and deriving it works for
+// both engines from metrics already collected.
+func (a *SaturationAnalyzer) serviceResidence(rm domain.ReplicaMetrics, key string, now time.Time) float64 {
+	// Measured directly where the engine publishes it. Preferred over the derived
+	// form because the derived prefill is sampled while nothing is queued, and real
+	// prefill grows under contention — an error that matters most where prefill is a
+	// large share of the residence, which is exactly where this metric is worth having.
+	if rm.AvgInferenceTime > 0 && rm.AvgInferenceTime <= MaxResidenceSeconds {
+		return rm.AvgInferenceTime
+	}
+	prefill, ok := a.serviceRates.Prefill(key, now)
+	if !ok {
+		return residenceSeconds(rm)
+	}
+	if rm.AvgITL <= 0 || rm.AvgOutputTokens <= 0 {
+		return residenceSeconds(rm)
+	}
+	w := prefill + rm.AvgOutputTokens*rm.AvgITL
+	if w <= 0 || math.IsNaN(w) || math.IsInf(w, 0) {
+		return residenceSeconds(rm)
+	}
+	if w > MaxResidenceSeconds {
+		return MaxResidenceSeconds
+	}
+	return w
 }
 
 // residenceSeconds estimates how long a request occupies the replica: time to the
@@ -700,7 +817,13 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	// Every cycle, at the limit or not, contributes to the bucket's work-per-request.
 	// It is the operating point, not a measurement of the limit, so it is recorded
 	// unconditionally — the whole point is to know how far below the limit we sit.
-	if residence := residenceSeconds(rm); residence > 0 {
+	// With nothing queued, time to first token is prefill and nothing else. Learning
+	// it here is what lets the operating point be computed from service time when the
+	// queue is deep and TTFT no longer can be.
+	if !backlogged && queueIsEmpty(rm) && rm.AvgTTFT > 0 {
+		a.serviceRates.ObservePrefill(key, rm.AvgTTFT, now)
+	}
+	if residence := a.serviceResidence(rm, key, now); residence > 0 {
 		a.serviceRates.ObserveWork(key, residence*tokensPerRequest(rm), now)
 	}
 

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -70,6 +70,20 @@ const (
 	// Five minutes is responsive within a load stage without chasing a single scrape.
 	ServiceRateSmoothingWindow = 5 * time.Minute
 
+	// WorkWindow is the window the bucket's operating point is held over, and it
+	// mirrors the demand side exactly: TokensInUse and QueueLength are collected as
+	// max_over_time(...[1m]), so the operating point is the MAXIMUM of what replicas
+	// reported over the same minute.
+	//
+	// Matching the operator, not just the timescale, is what keeps the ratio stable
+	// through a transient. An average would decay smoothly while demand held its peak
+	// and then stepped down, so at the moment demand's window rolled off, capacity
+	// would still be high and the fleet would shed — the exact failure this estimator
+	// exists to prevent. Reacting within a single cycle instead would drop capacity
+	// while demand still carried the peak, spiking utilization into a scale-up right
+	// after the fleet caught up. Both sides rise and fall together.
+	WorkWindow = time.Minute
+
 	// CeilingRelaxPerWindow is the factor the learned token ceiling relaxes by over
 	// one ServiceRateWindow with no fresh observation. The ceiling is a running
 	// minimum, so it relaxes *upward*: a single pessimistic measurement — taken
@@ -128,13 +142,18 @@ type bucketEntry struct {
 	ceiling      float64 // running min of resident tokens at the limit
 	ceilingSeen  time.Time
 	ceilingKnown bool
-	work         float64 // EWMA of residence x tokens-per-request, in token-seconds
 	workSeen     time.Time
-	workKnown    bool
-	workFrozen   float64 // the value every replica of the bucket reads this cycle
-	workSum      float64 // this cycle's samples, averaged at the next freeze
-	workTauSum   float64 // and their time constants, averaged with them
+	workSamples  []workSample // one per cycle, held for WorkWindow
+	workFrozen   float64      // the value every replica of the bucket reads this cycle
+	workSum      float64      // this cycle's samples, averaged at the next freeze
 	workCount    int
+}
+
+// workSample is one cycle's operating point: residence x tokens-per-request,
+// averaged across the replicas that reported it.
+type workSample struct {
+	at    time.Time
+	value float64
 }
 
 func newBucketStore() *bucketStore {
@@ -273,8 +292,7 @@ func (s *bucketStore) Ceiling(key string, now time.Time) (float64, bool) {
 
 // ObserveWork records this replica's work-per-request — residence time multiplied
 // by tokens per request, in token-seconds — as one sample of the bucket's operating
-// point. tau is the averaging time constant; the quantity changes on the residence
-// timescale, so that is what it is smoothed over at the next freeze.
+// point, to be averaged and folded in at the next freeze.
 //
 // Samples accumulate rather than folding in one at a time, because every replica of
 // a bucket reports in the same cycle at the same timestamp. Folding each in turn
@@ -284,8 +302,8 @@ func (s *bucketStore) Ceiling(key string, now time.Time) (float64, bool) {
 // then pull the whole bucket's capacity down and drive a spurious scale-up.
 //
 // The value is deliberately not read back here: see FrozenWork.
-func (s *bucketStore) ObserveWork(key string, work, tau float64, now time.Time) {
-	if work <= 0 || tau <= 0 {
+func (s *bucketStore) ObserveWork(key string, work float64, now time.Time) {
+	if work <= 0 {
 		return
 	}
 	s.mu.Lock()
@@ -293,7 +311,6 @@ func (s *bucketStore) ObserveWork(key string, work, tau float64, now time.Time) 
 
 	e := s.entry(key, now)
 	e.workSum += work
-	e.workTauSum += tau
 	e.workCount++
 }
 
@@ -313,9 +330,9 @@ func (s *bucketStore) FrozenWork(key string, now time.Time) (float64, bool) {
 	return e.workFrozen, true
 }
 
-// FreezeWork averages the samples each bucket collected last cycle, folds that mean
-// into the bucket's EWMA, and publishes it as the value this cycle's replicas will
-// read. It must be called once at the top of a cycle.
+// FreezeWork averages the samples each bucket collected last cycle, drops anything
+// older than WorkWindow, and publishes the maximum of what remains as the value this
+// cycle's replicas will read. It must be called once at the top of a cycle.
 //
 // Publishing at the cycle boundary is what makes the number identical across
 // siblings: aggregateByVariant takes the MEDIAN of per-replica capacities, so a
@@ -328,18 +345,24 @@ func (s *bucketStore) FreezeWork(now time.Time) {
 
 	for _, e := range s.entries {
 		if e.workCount > 0 {
-			n := float64(e.workCount)
-			sample, tau := e.workSum/n, e.workTauSum/n
-			e.workSum, e.workTauSum, e.workCount = 0, 0, 0
-			if e.workKnown {
-				e.work = ewmaStep(e.work, sample, now.Sub(e.workSeen).Seconds(), tau)
-			} else {
-				e.work, e.workKnown = sample, true
-			}
+			e.workSamples = append(e.workSamples, workSample{at: now, value: e.workSum / float64(e.workCount)})
+			e.workSum, e.workCount = 0, 0
 			e.workSeen = now
 		}
-		if e.workKnown {
-			e.workFrozen = e.work
+		kept := e.workSamples[:0]
+		peak := 0.0
+		for _, w := range e.workSamples {
+			if now.Sub(w.at) > WorkWindow {
+				continue
+			}
+			kept = append(kept, w)
+			if w.value > peak {
+				peak = w.value
+			}
+		}
+		e.workSamples = kept
+		if peak > 0 {
+			e.workFrozen = peak
 		}
 	}
 }
@@ -537,9 +560,7 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	// It is the operating point, not a measurement of the limit, so it is recorded
 	// unconditionally — the whole point is to know how far below the limit we sit.
 	if residence := residenceSeconds(rm); residence > 0 {
-		if work := residence * tokensPerRequest(rm); work > 0 {
-			a.serviceRates.ObserveWork(key, work, residence, now)
-		}
+		a.serviceRates.ObserveWork(key, residence*tokensPerRequest(rm), now)
 	}
 
 	ceiling, ok := a.serviceRates.Ceiling(key, now)

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -275,12 +275,17 @@ func residenceSeconds(rm domain.ReplicaMetrics) float64 {
 
 // serviceRateKey identifies a workload bucket for service-rate purposes.
 //
-// The input bucket is part of the key, unlike the k2 history key: mu is a property
+// Role is part of the key because a prefill replica and a decode replica of the
+// same model on the same accelerator are different services: they do different
+// work per request and complete at entirely different rates. Sharing a bucket
+// would let one calibrate the other's ceiling.
+//
+// The input bucket is part of it too, unlike the k2 history key: mu is a property
 // of the request shape, and 1000-token prompts and 300-token prompts are different
 // services on the same hardware. Keying only by output length would average them.
-func serviceRateKey(modelID, accelerator string, gpuCount int, avgInput, avgOutput float64) string {
-	return fmt.Sprintf("%s|%s|%d|in:%s|out:%s",
-		modelID, accelerator, gpuCount,
+func serviceRateKey(modelID, accelerator, role string, gpuCount int, avgInput, avgOutput float64) string {
+	return fmt.Sprintf("%s|%s|%s|%d|in:%s|out:%s",
+		modelID, accelerator, canonicalRole(role), gpuCount,
 		classifyOutputLength(avgInput), classifyOutputLength(avgOutput))
 }
 
@@ -300,6 +305,7 @@ func serviceRateKey(modelID, accelerator string, gpuCount int, avgInput, avgOutp
 func (a *SaturationAnalyzer) rateAnchoredK2(
 	rm domain.ReplicaMetrics,
 	modelID string,
+	role string,
 	gpuCount int,
 	k1 int64,
 	queueThreshold float64,
@@ -309,7 +315,7 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 		return 0, 0, false, false
 	}
 
-	key := serviceRateKey(modelID, rm.AcceleratorName, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
+	key := serviceRateKey(modelID, rm.AcceleratorName, role, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
 
 	// Only a sustained backlog establishes a ceiling; see the package comment.
 	backlogged := float64(rm.QueueLength) >= queueThreshold
@@ -325,9 +331,14 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	}
 	lambda := a.arrivals.Smooth(smoothingKey, rm.ArrivalRate, residenceSeconds(rm), now)
 
-	// KvUsageInstant is the un-peaked reading; the 1-minute max used for demand
-	// would over-state the operating point and inflate the estimate.
-	occupancy := rm.KvUsageInstant * float64(rm.TotalKvCapacityTokens)
+	// Scale by the same occupancy figure demand is built from, not the instantaneous
+	// reading. Demand is TokensInUse (a 1-minute max) plus the queue charge, so
+	// dividing it by a capacity derived from an instantaneous reading would inflate
+	// utilization by whatever the peak-to-instant spread happens to be — a spiky
+	// replica would look far more saturated than a steady one at the same load.
+	// Using the same aggregation on both sides makes the occupancy term cancel:
+	// with no queue, utilization reduces to lambda/mu, which is the whole intent.
+	occupancy := float64(rm.TokensInUse)
 	if occupancy <= 0 {
 		return 0, 0, false, false
 	}
@@ -346,6 +357,15 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	}
 
 	k2 := occupancy * ratio
+	// A replica with no queue is, by observation, coping with what it currently
+	// holds, so its capacity is at least that. Without this floor a lambda that
+	// momentarily edges past a conservatively-measured mu would cut capacity below
+	// the load the replica is visibly handling and demand a scale-up on evidence
+	// that does not exist. It binds only when ratio < 1 with an empty queue; a
+	// backlogged replica is genuinely over capacity and keeps the raw value.
+	if !backlogged && k2 < occupancy {
+		k2 = occupancy
+	}
 	if floor := float64(k1) * MinRateAnchoredFraction; k2 < floor {
 		k2 = floor
 	}

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -18,7 +18,16 @@ import (
 // low, so the estimate carries no information about the binding constraint.
 //
 // This estimator anchors on the one quantity that is meaningful whichever resource
-// binds: while a replica has a backlog, its completion rate IS its service rate.
+// binds: while a replica cannot keep up, its completion rate IS its service rate.
+//
+// "Cannot keep up" has to be established, not assumed. With no backlog, completions
+// equal arrivals at any load — flow conservation — so an idle replica's completion
+// rate says nothing about its ceiling. mu is therefore recorded only from replicas
+// with a queue at least QueueLengthThreshold deep, and a bucket needs
+// MinServiceRateSamples such observations before it will answer. Without that,
+// one burst of arrival jitter would pin mu at whatever the replica happened to be
+// doing, and every later lambda near that value would read as saturation at low
+// occupancy — over-provisioning, the mirror of the bug this replaces.
 //
 //	mu = highest completion rate seen for this workload bucket while queued
 //	k2 = occupancy × (mu / lambda)
@@ -57,6 +66,11 @@ const (
 	MinRateRatio = 0.05
 	MaxRateRatio = 20.0
 
+	// MinServiceRateSamples is how many qualifying observations a bucket needs
+	// before its service rate is usable. One observation cannot distinguish a real
+	// ceiling from a single slow interval.
+	MinServiceRateSamples = 2
+
 	// MinRateAnchoredFraction floors the estimate at a fraction of k1. A replica
 	// that has stalled completely (mu near zero while requests are queued) would
 	// otherwise drive capacity to ~0 and demand an unbounded scale-up.
@@ -75,6 +89,7 @@ type serviceRateStore struct {
 type serviceRateEntry struct {
 	rate     float64
 	observed time.Time
+	samples  int
 }
 
 func newServiceRateStore() *serviceRateStore {
@@ -92,9 +107,10 @@ func (s *serviceRateStore) Observe(key string, rate float64, now time.Time) {
 
 	e, ok := s.entries[key]
 	if !ok {
-		s.entries[key] = &serviceRateEntry{rate: rate, observed: now}
+		s.entries[key] = &serviceRateEntry{rate: rate, observed: now, samples: 1}
 		return
 	}
+	e.samples++
 	// Compare against the decayed value so a stale peak yields to a fresh, lower
 	// observation rather than persisting until eviction.
 	if decayed := decayRate(e.rate, now.Sub(e.observed)); rate >= decayed {
@@ -113,6 +129,9 @@ func (s *serviceRateStore) Rate(key string, now time.Time) (float64, bool) {
 
 	e, ok := s.entries[key]
 	if !ok {
+		return 0, false
+	}
+	if e.samples < MinServiceRateSamples {
 		return 0, false
 	}
 	if now.Sub(e.observed) > ServiceRateWindow {
@@ -181,6 +200,7 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	modelID string,
 	gpuCount int,
 	k1 int64,
+	queueThreshold float64,
 	now time.Time,
 ) (int64, k2Source, bool, bool) {
 	if a.serviceRates == nil {
@@ -189,8 +209,9 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 
 	key := serviceRateKey(modelID, rm.AcceleratorName, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
 
-	// A replica with a backlog is serving at capacity: record what it achieved.
-	if rm.QueueLength > 0 && rm.RequestRate > 0 {
+	// Only a sustained backlog establishes a ceiling; see the package comment.
+	backlogged := float64(rm.QueueLength) >= queueThreshold
+	if backlogged && rm.RequestRate > 0 {
 		a.serviceRates.Observe(key, rm.RequestRate, now)
 	}
 
@@ -201,7 +222,7 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 		return 0, 0, false, false
 	}
 
-	ratio, src, ok := a.saturationRatio(rm, key, now)
+	ratio, src, ok := a.saturationRatio(rm, key, backlogged, now)
 	if !ok {
 		return 0, 0, false, false
 	}
@@ -229,11 +250,13 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 //
 //  1. EPP arrival rate. The intended path: lambda is measured independently of the
 //     engine, so the ratio holds whether or not the replica is keeping up.
-//  2. Backlog. A queueing replica is saturated by observation: arrivals exceed
-//     service, so the ratio is at most 1 and capacity is the current occupancy.
-//     This needs neither lambda nor a calibrated mu, which makes it the safety net
-//     for a fleet with no EPP and no prior calibration — and it is exactly the
-//     prefill-heavy case the occupancy estimator misreads as idle.
+//  2. Backlog. A replica queueing at least QueueLengthThreshold deep is saturated
+//     by observation: arrivals exceed service, so the ratio is at most 1 and
+//     capacity is the current occupancy. This needs neither lambda nor a calibrated
+//     mu, which makes it the safety net for a fleet with no EPP and no prior
+//     calibration — and it is exactly the prefill-heavy case the occupancy
+//     estimator misreads as idle. A shallower queue does not qualify: arrival
+//     jitter produces one every so often at any load.
 //  3. Completion rate as lambda. With no queue, everything that arrives is served
 //     within the scrape window, so completions are arrivals. Valid only in that
 //     case, which is why it sits behind the backlog check rather than in front.
@@ -242,6 +265,7 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 func (a *SaturationAnalyzer) saturationRatio(
 	rm domain.ReplicaMetrics,
 	key string,
+	backlogged bool,
 	now time.Time,
 ) (float64, k2Source, bool) {
 	muRate, haveMu := a.serviceRates.Rate(key, now)
@@ -249,7 +273,7 @@ func (a *SaturationAnalyzer) saturationRatio(
 	if rm.ArrivalRate > 0 && haveMu {
 		return muRate / rm.ArrivalRate, k2SrcRateAnchored, true
 	}
-	if rm.QueueLength > 0 {
+	if backlogged {
 		return 1.0, k2SrcRateBacklog, true
 	}
 	if haveMu && rm.RequestRate > 0 {

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -60,11 +60,15 @@ const (
 	// rare, so this is generous relative to the optimize interval.
 	ServiceRateWindow = 30 * time.Minute
 
-	// ServiceRateDecayPerWindow is the fraction the retained service rate decays to
-	// over one ServiceRateWindow with no fresh observation. Decay matters because
-	// the rate is a running maximum: without it, one unusually fast interval would
-	// pin it high for as long as the entry lives.
-	ServiceRateDecayPerWindow = 0.75
+	// ServiceRateSmoothingWindow is the time constant over which mu tracks the
+	// completion rates observed under backlog. While a replica is backlogged it is
+	// never idle, so every such sample IS its service rate — there is no reason to
+	// prefer the largest, and a running maximum could only ratchet upward. It has to
+	// move down as readily as up: when prompts get longer within a bucket the true
+	// mu falls, and an estimate that lags overstates capacity and under-scales.
+	//
+	// Five minutes is responsive within a load stage without chasing a single scrape.
+	ServiceRateSmoothingWindow = 5 * time.Minute
 
 	// CeilingRelaxPerWindow is the factor the learned token ceiling relaxes by over
 	// one ServiceRateWindow with no fresh observation. The ceiling is a running
@@ -124,6 +128,13 @@ type bucketEntry struct {
 	ceiling      float64 // running min of resident tokens at the limit
 	ceilingSeen  time.Time
 	ceilingKnown bool
+	work         float64 // EWMA of residence x tokens-per-request, in token-seconds
+	workSeen     time.Time
+	workKnown    bool
+	workFrozen   float64 // the value every replica of the bucket reads this cycle
+	workSum      float64 // this cycle's samples, averaged at the next freeze
+	workTauSum   float64 // and their time constants, averaged with them
+	workCount    int
 }
 
 func newBucketStore() *bucketStore {
@@ -159,6 +170,9 @@ func (s *bucketStore) pruneLocked(timeout time.Duration, now time.Time) int {
 		if e.ceilingSeen.After(last) {
 			last = e.ceilingSeen
 		}
+		if e.workSeen.After(last) {
+			last = e.workSeen
+		}
 		if now.Sub(last) > timeout {
 			delete(s.entries, k)
 			removed++
@@ -167,9 +181,15 @@ func (s *bucketStore) pruneLocked(timeout time.Duration, now time.Time) int {
 	return removed
 }
 
-// ObserveRate records a completion rate for a bucket, keeping the running maximum.
+// ObserveRate folds a completion rate into the bucket's service-rate estimate.
 // Callers must only pass rates measured while the replica had a backlog: with no
 // backlog, completions equal arrivals at any load and say nothing about the limit.
+//
+// Symmetric by construction. The ceiling is a running minimum, so it errs toward
+// less capacity and more replicas; a running maximum here would err the opposite
+// way, toward more capacity and fewer replicas, and only decay slowly back. Under
+// backlog every sample is a valid reading of the service rate, so the mean of them
+// is both the better estimate and the one that moves in either direction.
 func (s *bucketStore) ObserveRate(key string, rate float64, now time.Time) {
 	if rate <= 0 {
 		return
@@ -183,13 +203,7 @@ func (s *bucketStore) ObserveRate(key string, rate float64, now time.Time) {
 		return
 	}
 	e.rateSamples++
-	// Compare against the decayed value so a stale peak yields to a fresh, lower
-	// observation rather than persisting until eviction.
-	if decayed := decayRate(e.rate, now.Sub(e.rateSeen)); rate >= decayed {
-		e.rate = rate
-	} else {
-		e.rate = decayed
-	}
+	e.rate = ewmaStep(e.rate, rate, now.Sub(e.rateSeen).Seconds(), ServiceRateSmoothingWindow.Seconds())
 	e.rateSeen = now
 }
 
@@ -206,11 +220,10 @@ func (s *bucketStore) Rate(key string, now time.Time) (float64, bool) {
 	if now.Sub(e.rateSeen) > ServiceRateWindow {
 		return 0, false
 	}
-	r := decayRate(e.rate, now.Sub(e.rateSeen))
-	if r <= 0 {
+	if e.rate <= 0 {
 		return 0, false
 	}
-	return r, true
+	return e.rate, true
 }
 
 // ObserveCeiling records the resident token count measured while a replica was at
@@ -258,6 +271,79 @@ func (s *bucketStore) Ceiling(key string, now time.Time) (float64, bool) {
 	return c, true
 }
 
+// ObserveWork records this replica's work-per-request — residence time multiplied
+// by tokens per request, in token-seconds — as one sample of the bucket's operating
+// point. tau is the averaging time constant; the quantity changes on the residence
+// timescale, so that is what it is smoothed over at the next freeze.
+//
+// Samples accumulate rather than folding in one at a time, because every replica of
+// a bucket reports in the same cycle at the same timestamp. Folding each in turn
+// would give the first replica of the loop the entire weight — the rest arrive with
+// a zero time delta and change nothing — making the bucket's operating point depend
+// on iteration order. A replica that had just started, with a short residence, could
+// then pull the whole bucket's capacity down and drive a spurious scale-up.
+//
+// The value is deliberately not read back here: see FrozenWork.
+func (s *bucketStore) ObserveWork(key string, work, tau float64, now time.Time) {
+	if work <= 0 || tau <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e := s.entry(key, now)
+	e.workSum += work
+	e.workTauSum += tau
+	e.workCount++
+}
+
+// FrozenWork returns the work-per-request every replica of the bucket scales by
+// this cycle, and false when none has been frozen yet.
+func (s *bucketStore) FrozenWork(key string, now time.Time) (float64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.entries[key]
+	if !ok || e.workFrozen <= 0 {
+		return 0, false
+	}
+	if now.Sub(e.workSeen) > ServiceRateWindow {
+		return 0, false
+	}
+	return e.workFrozen, true
+}
+
+// FreezeWork averages the samples each bucket collected last cycle, folds that mean
+// into the bucket's EWMA, and publishes it as the value this cycle's replicas will
+// read. It must be called once at the top of a cycle.
+//
+// Publishing at the cycle boundary is what makes the number identical across
+// siblings: aggregateByVariant takes the MEDIAN of per-replica capacities, so a
+// value that moved as the loop progressed would blend incommensurable figures. It
+// costs one cycle of lag, which is the price of that guarantee. Analyze is never
+// concurrent, so a plain sweep is enough.
+func (s *bucketStore) FreezeWork(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, e := range s.entries {
+		if e.workCount > 0 {
+			n := float64(e.workCount)
+			sample, tau := e.workSum/n, e.workTauSum/n
+			e.workSum, e.workTauSum, e.workCount = 0, 0, 0
+			if e.workKnown {
+				e.work = ewmaStep(e.work, sample, now.Sub(e.workSeen).Seconds(), tau)
+			} else {
+				e.work, e.workKnown = sample, true
+			}
+			e.workSeen = now
+		}
+		if e.workKnown {
+			e.workFrozen = e.work
+		}
+	}
+}
+
 // EvictStale drops buckets with no observation of either kind within timeout,
 // returning the number removed. Mirrors EvictStaleHistory so the stores age out
 // together.
@@ -265,16 +351,6 @@ func (s *bucketStore) EvictStale(timeout time.Duration, now time.Time) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.pruneLocked(timeout, now)
-}
-
-// decayRate applies exponential decay so an unrefreshed service rate loses
-// authority smoothly: after one ServiceRateWindow it retains
-// ServiceRateDecayPerWindow of its value.
-func decayRate(rate float64, age time.Duration) float64 {
-	if age <= 0 {
-		return rate
-	}
-	return rate * math.Pow(ServiceRateDecayPerWindow, age.Seconds()/ServiceRateWindow.Seconds())
 }
 
 // relaxCeiling grows an unrefreshed ceiling so capacity drifts back toward the
@@ -332,19 +408,25 @@ func (s *arrivalSmoother) Smooth(key string, rate, tau float64, now time.Time) f
 		s.entries[key] = &arrivalEntry{rate: rate, observed: now}
 		return rate
 	}
-	dt := now.Sub(e.observed).Seconds()
-	if dt <= 0 {
-		return e.rate
+	if dt := now.Sub(e.observed).Seconds(); dt > 0 {
+		e.rate = ewmaStep(e.rate, rate, dt, tau)
+		e.observed = now
 	}
-	// Older than a few time constants: the previous value carries no information.
-	if dt > tau*ArrivalSmoothingResetFactor {
-		e.rate, e.observed = rate, now
-		return rate
-	}
-	alpha := 1 - math.Exp(-dt/tau)
-	e.rate += alpha * (rate - e.rate)
-	e.observed = now
 	return e.rate
+}
+
+// ewmaStep folds sample into prev with a weight derived from the actual gap between
+// samples, so an irregular optimize interval or a missed cycle does not distort the
+// average. A gap longer than a few time constants discards prev outright: it carries
+// no information about the present.
+func ewmaStep(prev, sample, dt, tau float64) float64 {
+	if dt <= 0 || tau <= 0 {
+		return prev
+	}
+	if dt > tau*ArrivalSmoothingResetFactor {
+		return sample
+	}
+	return prev + (1-math.Exp(-dt/tau))*(sample-prev)
 }
 
 // EvictStale drops replicas not seen within timeout, returning the number removed.
@@ -401,12 +483,19 @@ func serviceRateKey(modelID, accelerator, role string, gpuCount int, avgInput, a
 }
 
 // rateAnchoredK2 returns the compute-bound capacity in KV tokens for this
-// replica's bucket, and which signal produced it.
+// replica's bucket, the load-independent reference to store, and which signal
+// produced the capacity.
 //
-// The value is the bucket's learned ceiling wherever one exists, so it is the same
-// for every replica of the variant and does not move with this cycle's arrival
-// rate. Before anything has been learned, a replica that is over its limit right
-// now still reports its own occupancy, so the first overload is not missed.
+// The capacity is the bucket's learned ceiling, scaled down by how far this cycle's
+// operating point sits below the one the ceiling was measured at — see
+// residenceScaledCapacity for why that scaling is the point of the whole design.
+// Before anything has been learned, a replica that is over its limit right now
+// still reports its own occupancy, so the first overload is not missed.
+//
+// The reference return is the unscaled ceiling. Capacity moves with contention and
+// so must never be persisted: the capacity store feeds variants with no live
+// replicas and cross-variant estimation, both of which need a number that means
+// "what this replica can do", not "what it is doing now".
 //
 // Returns false when nothing has been learned and the replica is not currently
 // over its limit, in which case the caller falls through to the occupancy-based
@@ -419,9 +508,9 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	k1 int64,
 	queueThreshold float64,
 	now time.Time,
-) (int64, k2Source, bool) {
+) (int64, int64, k2Source, bool) {
 	if a.serviceRates == nil {
-		return 0, 0, false
+		return 0, 0, 0, false
 	}
 
 	key := serviceRateKey(modelID, rm.AcceleratorName, role, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
@@ -433,26 +522,110 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	}
 	atLimit := backlogged || a.arrivalsReachedServiceRate(rm, key, now)
 
-	// Whether anything was known before this cycle, purely so the source label can
-	// distinguish a fresh measurement from a carried-over one. Both are the same
-	// number and take the same path; the distinction is for the cycle log.
-	_, hadCeiling := a.serviceRates.Ceiling(key, now)
-
-	// Measurement: at the limit, resident tokens are what the limit is worth.
-	occupancy := float64(rm.TokensInUse)
-	if atLimit && occupancy > 0 {
+	// Measurement: under backlog, resident tokens are what the limit is worth.
+	//
+	// Only under backlog. Arrivals reaching the service rate is enough to say the
+	// replica is at its limit — it is how the limit is caught before a queue forms —
+	// but it is not a measurement of the limit: with no queue, low occupancy means
+	// the replica is keeping up comfortably, not that its ceiling has fallen.
+	// Recording it would ratchet the running minimum down on evidence of health.
+	if occupancy := limitOccupancy(rm); backlogged && occupancy > 0 {
 		a.serviceRates.ObserveCeiling(key, occupancy, now)
+	}
+
+	// Every cycle, at the limit or not, contributes to the bucket's work-per-request.
+	// It is the operating point, not a measurement of the limit, so it is recorded
+	// unconditionally — the whole point is to know how far below the limit we sit.
+	if residence := residenceSeconds(rm); residence > 0 {
+		if work := residence * tokensPerRequest(rm); work > 0 {
+			a.serviceRates.ObserveWork(key, work, residence, now)
+		}
 	}
 
 	ceiling, ok := a.serviceRates.Ceiling(key, now)
 	if !ok {
-		return 0, 0, false
+		return 0, 0, 0, false
 	}
+	// The three labels say which regime produced the number: at the limit right now,
+	// carrying a limit measured earlier, or holding a limit measured earlier scaled
+	// to a lighter operating point. That is what the offline replay has to separate.
 	src := k2SrcRateAnchored
-	if !hadCeiling {
+	if atLimit {
 		src = k2SrcRateBacklog
 	}
-	return clampCeiling(ceiling, k1), src, true
+
+	reference := clampCeiling(ceiling, k1)
+	capacity := reference
+	if scaled, ok := a.residenceScaledCapacity(key, ceiling, now); ok {
+		capacity = clampCeiling(scaled, k1)
+		src = k2SrcRateResidence
+	}
+	return capacity, reference, src, true
+}
+
+// residenceScaledCapacity expresses the bucket's capacity at this cycle's operating
+// point, and reports false when it should be left at the measured ceiling.
+//
+// A ceiling alone cannot stop the collapse that validation round 1 measured. Demand
+// is resident tokens, lambda x W x tokensPerRequest, so it falls when replicas are
+// added: contention drops, residence W drops, and the queue term disappears
+// outright. Supply held flat against a shrinking demand reads as abundant spare
+// capacity, and the fleet sheds the replicas that had just fixed the problem.
+//
+// By Little's law a replica at its limit holds mu x W x tokensPerRequest tokens, so
+// that product IS the capacity in the units the engine speaks, at whatever operating
+// point W describes. Scaling supply by it makes demand/supply equal lambda/mu, which
+// does not move when replicas are added — only lambda per replica does. At the
+// moment of calibration the two agree exactly (lambda = mu there, so the product
+// equals the occupancy that set the ceiling), so nothing jumps when this engages.
+//
+// The result is clamped at the ceiling and never above it: W is derived from TTFT,
+// which includes time queued, so a backlogged replica reports an inflated W. Letting
+// that raise capacity would relax the bound exactly when the replica is failing. One
+// direction only — contention below the calibration point may lower capacity,
+// queueing above it may not raise it.
+func (a *SaturationAnalyzer) residenceScaledCapacity(key string, ceiling float64, now time.Time) (float64, bool) {
+	muRate, ok := a.serviceRates.Rate(key, now)
+	if !ok {
+		return 0, false
+	}
+	work, ok := a.serviceRates.FrozenWork(key, now)
+	if !ok {
+		return 0, false
+	}
+	scaled := muRate * work
+	if scaled <= 0 || math.IsNaN(scaled) || math.IsInf(scaled, 0) {
+		return 0, false
+	}
+	if scaled >= ceiling {
+		return 0, false
+	}
+	return scaled, true
+}
+
+// limitOccupancy is the resident token count to record as a measurement of the
+// limit. It prefers the instantaneous KV reading over TokensInUse, which is derived
+// from max_over_time(...[1m]) — the highest occupancy of the last minute, not the
+// occupancy at the moment the replica was seen unable to keep up. Since the ceiling
+// is a running minimum, a peak-derived input biases it high in the one direction
+// that costs replicas. Falls back when the instantaneous reading is unavailable.
+func limitOccupancy(rm domain.ReplicaMetrics) float64 {
+	if rm.KvUsageInstant > 0 && rm.TotalKvCapacityTokens > 0 {
+		if tokens := rm.KvUsageInstant * float64(rm.TotalKvCapacityTokens); tokens > 0 &&
+			!math.IsNaN(tokens) && !math.IsInf(tokens, 0) {
+			return tokens
+		}
+	}
+	return float64(rm.TokensInUse)
+}
+
+// tokensPerRequest is the KV footprint of one request of this bucket's shape.
+func tokensPerRequest(rm domain.ReplicaMetrics) float64 {
+	t := rm.AvgInputTokens + rm.AvgOutputTokens
+	if t <= 0 || math.IsNaN(t) || math.IsInf(t, 0) {
+		return 0
+	}
+	return t
 }
 
 // arrivalsReachedServiceRate reports whether arrivals have caught up with the

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -61,10 +61,11 @@ const (
 	// the estimate high for as long as the entry lives.
 	ServiceRateDecayPerWindow = 0.75
 
-	// MinRateRatio and MaxRateRatio clamp mu/lambda. A mis-scraped or transiently
-	// zero rate must not be able to swing capacity by orders of magnitude.
+	// MinRateRatio floors mu/lambda so a mis-scraped or transiently collapsed
+	// service rate cannot drive capacity to nearly zero. There is no upper clamp:
+	// a ratio above 1 means the replica has headroom, and the estimator declines
+	// rather than reporting a headroom-scaled figure as capacity.
 	MinRateRatio = 0.05
-	MaxRateRatio = 20.0
 
 	// MinServiceRateSamples is how many qualifying observations a bucket needs
 	// before its service rate is usable. One observation cannot distinguish a real
@@ -290,18 +291,26 @@ func serviceRateKey(modelID, accelerator, role string, gpuCount int, avgInput, a
 }
 
 // rateAnchoredK2 estimates the compute-bound capacity in KV tokens from the
-// replica's distance to rate saturation, returning the value, which signal
-// produced it, and whether that value is a measured ceiling.
+// replica's distance to rate saturation, returning the value and which signal
+// produced it.
 //
-// The ceiling flag governs persistence, not the scaling decision. At lambda >= mu
-// the replica is at or past saturation, so occupancy × mu/lambda is what it was
-// actually able to hold — worth writing to the capacity store. Below saturation
-// the same expression is occupancy scaled by headroom: correct for this cycle's
-// utilization, but not a property of the variant, and persisting it would
-// under-state capacity for zero-replica estimation and cross-variant lookups.
+// It answers ONLY when the replica is at or past saturation (lambda >= mu). Below
+// saturation, occupancy × mu/lambda is occupancy scaled by headroom — a statement
+// about slack, not a capacity. Returning it would be wrong in two places: it is not
+// a ceiling, so it must not be persisted; and aggregateByVariant takes the MEDIAN
+// of per-replica capacities, where an idle replica's headroom-scaled number sits
+// next to a backlogged sibling's genuine ceiling as though the two were
+// commensurable. With one replica queueing twelve deep and an idle sibling, that
+// median lifted variant capacity enough to turn a scale-up into a scale-down —
+// reintroducing the shed-to-one this estimator exists to prevent, by a new route.
 //
-// Returns false when no signal is usable, in which case the caller falls through
-// to the existing occupancy-based chain.
+// Declining above saturation loses nothing: detecting saturation the occupancy path
+// misses is the whole purpose, and when a replica genuinely has headroom the
+// occupancy path's ceiling is the better answer. Everything this function returns
+// is therefore a measured ceiling, which is what makes it safe to persist.
+//
+// Returns false when no signal is usable or the replica has headroom, in which case
+// the caller falls through to the existing occupancy-based chain.
 func (a *SaturationAnalyzer) rateAnchoredK2(
 	rm domain.ReplicaMetrics,
 	modelID string,
@@ -310,9 +319,9 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	k1 int64,
 	queueThreshold float64,
 	now time.Time,
-) (int64, k2Source, bool, bool) {
+) (int64, k2Source, bool) {
 	if a.serviceRates == nil {
-		return 0, 0, false, false
+		return 0, 0, false
 	}
 
 	key := serviceRateKey(modelID, rm.AcceleratorName, role, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
@@ -340,20 +349,19 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	// with no queue, utilization reduces to lambda/mu, which is the whole intent.
 	occupancy := float64(rm.TokensInUse)
 	if occupancy <= 0 {
-		return 0, 0, false, false
+		return 0, 0, false
 	}
 
 	ratio, src, ok := a.saturationRatio(rm, key, lambda, backlogged, now)
 	if !ok {
-		return 0, 0, false, false
+		return 0, 0, false
 	}
-	// At or past saturation the replica demonstrated this capacity; below it, the
-	// value is headroom-scaled and must not be persisted as a ceiling.
-	ceiling := ratio <= 1.0
+	// Headroom is not a capacity: stay silent and let the occupancy path answer.
+	if ratio > 1.0 {
+		return 0, 0, false
+	}
 	if ratio < MinRateRatio {
 		ratio = MinRateRatio
-	} else if ratio > MaxRateRatio {
-		ratio = MaxRateRatio
 	}
 
 	k2 := occupancy * ratio
@@ -370,9 +378,9 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 		k2 = floor
 	}
 	if k2 <= 0 || math.IsNaN(k2) || math.IsInf(k2, 0) {
-		return 0, 0, false, false
+		return 0, 0, false
 	}
-	return int64(k2), src, ceiling, true
+	return int64(k2), src, true
 }
 
 // saturationRatio returns mu/lambda — how much service headroom the replica has —

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -71,6 +71,16 @@ const (
 	// ceiling from a single slow interval.
 	MinServiceRateSamples = 2
 
+	// MinResidenceSeconds and MaxResidenceSeconds bound the residence estimate used
+	// as the arrival-smoothing time constant, so a garbage latency reading cannot
+	// turn the average into either a passthrough or a frozen value.
+	MinResidenceSeconds = 1.0
+	MaxResidenceSeconds = 300.0
+
+	// ArrivalSmoothingResetFactor is how many time constants may pass before the
+	// previous arrival average is discarded rather than blended.
+	ArrivalSmoothingResetFactor = 3.0
+
 	// MinRateAnchoredFraction floors the estimate at a fraction of k1. A replica
 	// that has stalled completely (mu near zero while requests are queued) would
 	// otherwise drive capacity to ~0 and demand an unbounded scale-up.
@@ -171,6 +181,98 @@ func decayRate(rate float64, age time.Duration) float64 {
 	return rate * math.Pow(ServiceRateDecayPerWindow, windows)
 }
 
+// arrivalSmoother holds a per-replica exponentially-weighted arrival rate.
+//
+// A completion happens one residence time after the arrival that caused it, so a
+// completion-derived mu and an instantaneous lambda are measured on different time
+// bases: during a ramp, completions still reflect the lighter load of W seconds
+// ago and mu/lambda reads as saturation on a replica that is coping. Occupancy has
+// the same property — it is a stock that already integrates arrivals over W.
+// Averaging lambda over roughly W puts all three on the same footing.
+type arrivalSmoother struct {
+	mu      sync.Mutex
+	entries map[string]*arrivalEntry
+}
+
+type arrivalEntry struct {
+	rate     float64
+	observed time.Time
+}
+
+func newArrivalSmoother() *arrivalSmoother {
+	return &arrivalSmoother{entries: make(map[string]*arrivalEntry)}
+}
+
+// Smooth folds a new arrival-rate sample into the replica's EWMA and returns the
+// smoothed value. tau is the averaging time constant — the residence estimate.
+// The weight is derived from the actual gap between samples, so an irregular
+// optimize interval or a missed cycle does not distort the average.
+func (s *arrivalSmoother) Smooth(key string, rate, tau float64, now time.Time) float64 {
+	if rate <= 0 {
+		return rate
+	}
+	if tau <= 0 {
+		return rate
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.entries[key]
+	if !ok {
+		s.entries[key] = &arrivalEntry{rate: rate, observed: now}
+		return rate
+	}
+	dt := now.Sub(e.observed).Seconds()
+	if dt <= 0 {
+		return e.rate
+	}
+	// Older than a few time constants: the previous value carries no information.
+	if dt > tau*ArrivalSmoothingResetFactor {
+		e.rate, e.observed = rate, now
+		return rate
+	}
+	alpha := 1 - math.Exp(-dt/tau)
+	e.rate += alpha * (rate - e.rate)
+	e.observed = now
+	return e.rate
+}
+
+// EvictStale drops replicas not seen within timeout, returning the number removed.
+func (s *arrivalSmoother) EvictStale(timeout time.Duration, now time.Time) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	removed := 0
+	for k, e := range s.entries {
+		if now.Sub(e.observed) > timeout {
+			delete(s.entries, k)
+			removed++
+		}
+	}
+	return removed
+}
+
+// residenceSeconds estimates how long a request occupies the replica: time to the
+// first token plus one inter-token latency per output token. Both inputs are
+// already collected per replica. Returns 0 when they are unavailable, which leaves
+// the arrival rate unsmoothed rather than smoothing it by a made-up constant.
+func residenceSeconds(rm domain.ReplicaMetrics) float64 {
+	if rm.AvgITL <= 0 || rm.AvgOutputTokens <= 0 {
+		return 0
+	}
+	w := rm.AvgTTFT + rm.AvgOutputTokens*rm.AvgITL
+	if w <= 0 || math.IsNaN(w) || math.IsInf(w, 0) {
+		return 0
+	}
+	if w < MinResidenceSeconds {
+		return MinResidenceSeconds
+	}
+	if w > MaxResidenceSeconds {
+		return MaxResidenceSeconds
+	}
+	return w
+}
+
 // serviceRateKey identifies a workload bucket for service-rate purposes.
 //
 // The input bucket is part of the key, unlike the k2 history key: mu is a property
@@ -215,6 +317,14 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 		a.serviceRates.Observe(key, rm.RequestRate, now)
 	}
 
+	// Put lambda on the same time base as the completion-derived mu and the
+	// occupancy stock, both of which integrate over a residence time.
+	smoothingKey := rm.PodName
+	if smoothingKey == "" {
+		smoothingKey = key
+	}
+	lambda := a.arrivals.Smooth(smoothingKey, rm.ArrivalRate, residenceSeconds(rm), now)
+
 	// KvUsageInstant is the un-peaked reading; the 1-minute max used for demand
 	// would over-state the operating point and inflate the estimate.
 	occupancy := rm.KvUsageInstant * float64(rm.TotalKvCapacityTokens)
@@ -222,7 +332,7 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 		return 0, 0, false, false
 	}
 
-	ratio, src, ok := a.saturationRatio(rm, key, backlogged, now)
+	ratio, src, ok := a.saturationRatio(rm, key, lambda, backlogged, now)
 	if !ok {
 		return 0, 0, false, false
 	}
@@ -248,8 +358,10 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 // saturationRatio returns mu/lambda — how much service headroom the replica has —
 // from the best signal available, in descending order of directness:
 //
-//  1. EPP arrival rate. The intended path: lambda is measured independently of the
-//     engine, so the ratio holds whether or not the replica is keeping up.
+//  1. EPP arrival rate, smoothed over a residence time. The intended path: lambda
+//     is measured independently of the engine, so the ratio holds whether or not
+//     the replica is keeping up. Smoothing matters because completions lag their
+//     arrivals — see arrivalSmoother.
 //  2. Backlog. A replica queueing at least QueueLengthThreshold deep is saturated
 //     by observation: arrivals exceed service, so the ratio is at most 1 and
 //     capacity is the current occupancy. This needs neither lambda nor a calibrated
@@ -265,13 +377,14 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 func (a *SaturationAnalyzer) saturationRatio(
 	rm domain.ReplicaMetrics,
 	key string,
+	lambda float64,
 	backlogged bool,
 	now time.Time,
 ) (float64, k2Source, bool) {
 	muRate, haveMu := a.serviceRates.Rate(key, now)
 
-	if rm.ArrivalRate > 0 && haveMu {
-		return muRate / rm.ArrivalRate, k2SrcRateAnchored, true
+	if lambda > 0 && haveMu {
+		return muRate / lambda, k2SrcRateAnchored, true
 	}
 	if backlogged {
 		return 1.0, k2SrcRateBacklog, true

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -1,8 +1,10 @@
 package saturation_v2
 
 import (
+	"cmp"
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -91,10 +93,20 @@ const (
 	// drifts back toward the memory bound in the absence of evidence.
 	CeilingRelaxPerWindow = 1.25
 
-	// MinServiceRateSamples is how many qualifying observations a bucket needs
-	// before its service rate is usable. One observation cannot distinguish a real
-	// limit from a single slow interval.
+	// MinServiceRateSamples is how many qualifying CYCLES a bucket needs before its
+	// service rate is usable. One cycle cannot distinguish a real limit from a single
+	// slow interval. Counting cycles rather than observations matters: every replica
+	// of a bucket reports in the same cycle, so counting observations would let two
+	// replicas satisfy this in one interval and defeat the guard.
 	MinServiceRateSamples = 2
+
+	// MinCeilingLowerCycles is how many consecutive cycles must agree before the
+	// learned ceiling is lowered. Lowering is the dangerous direction: the ceiling
+	// sets the whole loop gain, so a single unrepresentative reading — a replica that
+	// has just started and holds almost nothing, or one degraded pod among healthy
+	// siblings — would otherwise pin the entire bucket near the floor and take hours
+	// to relax back. Raising it needs no such delay.
+	MinCeilingLowerCycles = 2
 
 	// SaturationEnterRatio is the fraction of the service rate at which arrivals
 	// are treated as having reached it. Slightly below 1 so the limit is recognised
@@ -135,18 +147,38 @@ type bucketStore struct {
 	entries map[string]*bucketEntry
 }
 
+// bucketEntry holds one workload bucket's learned state. Every quantity is folded
+// once per cycle by BeginCycle rather than per observation: replicas of a bucket all
+// report within the same cycle at the same timestamp, so folding on arrival gives the
+// first replica the entire weight and makes the result depend on the order the loop
+// happened to reach them — which, since ReplicaMetrics is built by ranging a map, is
+// not even stable between cycles.
 type bucketEntry struct {
-	rate         float64 // mu: running max of completion rate under backlog
-	rateSamples  int
-	rateSeen     time.Time
-	ceiling      float64 // running min of resident tokens at the limit
-	ceilingSeen  time.Time
-	ceilingKnown bool
-	workSeen     time.Time
-	workSamples  []workSample // one per cycle, held for WorkWindow
-	workFrozen   float64      // the value every replica of the bucket reads this cycle
-	workSum      float64      // this cycle's samples, averaged at the next freeze
-	workCount    int
+	// touched is the last time any replica reported into this bucket. Observations
+	// accumulate and are only folded at the cycle boundary, so the folded timestamps
+	// lag by a cycle and cannot be used to decide staleness — a bucket observed but
+	// not yet folded would look infinitely old and be evicted with its samples.
+	touched time.Time
+
+	rate        float64 // mu: mean completion rate under backlog
+	rateSamples int     // qualifying cycles, not observations
+	rateSeen    time.Time
+	rateSum     float64 // this cycle's samples, averaged at the next cycle boundary
+	rateCount   int
+
+	ceiling       float64 // resident tokens at the limit; lowered only on sustained evidence
+	ceilingSeen   time.Time
+	ceilingKnown  bool
+	ceilingSum    float64 // this cycle's lowest qualifying observation
+	ceilingHas    bool
+	pendingLower  float64 // a lower reading waiting to be confirmed by another cycle
+	pendingCycles int
+
+	workSeen    time.Time
+	workSamples []workSample // one per cycle, held for WorkWindow
+	workFrozen  float64      // the value every replica of the bucket reads this cycle
+	workSum     float64      // this cycle's samples, averaged at the next cycle boundary
+	workCount   int
 }
 
 // workSample is one cycle's operating point: residence x tokens-per-request,
@@ -177,6 +209,7 @@ func (s *bucketStore) entry(key string, now time.Time) *bucketEntry {
 		e = &bucketEntry{}
 		s.entries[key] = e
 	}
+	e.touched = now
 	return e
 }
 
@@ -185,14 +218,7 @@ func (s *bucketStore) entry(key string, now time.Time) *bucketEntry {
 func (s *bucketStore) pruneLocked(timeout time.Duration, now time.Time) int {
 	removed := 0
 	for k, e := range s.entries {
-		last := e.rateSeen
-		if e.ceilingSeen.After(last) {
-			last = e.ceilingSeen
-		}
-		if e.workSeen.After(last) {
-			last = e.workSeen
-		}
-		if now.Sub(last) > timeout {
+		if now.Sub(e.touched) > timeout {
 			delete(s.entries, k)
 			removed++
 		}
@@ -210,20 +236,15 @@ func (s *bucketStore) pruneLocked(timeout time.Duration, now time.Time) int {
 // backlog every sample is a valid reading of the service rate, so the mean of them
 // is both the better estimate and the one that moves in either direction.
 func (s *bucketStore) ObserveRate(key string, rate float64, now time.Time) {
-	if rate <= 0 {
+	if !(rate > 0) || math.IsInf(rate, 0) { // NaN fails the > comparison
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	e := s.entry(key, now)
-	if e.rateSamples == 0 {
-		e.rate, e.rateSamples, e.rateSeen = rate, 1, now
-		return
-	}
-	e.rateSamples++
-	e.rate = ewmaStep(e.rate, rate, now.Sub(e.rateSeen).Seconds(), ServiceRateSmoothingWindow.Seconds())
-	e.rateSeen = now
+	e.rateSum += rate
+	e.rateCount++
 }
 
 // Rate returns the bucket's service-rate estimate, decayed by age, and false when
@@ -246,28 +267,51 @@ func (s *bucketStore) Rate(key string, now time.Time) (float64, bool) {
 }
 
 // ObserveCeiling records the resident token count measured while a replica was at
-// its limit, keeping the running minimum — the lowest occupancy at which a replica
-// was seen unable to keep up is the conservative reading of the bucket's capacity.
+// its limit. Within a cycle the lowest such reading wins; whether it becomes the
+// bucket's ceiling is decided at the cycle boundary, in applyCeiling.
 func (s *bucketStore) ObserveCeiling(key string, tokens float64, now time.Time) {
-	if tokens <= 0 {
+	if !(tokens > 0) || math.IsInf(tokens, 0) {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	e := s.entry(key, now)
+	if !e.ceilingHas || tokens < e.ceilingSum {
+		e.ceilingSum, e.ceilingHas = tokens, true
+	}
+}
+
+// applyCeiling folds one cycle's observation into the learned ceiling. Callers hold
+// s.mu.
+//
+// Raising is immediate: an old pessimistic reading must give way to fresh evidence
+// rather than capping the bucket indefinitely. Lowering waits for MinCeilingLowerCycles
+// consecutive cycles to agree, and then adopts the least extreme of them, because a
+// ceiling that fell on one reading would hand a single cold or degraded replica the
+// power to set capacity for every sibling and hold it there for hours.
+func (e *bucketEntry) applyCeiling(tokens float64, now time.Time) {
 	if !e.ceilingKnown {
 		e.ceiling, e.ceilingKnown, e.ceilingSeen = tokens, true, now
 		return
 	}
-	// Compare against the relaxed value so an old pessimistic reading gives way to
-	// a fresh higher one instead of capping the bucket indefinitely.
-	if relaxed := relaxCeiling(e.ceiling, now.Sub(e.ceilingSeen)); tokens <= relaxed {
-		e.ceiling = tokens
-	} else {
-		e.ceiling = relaxed
+	// Compared against the ceiling itself, not against its relaxed value: an
+	// unchanged reading is infinitesimally below the relaxed figure every cycle, and
+	// treating that as a lowering would keep a pending candidate permanently open.
+	if tokens >= e.ceiling {
+		relaxed := relaxCeiling(e.ceiling, now.Sub(e.ceilingSeen))
+		e.ceiling, e.ceilingSeen = math.Min(tokens, relaxed), now
+		e.pendingLower, e.pendingCycles = 0, 0
+		return
 	}
-	e.ceilingSeen = now
+	e.pendingCycles++
+	if e.pendingCycles == 1 || tokens > e.pendingLower {
+		e.pendingLower = tokens
+	}
+	if e.pendingCycles >= MinCeilingLowerCycles {
+		e.ceiling, e.ceilingSeen = e.pendingLower, now
+		e.pendingLower, e.pendingCycles = 0, 0
+	}
 }
 
 // Ceiling returns the bucket's learned token ceiling, relaxed by age, and false
@@ -330,40 +374,64 @@ func (s *bucketStore) FrozenWork(key string, now time.Time) (float64, bool) {
 	return e.workFrozen, true
 }
 
-// FreezeWork averages the samples each bucket collected last cycle, drops anything
-// older than WorkWindow, and publishes the maximum of what remains as the value this
-// cycle's replicas will read. It must be called once at the top of a cycle.
+// BeginCycle folds everything each bucket collected last cycle and publishes the
+// operating point this cycle's replicas will read. It must be called once at the top
+// of a cycle, before any replica is looked at.
+//
+// The service rate takes the cycle's mean, the ceiling its lowest qualifying reading,
+// and the operating point the maximum of the per-cycle means still inside WorkWindow
+// — the same operator the demand side is collected with, so both hold their peak and
+// step down together rather than one decaying past the other.
+//
+// Publishing at the cycle boundary is also what makes the operating point identical
+// across siblings: aggregateByVariant takes the MEDIAN of per-replica capacities, so a
+// value that moved as the loop progressed would blend incommensurable figures.
 //
 // Publishing at the cycle boundary is what makes the number identical across
 // siblings: aggregateByVariant takes the MEDIAN of per-replica capacities, so a
 // value that moved as the loop progressed would blend incommensurable figures. It
 // costs one cycle of lag, which is the price of that guarantee. Analyze is never
 // concurrent, so a plain sweep is enough.
-func (s *bucketStore) FreezeWork(now time.Time) {
+func (s *bucketStore) BeginCycle(now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	for _, e := range s.entries {
+		if e.rateCount > 0 {
+			sample := e.rateSum / float64(e.rateCount)
+			e.rateSum, e.rateCount = 0, 0
+			if e.rateSamples == 0 {
+				e.rate = sample
+			} else {
+				e.rate = ewmaStep(e.rate, sample, now.Sub(e.rateSeen).Seconds(), ServiceRateSmoothingWindow.Seconds())
+			}
+			e.rateSamples++
+			e.rateSeen = now
+		}
+
+		if e.ceilingHas {
+			e.applyCeiling(e.ceilingSum, now)
+			e.ceilingSum, e.ceilingHas = 0, false
+		}
+
 		if e.workCount > 0 {
 			e.workSamples = append(e.workSamples, workSample{at: now, value: e.workSum / float64(e.workCount)})
 			e.workSum, e.workCount = 0, 0
 			e.workSeen = now
 		}
-		kept := e.workSamples[:0]
-		peak := 0.0
-		for _, w := range e.workSamples {
-			if now.Sub(w.at) > WorkWindow {
-				continue
-			}
-			kept = append(kept, w)
-			if w.value > peak {
-				peak = w.value
-			}
+		e.workSamples = slices.DeleteFunc(e.workSamples, func(w workSample) bool {
+			return now.Sub(w.at) > WorkWindow
+		})
+		// An empty window means no live evidence of the operating point, so the
+		// estimator declines and falls back to the ceiling rather than scaling by a
+		// figure from before the gap.
+		if len(e.workSamples) == 0 {
+			e.workFrozen = 0
+			continue
 		}
-		e.workSamples = kept
-		if peak > 0 {
-			e.workFrozen = peak
-		}
+		e.workFrozen = slices.MaxFunc(e.workSamples, func(a, b workSample) int {
+			return cmp.Compare(a.value, b.value)
+		}).value
 	}
 }
 
@@ -471,6 +539,15 @@ func (s *arrivalSmoother) EvictStale(timeout time.Duration, now time.Time) int {
 // first token plus one inter-token latency per output token. Both inputs are
 // already collected per replica. Returns 0 when they are unavailable, which leaves
 // the arrival rate unsmoothed rather than smoothing it by a made-up constant.
+//
+// Only the upper bound is applied here. MinResidenceSeconds exists to keep a garbage
+// latency reading from turning the arrival average into a passthrough, and it is
+// applied at that call site — see smoothingTau. Applying it to capacity would be a
+// one-directional inflation: capacity is mu x W x tokensPerRequest, so a floor that
+// only ever raises W only ever raises supply, while demand has no matching floor. A
+// workload generating 16 tokens at 8ms each has a true residence near 0.2s, and
+// rounding that up to 1s overstates supply more than fourfold — enough that a fleet
+// at full utilization reports a quarter of it and never scales up at all.
 func residenceSeconds(rm domain.ReplicaMetrics) float64 {
 	if rm.AvgITL <= 0 || rm.AvgOutputTokens <= 0 {
 		return 0
@@ -479,11 +556,22 @@ func residenceSeconds(rm domain.ReplicaMetrics) float64 {
 	if w <= 0 || math.IsNaN(w) || math.IsInf(w, 0) {
 		return 0
 	}
-	if w < MinResidenceSeconds {
-		return MinResidenceSeconds
-	}
 	if w > MaxResidenceSeconds {
 		return MaxResidenceSeconds
+	}
+	return w
+}
+
+// smoothingTau is the residence estimate as an averaging time constant, floored so a
+// tiny reading cannot make the arrival average a passthrough. Returns 0 when there is
+// no usable residence, which leaves the rate unsmoothed.
+func smoothingTau(rm domain.ReplicaMetrics) float64 {
+	w := residenceSeconds(rm)
+	if w <= 0 {
+		return 0
+	}
+	if w < MinResidenceSeconds {
+		return MinResidenceSeconds
 	}
 	return w
 }
@@ -502,7 +590,7 @@ func residenceSeconds(rm domain.ReplicaMetrics) float64 {
 func serviceRateKey(modelID, accelerator, role string, gpuCount int, avgInput, avgOutput float64) string {
 	return fmt.Sprintf("%s|%s|%s|%d|in:%s|out:%s",
 		modelID, accelerator, canonicalRole(role), gpuCount,
-		classifyOutputLength(avgInput), classifyOutputLength(avgOutput))
+		classifyInputLength(avgInput), classifyOutputLength(avgOutput))
 }
 
 // rateAnchoredK2 returns the compute-bound capacity in KV tokens for this
@@ -538,21 +626,26 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 
 	key := serviceRateKey(modelID, rm.AcceleratorName, role, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
 
-	// Detector: rates decide whether this replica is at its limit.
-	backlogged := float64(rm.QueueLength) >= queueThreshold
+	// Detector and measurement, read at the same instant — see limitEvidence.
+	backlogged, occupancy := limitEvidence(rm, queueThreshold)
 	if backlogged && rm.RequestRate > 0 {
 		a.serviceRates.ObserveRate(key, rm.RequestRate, now)
 	}
 	atLimit := backlogged || a.arrivalsReachedServiceRate(rm, key, now)
 
-	// Measurement: under backlog, resident tokens are what the limit is worth.
+	// A replica may only define the bucket's ceiling while it is both backlogged and
+	// completing work. Backlog alone is not enough: a replica that has just started
+	// takes a routed burst before its cache fills, and one that has stalled queues
+	// without completing anything. Either would report a tiny occupancy as "the
+	// occupancy at which this bucket cannot keep up" and, since the ceiling sets the
+	// whole loop gain, pin every sibling near the floor. Requiring completions is the
+	// same guard the service rate already applies, for the same reason.
 	//
-	// Only under backlog. Arrivals reaching the service rate is enough to say the
-	// replica is at its limit — it is how the limit is caught before a queue forms —
-	// but it is not a measurement of the limit: with no queue, low occupancy means
-	// the replica is keeping up comfortably, not that its ceiling has fallen.
-	// Recording it would ratchet the running minimum down on evidence of health.
-	if occupancy := limitOccupancy(rm); backlogged && occupancy > 0 {
+	// Arrivals reaching the service rate is enough to say the replica is at its limit
+	// — it is how the limit is caught before a queue forms — but it is not a
+	// measurement of one: with no queue, low occupancy is evidence the replica is
+	// keeping up, not that its ceiling has fallen.
+	if backlogged && rm.RequestRate > 0 && occupancy > 0 {
 		a.serviceRates.ObserveCeiling(key, occupancy, now)
 	}
 
@@ -624,20 +717,28 @@ func (a *SaturationAnalyzer) residenceScaledCapacity(key string, ceiling float64
 	return scaled, true
 }
 
-// limitOccupancy is the resident token count to record as a measurement of the
-// limit. It prefers the instantaneous KV reading over TokensInUse, which is derived
-// from max_over_time(...[1m]) — the highest occupancy of the last minute, not the
-// occupancy at the moment the replica was seen unable to keep up. Since the ceiling
-// is a running minimum, a peak-derived input biases it high in the one direction
-// that costs replicas. Falls back when the instantaneous reading is unavailable.
-func limitOccupancy(rm domain.ReplicaMetrics) float64 {
-	if rm.KvUsageInstant > 0 && rm.TotalKvCapacityTokens > 0 {
-		if tokens := rm.KvUsageInstant * float64(rm.TotalKvCapacityTokens); tokens > 0 &&
-			!math.IsNaN(tokens) && !math.IsInf(tokens, 0) {
-			return tokens
+// limitEvidence reports whether the replica is failing to keep up, and the resident
+// token count to record if it is. Both readings come from the same time base, and
+// that pairing is the point of the function.
+//
+// QueueLength and TokensInUse are collected as max_over_time(...[1m]): the demand
+// path wants the peak, since erring high on outstanding work is its safe direction.
+// Read one of them against an instantaneous sample of the other and the estimator
+// breaks in a specific, severe way — the latched queue keeps the gate open for a full
+// minute after a backlog clears, while the instantaneous occupancy has already
+// collapsed, so a replica that is now comfortably keeping up gets recorded as its own
+// limit. The ceiling then falls to its floor and the fleet scales out against it.
+//
+// So: instantaneous gate with instantaneous occupancy when both are collected,
+// otherwise the one-minute peak of both. Either pair is self-consistent.
+func limitEvidence(rm domain.ReplicaMetrics, queueThreshold float64) (bool, float64) {
+	if rm.HasQueueLengthInstant && rm.KvUsageInstant > 0 && rm.TotalKvCapacityTokens > 0 {
+		tokens := rm.KvUsageInstant * float64(rm.TotalKvCapacityTokens)
+		if tokens > 0 && !math.IsNaN(tokens) && !math.IsInf(tokens, 0) {
+			return rm.QueueLengthInstant >= queueThreshold, tokens
 		}
 	}
-	return float64(rm.TokensInUse)
+	return float64(rm.QueueLength) >= queueThreshold, float64(rm.TokensInUse)
 }
 
 // tokensPerRequest is the KV footprint of one request of this bucket's shape.
@@ -667,7 +768,7 @@ func (a *SaturationAnalyzer) arrivalsReachedServiceRate(rm domain.ReplicaMetrics
 	if smoothingKey == "" {
 		smoothingKey = key
 	}
-	lambda := a.arrivals.Smooth(smoothingKey, rm.ArrivalRate, residenceSeconds(rm), now)
+	lambda := a.arrivals.Smooth(smoothingKey, rm.ArrivalRate, smoothingTau(rm), now)
 	if lambda <= 0 {
 		lambda = rm.RequestRate
 	}

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -94,6 +94,11 @@ const (
 	// previous arrival average is discarded rather than blended.
 	ArrivalSmoothingResetFactor = 3.0
 
+	// BucketPruneThreshold is the map size at which adding a new bucket first tries
+	// pruning stale ones. Small enough that the map stays bounded, large enough that
+	// a normal fleet never pays for a sweep.
+	BucketPruneThreshold = 32
+
 	// MinRateAnchoredFraction floors the learned ceiling at a fraction of k1. A
 	// replica that stalled completely while requests queued would otherwise teach
 	// the bucket a near-zero capacity and demand an unbounded scale-up.
@@ -125,14 +130,41 @@ func newBucketStore() *bucketStore {
 	return &bucketStore{entries: make(map[string]*bucketEntry)}
 }
 
-// entry returns the bucket's entry, creating it when absent. Callers hold s.mu.
-func (s *bucketStore) entry(key string) *bucketEntry {
+// entry returns the bucket's entry, creating it when absent, and opportunistically
+// prunes buckets nothing has touched for HistoryEvictionTimeout. Callers hold s.mu.
+//
+// Pruning on write rather than from a periodic caller is deliberate: nothing in the
+// engine currently drives eviction for the analyzer's other stores either, so a
+// store that depended on being swept would grow without bound the moment the
+// estimator was switched on. Buckets are keyed by model, accelerator, role, GPU
+// count and request shape, so the map is small and a sweep is cheap.
+func (s *bucketStore) entry(key string, now time.Time) *bucketEntry {
 	e, ok := s.entries[key]
 	if !ok {
+		if len(s.entries) >= BucketPruneThreshold {
+			s.pruneLocked(HistoryEvictionTimeout, now)
+		}
 		e = &bucketEntry{}
 		s.entries[key] = e
 	}
 	return e
+}
+
+// pruneLocked drops buckets with no observation of either kind within timeout.
+// Callers hold s.mu.
+func (s *bucketStore) pruneLocked(timeout time.Duration, now time.Time) int {
+	removed := 0
+	for k, e := range s.entries {
+		last := e.rateSeen
+		if e.ceilingSeen.After(last) {
+			last = e.ceilingSeen
+		}
+		if now.Sub(last) > timeout {
+			delete(s.entries, k)
+			removed++
+		}
+	}
+	return removed
 }
 
 // ObserveRate records a completion rate for a bucket, keeping the running maximum.
@@ -145,7 +177,7 @@ func (s *bucketStore) ObserveRate(key string, rate float64, now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	e := s.entry(key)
+	e := s.entry(key, now)
 	if e.rateSamples == 0 {
 		e.rate, e.rateSamples, e.rateSeen = rate, 1, now
 		return
@@ -191,7 +223,7 @@ func (s *bucketStore) ObserveCeiling(key string, tokens float64, now time.Time) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	e := s.entry(key)
+	e := s.entry(key, now)
 	if !e.ceilingKnown {
 		e.ceiling, e.ceilingKnown, e.ceilingSeen = tokens, true, now
 		return
@@ -232,19 +264,7 @@ func (s *bucketStore) Ceiling(key string, now time.Time) (float64, bool) {
 func (s *bucketStore) EvictStale(timeout time.Duration, now time.Time) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	removed := 0
-	for k, e := range s.entries {
-		last := e.rateSeen
-		if e.ceilingSeen.After(last) {
-			last = e.ceilingSeen
-		}
-		if now.Sub(last) > timeout {
-			delete(s.entries, k)
-			removed++
-		}
-	}
-	return removed
+	return s.pruneLocked(timeout, now)
 }
 
 // decayRate applies exponential decay so an unrefreshed service rate loses
@@ -300,6 +320,15 @@ func (s *arrivalSmoother) Smooth(key string, rate, tau float64, now time.Time) f
 
 	e, ok := s.entries[key]
 	if !ok {
+		// Keyed per pod, so this map grows with pod churn; prune on insert for the
+		// same reason bucketStore does.
+		if len(s.entries) >= BucketPruneThreshold {
+			for k, old := range s.entries {
+				if now.Sub(old.observed) > HistoryEvictionTimeout {
+					delete(s.entries, k)
+				}
+			}
+		}
 		s.entries[key] = &arrivalEntry{rate: rate, observed: now}
 		return rate
 	}

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -77,6 +77,16 @@ const (
 	// by construction: only unqueued cycles qualify.
 	PrefillSmoothingWindow = 10 * time.Minute
 
+	// ArrivalPeakWindow is how long a variant's summed arrival rate is held at its
+	// maximum. Arrivals do not change when replicas do — that invariance is the whole
+	// basis of the scale-down floor — but the *measurement* of them does: ArrivalRate
+	// is a one-minute rate per pod, summed across pods. Remove a pod and its share
+	// leaves the sum at once, while the survivors take a minute to report their larger
+	// share. The sum therefore dips by roughly 1/N after every shed, which weakens the
+	// floor, which permits the next shed. Two minutes outlasts both the rate window
+	// and the interval between drains.
+	ArrivalPeakWindow = 2 * time.Minute
+
 	// WorkWindow is the window the bucket's operating point is held over, and it
 	// mirrors the demand side exactly: TokensInUse and QueueLength are collected as
 	// max_over_time(...[1m]), so the operating point is the MAXIMUM of what replicas
@@ -514,6 +524,43 @@ func relaxCeiling(ceiling float64, age time.Duration) float64 {
 		return ceiling
 	}
 	return ceiling * math.Pow(CeilingRelaxPerWindow, age.Seconds()/ServiceRateWindow.Seconds())
+}
+
+// peakWindow holds a keyed value at its maximum over a window.
+type peakWindow struct {
+	mu      sync.Mutex
+	entries map[string][]workSample
+}
+
+func newPeakWindow() *peakWindow {
+	return &peakWindow{entries: make(map[string][]workSample)}
+}
+
+// Observe records a sample and returns the maximum still inside the window.
+func (p *peakWindow) Observe(key string, value float64, now time.Time) float64 {
+	if !(value > 0) || math.IsInf(value, 0) {
+		return value
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	kept := make([]workSample, 0, len(p.entries[key])+1)
+	kept = append(kept, p.entries[key]...)
+	kept = append(kept, workSample{at: now, value: value})
+	kept = slices.DeleteFunc(kept, func(w workSample) bool {
+		return now.Sub(w.at) > ArrivalPeakWindow
+	})
+	if len(p.entries) >= BucketPruneThreshold {
+		for k, samples := range p.entries {
+			if len(samples) == 0 || now.Sub(samples[len(samples)-1].at) > ArrivalPeakWindow {
+				delete(p.entries, k)
+			}
+		}
+	}
+	p.entries[key] = kept
+	return slices.MaxFunc(kept, func(a, b workSample) int {
+		return cmp.Compare(a.value, b.value)
+	}).value
 }
 
 // arrivalSmoother holds a per-replica exponentially-weighted arrival rate.

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -587,10 +587,56 @@ func smoothingTau(rm domain.ReplicaMetrics) float64 {
 // property of the request shape, and 1000-token prompts and 300-token prompts are
 // different services on the same hardware. Keying only by output length would
 // average them.
-func serviceRateKey(modelID, accelerator, role string, gpuCount int, avgInput, avgOutput float64) string {
+func serviceRateKey(modelID, accelerator, role string, gpuCount int, shape variantShape) string {
 	return fmt.Sprintf("%s|%s|%s|%d|in:%s|out:%s",
 		modelID, accelerator, canonicalRole(role), gpuCount,
-		classifyInputLength(avgInput), classifyOutputLength(avgOutput))
+		classifyInputLength(shape.avgInput), classifyOutputLength(shape.avgOutput))
+}
+
+// variantShape is the request shape of a variant as a whole, averaged over its live
+// replicas.
+//
+// The shape has to come from the variant, not from each replica, even though the
+// metrics are per-replica. Replicas of one variant serve the same traffic, so their
+// averages differ only by sampling noise — but that noise is enough to put two
+// siblings either side of a bucket threshold, and then they learn independent
+// ceilings and service rates. aggregateByVariant takes the MEDIAN of per-replica
+// capacities, so the two figures get blended even though they measure different
+// things, and a variant whose average sits near a threshold flips its whole estimate
+// every cycle as replicas drift across it. Keying on the variant makes the boundary a
+// property of the workload rather than of individual scrapes.
+type variantShape struct {
+	avgInput  float64
+	avgOutput float64
+}
+
+// variantShapes averages the request shape across each variant's replicas.
+func variantShapes(metrics []domain.ReplicaMetrics) map[string]variantShape {
+	type acc struct {
+		in, out float64
+		n       float64
+	}
+	sums := make(map[string]*acc, len(metrics))
+	for _, rm := range metrics {
+		if rm.AvgInputTokens <= 0 && rm.AvgOutputTokens <= 0 {
+			continue
+		}
+		a, ok := sums[rm.VariantName]
+		if !ok {
+			a = &acc{}
+			sums[rm.VariantName] = a
+		}
+		a.in += rm.AvgInputTokens
+		a.out += rm.AvgOutputTokens
+		a.n++
+	}
+	shapes := make(map[string]variantShape, len(sums))
+	for variant, a := range sums {
+		if a.n > 0 {
+			shapes[variant] = variantShape{avgInput: a.in / a.n, avgOutput: a.out / a.n}
+		}
+	}
+	return shapes
 }
 
 // rateAnchoredK2 returns the compute-bound capacity in KV tokens for this
@@ -616,6 +662,7 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	modelID string,
 	role string,
 	gpuCount int,
+	shape variantShape,
 	k1 int64,
 	queueThreshold float64,
 	now time.Time,
@@ -624,7 +671,7 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 		return 0, 0, 0, false
 	}
 
-	key := serviceRateKey(modelID, rm.AcceleratorName, role, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
+	key := serviceRateKey(modelID, rm.AcceleratorName, role, gpuCount, shape)
 
 	// Detector and measurement, read at the same instant — see limitEvidence.
 	backlogged, occupancy := limitEvidence(rm, queueThreshold)
@@ -673,6 +720,20 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	if scaled, ok := a.residenceScaledCapacity(key, ceiling, now); ok {
 		capacity = clampCeiling(scaled, k1)
 		src = k2SrcRateResidence
+	}
+
+	// Arrivals have caught up with the service rate while nothing has queued yet. The
+	// replica is at its limit, and reporting capacity above what it is already holding
+	// would hide that until a queue forms. Waiting for the queue is what this cannot
+	// afford: a replica takes about ninety seconds from decision to serving, so the
+	// backlog that accumulates while one starts is set by how early the decision was
+	// made. Capacity is held at the current occupancy, which reads as fully utilized
+	// without claiming the replica is over its limit.
+	//
+	// One direction only, and floored by clampCeiling, so a mis-scraped arrival rate
+	// cannot drive capacity toward zero.
+	if atLimit && !backlogged && occupancy > 0 && occupancy < float64(capacity) {
+		capacity = clampCeiling(occupancy, k1)
 	}
 	return capacity, reference, src, true
 }

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -730,10 +730,18 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 	// made. Capacity is held at the current occupancy, which reads as fully utilized
 	// without claiming the replica is over its limit.
 	//
+	// The figure used here is the one demand is built from, not the instantaneous
+	// sample the ceiling is measured with. Demand is TokensInUse, a one-minute peak;
+	// holding capacity at a lower instantaneous reading would make utilization the
+	// ratio between the two, which on bursty traffic is several times one and would
+	// ask for several times the replicas. Matching it lands utilization at exactly
+	// one: saturated, scale up by the threshold's margin, nothing more.
+	//
 	// One direction only, and floored by clampCeiling, so a mis-scraped arrival rate
 	// cannot drive capacity toward zero.
-	if atLimit && !backlogged && occupancy > 0 && occupancy < float64(capacity) {
-		capacity = clampCeiling(occupancy, k1)
+	if demandSide := float64(rm.TokensInUse); atLimit && !backlogged &&
+		demandSide > 0 && demandSide < float64(capacity) {
+		capacity = clampCeiling(demandSide, k1)
 	}
 	return capacity, reference, src, true
 }

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -1,0 +1,259 @@
+package saturation_v2
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+// Rate-anchored compute capacity.
+//
+// The occupancy-based estimator records `tokensInUse` at the moment a replica was
+// seen queueing and calls that the compute bound. That is a KV *stock* standing in
+// for a *rate* limit, and on a prefill-heavy workload the two are unrelated: the
+// engine exhausts prompt-token throughput and queues while KV occupancy is still
+// low, so the estimate carries no information about the binding constraint.
+//
+// This estimator anchors on the one quantity that is meaningful whichever resource
+// binds: while a replica has a backlog, its completion rate IS its service rate.
+//
+//	mu = highest completion rate seen for this workload bucket while queued
+//	k2 = occupancy × (mu / lambda)
+//
+// At lambda == mu the replica is exactly saturated and k2 equals its current
+// occupancy, so utilization reads 100% even at 16% KV. At lambda == mu/2, k2 is
+// twice the occupancy and utilization reads 50%. The result stays in KV tokens, so
+// every downstream consumer (min(k1,k2), spareCapacity, the optimizer) is unchanged.
+//
+// See docs/plans/engine/rate-anchored-k2.md.
+
+// EnableRateAnchoredK2 selects the rate-anchored estimator. It is a build-time
+// constant rather than a ConfigMap setting: the estimator is under evaluation
+// against the occupancy-based one and is not something an operator should be
+// switching in a running cluster. Flip it here to run the comparison, and see
+// docs/plans/engine/rate-anchored-k2.md for the validation plan.
+//
+// With this false, SaturationAnalyzer.serviceRates stays nil and every path in
+// this file returns immediately, leaving the occupancy-based estimator unchanged.
+const EnableRateAnchoredK2 = false
+
+const (
+	// ServiceRateWindow is how long an observed service rate stays authoritative
+	// for its bucket. A replica only calibrates while it has a backlog, which may
+	// be rare, so this is generous relative to the optimize interval.
+	ServiceRateWindow = 30 * time.Minute
+
+	// ServiceRateDecayPerWindow is the fraction the retained maximum decays to
+	// over one ServiceRateWindow with no fresh observation. Decay matters because
+	// mu is a running maximum: without it, one unusually fast interval would pin
+	// the estimate high for as long as the entry lives.
+	ServiceRateDecayPerWindow = 0.75
+
+	// MinRateRatio and MaxRateRatio clamp mu/lambda. A mis-scraped or transiently
+	// zero rate must not be able to swing capacity by orders of magnitude.
+	MinRateRatio = 0.05
+	MaxRateRatio = 20.0
+
+	// MinRateAnchoredFraction floors the estimate at a fraction of k1. A replica
+	// that has stalled completely (mu near zero while requests are queued) would
+	// otherwise drive capacity to ~0 and demand an unbounded scale-up.
+	MinRateAnchoredFraction = 0.05
+)
+
+// serviceRateStore holds the observed service rate (mu, requests/second) per
+// workload bucket. Entries are updated only from replicas that had a backlog at
+// the time of observation — an idle replica's completion rate reflects arrivals,
+// not capacity.
+type serviceRateStore struct {
+	mu      sync.Mutex
+	entries map[string]*serviceRateEntry
+}
+
+type serviceRateEntry struct {
+	rate     float64
+	observed time.Time
+}
+
+func newServiceRateStore() *serviceRateStore {
+	return &serviceRateStore{entries: make(map[string]*serviceRateEntry)}
+}
+
+// Observe records a completion rate for a bucket, keeping the running maximum.
+// Callers must only pass rates measured while the replica had a backlog.
+func (s *serviceRateStore) Observe(key string, rate float64, now time.Time) {
+	if rate <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.entries[key]
+	if !ok {
+		s.entries[key] = &serviceRateEntry{rate: rate, observed: now}
+		return
+	}
+	// Compare against the decayed value so a stale peak yields to a fresh, lower
+	// observation rather than persisting until eviction.
+	if decayed := decayRate(e.rate, now.Sub(e.observed)); rate >= decayed {
+		e.rate = rate
+	} else {
+		e.rate = decayed
+	}
+	e.observed = now
+}
+
+// Rate returns the current service-rate estimate for a bucket, decayed by age,
+// and false when the bucket has no usable observation.
+func (s *serviceRateStore) Rate(key string, now time.Time) (float64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.entries[key]
+	if !ok {
+		return 0, false
+	}
+	if now.Sub(e.observed) > ServiceRateWindow {
+		return 0, false
+	}
+	r := decayRate(e.rate, now.Sub(e.observed))
+	if r <= 0 {
+		return 0, false
+	}
+	return r, true
+}
+
+// EvictStale drops entries with no observation within timeout, returning the
+// number removed. Mirrors EvictStaleHistory so both stores age out together.
+func (s *serviceRateStore) EvictStale(timeout time.Duration, now time.Time) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	removed := 0
+	for k, e := range s.entries {
+		if now.Sub(e.observed) > timeout {
+			delete(s.entries, k)
+			removed++
+		}
+	}
+	return removed
+}
+
+// decayRate applies exponential decay so an unrefreshed maximum loses authority
+// smoothly: after one ServiceRateWindow it retains ServiceRateDecayPerWindow of
+// its value.
+func decayRate(rate float64, age time.Duration) float64 {
+	if age <= 0 {
+		return rate
+	}
+	windows := age.Seconds() / ServiceRateWindow.Seconds()
+	return rate * math.Pow(ServiceRateDecayPerWindow, windows)
+}
+
+// serviceRateKey identifies a workload bucket for service-rate purposes.
+//
+// The input bucket is part of the key, unlike the k2 history key: mu is a property
+// of the request shape, and 1000-token prompts and 300-token prompts are different
+// services on the same hardware. Keying only by output length would average them.
+func serviceRateKey(modelID, accelerator string, gpuCount int, avgInput, avgOutput float64) string {
+	return fmt.Sprintf("%s|%s|%d|in:%s|out:%s",
+		modelID, accelerator, gpuCount,
+		classifyOutputLength(avgInput), classifyOutputLength(avgOutput))
+}
+
+// rateAnchoredK2 estimates the compute-bound capacity in KV tokens from the
+// replica's distance to rate saturation, returning the value, which signal
+// produced it, and whether that value is a measured ceiling.
+//
+// The ceiling flag governs persistence, not the scaling decision. At lambda >= mu
+// the replica is at or past saturation, so occupancy × mu/lambda is what it was
+// actually able to hold — worth writing to the capacity store. Below saturation
+// the same expression is occupancy scaled by headroom: correct for this cycle's
+// utilization, but not a property of the variant, and persisting it would
+// under-state capacity for zero-replica estimation and cross-variant lookups.
+//
+// Returns false when no signal is usable, in which case the caller falls through
+// to the existing occupancy-based chain.
+func (a *SaturationAnalyzer) rateAnchoredK2(
+	rm domain.ReplicaMetrics,
+	modelID string,
+	gpuCount int,
+	k1 int64,
+	now time.Time,
+) (int64, k2Source, bool, bool) {
+	if a.serviceRates == nil {
+		return 0, 0, false, false
+	}
+
+	key := serviceRateKey(modelID, rm.AcceleratorName, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
+
+	// A replica with a backlog is serving at capacity: record what it achieved.
+	if rm.QueueLength > 0 && rm.RequestRate > 0 {
+		a.serviceRates.Observe(key, rm.RequestRate, now)
+	}
+
+	// KvUsageInstant is the un-peaked reading; the 1-minute max used for demand
+	// would over-state the operating point and inflate the estimate.
+	occupancy := rm.KvUsageInstant * float64(rm.TotalKvCapacityTokens)
+	if occupancy <= 0 {
+		return 0, 0, false, false
+	}
+
+	ratio, src, ok := a.saturationRatio(rm, key, now)
+	if !ok {
+		return 0, 0, false, false
+	}
+	// At or past saturation the replica demonstrated this capacity; below it, the
+	// value is headroom-scaled and must not be persisted as a ceiling.
+	ceiling := ratio <= 1.0
+	if ratio < MinRateRatio {
+		ratio = MinRateRatio
+	} else if ratio > MaxRateRatio {
+		ratio = MaxRateRatio
+	}
+
+	k2 := occupancy * ratio
+	if floor := float64(k1) * MinRateAnchoredFraction; k2 < floor {
+		k2 = floor
+	}
+	if k2 <= 0 || math.IsNaN(k2) || math.IsInf(k2, 0) {
+		return 0, 0, false, false
+	}
+	return int64(k2), src, ceiling, true
+}
+
+// saturationRatio returns mu/lambda — how much service headroom the replica has —
+// from the best signal available, in descending order of directness:
+//
+//  1. EPP arrival rate. The intended path: lambda is measured independently of the
+//     engine, so the ratio holds whether or not the replica is keeping up.
+//  2. Backlog. A queueing replica is saturated by observation: arrivals exceed
+//     service, so the ratio is at most 1 and capacity is the current occupancy.
+//     This needs neither lambda nor a calibrated mu, which makes it the safety net
+//     for a fleet with no EPP and no prior calibration — and it is exactly the
+//     prefill-heavy case the occupancy estimator misreads as idle.
+//  3. Completion rate as lambda. With no queue, everything that arrives is served
+//     within the scrape window, so completions are arrivals. Valid only in that
+//     case, which is why it sits behind the backlog check rather than in front.
+//
+// Returning false leaves the decision to the occupancy-based chain.
+func (a *SaturationAnalyzer) saturationRatio(
+	rm domain.ReplicaMetrics,
+	key string,
+	now time.Time,
+) (float64, k2Source, bool) {
+	muRate, haveMu := a.serviceRates.Rate(key, now)
+
+	if rm.ArrivalRate > 0 && haveMu {
+		return muRate / rm.ArrivalRate, k2SrcRateAnchored, true
+	}
+	if rm.QueueLength > 0 {
+		return 1.0, k2SrcRateBacklog, true
+	}
+	if haveMu && rm.RequestRate > 0 {
+		return muRate / rm.RequestRate, k2SrcRateNoEPP, true
+	}
+	return 0, 0, false
+}

--- a/internal/engines/analyzers/saturation_v2/rate_capacity.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity.go
@@ -17,25 +17,30 @@ import (
 // engine exhausts prompt-token throughput and queues while KV occupancy is still
 // low, so the estimate carries no information about the binding constraint.
 //
-// This estimator anchors on the one quantity that is meaningful whichever resource
-// binds: while a replica cannot keep up, its completion rate IS its service rate.
+// This estimator splits the problem in two:
 //
-// "Cannot keep up" has to be established, not assumed. With no backlog, completions
-// equal arrivals at any load — flow conservation — so an idle replica's completion
-// rate says nothing about its ceiling. mu is therefore recorded only from replicas
-// with a queue at least QueueLengthThreshold deep, and a bucket needs
-// MinServiceRateSamples such observations before it will answer. Without that,
-// one burst of arrival jitter would pin mu at whatever the replica happened to be
-// doing, and every later lambda near that value would read as saturation at low
-// occupancy — over-provisioning, the mirror of the bug this replaces.
+//	detector:    rates decide WHEN a replica is at its limit
+//	measurement: tokens record WHAT that limit is
 //
-//	mu = highest completion rate seen for this workload bucket while queued
-//	k2 = occupancy × (mu / lambda)
+// A replica is at its limit when it has a sustained backlog, or when its arrival
+// rate has reached the service rate observed while it was backlogged. At that
+// moment its resident token count is a measurement of the limit, and it is stored
+// per workload bucket — model, accelerator, role, request shape — because it is a
+// property of that bucket, not of the individual replica or of the current cycle.
 //
-// At lambda == mu the replica is exactly saturated and k2 equals its current
-// occupancy, so utilization reads 100% even at 16% KV. At lambda == mu/2, k2 is
-// twice the occupancy and utilization reads 50%. The result stays in KV tokens, so
-// every downstream consumer (min(k1,k2), spareCapacity, the optimizer) is unchanged.
+// Keeping the measurement out of the per-cycle path is what makes the estimate
+// usable downstream, for two reasons that both bit earlier versions of this code:
+//
+//   - aggregateByVariant takes the MEDIAN of per-replica capacities. A number that
+//     varied per replica with that replica's own load was not commensurable across
+//     siblings: an idle replica's figure blended with a backlogged one's and lifted
+//     variant capacity enough to turn a scale-up into a scale-down. A bucket
+//     ceiling is identical for every replica of the variant, so the median is a
+//     no-op and cannot mix kinds.
+//   - a value recomputed from this cycle's lambda moved every cycle, which is a
+//     scaling oscillation waiting to happen. A stored ceiling changes only as the
+//     running minimum is lowered by a new observation or relaxed by decay, both of
+//     which are slow by construction.
 //
 // See docs/plans/engine/rate-anchored-k2.md.
 
@@ -50,27 +55,34 @@ import (
 const EnableRateAnchoredK2 = false
 
 const (
-	// ServiceRateWindow is how long an observed service rate stays authoritative
-	// for its bucket. A replica only calibrates while it has a backlog, which may
-	// be rare, so this is generous relative to the optimize interval.
+	// ServiceRateWindow is how long an observation stays authoritative for its
+	// bucket. A replica only calibrates while it is at its limit, which may be
+	// rare, so this is generous relative to the optimize interval.
 	ServiceRateWindow = 30 * time.Minute
 
-	// ServiceRateDecayPerWindow is the fraction the retained maximum decays to
+	// ServiceRateDecayPerWindow is the fraction the retained service rate decays to
 	// over one ServiceRateWindow with no fresh observation. Decay matters because
-	// mu is a running maximum: without it, one unusually fast interval would pin
-	// the estimate high for as long as the entry lives.
+	// the rate is a running maximum: without it, one unusually fast interval would
+	// pin it high for as long as the entry lives.
 	ServiceRateDecayPerWindow = 0.75
 
-	// MinRateRatio floors mu/lambda so a mis-scraped or transiently collapsed
-	// service rate cannot drive capacity to nearly zero. There is no upper clamp:
-	// a ratio above 1 means the replica has headroom, and the estimator declines
-	// rather than reporting a headroom-scaled figure as capacity.
-	MinRateRatio = 0.05
+	// CeilingRelaxPerWindow is the factor the learned token ceiling relaxes by over
+	// one ServiceRateWindow with no fresh observation. The ceiling is a running
+	// minimum, so it relaxes *upward*: a single pessimistic measurement — taken
+	// while a node was degraded, say — must not cap the variant forever. Capacity
+	// drifts back toward the memory bound in the absence of evidence.
+	CeilingRelaxPerWindow = 1.25
 
 	// MinServiceRateSamples is how many qualifying observations a bucket needs
 	// before its service rate is usable. One observation cannot distinguish a real
-	// ceiling from a single slow interval.
+	// limit from a single slow interval.
 	MinServiceRateSamples = 2
+
+	// SaturationEnterRatio is the fraction of the service rate at which arrivals
+	// are treated as having reached it. Slightly below 1 so the limit is recognised
+	// just before it is crossed, and so a lambda hovering at mu does not toggle the
+	// detector between cycles.
+	SaturationEnterRatio = 0.95
 
 	// MinResidenceSeconds and MaxResidenceSeconds bound the residence estimate used
 	// as the arrival-smoothing time constant, so a garbage latency reading cannot
@@ -82,88 +94,152 @@ const (
 	// previous arrival average is discarded rather than blended.
 	ArrivalSmoothingResetFactor = 3.0
 
-	// MinRateAnchoredFraction floors the estimate at a fraction of k1. A replica
-	// that has stalled completely (mu near zero while requests are queued) would
-	// otherwise drive capacity to ~0 and demand an unbounded scale-up.
+	// MinRateAnchoredFraction floors the learned ceiling at a fraction of k1. A
+	// replica that stalled completely while requests queued would otherwise teach
+	// the bucket a near-zero capacity and demand an unbounded scale-up.
 	MinRateAnchoredFraction = 0.05
 )
 
-// serviceRateStore holds the observed service rate (mu, requests/second) per
-// workload bucket. Entries are updated only from replicas that had a backlog at
-// the time of observation — an idle replica's completion rate reflects arrivals,
-// not capacity.
-type serviceRateStore struct {
+// bucketStore holds what has been learned about a workload bucket: the service
+// rate observed while a replica could not keep up (mu, requests/second), and the
+// resident token count measured at that moment (the compute-bound ceiling).
+//
+// Both are per bucket rather than per replica. Replicas of a variant run the same
+// model on the same hardware, so a limit measured on one applies to all — which is
+// what makes the value safe to put through aggregateByVariant's median.
+type bucketStore struct {
 	mu      sync.Mutex
-	entries map[string]*serviceRateEntry
+	entries map[string]*bucketEntry
 }
 
-type serviceRateEntry struct {
-	rate     float64
-	observed time.Time
-	samples  int
+type bucketEntry struct {
+	rate         float64 // mu: running max of completion rate under backlog
+	rateSamples  int
+	rateSeen     time.Time
+	ceiling      float64 // running min of resident tokens at the limit
+	ceilingSeen  time.Time
+	ceilingKnown bool
 }
 
-func newServiceRateStore() *serviceRateStore {
-	return &serviceRateStore{entries: make(map[string]*serviceRateEntry)}
+func newBucketStore() *bucketStore {
+	return &bucketStore{entries: make(map[string]*bucketEntry)}
 }
 
-// Observe records a completion rate for a bucket, keeping the running maximum.
-// Callers must only pass rates measured while the replica had a backlog.
-func (s *serviceRateStore) Observe(key string, rate float64, now time.Time) {
+// entry returns the bucket's entry, creating it when absent. Callers hold s.mu.
+func (s *bucketStore) entry(key string) *bucketEntry {
+	e, ok := s.entries[key]
+	if !ok {
+		e = &bucketEntry{}
+		s.entries[key] = e
+	}
+	return e
+}
+
+// ObserveRate records a completion rate for a bucket, keeping the running maximum.
+// Callers must only pass rates measured while the replica had a backlog: with no
+// backlog, completions equal arrivals at any load and say nothing about the limit.
+func (s *bucketStore) ObserveRate(key string, rate float64, now time.Time) {
 	if rate <= 0 {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	e, ok := s.entries[key]
-	if !ok {
-		s.entries[key] = &serviceRateEntry{rate: rate, observed: now, samples: 1}
+	e := s.entry(key)
+	if e.rateSamples == 0 {
+		e.rate, e.rateSamples, e.rateSeen = rate, 1, now
 		return
 	}
-	e.samples++
+	e.rateSamples++
 	// Compare against the decayed value so a stale peak yields to a fresh, lower
 	// observation rather than persisting until eviction.
-	if decayed := decayRate(e.rate, now.Sub(e.observed)); rate >= decayed {
+	if decayed := decayRate(e.rate, now.Sub(e.rateSeen)); rate >= decayed {
 		e.rate = rate
 	} else {
 		e.rate = decayed
 	}
-	e.observed = now
+	e.rateSeen = now
 }
 
-// Rate returns the current service-rate estimate for a bucket, decayed by age,
-// and false when the bucket has no usable observation.
-func (s *serviceRateStore) Rate(key string, now time.Time) (float64, bool) {
+// Rate returns the bucket's service-rate estimate, decayed by age, and false when
+// it has too few observations or has gone stale.
+func (s *bucketStore) Rate(key string, now time.Time) (float64, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	e, ok := s.entries[key]
-	if !ok {
+	if !ok || e.rateSamples < MinServiceRateSamples {
 		return 0, false
 	}
-	if e.samples < MinServiceRateSamples {
+	if now.Sub(e.rateSeen) > ServiceRateWindow {
 		return 0, false
 	}
-	if now.Sub(e.observed) > ServiceRateWindow {
-		return 0, false
-	}
-	r := decayRate(e.rate, now.Sub(e.observed))
+	r := decayRate(e.rate, now.Sub(e.rateSeen))
 	if r <= 0 {
 		return 0, false
 	}
 	return r, true
 }
 
-// EvictStale drops entries with no observation within timeout, returning the
-// number removed. Mirrors EvictStaleHistory so both stores age out together.
-func (s *serviceRateStore) EvictStale(timeout time.Duration, now time.Time) int {
+// ObserveCeiling records the resident token count measured while a replica was at
+// its limit, keeping the running minimum — the lowest occupancy at which a replica
+// was seen unable to keep up is the conservative reading of the bucket's capacity.
+func (s *bucketStore) ObserveCeiling(key string, tokens float64, now time.Time) {
+	if tokens <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e := s.entry(key)
+	if !e.ceilingKnown {
+		e.ceiling, e.ceilingKnown, e.ceilingSeen = tokens, true, now
+		return
+	}
+	// Compare against the relaxed value so an old pessimistic reading gives way to
+	// a fresh higher one instead of capping the bucket indefinitely.
+	if relaxed := relaxCeiling(e.ceiling, now.Sub(e.ceilingSeen)); tokens <= relaxed {
+		e.ceiling = tokens
+	} else {
+		e.ceiling = relaxed
+	}
+	e.ceilingSeen = now
+}
+
+// Ceiling returns the bucket's learned token ceiling, relaxed by age, and false
+// when nothing has been measured or the measurement has gone stale.
+func (s *bucketStore) Ceiling(key string, now time.Time) (float64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.entries[key]
+	if !ok || !e.ceilingKnown {
+		return 0, false
+	}
+	if now.Sub(e.ceilingSeen) > ServiceRateWindow {
+		return 0, false
+	}
+	c := relaxCeiling(e.ceiling, now.Sub(e.ceilingSeen))
+	if c <= 0 {
+		return 0, false
+	}
+	return c, true
+}
+
+// EvictStale drops buckets with no observation of either kind within timeout,
+// returning the number removed. Mirrors EvictStaleHistory so the stores age out
+// together.
+func (s *bucketStore) EvictStale(timeout time.Duration, now time.Time) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	removed := 0
 	for k, e := range s.entries {
-		if now.Sub(e.observed) > timeout {
+		last := e.rateSeen
+		if e.ceilingSeen.After(last) {
+			last = e.ceilingSeen
+		}
+		if now.Sub(last) > timeout {
 			delete(s.entries, k)
 			removed++
 		}
@@ -171,15 +247,23 @@ func (s *serviceRateStore) EvictStale(timeout time.Duration, now time.Time) int 
 	return removed
 }
 
-// decayRate applies exponential decay so an unrefreshed maximum loses authority
-// smoothly: after one ServiceRateWindow it retains ServiceRateDecayPerWindow of
-// its value.
+// decayRate applies exponential decay so an unrefreshed service rate loses
+// authority smoothly: after one ServiceRateWindow it retains
+// ServiceRateDecayPerWindow of its value.
 func decayRate(rate float64, age time.Duration) float64 {
 	if age <= 0 {
 		return rate
 	}
-	windows := age.Seconds() / ServiceRateWindow.Seconds()
-	return rate * math.Pow(ServiceRateDecayPerWindow, windows)
+	return rate * math.Pow(ServiceRateDecayPerWindow, age.Seconds()/ServiceRateWindow.Seconds())
+}
+
+// relaxCeiling grows an unrefreshed ceiling so capacity drifts back toward the
+// memory bound when no fresh evidence of a limit arrives.
+func relaxCeiling(ceiling float64, age time.Duration) float64 {
+	if age <= 0 {
+		return ceiling
+	}
+	return ceiling * math.Pow(CeilingRelaxPerWindow, age.Seconds()/ServiceRateWindow.Seconds())
 }
 
 // arrivalSmoother holds a per-replica exponentially-weighted arrival rate.
@@ -187,9 +271,8 @@ func decayRate(rate float64, age time.Duration) float64 {
 // A completion happens one residence time after the arrival that caused it, so a
 // completion-derived mu and an instantaneous lambda are measured on different time
 // bases: during a ramp, completions still reflect the lighter load of W seconds
-// ago and mu/lambda reads as saturation on a replica that is coping. Occupancy has
-// the same property — it is a stock that already integrates arrivals over W.
-// Averaging lambda over roughly W puts all three on the same footing.
+// ago and the comparison reads as saturation on a replica that is coping.
+// Averaging lambda over roughly W puts the two on the same footing.
 type arrivalSmoother struct {
 	mu      sync.Mutex
 	entries map[string]*arrivalEntry
@@ -209,10 +292,7 @@ func newArrivalSmoother() *arrivalSmoother {
 // The weight is derived from the actual gap between samples, so an irregular
 // optimize interval or a missed cycle does not distort the average.
 func (s *arrivalSmoother) Smooth(key string, rate, tau float64, now time.Time) float64 {
-	if rate <= 0 {
-		return rate
-	}
-	if tau <= 0 {
+	if rate <= 0 || tau <= 0 {
 		return rate
 	}
 	s.mu.Lock()
@@ -274,43 +354,34 @@ func residenceSeconds(rm domain.ReplicaMetrics) float64 {
 	return w
 }
 
-// serviceRateKey identifies a workload bucket for service-rate purposes.
+// serviceRateKey identifies a workload bucket.
 //
 // Role is part of the key because a prefill replica and a decode replica of the
 // same model on the same accelerator are different services: they do different
 // work per request and complete at entirely different rates. Sharing a bucket
-// would let one calibrate the other's ceiling.
+// would let one calibrate the other's limit.
 //
-// The input bucket is part of it too, unlike the k2 history key: mu is a property
-// of the request shape, and 1000-token prompts and 300-token prompts are different
-// services on the same hardware. Keying only by output length would average them.
+// The input bucket is part of it too, unlike the k2 history key: the limit is a
+// property of the request shape, and 1000-token prompts and 300-token prompts are
+// different services on the same hardware. Keying only by output length would
+// average them.
 func serviceRateKey(modelID, accelerator, role string, gpuCount int, avgInput, avgOutput float64) string {
 	return fmt.Sprintf("%s|%s|%s|%d|in:%s|out:%s",
 		modelID, accelerator, canonicalRole(role), gpuCount,
 		classifyOutputLength(avgInput), classifyOutputLength(avgOutput))
 }
 
-// rateAnchoredK2 estimates the compute-bound capacity in KV tokens from the
-// replica's distance to rate saturation, returning the value and which signal
-// produced it.
+// rateAnchoredK2 returns the compute-bound capacity in KV tokens for this
+// replica's bucket, and which signal produced it.
 //
-// It answers ONLY when the replica is at or past saturation (lambda >= mu). Below
-// saturation, occupancy × mu/lambda is occupancy scaled by headroom — a statement
-// about slack, not a capacity. Returning it would be wrong in two places: it is not
-// a ceiling, so it must not be persisted; and aggregateByVariant takes the MEDIAN
-// of per-replica capacities, where an idle replica's headroom-scaled number sits
-// next to a backlogged sibling's genuine ceiling as though the two were
-// commensurable. With one replica queueing twelve deep and an idle sibling, that
-// median lifted variant capacity enough to turn a scale-up into a scale-down —
-// reintroducing the shed-to-one this estimator exists to prevent, by a new route.
+// The value is the bucket's learned ceiling wherever one exists, so it is the same
+// for every replica of the variant and does not move with this cycle's arrival
+// rate. Before anything has been learned, a replica that is over its limit right
+// now still reports its own occupancy, so the first overload is not missed.
 //
-// Declining above saturation loses nothing: detecting saturation the occupancy path
-// misses is the whole purpose, and when a replica genuinely has headroom the
-// occupancy path's ceiling is the better answer. Everything this function returns
-// is therefore a measured ceiling, which is what makes it safe to persist.
-//
-// Returns false when no signal is usable or the replica has headroom, in which case
-// the caller falls through to the existing occupancy-based chain.
+// Returns false when nothing has been learned and the replica is not currently
+// over its limit, in which case the caller falls through to the occupancy-based
+// chain.
 func (a *SaturationAnalyzer) rateAnchoredK2(
 	rm domain.ReplicaMetrics,
 	modelID string,
@@ -326,99 +397,75 @@ func (a *SaturationAnalyzer) rateAnchoredK2(
 
 	key := serviceRateKey(modelID, rm.AcceleratorName, role, gpuCount, rm.AvgInputTokens, rm.AvgOutputTokens)
 
-	// Only a sustained backlog establishes a ceiling; see the package comment.
+	// Detector: rates decide whether this replica is at its limit.
 	backlogged := float64(rm.QueueLength) >= queueThreshold
 	if backlogged && rm.RequestRate > 0 {
-		a.serviceRates.Observe(key, rm.RequestRate, now)
+		a.serviceRates.ObserveRate(key, rm.RequestRate, now)
+	}
+	atLimit := backlogged || a.arrivalsReachedServiceRate(rm, key, now)
+
+	// Whether anything was known before this cycle, purely so the source label can
+	// distinguish a fresh measurement from a carried-over one. Both are the same
+	// number and take the same path; the distinction is for the cycle log.
+	_, hadCeiling := a.serviceRates.Ceiling(key, now)
+
+	// Measurement: at the limit, resident tokens are what the limit is worth.
+	occupancy := float64(rm.TokensInUse)
+	if atLimit && occupancy > 0 {
+		a.serviceRates.ObserveCeiling(key, occupancy, now)
 	}
 
-	// Put lambda on the same time base as the completion-derived mu and the
-	// occupancy stock, both of which integrate over a residence time.
+	ceiling, ok := a.serviceRates.Ceiling(key, now)
+	if !ok {
+		return 0, 0, false
+	}
+	src := k2SrcRateAnchored
+	if !hadCeiling {
+		src = k2SrcRateBacklog
+	}
+	return clampCeiling(ceiling, k1), src, true
+}
+
+// arrivalsReachedServiceRate reports whether arrivals have caught up with the
+// service rate measured while the replica was backlogged — the limit being reached
+// before a queue has formed.
+//
+// lambda comes from the EPP dispatch rate where available. Without EPP, and only
+// when there is no queue, completions stand in for arrivals: everything that
+// arrives is served within the window, so the two are equal. That substitution is
+// invalid under backlog, which is why the caller checks the queue first.
+func (a *SaturationAnalyzer) arrivalsReachedServiceRate(rm domain.ReplicaMetrics, key string, now time.Time) bool {
+	muRate, ok := a.serviceRates.Rate(key, now)
+	if !ok {
+		return false
+	}
+
 	smoothingKey := rm.PodName
 	if smoothingKey == "" {
 		smoothingKey = key
 	}
 	lambda := a.arrivals.Smooth(smoothingKey, rm.ArrivalRate, residenceSeconds(rm), now)
-
-	// Scale by the same occupancy figure demand is built from, not the instantaneous
-	// reading. Demand is TokensInUse (a 1-minute max) plus the queue charge, so
-	// dividing it by a capacity derived from an instantaneous reading would inflate
-	// utilization by whatever the peak-to-instant spread happens to be — a spiky
-	// replica would look far more saturated than a steady one at the same load.
-	// Using the same aggregation on both sides makes the occupancy term cancel:
-	// with no queue, utilization reduces to lambda/mu, which is the whole intent.
-	occupancy := float64(rm.TokensInUse)
-	if occupancy <= 0 {
-		return 0, 0, false
+	if lambda <= 0 {
+		lambda = rm.RequestRate
 	}
-
-	ratio, src, ok := a.saturationRatio(rm, key, lambda, backlogged, now)
-	if !ok {
-		return 0, 0, false
+	if lambda <= 0 || math.IsNaN(lambda) || math.IsInf(lambda, 0) {
+		return false
 	}
-	// Headroom is not a capacity: stay silent and let the occupancy path answer.
-	if ratio > 1.0 {
-		return 0, 0, false
-	}
-	if ratio < MinRateRatio {
-		ratio = MinRateRatio
-	}
-
-	k2 := occupancy * ratio
-	// A replica with no queue is, by observation, coping with what it currently
-	// holds, so its capacity is at least that. Without this floor a lambda that
-	// momentarily edges past a conservatively-measured mu would cut capacity below
-	// the load the replica is visibly handling and demand a scale-up on evidence
-	// that does not exist. It binds only when ratio < 1 with an empty queue; a
-	// backlogged replica is genuinely over capacity and keeps the raw value.
-	if !backlogged && k2 < occupancy {
-		k2 = occupancy
-	}
-	if floor := float64(k1) * MinRateAnchoredFraction; k2 < floor {
-		k2 = floor
-	}
-	if k2 <= 0 || math.IsNaN(k2) || math.IsInf(k2, 0) {
-		return 0, 0, false
-	}
-	return int64(k2), src, true
+	return lambda >= muRate*SaturationEnterRatio
 }
 
-// saturationRatio returns mu/lambda — how much service headroom the replica has —
-// from the best signal available, in descending order of directness:
-//
-//  1. EPP arrival rate, smoothed over a residence time. The intended path: lambda
-//     is measured independently of the engine, so the ratio holds whether or not
-//     the replica is keeping up. Smoothing matters because completions lag their
-//     arrivals — see arrivalSmoother.
-//  2. Backlog. A replica queueing at least QueueLengthThreshold deep is saturated
-//     by observation: arrivals exceed service, so the ratio is at most 1 and
-//     capacity is the current occupancy. This needs neither lambda nor a calibrated
-//     mu, which makes it the safety net for a fleet with no EPP and no prior
-//     calibration — and it is exactly the prefill-heavy case the occupancy
-//     estimator misreads as idle. A shallower queue does not qualify: arrival
-//     jitter produces one every so often at any load.
-//  3. Completion rate as lambda. With no queue, everything that arrives is served
-//     within the scrape window, so completions are arrivals. Valid only in that
-//     case, which is why it sits behind the backlog check rather than in front.
-//
-// Returning false leaves the decision to the occupancy-based chain.
-func (a *SaturationAnalyzer) saturationRatio(
-	rm domain.ReplicaMetrics,
-	key string,
-	lambda float64,
-	backlogged bool,
-	now time.Time,
-) (float64, k2Source, bool) {
-	muRate, haveMu := a.serviceRates.Rate(key, now)
-
-	if lambda > 0 && haveMu {
-		return muRate / lambda, k2SrcRateAnchored, true
+// clampCeiling keeps a learned ceiling within usable bounds. There is no upper
+// clamp: min(k1, k2) in the caller already prevents a compute bound from exceeding
+// the memory bound.
+func clampCeiling(tokens float64, k1 int64) int64 {
+	if math.IsNaN(tokens) || math.IsInf(tokens, 0) {
+		return k1
 	}
-	if backlogged {
-		return 1.0, k2SrcRateBacklog, true
+	if floor := float64(k1) * MinRateAnchoredFraction; tokens < floor {
+		tokens = floor
 	}
-	if haveMu && rm.RequestRate > 0 {
-		return muRate / rm.RequestRate, k2SrcRateNoEPP, true
+	if tokens <= 0 {
+		return k1
 	}
-	return 0, 0, false
+	return int64(tokens)
 }

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
@@ -1,6 +1,7 @@
 package saturation_v2
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -55,12 +56,15 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 
 	It("learns the measured limit into the capacity store", func() {
 		store := NewCapacityKnowledgeStore()
-		a := NewSaturationAnalyzer(store, withRateAnchoredK2(true))
+		clock := start
+		a := NewSaturationAnalyzer(store, withRateAnchoredK2(true), withClock(func() time.Time { return clock }))
 		cfg := scalingConfig()
 		rm := atLimit()
 
 		var rc *ReplicaCapacity
-		for i := 0; i < MinServiceRateSamples+1; i++ {
+		for i := 0; i <= MinServiceRateSamples+1; i++ {
+			clock = clock.Add(15 * time.Second)
+			a.serviceRates.BeginCycle(clock)
 			rc = a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
 		}
 		Expect(rc).NotTo(BeNil())
@@ -117,7 +121,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		off := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withClock(tick))
 		on := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true), withClock(tick))
 		for i := 0; i < MinServiceRateSamples+1; i++ {
-			on.serviceRates.FreezeWork(clock)
+			on.serviceRates.BeginCycle(clock)
 			_ = off.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth)
 			_ = on.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth)
 		}
@@ -139,7 +143,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 
 		var occupancyBased, rateBased *ReplicaCapacity
 		for i := 0; i < 40; i++ { // the operating point is smoothed over about a minute
-			on.serviceRates.FreezeWork(clock)
+			on.serviceRates.BeginCycle(clock)
 			occupancyBased = off.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
 			rateBased = on.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
 		}
@@ -162,17 +166,25 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		// and cross-variant estimation, where "what it is doing now" is meaningless.
 		rec := on.capacityStore.Get(namespace, modelID, variant)
 		Expect(rec).NotTo(BeNil())
-		Expect(rec.EffectiveCapacity).To(BeNumerically(">", rateBased.EffectiveCapacity))
+		// Exactly k1: the measured reference is above the memory bound here, so the
+		// clamp decides. Asserting only "> the scaled value" would pass just as
+		// happily on an unclamped 340k, or on the scaled value being stored.
+		Expect(rec.EffectiveCapacity).To(Equal(int64(0.8 * float64(kvCapacity))))
 	})
 
 	It("gives a backlogged replica and an idle sibling the same capacity", func() {
 		cfg := scalingConfig()
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		clock := start
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true),
+			withClock(func() time.Time { return clock }))
 
 		hot := atLimit()
-		for i := 0; i < MinServiceRateSamples+1; i++ {
+		for i := 0; i <= MinServiceRateSamples+1; i++ {
+			clock = clock.Add(15 * time.Second)
+			a.serviceRates.BeginCycle(clock)
 			_ = a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
 		}
+		a.serviceRates.BeginCycle(clock.Add(15 * time.Second))
 		hotRC := a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
 
 		cold := atLimit()
@@ -187,5 +199,90 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		Expect(coldRC.EffectiveCapacity).To(Equal(hotRC.EffectiveCapacity))
 		// The idle replica is not itself saturated: its own demand is what differs.
 		Expect(coldRC.ReplicaDemand).To(BeNumerically("<", hotRC.ReplicaDemand))
+	})
+})
+
+// This one goes through Analyze rather than computeReplicaCapacity, because the
+// property it checks lives in the wiring: BeginCycle has to run at the top of the
+// cycle, before any replica is looked at. Drop that call, or move it after the
+// per-replica loop, and every other test in this file still passes.
+var _ = Describe("Rate-anchored k2 through Analyze", func() {
+	const (
+		kvCapacity = int64(400_000)
+		namespace  = "ns"
+		modelID    = "m"
+		variant    = "v1"
+	)
+	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+	replica := func(pod string, queue int, tokens int64) domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               pod,
+			VariantName:           variant,
+			ModelID:               modelID,
+			Namespace:             namespace,
+			AcceleratorName:       "H100",
+			QueueLength:           queue,
+			QueueLengthInstant:    float64(queue),
+			HasQueueLengthInstant: true,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			KvCacheUsage:          float64(tokens) / float64(kvCapacity),
+			KvUsageInstant:        float64(tokens) / float64(kvCapacity),
+			TokensInUse:           tokens,
+			TotalKvCapacityTokens: kvCapacity,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+			AvgTTFT:               1.0,
+			AvgITL:                0.02,
+		}
+	}
+
+	It("gives a variant's replicas one capacity, cycle after cycle", func() {
+		clock := start
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true),
+			withClock(func() time.Time { return clock }))
+		cfg := &config.SaturationScalingConfig{
+			KvCacheThreshold:     0.8,
+			QueueLengthThreshold: 5,
+			AnalyzerName:         "saturation",
+			ScaleUpThreshold:     0.75,
+			ScaleDownBoundary:    0.60,
+		}
+
+		// Three backlogged replicas of one variant, at different occupancies — which
+		// is the realistic case, and the one where a per-replica capacity would put
+		// three different numbers through aggregateByVariant's median.
+		input := domain.AnalyzerInput{
+			ModelID:   modelID,
+			Namespace: namespace,
+			ReplicaMetrics: []domain.ReplicaMetrics{
+				replica("pod-a", 12, 60_000),
+				replica("pod-b", 9, 66_000),
+				replica("pod-c", 14, 58_000),
+			},
+			VariantStates: []domain.VariantReplicaState{{
+				VariantName: variant, Role: domain.RoleBoth,
+				GPUsPerReplica: 1, CurrentReplicas: 3,
+			}},
+			Config: cfg,
+		}
+
+		var result *domain.AnalyzerResult
+		for i := 0; i < 4; i++ {
+			clock = start.Add(time.Duration(i) * 15 * time.Second)
+			var err error
+			result, err = a.Analyze(context.Background(), input)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		Expect(result.VariantCapacities).To(HaveLen(1))
+		vc := result.VariantCapacities[0]
+		Expect(vc.PerReplicaCapacity).To(BeNumerically(">", 0))
+		// Supply is replicaCount x median(per-replica capacities), so equal values are
+		// what make that median a no-op. The lowest occupancy seen under backlog is
+		// 58k, and every replica must be reading it.
+		Expect(vc.TotalCapacity).To(BeNumerically("~", 3*vc.PerReplicaCapacity, 1))
+		Expect(vc.PerReplicaCapacity).To(BeNumerically("~", 58_000, 1_000))
 	})
 })

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
@@ -1,0 +1,184 @@
+package saturation_v2
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+// These exercise computeReplicaCapacity rather than rateAnchoredK2 in isolation.
+// The leaf tests pin the estimator's arithmetic; these pin the two things only the
+// caller can get wrong: which value the capacity store learns, and that nothing
+// changes at all when the estimator is off.
+var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
+	const (
+		kvCapacity = int64(400_000)
+		namespace  = "ns"
+		modelID    = "m"
+		variant    = "v1"
+	)
+
+	scalingConfig := func() *config.SaturationScalingConfig {
+		return &config.SaturationScalingConfig{
+			KvCacheThreshold:     0.8, // k1 = 320k
+			QueueLengthThreshold: 5,
+			AnalyzerName:         "saturation",
+			ScaleUpThreshold:     0.75,
+			ScaleDownBoundary:    0.60,
+		}
+	}
+
+	// backlogged is deep enough to calibrate mu at 8 req/s.
+	backlogged := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               "pod-a",
+			VariantName:           variant,
+			ModelID:               modelID,
+			Namespace:             namespace,
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			KvUsageInstant:        0.16,
+			KvCacheUsage:          0.20,
+			TokensInUse:           int64(0.20 * float64(kvCapacity)),
+			TotalKvCapacityTokens: kvCapacity,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+		}
+	}
+
+	It("persists a saturated reading as the learned ceiling", func() {
+		store := NewCapacityKnowledgeStore()
+		a := NewSaturationAnalyzer(store, withRateAnchoredK2(true))
+		cfg := scalingConfig()
+		rm := backlogged()
+
+		var rc *ReplicaCapacity
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			rc = a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
+		}
+		Expect(rc).NotTo(BeNil())
+
+		rec := store.Get(namespace, modelID, variant)
+		Expect(rec).NotTo(BeNil())
+		// lambda == mu at saturation, so the estimate is the occupancy the replica
+		// demonstrably held — that is a ceiling and belongs in the store.
+		Expect(rec.EffectiveCapacity).To(Equal(rc.EffectiveCapacity))
+	})
+
+	It("keeps a below-saturation reading out of the store", func() {
+		store := NewCapacityKnowledgeStore()
+		a := NewSaturationAnalyzer(store, withRateAnchoredK2(true))
+		cfg := scalingConfig()
+
+		rm := backlogged()
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_ = a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
+		}
+
+		// Now idle at a quarter of the ceiling: the estimate is occupancy scaled by
+		// headroom, which is not a property of the variant.
+		rm.QueueLength = 0
+		rm.ArrivalRate = 2.0
+		rc := a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
+		Expect(rc).NotTo(BeNil())
+
+		rec := store.Get(namespace, modelID, variant)
+		Expect(rec).NotTo(BeNil())
+		Expect(rec.EffectiveCapacity).NotTo(Equal(rc.EffectiveCapacity),
+			"the headroom-scaled value must not become the learned ceiling")
+		// What the store learns must still be usable for zero-replica sizing, i.e.
+		// bounded by the memory bound rather than by this cycle's arrival rate.
+		Expect(rec.EffectiveCapacity).To(BeNumerically("<=", int64(0.8*float64(kvCapacity))))
+		Expect(rec.EffectiveCapacity).To(BeNumerically(">", 0))
+	})
+
+	It("is inert when the estimator is off", func() {
+		cfg := scalingConfig()
+		rm := backlogged()
+
+		// Same inputs, same call sequence, with and without the estimator. With it
+		// off, every field the caller consumes must match the occupancy-based path.
+		off := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
+		Expect(off.serviceRates).To(BeNil(), "guards the default of EnableRateAnchoredK2")
+		Expect(off.arrivals).To(BeNil())
+
+		baseline := off.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
+		Expect(baseline).NotTo(BeNil())
+		Expect(baseline.K2Priority).NotTo(Equal(k2SrcRateAnchored))
+		Expect(baseline.K2Priority).NotTo(Equal(k2SrcRateBacklog))
+		Expect(baseline.K2Priority).NotTo(Equal(k2SrcRateNoEPP))
+
+		// A second analyzer, also off, must agree exactly — no hidden state.
+		again := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
+		repeat := again.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
+		Expect(repeat.EffectiveCapacity).To(Equal(baseline.EffectiveCapacity))
+		Expect(repeat.MemoryBoundCapacity).To(Equal(baseline.MemoryBoundCapacity))
+		Expect(repeat.ComputeBoundCapacity).To(Equal(baseline.ComputeBoundCapacity))
+		Expect(repeat.IsSaturated).To(Equal(baseline.IsSaturated))
+		Expect(repeat.ReplicaDemand).To(Equal(baseline.ReplicaDemand))
+	})
+
+	It("holds capacity after a drain where the occupancy estimator releases it", func() {
+		cfg := scalingConfig()
+
+		// Under a deep backlog the two estimators agree: the occupancy path records
+		// TokensInUse as k2, and the rate path's backlog branch returns the same
+		// figure. The divergence appears after the queue drains, which is where the
+		// shed-to-one came from.
+		peak := backlogged()
+		peak.KvCacheUsage = 0.85
+		peak.TokensInUse = int64(0.85 * float64(kvCapacity)) // 340k, above k1
+
+		off := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
+		on := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			_ = off.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth)
+			_ = on.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth)
+		}
+
+		// Queue drained, occupancy collapsed — but arrivals are unchanged, still at
+		// the measured ceiling. Nothing about the load has actually improved.
+		drained := peak
+		drained.QueueLength = 0
+		drained.KvCacheUsage = 0.16
+		drained.TokensInUse = int64(0.16 * float64(kvCapacity)) // 64k
+		drained.ArrivalRate = 8.0
+
+		occupancyBased := off.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
+		rateBased := on.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
+
+		// The occupancy path answers from its inflated history and reports abundant
+		// spare capacity: demand 64k against a capacity of k1.
+		Expect(occupancyBased.EffectiveCapacity).To(BeNumerically(">", drained.TokensInUse*3),
+			"documents the behaviour being replaced")
+		Expect(occupancyBased.IsSaturated).To(BeFalse())
+
+		// The rate path reads lambda still at the ceiling, so capacity tracks the
+		// load rather than a stale peak: utilization stays at 100% and nothing is shed.
+		Expect(rateBased.EffectiveCapacity).To(BeNumerically("~", float64(drained.TokensInUse), 1))
+		Expect(rateBased.K2Priority).To(Equal(k2SrcRateAnchored))
+		Expect(rateBased.IsSaturated).To(BeTrue())
+	})
+
+})
+
+var _ = Describe("Rate-anchored stores age out", func() {
+	It("evicts idle buckets and replicas", func() {
+		now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+		rates := newServiceRateStore()
+		rates.Observe("bucket", 5, now.Add(-2*time.Hour))
+		rates.Observe("bucket", 5, now.Add(-2*time.Hour))
+		Expect(rates.EvictStale(time.Hour, now)).To(Equal(1))
+
+		arrivals := newArrivalSmoother()
+		_ = arrivals.Smooth("pod", 5, 60, now.Add(-2*time.Hour))
+		Expect(arrivals.EvictStale(time.Hour, now)).To(Equal(1))
+	})
+})

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		Expect(rec.EffectiveCapacity).To(Equal(rc.EffectiveCapacity))
 	})
 
-	It("keeps a below-saturation reading out of the store", func() {
+	It("leaves the store untouched by a replica with headroom", func() {
 		store := NewCapacityKnowledgeStore()
 		a := NewSaturationAnalyzer(store, withRateAnchoredK2(true))
 		cfg := scalingConfig()
@@ -80,22 +80,54 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		for i := 0; i < MinServiceRateSamples; i++ {
 			_ = a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
 		}
+		saturated := store.Get(namespace, modelID, variant)
+		Expect(saturated).NotTo(BeNil())
 
-		// Now idle at a quarter of the ceiling: the estimate is occupancy scaled by
-		// headroom, which is not a property of the variant.
+		// Now idle at a quarter of the ceiling. The estimator declines rather than
+		// returning a headroom-scaled figure, so both this cycle's capacity and the
+		// persisted record come from the occupancy path — no headroom number can
+		// reach the store or the variant-level median.
 		rm.QueueLength = 0
 		rm.ArrivalRate = 2.0
 		rc := a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
 		Expect(rc).NotTo(BeNil())
+		Expect(rc.K2Priority).NotTo(Equal(k2SrcRateAnchored))
+		Expect(rc.K2Priority).NotTo(Equal(k2SrcRateNoEPP))
+		Expect(rc.K2Priority).NotTo(Equal(k2SrcRateBacklog))
 
 		rec := store.Get(namespace, modelID, variant)
 		Expect(rec).NotTo(BeNil())
-		Expect(rec.EffectiveCapacity).NotTo(Equal(rc.EffectiveCapacity),
-			"the headroom-scaled value must not become the learned ceiling")
-		// What the store learns must still be usable for zero-replica sizing, i.e.
-		// bounded by the memory bound rather than by this cycle's arrival rate.
+		Expect(rec.EffectiveCapacity).To(Equal(rc.EffectiveCapacity))
 		Expect(rec.EffectiveCapacity).To(BeNumerically("<=", int64(0.8*float64(kvCapacity))))
-		Expect(rec.EffectiveCapacity).To(BeNumerically(">", 0))
+	})
+
+	It("does not let an idle replica inflate capacity beside a backlogged sibling", func() {
+		cfg := scalingConfig()
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+
+		// pod-a is queueing twelve deep and calibrates the bucket.
+		hot := backlogged()
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			_ = a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
+		}
+		hotRC := a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
+
+		// pod-b is idle in the same bucket. aggregateByVariant takes the MEDIAN of
+		// per-replica capacities, so if the idle replica reported occupancy × its
+		// headroom the median would rise far above the backlogged replica's real
+		// ceiling and the variant would read as having spare capacity while a pod
+		// queues. Its capacity must therefore stay in the same range as its sibling's.
+		cold := backlogged()
+		cold.PodName = "pod-b"
+		cold.QueueLength = 0
+		cold.ArrivalRate = 2.0
+		coldRC := a.computeReplicaCapacity(cold, cfg, modelID, namespace, 1, domain.RoleBoth)
+
+		Expect(coldRC).NotTo(BeNil())
+		Expect(coldRC.EffectiveCapacity).To(BeNumerically("<=", int64(0.8*float64(kvCapacity))),
+			"an idle replica must never exceed the memory bound")
+		Expect(coldRC.EffectiveCapacity).To(BeNumerically("<=", hotRC.EffectiveCapacity*4),
+			"and must not tower over the backlogged sibling under a median")
 	})
 
 	It("is inert when the estimator is off", func() {

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
@@ -1,8 +1,6 @@
 package saturation_v2
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -10,10 +8,10 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
-// These exercise computeReplicaCapacity rather than rateAnchoredK2 in isolation.
-// The leaf tests pin the estimator's arithmetic; these pin the two things only the
-// caller can get wrong: which value the capacity store learns, and that nothing
-// changes at all when the estimator is off.
+// These exercise computeReplicaCapacity rather than rateAnchoredK2 in isolation:
+// what the capacity store learns, that nothing changes when the estimator is off,
+// and the two behaviours the design exists for — holding capacity after a drain,
+// and giving siblings a value the variant-level median can combine safely.
 var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 	const (
 		kvCapacity = int64(400_000)
@@ -32,8 +30,8 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		}
 	}
 
-	// backlogged is deep enough to calibrate mu at 8 req/s.
-	backlogged := func() domain.ReplicaMetrics {
+	// atLimit is queueing deep enough to calibrate, at 20% KV occupancy.
+	atLimit := func() domain.ReplicaMetrics {
 		return domain.ReplicaMetrics{
 			PodName:               "pod-a",
 			VariantName:           variant,
@@ -43,7 +41,6 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 			QueueLength:           12,
 			RequestRate:           8.0,
 			ArrivalRate:           8.0,
-			KvUsageInstant:        0.16,
 			KvCacheUsage:          0.20,
 			TokensInUse:           int64(0.20 * float64(kvCapacity)),
 			TotalKvCapacityTokens: kvCapacity,
@@ -52,90 +49,31 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		}
 	}
 
-	It("persists a saturated reading as the learned ceiling", func() {
+	It("learns the measured limit into the capacity store", func() {
 		store := NewCapacityKnowledgeStore()
 		a := NewSaturationAnalyzer(store, withRateAnchoredK2(true))
 		cfg := scalingConfig()
-		rm := backlogged()
+		rm := atLimit()
 
 		var rc *ReplicaCapacity
 		for i := 0; i < MinServiceRateSamples+1; i++ {
 			rc = a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
 		}
 		Expect(rc).NotTo(BeNil())
+		Expect(rc.K2Priority).To(BeElementOf(k2SrcRateBacklog, k2SrcRateAnchored))
 
 		rec := store.Get(namespace, modelID, variant)
 		Expect(rec).NotTo(BeNil())
-		// lambda == mu at saturation, so the estimate is the occupancy the replica
-		// demonstrably held — that is a ceiling and belongs in the store.
-		Expect(rec.EffectiveCapacity).To(Equal(rc.EffectiveCapacity))
-	})
-
-	It("leaves the store untouched by a replica with headroom", func() {
-		store := NewCapacityKnowledgeStore()
-		a := NewSaturationAnalyzer(store, withRateAnchoredK2(true))
-		cfg := scalingConfig()
-
-		rm := backlogged()
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_ = a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
-		}
-		saturated := store.Get(namespace, modelID, variant)
-		Expect(saturated).NotTo(BeNil())
-
-		// Now idle at a quarter of the ceiling. The estimator declines rather than
-		// returning a headroom-scaled figure, so both this cycle's capacity and the
-		// persisted record come from the occupancy path — no headroom number can
-		// reach the store or the variant-level median.
-		rm.QueueLength = 0
-		rm.ArrivalRate = 2.0
-		rc := a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
-		Expect(rc).NotTo(BeNil())
-		Expect(rc.K2Priority).NotTo(Equal(k2SrcRateAnchored))
-		Expect(rc.K2Priority).NotTo(Equal(k2SrcRateNoEPP))
-		Expect(rc.K2Priority).NotTo(Equal(k2SrcRateBacklog))
-
-		rec := store.Get(namespace, modelID, variant)
-		Expect(rec).NotTo(BeNil())
+		// What the store learns is a limit measured under load, so it is the same
+		// figure this cycle scaled on — no separate stored value is needed.
 		Expect(rec.EffectiveCapacity).To(Equal(rc.EffectiveCapacity))
 		Expect(rec.EffectiveCapacity).To(BeNumerically("<=", int64(0.8*float64(kvCapacity))))
 	})
 
-	It("does not let an idle replica inflate capacity beside a backlogged sibling", func() {
-		cfg := scalingConfig()
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-
-		// pod-a is queueing twelve deep and calibrates the bucket.
-		hot := backlogged()
-		for i := 0; i < MinServiceRateSamples+1; i++ {
-			_ = a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
-		}
-		hotRC := a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
-
-		// pod-b is idle in the same bucket. aggregateByVariant takes the MEDIAN of
-		// per-replica capacities, so if the idle replica reported occupancy × its
-		// headroom the median would rise far above the backlogged replica's real
-		// ceiling and the variant would read as having spare capacity while a pod
-		// queues. Its capacity must therefore stay in the same range as its sibling's.
-		cold := backlogged()
-		cold.PodName = "pod-b"
-		cold.QueueLength = 0
-		cold.ArrivalRate = 2.0
-		coldRC := a.computeReplicaCapacity(cold, cfg, modelID, namespace, 1, domain.RoleBoth)
-
-		Expect(coldRC).NotTo(BeNil())
-		Expect(coldRC.EffectiveCapacity).To(BeNumerically("<=", int64(0.8*float64(kvCapacity))),
-			"an idle replica must never exceed the memory bound")
-		Expect(coldRC.EffectiveCapacity).To(BeNumerically("<=", hotRC.EffectiveCapacity*4),
-			"and must not tower over the backlogged sibling under a median")
-	})
-
 	It("is inert when the estimator is off", func() {
 		cfg := scalingConfig()
-		rm := backlogged()
+		rm := atLimit()
 
-		// Same inputs, same call sequence, with and without the estimator. With it
-		// off, every field the caller consumes must match the occupancy-based path.
 		off := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
 		Expect(off.serviceRates).To(BeNil(), "guards the default of EnableRateAnchoredK2")
 		Expect(off.arrivals).To(BeNil())
@@ -144,9 +82,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		Expect(baseline).NotTo(BeNil())
 		Expect(baseline.K2Priority).NotTo(Equal(k2SrcRateAnchored))
 		Expect(baseline.K2Priority).NotTo(Equal(k2SrcRateBacklog))
-		Expect(baseline.K2Priority).NotTo(Equal(k2SrcRateNoEPP))
 
-		// A second analyzer, also off, must agree exactly — no hidden state.
 		again := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
 		repeat := again.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
 		Expect(repeat.EffectiveCapacity).To(Equal(baseline.EffectiveCapacity))
@@ -159,11 +95,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 	It("holds capacity after a drain where the occupancy estimator releases it", func() {
 		cfg := scalingConfig()
 
-		// Under a deep backlog the two estimators agree: the occupancy path records
-		// TokensInUse as k2, and the rate path's backlog branch returns the same
-		// figure. The divergence appears after the queue drains, which is where the
-		// shed-to-one came from.
-		peak := backlogged()
+		peak := atLimit()
 		peak.KvCacheUsage = 0.85
 		peak.TokensInUse = int64(0.85 * float64(kvCapacity)) // 340k, above k1
 
@@ -175,7 +107,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		}
 
 		// Queue drained, occupancy collapsed — but arrivals are unchanged, still at
-		// the measured ceiling. Nothing about the load has actually improved.
+		// the measured service rate. Nothing about the load has improved.
 		drained := peak
 		drained.QueueLength = 0
 		drained.KvCacheUsage = 0.16
@@ -186,31 +118,39 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		rateBased := on.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
 
 		// The occupancy path answers from its inflated history and reports abundant
-		// spare capacity: demand 64k against a capacity of k1.
+		// spare capacity: demand 64k against a capacity of k1. That is the shed.
 		Expect(occupancyBased.EffectiveCapacity).To(BeNumerically(">", drained.TokensInUse*3),
 			"documents the behaviour being replaced")
 		Expect(occupancyBased.IsSaturated).To(BeFalse())
 
-		// The rate path reads lambda still at the ceiling, so capacity tracks the
-		// load rather than a stale peak: utilization stays at 100% and nothing is shed.
-		Expect(rateBased.EffectiveCapacity).To(BeNumerically("~", float64(drained.TokensInUse), 1))
-		Expect(rateBased.K2Priority).To(Equal(k2SrcRateAnchored))
+		// The rate path still holds the limit it measured, so utilization stays high
+		// and nothing is shed.
+		Expect(rateBased.EffectiveCapacity).To(BeNumerically("<=", drained.TokensInUse),
+			"capacity tracks the measured limit, not a stale peak")
 		Expect(rateBased.IsSaturated).To(BeTrue())
 	})
 
-})
+	It("gives a backlogged replica and an idle sibling the same capacity", func() {
+		cfg := scalingConfig()
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 
-var _ = Describe("Rate-anchored stores age out", func() {
-	It("evicts idle buckets and replicas", func() {
-		now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+		hot := atLimit()
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			_ = a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
+		}
+		hotRC := a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
 
-		rates := newServiceRateStore()
-		rates.Observe("bucket", 5, now.Add(-2*time.Hour))
-		rates.Observe("bucket", 5, now.Add(-2*time.Hour))
-		Expect(rates.EvictStale(time.Hour, now)).To(Equal(1))
+		cold := atLimit()
+		cold.PodName = "pod-b"
+		cold.QueueLength = 0
+		cold.ArrivalRate = 2.0
+		coldRC := a.computeReplicaCapacity(cold, cfg, modelID, namespace, 1, domain.RoleBoth)
 
-		arrivals := newArrivalSmoother()
-		_ = arrivals.Smooth("pod", 5, 60, now.Add(-2*time.Hour))
-		Expect(arrivals.EvictStale(time.Hour, now)).To(Equal(1))
+		// aggregateByVariant takes the MEDIAN of per-replica capacities. Equal values
+		// make that median a no-op, so an idle sibling cannot lift variant capacity
+		// while another replica queues — the regression that reintroduced shed-to-one.
+		Expect(coldRC.EffectiveCapacity).To(Equal(hotRC.EffectiveCapacity))
+		// The idle replica is not itself saturated: its own demand is what differs.
+		Expect(coldRC.ReplicaDemand).To(BeNumerically("<", hotRC.ReplicaDemand))
 	})
 })

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
@@ -127,14 +127,18 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		// the load has improved, only the crowding.
 		drained := peak
 		drained.QueueLength = 0
-		drained.KvCacheUsage = 0.15
-		drained.TokensInUse = 60_000
+		drained.KvCacheUsage = 0.16
+		// Little's law puts the resident tokens at 8 x 6 x 1250 = 60k; TokensInUse is
+		// max_over_time(...[1m]), so it reads a little above that. That gap is the
+		// documented bias between the two sides' time bases, and it errs toward more
+		// replicas rather than fewer.
+		drained.TokensInUse = 63_000
 		drained.ArrivalRate = 8.0
 		drained.AvgTTFT = 1.0
 		drained.AvgITL = 0.02 // W = 6 s
 
 		var occupancyBased, rateBased *ReplicaCapacity
-		for i := 0; i < 2; i++ { // the operating point reaches replicas one cycle later
+		for i := 0; i < 40; i++ { // the operating point is smoothed over about a minute
 			on.serviceRates.FreezeWork(clock)
 			occupancyBased = off.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
 			rateBased = on.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
@@ -1,6 +1,8 @@
 package saturation_v2
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -19,6 +21,8 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		modelID    = "m"
 		variant    = "v1"
 	)
+
+	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 
 	scalingConfig := func() *config.SaturationScalingConfig {
 		return &config.SaturationScalingConfig{
@@ -95,39 +99,66 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 	It("holds capacity after a drain where the occupancy estimator releases it", func() {
 		cfg := scalingConfig()
 
+		// The peak that validation round 1 actually measured: a replica queueing with
+		// KV near full. Its occupancy is ABOVE k1, so the learned ceiling is discarded
+		// by min(k1, k2) and cannot help — only the operating point can. Little's law
+		// ties the numbers together: mu=8 req/s x W=34 s x 1250 tokens = 340k.
 		peak := atLimit()
 		peak.KvCacheUsage = 0.85
 		peak.TokensInUse = int64(0.85 * float64(kvCapacity)) // 340k, above k1
+		peak.AvgTTFT = 4.0
+		peak.AvgITL = 0.12 // W = 4 + 250 x 0.12 = 34 s
 
-		off := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
-		on := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		clock := start
+		tick := func() time.Time {
+			clock = clock.Add(15 * time.Second)
+			return clock
+		}
+		off := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withClock(tick))
+		on := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true), withClock(tick))
 		for i := 0; i < MinServiceRateSamples+1; i++ {
+			on.serviceRates.FreezeWork(clock)
 			_ = off.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth)
 			_ = on.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth)
 		}
 
-		// Queue drained, occupancy collapsed — but arrivals are unchanged, still at
-		// the measured service rate. Nothing about the load has improved.
+		// Queue drained and contention with it: residence falls to 6 s, so occupancy
+		// falls in step (8 x 6 x 1250 = 60k). Arrivals are unchanged — nothing about
+		// the load has improved, only the crowding.
 		drained := peak
 		drained.QueueLength = 0
-		drained.KvCacheUsage = 0.16
-		drained.TokensInUse = int64(0.16 * float64(kvCapacity)) // 64k
+		drained.KvCacheUsage = 0.15
+		drained.TokensInUse = 60_000
 		drained.ArrivalRate = 8.0
+		drained.AvgTTFT = 1.0
+		drained.AvgITL = 0.02 // W = 6 s
 
-		occupancyBased := off.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
-		rateBased := on.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
+		var occupancyBased, rateBased *ReplicaCapacity
+		for i := 0; i < 2; i++ { // the operating point reaches replicas one cycle later
+			on.serviceRates.FreezeWork(clock)
+			occupancyBased = off.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
+			rateBased = on.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
+		}
 
 		// The occupancy path answers from its inflated history and reports abundant
-		// spare capacity: demand 64k against a capacity of k1. That is the shed.
+		// spare capacity: demand 60k against a capacity of k1. That is the shed.
 		Expect(occupancyBased.EffectiveCapacity).To(BeNumerically(">", drained.TokensInUse*3),
 			"documents the behaviour being replaced")
 		Expect(occupancyBased.IsSaturated).To(BeFalse())
 
-		// The rate path still holds the limit it measured, so utilization stays high
-		// and nothing is shed.
+		// The rate path scales its capacity to the operating point, so utilization is
+		// where it was under load and nothing is shed.
 		Expect(rateBased.EffectiveCapacity).To(BeNumerically("<=", drained.TokensInUse),
-			"capacity tracks the measured limit, not a stale peak")
+			"capacity follows the operating point, not a stale peak")
 		Expect(rateBased.IsSaturated).To(BeTrue())
+		Expect(rateBased.K2Priority).To(Equal(k2SrcRateResidence))
+
+		// What the store kept is the load-independent measurement, not the scaled
+		// value this cycle decided on: the store feeds variants with no live replicas
+		// and cross-variant estimation, where "what it is doing now" is meaningless.
+		rec := on.capacityStore.Get(namespace, modelID, variant)
+		Expect(rec).NotTo(BeNil())
+		Expect(rec.EffectiveCapacity).To(BeNumerically(">", rateBased.EffectiveCapacity))
 	})
 
 	It("gives a backlogged replica and an idle sibling the same capacity", func() {
@@ -141,7 +172,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		hotRC := a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
 
 		cold := atLimit()
-		cold.PodName = "pod-b"
+		cold.PodName = siblingPod
 		cold.QueueLength = 0
 		cold.ArrivalRate = 2.0
 		coldRC := a.computeReplicaCapacity(cold, cfg, modelID, namespace, 1, domain.RoleBoth)

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_integration_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 	)
 
 	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	shape := variantShape{avgInput: 1000, avgOutput: 250}
 
 	scalingConfig := func() *config.SaturationScalingConfig {
 		return &config.SaturationScalingConfig{
@@ -65,7 +66,7 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		for i := 0; i <= MinServiceRateSamples+1; i++ {
 			clock = clock.Add(15 * time.Second)
 			a.serviceRates.BeginCycle(clock)
-			rc = a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
+			rc = a.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
 		}
 		Expect(rc).NotTo(BeNil())
 		Expect(rc.K2Priority).To(BeElementOf(k2SrcRateBacklog, k2SrcRateAnchored))
@@ -86,13 +87,13 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		Expect(off.serviceRates).To(BeNil(), "guards the default of EnableRateAnchoredK2")
 		Expect(off.arrivals).To(BeNil())
 
-		baseline := off.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
+		baseline := off.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
 		Expect(baseline).NotTo(BeNil())
 		Expect(baseline.K2Priority).NotTo(Equal(k2SrcRateAnchored))
 		Expect(baseline.K2Priority).NotTo(Equal(k2SrcRateBacklog))
 
 		again := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
-		repeat := again.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth)
+		repeat := again.computeReplicaCapacity(rm, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
 		Expect(repeat.EffectiveCapacity).To(Equal(baseline.EffectiveCapacity))
 		Expect(repeat.MemoryBoundCapacity).To(Equal(baseline.MemoryBoundCapacity))
 		Expect(repeat.ComputeBoundCapacity).To(Equal(baseline.ComputeBoundCapacity))
@@ -122,8 +123,8 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		on := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true), withClock(tick))
 		for i := 0; i < MinServiceRateSamples+1; i++ {
 			on.serviceRates.BeginCycle(clock)
-			_ = off.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth)
-			_ = on.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth)
+			_ = off.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
+			_ = on.computeReplicaCapacity(peak, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
 		}
 
 		// Queue drained and contention with it: residence falls to 6 s, so occupancy
@@ -144,8 +145,8 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		var occupancyBased, rateBased *ReplicaCapacity
 		for i := 0; i < 40; i++ { // the operating point is smoothed over about a minute
 			on.serviceRates.BeginCycle(clock)
-			occupancyBased = off.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
-			rateBased = on.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth)
+			occupancyBased = off.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
+			rateBased = on.computeReplicaCapacity(drained, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
 		}
 
 		// The occupancy path answers from its inflated history and reports abundant
@@ -182,16 +183,16 @@ var _ = Describe("Rate-anchored k2 through computeReplicaCapacity", func() {
 		for i := 0; i <= MinServiceRateSamples+1; i++ {
 			clock = clock.Add(15 * time.Second)
 			a.serviceRates.BeginCycle(clock)
-			_ = a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
+			_ = a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
 		}
 		a.serviceRates.BeginCycle(clock.Add(15 * time.Second))
-		hotRC := a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth)
+		hotRC := a.computeReplicaCapacity(hot, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
 
 		cold := atLimit()
 		cold.PodName = siblingPod
 		cold.QueueLength = 0
 		cold.ArrivalRate = 2.0
-		coldRC := a.computeReplicaCapacity(cold, cfg, modelID, namespace, 1, domain.RoleBoth)
+		coldRC := a.computeReplicaCapacity(cold, cfg, modelID, namespace, 1, domain.RoleBoth, shape)
 
 		// aggregateByVariant takes the MEDIAN of per-replica capacities. Equal values
 		// make that median a no-op, so an idle sibling cannot lift variant capacity

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -958,3 +958,113 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 			int(WorkWindow/interval)+1), "bounded by the window, not by the run length")
 	})
 })
+
+// The validation runs showed RATE-W — the only label where capacity is scaled below
+// the learned ceiling — firing once in thirty-five minutes on prefill-heavy traffic
+// against twenty-seven times on symmetric traffic. The cause is that TTFT carries
+// queue wait, so under backlog the residence it implies is several times the real
+// service time and the clamp holds capacity at the ceiling for the whole run.
+var _ = Describe("Service residence under a deep queue", func() {
+	const (
+		k1             = int64(320_000)
+		queueThreshold = 5.0
+		interval       = 15 * time.Second
+	)
+	start := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	shape := variantShape{avgInput: 1000, avgOutput: 250}
+
+	// Uncontended: nothing queued, so TTFT is prefill and nothing else.
+	quiet := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               "pod-a",
+			AcceleratorName:       "H100",
+			QueueLength:           0,
+			QueueLengthInstant:    0,
+			HasQueueLengthInstant: true,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			TokensInUse:           60_000,
+			KvUsageInstant:        0.15,
+			TotalKvCapacityTokens: 400_000,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+			AvgTTFT:               0.10, // prefill only
+			AvgITL:                0.02, // service residence = 0.1 + 5 = 5.1 s
+		}
+	}
+
+	It("uses prefill learned while idle instead of a queue-inflated TTFT", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		at := start
+
+		// Calibrate: a few quiet cycles teach the bucket what prefill costs, then a
+		// backlogged stretch teaches it the service rate and the ceiling.
+		for i := 0; i < 6; i++ {
+			a.serviceRates.BeginCycle(at)
+			_, _, _, _ = a.rateAnchoredK2(quiet(), "m", "", 1, shape, k1, queueThreshold, at)
+			at = at.Add(interval)
+		}
+		hot := quiet()
+		hot.QueueLength, hot.QueueLengthInstant = 140, 140
+		hot.AvgTTFT = 8.0 // queue wait dominates: TTFT is now 80x prefill
+		hot.TokensInUse = 300_000
+		hot.KvUsageInstant = 0.75
+		for i := 0; i < 4; i++ {
+			a.serviceRates.BeginCycle(at)
+			_, _, _, _ = a.rateAnchoredK2(hot, "m", "", 1, shape, k1, queueThreshold, at)
+			at = at.Add(interval)
+		}
+
+		a.serviceRates.BeginCycle(at)
+		k2, _, src, ok := a.rateAnchoredK2(hot, "m", "", 1, shape, k1, queueThreshold, at)
+		Expect(ok).To(BeTrue())
+
+		// mu x W_service x tokensPerRequest = 8 x 5.1 x 1250 = 51k, well under the
+		// ceiling, so the scaling engages and capacity reflects what the replica can
+		// actually serve. Read from TTFT the residence would be 13 s, the product
+		// 130k, and the clamp would have returned the ceiling instead.
+		Expect(src).To(Equal(k2SrcRateResidence))
+		Expect(k2).To(BeNumerically("~", 51_000, 5_000))
+		Expect(k2).To(BeNumerically("<", 130_000), "not the queue-inflated figure")
+	})
+
+	It("falls back to the plain residence until an idle cycle has been seen", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		hot := quiet()
+		hot.QueueLength, hot.QueueLengthInstant = 140, 140
+		hot.AvgTTFT = 8.0
+
+		at := start
+		for i := 0; i < 4; i++ {
+			a.serviceRates.BeginCycle(at)
+			_, _, _, _ = a.rateAnchoredK2(hot, "m", "", 1, shape, k1, queueThreshold, at)
+			at = at.Add(interval)
+		}
+		_, ok := a.serviceRates.Prefill(serviceRateKey("m", "H100", "", 1, shape), at)
+		Expect(ok).To(BeFalse(), "a backlogged TTFT must never be recorded as prefill")
+
+		// And the estimator still answers, from the contaminated residence, exactly as
+		// it did before — no worse, and still bounded by the clamp.
+		_, _, _, answered := a.rateAnchoredK2(hot, "m", "", 1, shape, k1, queueThreshold, at)
+		Expect(answered).To(BeTrue())
+	})
+})
+
+var _ = Describe("Learned prefill retention", func() {
+	now := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+
+	It("outlives the service-rate window", func() {
+		s := newBucketStore()
+		s.ObservePrefill("k", 0.1, now)
+		s.BeginCycle(now)
+
+		// A sustained overload has no unqueued cycles to refresh this, and expiring it
+		// would drop the estimator back to the queue-contaminated residence exactly
+		// when the queue is deep.
+		_, ok := s.Prefill("k", now.Add(ServiceRateWindow+time.Minute))
+		Expect(ok).To(BeTrue())
+
+		_, ok = s.Prefill("k", now.Add(HistoryEvictionTimeout+time.Minute))
+		Expect(ok).To(BeFalse(), "but not past the bucket's own lifetime")
+	})
+})

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -15,6 +15,7 @@ var _ = Describe("Service rate store", func() {
 	It("keeps the highest rate observed for a bucket", func() {
 		s := newServiceRateStore()
 		s.Observe("k", 4.0, now)
+		// three observations, so the sample floor is satisfied
 		s.Observe("k", 9.0, now.Add(time.Minute))
 		s.Observe("k", 6.0, now.Add(2*time.Minute))
 
@@ -23,6 +24,18 @@ var _ = Describe("Service rate store", func() {
 		// Slightly under 9 because the peak decays between observations; the
 		// point is that the later, lower 6.0 did not replace it.
 		Expect(rate).To(BeNumerically("~", 9.0, 0.2))
+	})
+
+	It("withholds an estimate until a second qualifying observation", func() {
+		s := newServiceRateStore()
+		s.Observe("k", 7.0, now)
+
+		_, ok := s.Rate("k", now)
+		Expect(ok).To(BeFalse(), "one observation cannot distinguish a ceiling from a slow interval")
+
+		s.Observe("k", 7.0, now)
+		_, ok = s.Rate("k", now)
+		Expect(ok).To(BeTrue())
 	})
 
 	It("ignores non-positive rates", func() {
@@ -41,6 +54,7 @@ var _ = Describe("Service rate store", func() {
 
 	It("decays an unrefreshed maximum", func() {
 		s := newServiceRateStore()
+		s.Observe("k", 10.0, now)
 		s.Observe("k", 10.0, now)
 
 		rate, ok := s.Rate("k", now.Add(ServiceRateWindow))
@@ -62,6 +76,7 @@ var _ = Describe("Service rate store", func() {
 	It("stops answering past the window", func() {
 		s := newServiceRateStore()
 		s.Observe("k", 10.0, now)
+		s.Observe("k", 10.0, now)
 
 		_, ok := s.Rate("k", now.Add(ServiceRateWindow+time.Second))
 		Expect(ok).To(BeFalse())
@@ -69,6 +84,7 @@ var _ = Describe("Service rate store", func() {
 
 	It("evicts entries older than the timeout", func() {
 		s := newServiceRateStore()
+		s.Observe("fresh", 5.0, now)
 		s.Observe("fresh", 5.0, now)
 		s.Observe("stale", 5.0, now.Add(-2*time.Hour))
 
@@ -86,10 +102,18 @@ var _ = Describe("Service rate store", func() {
 
 var _ = Describe("Rate-anchored k2", func() {
 	const (
-		kvCapacity = int64(400_000)
-		k1         = int64(320_000) // 0.8 × kvCapacity
+		kvCapacity     = int64(400_000)
+		k1             = int64(320_000) // 0.8 × kvCapacity
+		queueThreshold = 5.0            // config.DefaultQueueLengthThreshold
 	)
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	// calibrate drives enough qualifying observations to establish mu for the bucket.
+	calibrate := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics) {
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		}
+	}
 
 	// saturatedReplica is queueing at 16% KV — the prefill-heavy regime the
 	// occupancy-based estimator cannot express.
@@ -108,7 +132,7 @@ var _ = Describe("Rate-anchored k2", func() {
 
 	It("declines when the estimator is not enabled", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
-		_, _, _, ok := a.rateAnchoredK2(saturatedReplica(), "m", 1, k1, now)
+		_, _, _, ok := a.rateAnchoredK2(saturatedReplica(), "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -116,7 +140,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
 
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		// lambda == mu, so capacity equals current occupancy: demand/supply == 1
 		// even though only 16% of KV is in use.
@@ -126,12 +150,12 @@ var _ = Describe("Rate-anchored k2", func() {
 	It("scales capacity by the distance to saturation", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
-		_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, now) // records mu = 8 req/s
+		calibrate(a, rm) // establishes mu = 8 req/s for this bucket
 
 		// Same bucket, half the arrival rate and no backlog: twice the headroom.
 		rm.QueueLength = 0
 		rm.ArrivalRate = 4.0
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16*2, 1))
 	})
@@ -141,7 +165,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := saturatedReplica()
 		rm.ArrivalRate = 0
 
-		k2, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		k2, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog))
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
@@ -150,12 +174,12 @@ var _ = Describe("Rate-anchored k2", func() {
 	It("falls back to completions as lambda when there is no queue and no EPP", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
-		_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, now) // records mu = 8 req/s
+		calibrate(a, rm) // establishes mu = 8 req/s for this bucket
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 0
 		rm.RequestRate = 4.0 // no queue, so completions are arrivals
-		k2, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		k2, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateNoEPP))
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16*2, 1))
@@ -167,14 +191,22 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm.QueueLength = 0 // no backlog to fall back on
 		rm.ArrivalRate = 0 // no EPP
 		rm.RequestRate = 0 // and nothing completing
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("prefers the EPP arrival rate over the fallbacks", func() {
+	It("prefers the EPP arrival rate once mu is established", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
-		_, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+
+		// Before calibration the backlog itself is the only usable signal.
+		_, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateBacklog))
+
+		// Once the bucket has enough qualifying observations, lambda wins.
+		calibrate(a, rm)
+		_, src, _, ok = a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateAnchored))
 	})
@@ -184,18 +216,18 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := saturatedReplica()
 		rm.KvUsageInstant = 0
 
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
 	It("clamps the ratio so a collapsed arrival rate cannot inflate capacity", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
-		_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, now)
+		calibrate(a, rm)
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 0.0001 // mu/lambda would be 80000×
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically("<=", int64(float64(kvCapacity)*0.16*MaxRateRatio)))
 	})
@@ -207,14 +239,17 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm.ArrivalRate = 50.0
 		rm.KvUsageInstant = 0.01
 
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically(">=", int64(float64(k1)*MinRateAnchoredFraction)))
 	})
 })
 
 var _ = Describe("Rate-anchored k2 and the capacity store", func() {
-	const kvCapacity = int64(400_000)
+	const (
+		kvCapacity     = int64(400_000)
+		queueThreshold = 5.0
+	)
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 
 	replica := func() domain.ReplicaMetrics {
@@ -233,7 +268,7 @@ var _ = Describe("Rate-anchored k2 and the capacity store", func() {
 
 	It("marks a saturated reading as a ceiling", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		_, _, ceiling, ok := a.rateAnchoredK2(replica(), "m", 1, int64(320_000), now)
+		_, _, ceiling, ok := a.rateAnchoredK2(replica(), "m", 1, int64(320_000), queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(ceiling).To(BeTrue(), "lambda >= mu means the replica demonstrated this capacity")
 	})
@@ -241,12 +276,62 @@ var _ = Describe("Rate-anchored k2 and the capacity store", func() {
 	It("does not mark a below-saturation reading as a ceiling", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := replica()
-		_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, int64(320_000), now) // calibrate mu = 8
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, int64(320_000), queueThreshold, now)
+		}
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 2.0 // well below mu: this is headroom, not a ceiling
-		_, _, ceiling, ok := a.rateAnchoredK2(rm, "m", 1, int64(320_000), now)
+		_, _, ceiling, ok := a.rateAnchoredK2(rm, "m", 1, int64(320_000), queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(ceiling).To(BeFalse())
+	})
+})
+
+var _ = Describe("Rate-anchored k2 and transient queues", func() {
+	const (
+		kvCapacity     = int64(400_000)
+		k1             = int64(320_000)
+		queueThreshold = 5.0
+	)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	// A replica comfortably keeping up: low occupancy, arrivals served as they come,
+	// and a single request briefly waiting from arrival jitter. mu == lambda here is
+	// flow conservation, not evidence of a ceiling, so nothing may be concluded.
+	keepingUp := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			AcceleratorName:       "H100",
+			QueueLength:           1,
+			RequestRate:           3.0,
+			ArrivalRate:           3.0,
+			KvUsageInstant:        0.08,
+			TotalKvCapacityTokens: kvCapacity,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+		}
+	}
+
+	It("does not calibrate mu from a queue shallower than the threshold", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := keepingUp()
+		for i := 0; i < 5; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		}
+
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse(), "a one-deep queue is arrival jitter, not a ceiling")
+	})
+
+	It("does not declare saturation from a single deep-queue sample", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := keepingUp()
+		rm.QueueLength = 6 // one qualifying observation, below MinServiceRateSamples
+
+		_, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		// The backlog path still fires — a deep queue now is saturation now — but mu
+		// is not yet established, so no ratio is derived from it.
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateBacklog))
 	})
 })

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -1,6 +1,7 @@
 package saturation_v2
 
 import (
+	"fmt"
 	"math"
 	"time"
 
@@ -391,5 +392,43 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm.ArrivalRate = 1
 		_, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue(), "the ceiling measured under backlog still applies")
+	})
+})
+
+var _ = Describe("Bucket store — bounded growth", func() {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	It("prunes stale buckets when a new one is inserted", func() {
+		s := newBucketStore()
+		// Fill past the prune threshold with buckets nobody has touched in a day.
+		old := now.Add(-2 * HistoryEvictionTimeout)
+		for i := 0; i < BucketPruneThreshold; i++ {
+			s.ObserveCeiling(fmt.Sprintf("stale-%d", i), 1000, old)
+		}
+		Expect(s.entries).To(HaveLen(BucketPruneThreshold))
+
+		s.ObserveCeiling("fresh", 2000, now)
+		Expect(s.entries).To(HaveLen(1), "the stale buckets went with the insert")
+		_, ok := s.Ceiling("fresh", now)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("keeps buckets that are still in use", func() {
+		s := newBucketStore()
+		for i := 0; i < BucketPruneThreshold; i++ {
+			s.ObserveCeiling(fmt.Sprintf("live-%d", i), 1000, now)
+		}
+		s.ObserveCeiling("one-more", 1000, now)
+		Expect(s.entries).To(HaveLen(BucketPruneThreshold + 1))
+	})
+
+	It("prunes per-pod arrival entries the same way", func() {
+		s := newArrivalSmoother()
+		old := now.Add(-2 * HistoryEvictionTimeout)
+		for i := 0; i < BucketPruneThreshold; i++ {
+			_ = s.Smooth(fmt.Sprintf("gone-%d", i), 4, 60, old)
+		}
+		_ = s.Smooth("current", 4, 60, now)
+		Expect(s.entries).To(HaveLen(1))
 	})
 })

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -1,6 +1,7 @@
 package saturation_v2
 
 import (
+	"math"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -94,8 +95,8 @@ var _ = Describe("Service rate store", func() {
 	})
 
 	It("separates buckets by input length", func() {
-		short := serviceRateKey("m", "H100", 1, 300, 300)
-		long := serviceRateKey("m", "H100", 1, 1000, 300)
+		short := serviceRateKey("m", "H100", "decode", 1, 300, 300)
+		long := serviceRateKey("m", "H100", "decode", 1, 1000, 300)
 		Expect(short).NotTo(Equal(long))
 	})
 })
@@ -111,7 +112,7 @@ var _ = Describe("Rate-anchored k2", func() {
 	// calibrate drives enough qualifying observations to establish mu for the bucket.
 	calibrate := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics) {
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 	}
 
@@ -124,6 +125,7 @@ var _ = Describe("Rate-anchored k2", func() {
 			RequestRate:           8.0,
 			ArrivalRate:           8.0,
 			KvUsageInstant:        0.16,
+			TokensInUse:           int64(0.16 * float64(kvCapacity)),
 			TotalKvCapacityTokens: kvCapacity,
 			AvgInputTokens:        1000,
 			AvgOutputTokens:       250,
@@ -132,19 +134,36 @@ var _ = Describe("Rate-anchored k2", func() {
 
 	It("declines when the estimator is not enabled", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
-		_, _, _, ok := a.rateAnchoredK2(saturatedReplica(), "m", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(saturatedReplica(), "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("reads 100% utilization for a replica at rate saturation", func() {
+	It("reads 100% utilization from the backlog before mu is calibrated", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
 
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		k2, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
-		// lambda == mu, so capacity equals current occupancy: demand/supply == 1
-		// even though only 16% of KV is in use.
+		// No mu yet, so this is the backlog path — assert the source, otherwise the
+		// numeric result is indistinguishable from the lambda path.
+		Expect(src).To(Equal(k2SrcRateBacklog))
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
+	})
+
+	It("reads 100% utilization from lambda == mu with no queue", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		calibrate(a, rm) // mu = 8 req/s
+
+		// Arrivals exactly at the ceiling, nothing queued yet: this is the case the
+		// ratio arithmetic exists for, and it must come from the lambda path.
+		rm.QueueLength = 0
+		rm.ArrivalRate = 8.0
+		k2, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateAnchored))
+		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1),
+			"capacity equals occupancy, so utilization reads 100% at 16% KV")
 	})
 
 	It("scales capacity by the distance to saturation", func() {
@@ -155,7 +174,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		// Same bucket, half the arrival rate and no backlog: twice the headroom.
 		rm.QueueLength = 0
 		rm.ArrivalRate = 4.0
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16*2, 1))
 	})
@@ -165,7 +184,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := saturatedReplica()
 		rm.ArrivalRate = 0
 
-		k2, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		k2, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog))
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
@@ -179,7 +198,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm.QueueLength = 0
 		rm.ArrivalRate = 0
 		rm.RequestRate = 4.0 // no queue, so completions are arrivals
-		k2, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		k2, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateNoEPP))
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16*2, 1))
@@ -191,7 +210,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm.QueueLength = 0 // no backlog to fall back on
 		rm.ArrivalRate = 0 // no EPP
 		rm.RequestRate = 0 // and nothing completing
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -200,23 +219,23 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := saturatedReplica()
 
 		// Before calibration the backlog itself is the only usable signal.
-		_, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		_, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog))
 
 		// Once the bucket has enough qualifying observations, lambda wins.
 		calibrate(a, rm)
-		_, src, _, ok = a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		_, src, _, ok = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateAnchored))
 	})
 
-	It("declines when the instantaneous KV reading is missing", func() {
+	It("declines when the occupancy reading is missing", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
-		rm.KvUsageInstant = 0
+		rm.TokensInUse = 0
 
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -227,7 +246,7 @@ var _ = Describe("Rate-anchored k2", func() {
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 0.0001 // mu/lambda would be 80000×
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically("<=", int64(float64(kvCapacity)*0.16*MaxRateRatio)))
 	})
@@ -237,9 +256,9 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := saturatedReplica()
 		rm.RequestRate = 0.01
 		rm.ArrivalRate = 50.0
-		rm.KvUsageInstant = 0.01
+		rm.TokensInUse = int64(0.01 * float64(kvCapacity))
 
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically(">=", int64(float64(k1)*MinRateAnchoredFraction)))
 	})
@@ -260,6 +279,7 @@ var _ = Describe("Rate-anchored k2 and the capacity store", func() {
 			RequestRate:           8.0,
 			ArrivalRate:           8.0,
 			KvUsageInstant:        0.16,
+			TokensInUse:           int64(0.16 * float64(kvCapacity)),
 			TotalKvCapacityTokens: kvCapacity,
 			AvgInputTokens:        1000,
 			AvgOutputTokens:       250,
@@ -268,7 +288,7 @@ var _ = Describe("Rate-anchored k2 and the capacity store", func() {
 
 	It("marks a saturated reading as a ceiling", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		_, _, ceiling, ok := a.rateAnchoredK2(replica(), "m", 1, int64(320_000), queueThreshold, now)
+		_, _, ceiling, ok := a.rateAnchoredK2(replica(), "m", "", 1, int64(320_000), queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(ceiling).To(BeTrue(), "lambda >= mu means the replica demonstrated this capacity")
 	})
@@ -277,12 +297,12 @@ var _ = Describe("Rate-anchored k2 and the capacity store", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := replica()
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, int64(320_000), queueThreshold, now)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, int64(320_000), queueThreshold, now)
 		}
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 2.0 // well below mu: this is headroom, not a ceiling
-		_, _, ceiling, ok := a.rateAnchoredK2(rm, "m", 1, int64(320_000), queueThreshold, now)
+		_, _, ceiling, ok := a.rateAnchoredK2(rm, "m", "", 1, int64(320_000), queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(ceiling).To(BeFalse())
 	})
@@ -306,6 +326,7 @@ var _ = Describe("Rate-anchored k2 and transient queues", func() {
 			RequestRate:           3.0,
 			ArrivalRate:           3.0,
 			KvUsageInstant:        0.08,
+			TokensInUse:           int64(0.08 * float64(kvCapacity)),
 			TotalKvCapacityTokens: kvCapacity,
 			AvgInputTokens:        1000,
 			AvgOutputTokens:       250,
@@ -316,10 +337,10 @@ var _ = Describe("Rate-anchored k2 and transient queues", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := keepingUp()
 		for i := 0; i < 5; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse(), "a one-deep queue is arrival jitter, not a ceiling")
 	})
 
@@ -328,7 +349,7 @@ var _ = Describe("Rate-anchored k2 and transient queues", func() {
 		rm := keepingUp()
 		rm.QueueLength = 6 // one qualifying observation, below MinServiceRateSamples
 
-		_, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, queueThreshold, now)
+		_, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		// The backlog path still fires — a deep queue now is saturation now — but mu
 		// is not yet established, so no ratio is derived from it.
 		Expect(ok).To(BeTrue())
@@ -414,5 +435,219 @@ var _ = Describe("Residence estimate", func() {
 		Expect(residenceSeconds(domain.ReplicaMetrics{
 			AvgTTFT: 1e6, AvgITL: 1, AvgOutputTokens: 1,
 		})).To(Equal(MaxResidenceSeconds))
+	})
+})
+
+var _ = Describe("Rate-anchored k2 across roles and load levels", func() {
+	const (
+		kvCapacity     = int64(400_000)
+		k1             = int64(320_000)
+		queueThreshold = 5.0
+	)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	backlogged := func(role string, rate float64) domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               "pod-" + role,
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           rate,
+			ArrivalRate:           rate,
+			KvUsageInstant:        0.16,
+			TokensInUse:           int64(0.16 * float64(kvCapacity)),
+			TotalKvCapacityTokens: kvCapacity,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+		}
+	}
+
+	It("does not let one role calibrate another's ceiling", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+
+		// A decode replica establishes mu = 20 req/s.
+		dec := backlogged(domain.RoleDecode, 20)
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, k1, queueThreshold, now)
+		}
+
+		// A prefill replica of the same model on the same accelerator must not
+		// inherit it: prefill completes at a different rate for the same requests.
+		pre := backlogged(domain.RolePrefill, 3)
+		pre.QueueLength = 0
+		_, src, _, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse(), "prefill has no calibration of its own yet")
+		Expect(src).To(Equal(k2Source(0)))
+	})
+
+	It("calibrates each role independently", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		for _, role := range []string{domain.RolePrefill, domain.RoleDecode, domain.RoleBoth} {
+			rm := backlogged(role, 10)
+			for i := 0; i < MinServiceRateSamples; i++ {
+				_, _, _, _ = a.rateAnchoredK2(rm, "m", role, 1, k1, queueThreshold, now)
+			}
+			rm.QueueLength = 0
+			rm.ArrivalRate = 5 // half the ceiling
+			k2, src, _, ok := a.rateAnchoredK2(rm, "m", role, 1, k1, queueThreshold, now)
+			Expect(ok).To(BeTrue(), "role %s", role)
+			Expect(src).To(Equal(k2SrcRateAnchored))
+			Expect(k2).To(BeNumerically(">", int64(float64(kvCapacity)*0.16)), "role %s has headroom", role)
+		}
+	})
+
+	It("does not cut capacity below what a queue-free replica is visibly handling", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+
+		// Calibrated conservatively at 8 req/s during a rough patch.
+		rm := backlogged(domain.RoleBoth, 8)
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
+		}
+
+		// Now running slightly past that rate with nothing queued: the replica is
+		// keeping up, so capacity must not be reported below its occupancy.
+		rm.QueueLength = 0
+		rm.ArrivalRate = 12
+		rm.RequestRate = 12
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now.Add(time.Minute))
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically(">=", int64(float64(kvCapacity)*0.16)),
+			"utilization must not exceed 100% for a replica with an empty queue")
+	})
+
+	It("leaves k1 as the bound when the replica has ample headroom", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := backlogged(domain.RoleBoth, 20)
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
+		}
+
+		// A quarter of the ceiling, and holding a healthy chunk of KV.
+		rm.QueueLength = 0
+		rm.ArrivalRate = 5
+		rm.TokensInUse = int64(0.5 * float64(kvCapacity))
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		// 0.5 × 400k × 4 = 800k > k1, so min(k1, k2) keeps the memory bound.
+		Expect(k2).To(BeNumerically(">", k1), "the memory bound should win, not be undercut")
+	})
+})
+
+var _ = Describe("Rate-anchored k2 with degenerate or missing signals", func() {
+	const (
+		kvCapacity     = int64(400_000)
+		k1             = int64(320_000)
+		queueThreshold = 5.0
+	)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	base := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               "pod-a",
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			KvUsageInstant:        0.16,
+			TokensInUse:           int64(0.16 * float64(kvCapacity)),
+			TotalKvCapacityTokens: kvCapacity,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+		}
+	}
+
+	It("never calibrates a prefill replica that reports no completions", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		// A disaggregated prefill pod completes few or no generation tokens, so the
+		// completion-rate metric can read zero even under a deep backlog.
+		rm := base()
+		rm.RequestRate = 0
+		for i := 0; i < 5; i++ {
+			_, src, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+			Expect(ok).To(BeTrue())
+			// The backlog is real, so saturation is reported — but from the queue,
+			// never from a fabricated ceiling.
+			Expect(src).To(Equal(k2SrcRateBacklog))
+		}
+
+		// With the queue drained there is nothing left to conclude from.
+		rm.QueueLength = 0
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("declines a negative arrival rate rather than inverting the ratio", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := base()
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		}
+
+		rm.QueueLength = 0
+		rm.ArrivalRate = -5 // mis-scraped
+		rm.RequestRate = 0
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("does not propagate a NaN arrival rate into capacity", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := base()
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		}
+
+		rm.QueueLength = 0
+		rm.ArrivalRate = math.NaN()
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		// A NaN ratio is caught before the int64 conversion, so either the estimator
+		// declines or it returns a sane positive token count — never garbage.
+		if ok {
+			Expect(k2).To(BeNumerically(">", 0))
+			Expect(k2).To(BeNumerically("<=", k1))
+		}
+	})
+
+	It("declines a cold replica with no occupancy and no calibration", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := base()
+		rm.QueueLength = 0
+		rm.TokensInUse = 0 // just became ready, KV still empty
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("shares mu across replicas of a variant but smooths arrivals per replica", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+
+		// pod-a is backlogged and establishes the bucket's ceiling.
+		hot := base()
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _, _ = a.rateAnchoredK2(hot, "m", "", 1, k1, queueThreshold, now)
+		}
+
+		// pod-b, same variant and shape, idle at a quarter of the ceiling. It gets
+		// the shared mu, and its own arrival history — not pod-a's.
+		cold := base()
+		cold.PodName = "pod-b"
+		cold.QueueLength = 0
+		cold.ArrivalRate = 2.0
+		k2, src, _, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateAnchored))
+		Expect(k2).To(BeNumerically(">", int64(float64(kvCapacity)*0.16)),
+			"an idle replica must read as having headroom, not as saturated")
+	})
+
+	It("collapses onto one smoothing entry when replicas report no pod name", func() {
+		// Documents a real limitation rather than asserting it is harmless: with
+		// PodName empty the smoother falls back to the bucket key, so two such
+		// replicas share one arrival average.
+		s := newArrivalSmoother()
+		first := s.Smooth("bucket", 4.0, 60, now)
+		second := s.Smooth("bucket", 40.0, 60, now.Add(time.Second))
+		Expect(first).To(Equal(4.0))
+		Expect(second).To(BeNumerically("<", 40.0),
+			"the second replica's rate is blended into the first's average")
 	})
 })

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("Bucket store — service rate", func() {
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 
-	It("keeps the highest rate observed", func() {
+	It("tracks the mean of what it sees, in both directions", func() {
 		s := newBucketStore()
 		s.ObserveRate("k", 4.0, now)
 		s.ObserveRate("k", 9.0, now.Add(time.Minute))
@@ -22,9 +22,31 @@ var _ = Describe("Bucket store — service rate", func() {
 
 		rate, ok := s.Rate("k", now.Add(2*time.Minute))
 		Expect(ok).To(BeTrue())
-		// Slightly under 9 because the peak decays between observations; the point
-		// is that the later, lower 6.0 did not replace it.
-		Expect(rate).To(BeNumerically("~", 9.0, 0.2))
+		// Between the samples, not pinned to the largest. Under backlog the server is
+		// never idle, so every sample is a reading of the service rate — preferring
+		// the maximum would only ratchet capacity upward and under-scale.
+		Expect(rate).To(BeNumerically(">", 4.0))
+		Expect(rate).To(BeNumerically("<", 9.0))
+	})
+
+	It("comes down when the workload gets heavier within a bucket", func() {
+		s := newBucketStore()
+		at := now
+		for i := 0; i < 6; i++ { // calibrate at 10 req/s
+			s.ObserveRate("k", 10.0, at)
+			at = at.Add(30 * time.Second)
+		}
+		fast, _ := s.Rate("k", at)
+
+		for i := 0; i < 12; i++ { // longer prompts: the same replica now serves 5/s
+			s.ObserveRate("k", 5.0, at)
+			at = at.Add(30 * time.Second)
+		}
+		slow, ok := s.Rate("k", at)
+
+		Expect(ok).To(BeTrue())
+		Expect(slow).To(BeNumerically("<", fast*0.8),
+			"a running maximum would still be reporting the old rate here")
 	})
 
 	It("withholds an estimate until a second observation", func() {
@@ -46,17 +68,17 @@ var _ = Describe("Bucket store — service rate", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("decays an unrefreshed rate and expires it past the window", func() {
+	It("holds an unrefreshed rate and expires it past the window", func() {
 		s := newBucketStore()
 		s.ObserveRate("k", 10.0, now)
 		s.ObserveRate("k", 10.0, now)
 
 		rate, ok := s.Rate("k", now.Add(ServiceRateWindow))
 		Expect(ok).To(BeTrue())
-		Expect(rate).To(BeNumerically("~", 10.0*ServiceRateDecayPerWindow, 0.01))
+		Expect(rate).To(BeNumerically("~", 10.0, 0.01))
 
 		_, ok = s.Rate("k", now.Add(ServiceRateWindow+time.Second))
-		Expect(ok).To(BeFalse())
+		Expect(ok).To(BeFalse(), "stale evidence is dropped rather than aged into a guess")
 	})
 })
 
@@ -179,6 +201,9 @@ var _ = Describe("Residence estimate", func() {
 	})
 })
 
+// siblingPod names the second replica wherever a test needs two of them.
+const siblingPod = "pod-b"
+
 var _ = Describe("Rate-anchored k2", func() {
 	const (
 		kvCapacity     = int64(400_000)
@@ -205,19 +230,19 @@ var _ = Describe("Rate-anchored k2", func() {
 	// learn drives enough cycles to establish both the service rate and the ceiling.
 	learn := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics) {
 		for i := 0; i < MinServiceRateSamples+1; i++ {
-			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 	}
 
 	It("declines when the estimator is not enabled", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
-		_, _, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
 	It("reports the current occupancy on a first overload, before anything is learned", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		k2, src, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, now)
+		k2, _, src, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog))
 		Expect(k2).To(BeNumerically("~", float64(occupancy), 1),
@@ -229,9 +254,9 @@ var _ = Describe("Rate-anchored k2", func() {
 		hot := atLimit()
 		learn(a, hot)
 
-		hotK2, hotSrc, ok := a.rateAnchoredK2(hot, "m", "", 1, k1, queueThreshold, now)
+		hotK2, _, hotSrc, ok := a.rateAnchoredK2(hot, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
-		Expect(hotSrc).To(Equal(k2SrcRateAnchored))
+		Expect(hotSrc).To(Equal(k2SrcRateBacklog), "backlogged: at its limit this cycle")
 
 		// An idle sibling: different pod, no queue, a quarter of the arrival rate.
 		// It must report the SAME capacity, because capacity is a property of the
@@ -239,12 +264,12 @@ var _ = Describe("Rate-anchored k2", func() {
 		// anything load-dependent here would blend incommensurable numbers and could
 		// lift variant capacity while a sibling queues.
 		cold := atLimit()
-		cold.PodName = "pod-b"
+		cold.PodName = siblingPod
 		cold.QueueLength = 0
 		cold.ArrivalRate = 2.0
-		coldK2, coldSrc, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now)
+		coldK2, _, coldSrc, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
-		Expect(coldSrc).To(Equal(k2SrcRateAnchored))
+		Expect(coldSrc).To(Equal(k2SrcRateAnchored), "not at its limit: carrying the bucket's ceiling")
 		Expect(coldK2).To(Equal(hotK2), "the median across replicas must be a no-op")
 	})
 
@@ -258,7 +283,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		for i, lambda := range []float64{8.0, 7.2, 8.6, 7.9, 8.3} {
 			rm.ArrivalRate = lambda
 			rm.QueueLength = 0
-			k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold,
+			k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold,
 				now.Add(time.Duration(i)*15*time.Second))
 			Expect(ok).To(BeTrue())
 			seen = append(seen, k2)
@@ -276,32 +301,37 @@ var _ = Describe("Rate-anchored k2", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := atLimit()
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 
-		// Queue drained but arrivals still at the ceiling, and occupancy lower than
-		// what was measured under backlog: the lower reading is now the ceiling.
+		// Queue drained but arrivals still at the service rate: the replica is at its
+		// limit, and the detector says so with no queue to go on.
 		rm.QueueLength = 0
 		rm.TokensInUse = 48_000
-		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		k2, _, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateAnchored))
-		Expect(k2).To(BeNumerically("~", 48_000, 1))
+		Expect(src).To(Equal(k2SrcRateBacklog), "the arrivals path fired without a queue")
+		// The lower occupancy must NOT become the new ceiling. With no queue it is
+		// evidence the replica is keeping up, not evidence its limit has fallen —
+		// recording it would ratchet capacity down on evidence of health.
+		Expect(k2).To(BeNumerically("~", occupancy, 1))
 	})
 
 	It("uses completions as arrivals when there is no EPP and no queue", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := atLimit()
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 0   // no EPP
 		rm.RequestRate = 8.0 // completions == arrivals with no queue
-		_, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateAnchored))
+		// RATE-now is only reachable here through the completions substitution: with
+		// no queue and no EPP there is nothing else that could flag the limit.
+		Expect(src).To(Equal(k2SrcRateBacklog))
 	})
 
 	It("declines for an idle replica in a bucket that has learned nothing", func() {
@@ -309,7 +339,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := atLimit()
 		rm.QueueLength = 0
 		rm.ArrivalRate = 1.0
-		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -317,7 +347,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := atLimit()
 		rm.TokensInUse = 0 // just became ready, KV still empty
-		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -326,7 +356,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := atLimit()
 		rm.QueueLength = 1 // arrival jitter, not a limit
 		for i := 0; i < 5; i++ {
-			_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 			Expect(ok).To(BeFalse())
 		}
 	})
@@ -335,7 +365,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := atLimit()
 		rm.TokensInUse = 100 // stalled with a deep queue and almost nothing resident
-		k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically(">=", int64(float64(k1)*MinRateAnchoredFraction)))
 	})
@@ -349,7 +379,7 @@ var _ = Describe("Rate-anchored k2", func() {
 			rm.QueueLength = 0
 			rm.ArrivalRate = bad
 			rm.RequestRate = 0
-			k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 			if ok {
 				Expect(k2).To(BeNumerically(">", 0))
 			}
@@ -362,7 +392,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		dec := atLimit()
 		dec.RequestRate, dec.ArrivalRate = 20, 20
 		for i := 0; i < MinServiceRateSamples+1; i++ {
-			_, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, k1, queueThreshold, now)
+			_, _, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, k1, queueThreshold, now)
 		}
 
 		// A prefill replica of the same model on the same accelerator must not
@@ -371,7 +401,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		pre.PodName = "pod-p"
 		pre.QueueLength = 0
 		pre.ArrivalRate = 3
-		_, _, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -381,7 +411,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := atLimit()
 		rm.RequestRate = 0
 		for i := 0; i < 5; i++ {
-			_, src, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+			_, _, src, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
 			Expect(ok).To(BeTrue())
 			// The queue is real, so the limit is measured from it — but no service
 			// rate is ever learned, so nothing is inferred from a rate comparison.
@@ -390,7 +420,7 @@ var _ = Describe("Rate-anchored k2", func() {
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 1
-		_, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue(), "the ceiling measured under backlog still applies")
 	})
 })
@@ -430,5 +460,251 @@ var _ = Describe("Bucket store — bounded growth", func() {
 		}
 		_ = s.Smooth("current", 4, 60, now)
 		Expect(s.entries).To(HaveLen(1))
+	})
+})
+
+var _ = Describe("Rate-anchored k2 at the current operating point", func() {
+	const (
+		kvCapacity     = int64(400_000)
+		k1             = int64(320_000)
+		queueThreshold = 5.0
+		interval       = 15 * time.Second
+	)
+	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+	// The numbers are Little's-law consistent, or the arithmetic below would be a
+	// coincidence rather than the property under test: a replica serving mu = 8 req/s
+	// with residence W = 6 s at 1250 tokens per request holds 8 x 6 x 1250 = 60_000
+	// tokens. That is the occupancy at the limit, hence the ceiling.
+	atLimit := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               "pod-a",
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			TokensInUse:           60_000,
+			TotalKvCapacityTokens: kvCapacity,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+			AvgTTFT:               1.0,
+			AvgITL:                0.02, // W = 1.0 + 250 x 0.02 = 6 s
+		}
+	}
+
+	// Same arrivals, no queue, half the residence: what a replica looks like once
+	// siblings have absorbed the backlog. Occupancy follows W down (8 x 3 x 1250).
+	drained := func() domain.ReplicaMetrics {
+		rm := atLimit()
+		rm.QueueLength = 0
+		rm.TokensInUse = 30_000
+		rm.AvgTTFT = 0.5
+		rm.AvgITL = 0.01 // W = 3 s
+		return rm
+	}
+
+	// cycle mirrors production: freeze the bucket's operating point, then compute.
+	cycle := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics, at time.Time) (int64, int64, k2Source, bool) {
+		a.serviceRates.FreezeWork(at)
+		return a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, at)
+	}
+
+	run := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics, from time.Time, n int) (int64, k2Source) {
+		var k2 int64
+		var src k2Source
+		for i := 0; i < n; i++ {
+			k2, _, src, _ = cycle(a, rm, from.Add(time.Duration(i)*interval))
+		}
+		return k2, src
+	}
+
+	It("does not move the capacity it just measured", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		k2, src := run(a, atLimit(), start, 3)
+
+		// mu x W x tokensPerRequest equals the occupancy that set the ceiling, so
+		// engaging the scaling changes nothing at the point it was calibrated.
+		Expect(k2).To(Equal(int64(60_000)))
+		Expect(src).To(Equal(k2SrcRateBacklog), "still at its limit")
+	})
+
+	It("holds utilization flat when contention falls away", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		hotK2, _ := run(a, atLimit(), start, 3)
+		hot := atLimit()
+		hotUtilization := float64(hot.TokensInUse) / float64(hotK2)
+
+		// Two cycles: the operating point is published at the top of the next cycle,
+		// so a change takes one cycle to reach every replica of the bucket.
+		coldK2, coldSrc := run(a, drained(), start.Add(3*interval), 2)
+		cold := drained()
+		coldUtilization := float64(cold.TokensInUse) / float64(coldK2)
+
+		Expect(coldSrc).To(Equal(k2SrcRateResidence))
+		Expect(coldK2).To(BeNumerically("<", hotK2), "capacity follows the operating point down")
+		// This is the whole fix: demand fell by half when the backlog cleared, and
+		// capacity fell with it, so nothing reads as spare capacity and nothing is
+		// shed. Round 1 held capacity flat here and sheds to one replica.
+		Expect(coldUtilization).To(BeNumerically("~", hotUtilization, 0.01))
+	})
+
+	It("never scales capacity above the limit it measured", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		run(a, atLimit(), start, 3)
+
+		// A deep queue inflates TTFT, so W reads high — that is queueing time, not
+		// capacity. Letting it raise the bound would relax it exactly when the
+		// replica is failing.
+		queued := atLimit()
+		queued.QueueLength = 140
+		queued.AvgTTFT = 8.0 // W = 13 s, more than double the calibration point
+		k2, _, src, ok := cycle(a, queued, start.Add(4*interval))
+
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically("<=", int64(60_000)))
+		Expect(src).NotTo(Equal(k2SrcRateResidence))
+	})
+
+	It("gives every replica of a bucket the same capacity within a cycle", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		run(a, atLimit(), start, 3)
+		run(a, drained(), start.Add(3*interval), 2)
+
+		// Siblings report slightly different residences; they must still scale by one
+		// number, because aggregateByVariant takes the MEDIAN of per-replica values.
+		at := start.Add(5 * interval)
+		a.serviceRates.FreezeWork(at)
+		first := drained()
+		second := drained()
+		second.PodName = siblingPod
+		second.AvgTTFT = 0.9
+		second.AvgITL = 0.03 // a materially longer W than pod-a's
+
+		k2a, _, _, _ := a.rateAnchoredK2(first, "m", "", 1, k1, queueThreshold, at)
+		k2b, _, _, _ := a.rateAnchoredK2(second, "m", "", 1, k1, queueThreshold, at)
+		Expect(k2b).To(Equal(k2a))
+	})
+
+	It("holds at the ceiling until an operating point has been published", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		// No FreezeWork call at all: nothing has been published, so there is nothing
+		// to scale by and the estimator answers with the measured ceiling.
+		var k2 int64
+		var src k2Source
+		for i := 0; i < 3; i++ {
+			k2, _, src, _ = a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold,
+				start.Add(time.Duration(i)*interval))
+		}
+		Expect(k2).To(Equal(int64(60_000)))
+		Expect(src).NotTo(Equal(k2SrcRateResidence))
+	})
+})
+
+var _ = Describe("Rate-anchored k2 operating point across siblings", func() {
+	const (
+		k1             = int64(320_000)
+		queueThreshold = 5.0
+		interval       = 15 * time.Second
+	)
+	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+	atLimit := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               "pod-a",
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			TokensInUse:           60_000,
+			TotalKvCapacityTokens: 400_000,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+			AvgTTFT:               1.0,
+			AvgITL:                0.02, // W = 6 s, work = 7500 token-seconds
+		}
+	}
+
+	It("averages the operating point over the cycle's replicas, whatever their order", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			at := start.Add(time.Duration(i) * interval)
+			a.serviceRates.FreezeWork(at)
+			_, _, _, _ = a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, at)
+		}
+
+		// One cycle, two replicas with materially different residences: 3 s and 1.2 s,
+		// so 3750 and 1500 token-seconds. Whichever the loop reaches first, the bucket
+		// must land on the mean — 2625 — and not on either endpoint.
+		at := start.Add(3 * interval)
+		a.serviceRates.FreezeWork(at)
+		slow := atLimit()
+		slow.QueueLength = 0
+		slow.AvgTTFT, slow.AvgITL = 0.5, 0.01 // W = 3 s
+		fast := slow
+		fast.PodName = siblingPod
+		fast.AvgTTFT, fast.AvgITL = 0.2, 0.004 // W = 1.2 s
+		_, _, _, _ = a.rateAnchoredK2(slow, "m", "", 1, k1, queueThreshold, at)
+		_, _, _, _ = a.rateAnchoredK2(fast, "m", "", 1, k1, queueThreshold, at)
+
+		next := at.Add(interval)
+		a.serviceRates.FreezeWork(next)
+		k2, _, src, ok := a.rateAnchoredK2(slow, "m", "", 1, k1, queueThreshold, next)
+
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateResidence))
+		// mu x mean work = 8 x 2625, less the slow decay mu carries with age. Taking
+		// the first replica alone would give 30_000 and the second alone 12_000 — and
+		// which one it was would depend on the order the loop reached them.
+		Expect(k2).To(BeNumerically("~", 21_000, 210)) // within 1%
+	})
+})
+
+var _ = Describe("Rate-anchored k2 ceiling measurement", func() {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+	It("measures the limit from the instantaneous reading, not the minute's peak", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := domain.ReplicaMetrics{
+			PodName:               "pod-a",
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			TokensInUse:           120_000, // max_over_time: the last minute's peak
+			KvUsageInstant:        0.15,    // 60k: where it actually is now
+			TotalKvCapacityTokens: 400_000,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+		}
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0,
+				now.Add(time.Duration(i)*15*time.Second))
+		}
+
+		// The ceiling is a running minimum, so feeding it a peak biases it high in the
+		// one direction that costs replicas.
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, now.Add(time.Minute))
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically("~", 60_000, 1))
+	})
+
+	It("falls back to the averaged reading when no instantaneous one is collected", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := domain.ReplicaMetrics{
+			PodName:               "pod-a",
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			TokensInUse:           120_000,
+			TotalKvCapacityTokens: 400_000,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+		}
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0,
+				now.Add(time.Duration(i)*15*time.Second))
+		}
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, now.Add(time.Minute))
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically("~", 120_000, 1))
 	})
 })

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -534,9 +534,10 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 		hot := atLimit()
 		hotUtilization := float64(hot.TokensInUse) / float64(hotK2)
 
-		// Two cycles: the operating point is published at the top of the next cycle,
-		// so a change takes one cycle to reach every replica of the bucket.
-		coldK2, coldSrc := run(a, drained(), start.Add(3*interval), 2)
+		// The operating point is smoothed over WorkSmoothingWindow, deliberately the
+		// same order as the one-minute window demand is collected over, so it takes
+		// several cycles rather than one to follow the drain down.
+		coldK2, coldSrc := run(a, drained(), start.Add(3*interval), 40)
 		cold := drained()
 		coldUtilization := float64(cold.TokensInUse) / float64(coldK2)
 
@@ -545,7 +546,7 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 		// This is the whole fix: demand fell by half when the backlog cleared, and
 		// capacity fell with it, so nothing reads as spare capacity and nothing is
 		// shed. Round 1 held capacity flat here and sheds to one replica.
-		Expect(coldUtilization).To(BeNumerically("~", hotUtilization, 0.01))
+		Expect(coldUtilization).To(BeNumerically("~", hotUtilization, 0.02))
 	})
 
 	It("never scales capacity above the limit it measured", func() {
@@ -635,27 +636,29 @@ var _ = Describe("Rate-anchored k2 operating point across siblings", func() {
 		// One cycle, two replicas with materially different residences: 3 s and 1.2 s,
 		// so 3750 and 1500 token-seconds. Whichever the loop reaches first, the bucket
 		// must land on the mean — 2625 — and not on either endpoint.
-		at := start.Add(3 * interval)
-		a.serviceRates.FreezeWork(at)
 		slow := atLimit()
 		slow.QueueLength = 0
 		slow.AvgTTFT, slow.AvgITL = 0.5, 0.01 // W = 3 s
 		fast := slow
 		fast.PodName = siblingPod
 		fast.AvgTTFT, fast.AvgITL = 0.2, 0.004 // W = 1.2 s
-		_, _, _, _ = a.rateAnchoredK2(slow, "m", "", 1, k1, queueThreshold, at)
-		_, _, _, _ = a.rateAnchoredK2(fast, "m", "", 1, k1, queueThreshold, at)
 
-		next := at.Add(interval)
-		a.serviceRates.FreezeWork(next)
-		k2, _, src, ok := a.rateAnchoredK2(slow, "m", "", 1, k1, queueThreshold, next)
+		var k2 int64
+		var src k2Source
+		var ok bool
+		for i := 3; i < 43; i++ { // long enough for the smoothed value to settle
+			at := start.Add(time.Duration(i) * interval)
+			a.serviceRates.FreezeWork(at)
+			k2, _, src, ok = a.rateAnchoredK2(slow, "m", "", 1, k1, queueThreshold, at)
+			_, _, _, _ = a.rateAnchoredK2(fast, "m", "", 1, k1, queueThreshold, at)
+		}
 
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateResidence))
-		// mu x mean work = 8 x 2625, less the slow decay mu carries with age. Taking
-		// the first replica alone would give 30_000 and the second alone 12_000 — and
-		// which one it was would depend on the order the loop reached them.
-		Expect(k2).To(BeNumerically("~", 21_000, 210)) // within 1%
+		// mu x mean work = 8 x 2625. Taking the first replica alone would give 30_000
+		// and the second alone 12_000 — and which one it was would depend on the order
+		// the loop reached them.
+		Expect(k2).To(BeNumerically("~", 21_000, 420)) // within 2%
 	})
 })
 
@@ -706,5 +709,102 @@ var _ = Describe("Rate-anchored k2 ceiling measurement", func() {
 		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically("~", 120_000, 1))
+	})
+})
+
+var _ = Describe("Rate-anchored k2 responsiveness", func() {
+	const (
+		k1             = int64(320_000)
+		queueThreshold = 5.0
+		interval       = 15 * time.Second
+	)
+	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+	base := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			PodName:               "pod-a",
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			TokensInUse:           60_000,
+			KvUsageInstant:        0.15,
+			TotalKvCapacityTokens: 400_000,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+			AvgTTFT:               1.0,
+			AvgITL:                0.02, // W = 6 s
+		}
+	}
+
+	// A replica takes about 90 seconds from scale-up decision to serving, so a
+	// capacity estimate that lagged a rising load would put that delay on top of a
+	// queue that is already building. Nothing here may hold a scale-up back.
+	It("reports saturation on the first cycle of a rising load", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		for i := 0; i < 5; i++ {
+			at := start.Add(time.Duration(i) * interval)
+			a.serviceRates.FreezeWork(at)
+			_, _, _, _ = a.rateAnchoredK2(base(), "m", "", 1, k1, queueThreshold, at)
+		}
+
+		// Load steps up: more queued, more resident, and a longer residence because
+		// requests are now waiting. Capacity must not follow the residence upward.
+		ramp := base()
+		ramp.QueueLength = 60
+		ramp.TokensInUse = 90_000
+		ramp.KvUsageInstant = 0.225
+		ramp.AvgTTFT = 9.0 // W = 14 s, more than double
+
+		at := start.Add(5 * interval)
+		a.serviceRates.FreezeWork(at)
+		k2, _, _, ok := a.rateAnchoredK2(ramp, "m", "", 1, k1, queueThreshold, at)
+
+		Expect(ok).To(BeTrue())
+		// Clamped at the measured ceiling: an inflated residence is queueing time, and
+		// letting it raise capacity would mask the very overload that produced it.
+		Expect(k2).To(BeNumerically("<=", int64(60_000)))
+		Expect(k2).To(BeNumerically("<", ramp.TokensInUse),
+			"demand already exceeds capacity, on the first cycle, with no window to wait out")
+	})
+
+	It("holds the operating point for the window, then steps down with demand", func() {
+		s := newBucketStore()
+		at := start
+		s.ObserveWork("k", 7500, at)
+		s.FreezeWork(at)
+		peak, _ := s.FrozenWork("k", at)
+		Expect(peak).To(BeNumerically("~", 7500, 1))
+
+		// Contention falls away. Demand is max_over_time(...[1m]) and still carries
+		// its peak, so the operating point must carry its own for the same minute —
+		// decaying here instead would drop capacity while demand stayed high, and the
+		// ratio would read as spare capacity.
+		for i := 1; i <= 3; i++ {
+			at = start.Add(time.Duration(i) * interval)
+			s.ObserveWork("k", 3750, at)
+			s.FreezeWork(at)
+			held, ok := s.FrozenWork("k", at)
+			Expect(ok).To(BeTrue())
+			Expect(held).To(BeNumerically("~", 7500, 1), "still inside the window")
+		}
+
+		at = start.Add(WorkWindow + interval)
+		s.ObserveWork("k", 3750, at)
+		s.FreezeWork(at)
+		stepped, ok := s.FrozenWork("k", at)
+		Expect(ok).To(BeTrue())
+		Expect(stepped).To(BeNumerically("~", 3750, 1), "the peak has aged out, as demand's has")
+	})
+
+	It("keeps only a window's worth of samples", func() {
+		s := newBucketStore()
+		for i := 0; i < 200; i++ {
+			at := start.Add(time.Duration(i) * interval)
+			s.ObserveWork("k", 5000, at)
+			s.FreezeWork(at)
+		}
+		Expect(len(s.entries["k"].workSamples)).To(BeNumerically("<=",
+			int(WorkWindow/interval)+1), "bounded by the window, not by the run length")
 	})
 })

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -1068,3 +1068,42 @@ var _ = Describe("Learned prefill retention", func() {
 		Expect(ok).To(BeFalse(), "but not past the bucket's own lifetime")
 	})
 })
+
+// The scale-down floor rests on arrivals being invariant to the replica count. The
+// measurement is not: ArrivalRate is a one-minute rate per pod, summed across pods, so
+// removing a pod drops its share from the sum at once while the survivors take a
+// minute to report their larger share. Left alone, each shed weakens the floor enough
+// to permit the next one — the cascade to a single replica, produced by the guard that
+// exists to prevent it.
+var _ = Describe("Arrival peak window", func() {
+	now := time.Date(2026, 8, 2, 9, 0, 0, 0, time.UTC)
+
+	It("holds the sum through the dip a scale-down produces", func() {
+		p := newPeakWindow()
+		Expect(p.Observe("v1", 24, now)).To(BeNumerically("~", 24, 0.01))
+
+		// A replica goes. Four of five pods still report their old per-pod share, so
+		// the sum reads a fifth low even though arrivals have not changed at all.
+		Expect(p.Observe("v1", 19.2, now.Add(15*time.Second))).To(BeNumerically("~", 24, 0.01))
+		Expect(p.Observe("v1", 19.2, now.Add(30*time.Second))).To(BeNumerically("~", 24, 0.01))
+
+		// And once the survivors catch up, the true figure is back on its own.
+		Expect(p.Observe("v1", 24, now.Add(75*time.Second))).To(BeNumerically("~", 24, 0.01))
+	})
+
+	It("lets a genuine drop through once the window has passed", func() {
+		p := newPeakWindow()
+		_ = p.Observe("v1", 24, now)
+		Expect(p.Observe("v1", 6, now.Add(ArrivalPeakWindow+time.Second))).
+			To(BeNumerically("~", 6, 0.01), "real load changes must not be held forever")
+	})
+
+	It("keeps its map bounded", func() {
+		p := newPeakWindow()
+		for i := 0; i < 200; i++ {
+			p.Observe(fmt.Sprintf("stale-%d", i), 10, now)
+		}
+		p.Observe("fresh", 10, now.Add(2*ArrivalPeakWindow))
+		Expect(len(p.entries)).To(BeNumerically("<=", BucketPruneThreshold+1))
+	})
+})

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -335,3 +335,84 @@ var _ = Describe("Rate-anchored k2 and transient queues", func() {
 		Expect(src).To(Equal(k2SrcRateBacklog))
 	})
 })
+
+var _ = Describe("Arrival smoothing over the residence time", func() {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	It("returns the first sample unchanged", func() {
+		s := newArrivalSmoother()
+		Expect(s.Smooth("pod", 10.0, 60, now)).To(Equal(10.0))
+	})
+
+	It("lags a step change instead of following it", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("pod", 4.0, 60, now)
+
+		// One quarter of a time constant later the rate quadruples. A replica
+		// serving what arrived a residence ago has not felt this yet.
+		got := s.Smooth("pod", 16.0, 60, now.Add(15*time.Second))
+		Expect(got).To(BeNumerically(">", 4.0))
+		Expect(got).To(BeNumerically("<", 16.0))
+	})
+
+	It("converges on the new rate once a few time constants have passed", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("pod", 4.0, 10, now)
+		got := 0.0
+		for i := 1; i <= 10; i++ {
+			got = s.Smooth("pod", 16.0, 10, now.Add(time.Duration(i)*10*time.Second))
+		}
+		Expect(got).To(BeNumerically("~", 16.0, 0.5))
+	})
+
+	It("discards a stale average rather than blending it", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("pod", 4.0, 10, now)
+		// Well beyond the reset factor: the old value carries no information.
+		Expect(s.Smooth("pod", 16.0, 10, now.Add(time.Hour))).To(Equal(16.0))
+	})
+
+	It("passes the rate through when the residence estimate is unavailable", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("pod", 4.0, 0, now)
+		Expect(s.Smooth("pod", 16.0, 0, now.Add(time.Second))).To(Equal(16.0))
+	})
+
+	It("keeps replicas separate", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("a", 4.0, 60, now)
+		Expect(s.Smooth("b", 20.0, 60, now)).To(Equal(20.0))
+	})
+
+	It("evicts replicas not seen within the timeout", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("fresh", 4.0, 60, now)
+		_ = s.Smooth("gone", 4.0, 60, now.Add(-2*time.Hour))
+		Expect(s.EvictStale(time.Hour, now)).To(Equal(1))
+	})
+})
+
+var _ = Describe("Residence estimate", func() {
+	It("is time to first token plus one ITL per output token", func() {
+		w := residenceSeconds(domain.ReplicaMetrics{
+			AvgTTFT:         2.0,
+			AvgITL:          0.02,
+			AvgOutputTokens: 250,
+		})
+		Expect(w).To(BeNumerically("~", 2.0+250*0.02, 0.001))
+	})
+
+	It("declines without latency data, leaving the arrival rate unsmoothed", func() {
+		Expect(residenceSeconds(domain.ReplicaMetrics{AvgOutputTokens: 250})).To(BeZero())
+		Expect(residenceSeconds(domain.ReplicaMetrics{AvgITL: 0.02})).To(BeZero())
+	})
+
+	It("bounds an implausible reading", func() {
+		Expect(residenceSeconds(domain.ReplicaMetrics{
+			AvgTTFT: 0, AvgITL: 0.0000001, AvgOutputTokens: 1,
+		})).To(Equal(MinResidenceSeconds))
+		Expect(residenceSeconds(domain.ReplicaMetrics{
+			AvgTTFT: 1e6, AvgITL: 1, AvgOutputTokens: 1,
+		})).To(Equal(MaxResidenceSeconds))
+	})
+})

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -11,14 +11,31 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
+// rateCycle and ceilingCycle mirror one optimize cycle: replicas observe, then the
+// boundary folds what they observed. Reading without crossing a boundary is not a
+// state production can be in, so the tests do not exercise one.
+func rateCycle(s *bucketStore, key string, rates []float64, at time.Time) { //nolint:unparam // one bucket is enough for these; the parameter keeps the helper honest
+	for _, r := range rates {
+		s.ObserveRate(key, r, at)
+	}
+	s.BeginCycle(at)
+}
+
+func ceilingCycle(s *bucketStore, key string, tokens []float64, at time.Time) {
+	for _, t := range tokens {
+		s.ObserveCeiling(key, t, at)
+	}
+	s.BeginCycle(at)
+}
+
 var _ = Describe("Bucket store — service rate", func() {
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 
 	It("tracks the mean of what it sees, in both directions", func() {
 		s := newBucketStore()
-		s.ObserveRate("k", 4.0, now)
-		s.ObserveRate("k", 9.0, now.Add(time.Minute))
-		s.ObserveRate("k", 6.0, now.Add(2*time.Minute))
+		rateCycle(s, "k", []float64{4.0}, now)
+		rateCycle(s, "k", []float64{9.0}, now.Add(time.Minute))
+		rateCycle(s, "k", []float64{6.0}, now.Add(2*time.Minute))
 
 		rate, ok := s.Rate("k", now.Add(2*time.Minute))
 		Expect(ok).To(BeTrue())
@@ -33,13 +50,13 @@ var _ = Describe("Bucket store — service rate", func() {
 		s := newBucketStore()
 		at := now
 		for i := 0; i < 6; i++ { // calibrate at 10 req/s
-			s.ObserveRate("k", 10.0, at)
+			rateCycle(s, "k", []float64{10.0}, at)
 			at = at.Add(30 * time.Second)
 		}
 		fast, _ := s.Rate("k", at)
 
 		for i := 0; i < 12; i++ { // longer prompts: the same replica now serves 5/s
-			s.ObserveRate("k", 5.0, at)
+			rateCycle(s, "k", []float64{5.0}, at)
 			at = at.Add(30 * time.Second)
 		}
 		slow, ok := s.Rate("k", at)
@@ -49,29 +66,60 @@ var _ = Describe("Bucket store — service rate", func() {
 			"a running maximum would still be reporting the old rate here")
 	})
 
-	It("withholds an estimate until a second observation", func() {
+	It("withholds an estimate until a second cycle", func() {
 		s := newBucketStore()
-		s.ObserveRate("k", 7.0, now)
+		rateCycle(s, "k", []float64{7.0}, now)
 		_, ok := s.Rate("k", now)
-		Expect(ok).To(BeFalse(), "one observation cannot distinguish a limit from a slow interval")
+		Expect(ok).To(BeFalse(), "one cycle cannot distinguish a limit from a slow interval")
 
-		s.ObserveRate("k", 7.0, now)
-		_, ok = s.Rate("k", now)
+		rateCycle(s, "k", []float64{7.0}, now.Add(time.Minute))
+		_, ok = s.Rate("k", now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 	})
 
-	It("ignores non-positive rates", func() {
+	It("counts cycles, not the replicas reporting in them", func() {
 		s := newBucketStore()
-		s.ObserveRate("k", 0, now)
-		s.ObserveRate("k", -3, now)
+		// Four replicas of one bucket, all backlogged, all in the same cycle. That is
+		// one interval of evidence however many pods produced it.
+		rateCycle(s, "k", []float64{7.0, 7.0, 7.0, 7.0}, now)
 		_, ok := s.Rate("k", now)
+		Expect(ok).To(BeFalse(), "MinServiceRateSamples must not be satisfiable within one cycle")
+	})
+
+	It("averages the cycle's replicas rather than taking whichever reported first", func() {
+		s := newBucketStore()
+		rateCycle(s, "k", []float64{4.0, 8.0, 12.0}, now)
+		rateCycle(s, "k", []float64{4.0, 8.0, 12.0}, now.Add(time.Minute))
+
+		rate, ok := s.Rate("k", now.Add(time.Minute))
+		Expect(ok).To(BeTrue())
+		// ReplicaMetrics is built by ranging a map, so "whichever reported first" is
+		// not even stable between cycles — mu would jitter with no smoothing at all.
+		Expect(rate).To(BeNumerically("~", 8.0, 0.01))
+	})
+
+	It("ignores rates that are not usable numbers", func() {
+		s := newBucketStore()
+		rateCycle(s, "k", []float64{0, -3, math.NaN(), math.Inf(1)}, now)
+		rateCycle(s, "k", []float64{0, -3, math.NaN(), math.Inf(1)}, now.Add(time.Minute))
+		_, ok := s.Rate("k", now.Add(time.Minute))
 		Expect(ok).To(BeFalse())
+
+		// And a poisoned value must not survive a later good one: NaN folded into the
+		// EWMA would stay NaN forever, and Rate's own `<= 0` guard does not catch it.
+		rateCycle(s, "k", []float64{math.NaN()}, now.Add(2*time.Minute))
+		rateCycle(s, "k", []float64{6.0}, now.Add(3*time.Minute))
+		rateCycle(s, "k", []float64{6.0}, now.Add(4*time.Minute))
+		rate, ok := s.Rate("k", now.Add(4*time.Minute))
+		Expect(ok).To(BeTrue())
+		Expect(math.IsNaN(rate)).To(BeFalse())
+		Expect(rate).To(BeNumerically("~", 6.0, 0.01))
 	})
 
 	It("holds an unrefreshed rate and expires it past the window", func() {
 		s := newBucketStore()
-		s.ObserveRate("k", 10.0, now)
-		s.ObserveRate("k", 10.0, now)
+		rateCycle(s, "k", []float64{10.0}, now)
+		rateCycle(s, "k", []float64{10.0}, now)
 
 		rate, ok := s.Rate("k", now.Add(ServiceRateWindow))
 		Expect(ok).To(BeTrue())
@@ -87,9 +135,7 @@ var _ = Describe("Bucket store — token ceiling", func() {
 
 	It("keeps the lowest occupancy at which a limit was seen", func() {
 		s := newBucketStore()
-		s.ObserveCeiling("k", 90_000, now)
-		s.ObserveCeiling("k", 64_000, now)
-		s.ObserveCeiling("k", 80_000, now)
+		ceilingCycle(s, "k", []float64{90_000, 64_000, 80_000}, now)
 
 		c, ok := s.Ceiling("k", now)
 		Expect(ok).To(BeTrue())
@@ -99,7 +145,7 @@ var _ = Describe("Bucket store — token ceiling", func() {
 
 	It("relaxes upward when no fresh limit is observed", func() {
 		s := newBucketStore()
-		s.ObserveCeiling("k", 64_000, now)
+		ceilingCycle(s, "k", []float64{64_000}, now)
 
 		c, ok := s.Ceiling("k", now.Add(ServiceRateWindow))
 		Expect(ok).To(BeTrue())
@@ -109,8 +155,8 @@ var _ = Describe("Bucket store — token ceiling", func() {
 
 	It("lets a fresh higher measurement win over a relaxed one", func() {
 		s := newBucketStore()
-		s.ObserveCeiling("k", 64_000, now)
-		s.ObserveCeiling("k", 120_000, now.Add(ServiceRateWindow))
+		ceilingCycle(s, "k", []float64{64_000}, now)
+		ceilingCycle(s, "k", []float64{120_000}, now.Add(ServiceRateWindow))
 
 		c, ok := s.Ceiling("k", now.Add(ServiceRateWindow))
 		Expect(ok).To(BeTrue())
@@ -193,11 +239,19 @@ var _ = Describe("Residence estimate", func() {
 		Expect(residenceSeconds(domain.ReplicaMetrics{AvgITL: 0.02})).To(BeZero())
 	})
 
-	It("bounds an implausible reading", func() {
-		Expect(residenceSeconds(domain.ReplicaMetrics{AvgITL: 1e-7, AvgOutputTokens: 1})).
-			To(Equal(MinResidenceSeconds))
+	It("bounds an implausible reading from above", func() {
 		Expect(residenceSeconds(domain.ReplicaMetrics{AvgTTFT: 1e6, AvgITL: 1, AvgOutputTokens: 1})).
 			To(Equal(MaxResidenceSeconds))
+	})
+
+	It("floors the smoothing constant but not the residence itself", func() {
+		short := domain.ReplicaMetrics{AvgITL: 0.008, AvgOutputTokens: 16} // W = 0.128 s
+		Expect(residenceSeconds(short)).To(BeNumerically("~", 0.128, 1e-9),
+			"capacity is mu x W x tokensPerRequest, so a floor here inflates supply "+
+				"in one direction while demand has no matching floor")
+		Expect(smoothingTau(short)).To(Equal(MinResidenceSeconds),
+			"the floor exists to keep the arrival average from becoming a passthrough")
+		Expect(smoothingTau(domain.ReplicaMetrics{})).To(BeZero())
 	})
 })
 
@@ -227,10 +281,17 @@ var _ = Describe("Rate-anchored k2", func() {
 		}
 	}
 
+	// step is one optimize cycle: cross the boundary that folds what the last cycle
+	// observed, then look at the replica. Mirrors Analyze.
+	step := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics, at time.Time) (int64, int64, k2Source, bool) {
+		a.serviceRates.BeginCycle(at)
+		return a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, at)
+	}
+
 	// learn drives enough cycles to establish both the service rate and the ceiling.
 	learn := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics) {
-		for i := 0; i < MinServiceRateSamples+1; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		for i := 0; i <= MinServiceRateSamples+1; i++ {
+			_, _, _, _ = step(a, rm, now.Add(time.Duration(i)*15*time.Second))
 		}
 	}
 
@@ -240,9 +301,15 @@ var _ = Describe("Rate-anchored k2", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("reports the current occupancy on a first overload, before anything is learned", func() {
+	It("reports the measured occupancy from the cycle after a first overload", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		k2, _, src, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, now)
+
+		// Nothing is folded until a cycle boundary, so the first overloaded cycle has
+		// nothing to answer with and the occupancy chain handles it.
+		_, _, _, ok := step(a, atLimit(), now)
+		Expect(ok).To(BeFalse())
+
+		k2, _, src, ok := step(a, atLimit(), now.Add(15*time.Second))
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog))
 		Expect(k2).To(BeNumerically("~", float64(occupancy), 1),
@@ -254,7 +321,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		hot := atLimit()
 		learn(a, hot)
 
-		hotK2, _, hotSrc, ok := a.rateAnchoredK2(hot, "m", "", 1, k1, queueThreshold, now)
+		hotK2, _, hotSrc, ok := step(a, hot, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		Expect(hotSrc).To(Equal(k2SrcRateBacklog), "backlogged: at its limit this cycle")
 
@@ -267,7 +334,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		cold.PodName = siblingPod
 		cold.QueueLength = 0
 		cold.ArrivalRate = 2.0
-		coldK2, _, coldSrc, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now)
+		coldK2, _, coldSrc, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		Expect(coldSrc).To(Equal(k2SrcRateAnchored), "not at its limit: carrying the bucket's ceiling")
 		Expect(coldK2).To(Equal(hotK2), "the median across replicas must be a no-op")
@@ -300,34 +367,31 @@ var _ = Describe("Rate-anchored k2", func() {
 	It("detects the limit from arrivals reaching the service rate, with no queue", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := atLimit()
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		}
+		learn(a, rm)
 
 		// Queue drained but arrivals still at the service rate: the replica is at its
 		// limit, and the detector says so with no queue to go on.
 		rm.QueueLength = 0
 		rm.TokensInUse = 48_000
-		k2, _, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		k2, _, src, ok := step(a, rm, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog), "the arrivals path fired without a queue")
 		// The lower occupancy must NOT become the new ceiling. With no queue it is
 		// evidence the replica is keeping up, not evidence its limit has fallen —
-		// recording it would ratchet capacity down on evidence of health.
-		Expect(k2).To(BeNumerically("~", occupancy, 1))
+		// recording it would ratchet capacity down on evidence of health. (Within a
+		// per-cent: an unrefreshed ceiling relaxes upward with age.)
+		Expect(k2).To(BeNumerically("~", occupancy, float64(occupancy)*0.01))
 	})
 
 	It("uses completions as arrivals when there is no EPP and no queue", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := atLimit()
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		}
+		learn(a, rm)
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 0   // no EPP
 		rm.RequestRate = 8.0 // completions == arrivals with no queue
-		_, _, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, src, ok := step(a, rm, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		// RATE-now is only reachable here through the completions substitution: with
 		// no queue and no EPP there is nothing else that could flag the limit.
@@ -361,13 +425,49 @@ var _ = Describe("Rate-anchored k2", func() {
 		}
 	})
 
-	It("floors the ceiling so a stalled replica cannot demand unbounded scale-up", func() {
+	It("ignores a replica that queues without completing anything", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := atLimit()
-		rm.TokensInUse = 100 // stalled with a deep queue and almost nothing resident
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		healthy := atLimit()
+		learn(a, healthy)
+		before, _, _, ok := step(a, healthy, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
-		Expect(k2).To(BeNumerically(">=", int64(float64(k1)*MinRateAnchoredFraction)))
+
+		// A replica with a deep queue, almost nothing resident, and no completions: a
+		// pod that has just started and taken a routed burst, or one that has stalled.
+		// Either way it is not evidence of what this bucket can hold, and letting it
+		// set the ceiling would pin every sibling near the floor for hours.
+		cold := atLimit()
+		cold.PodName = siblingPod
+		cold.TokensInUse = 100
+		cold.KvUsageInstant = 0
+		cold.RequestRate = 0
+		for i := 1; i <= 4; i++ {
+			_, _, _, _ = step(a, cold, now.Add(time.Minute+time.Duration(i)*15*time.Second))
+		}
+		after, _, _, ok := step(a, healthy, now.Add(2*time.Minute))
+		Expect(ok).To(BeTrue())
+		Expect(after).To(BeNumerically(">=", before), "the cold replica taught the bucket nothing")
+	})
+
+	It("needs the same reading twice before it lowers the ceiling", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		learn(a, atLimit())
+
+		lower := atLimit()
+		lower.TokensInUse = 20_000 // well under the learned 64k
+		first, _, _, ok := step(a, lower, now.Add(time.Minute))
+		Expect(ok).To(BeTrue())
+		Expect(first).To(BeNumerically("~", occupancy, float64(occupancy)*0.01),
+			"the first low reading has not been folded yet")
+
+		second, _, _, ok := step(a, lower, now.Add(time.Minute+15*time.Second))
+		Expect(ok).To(BeTrue())
+		Expect(second).To(BeNumerically("~", occupancy, float64(occupancy)*0.01),
+			"one cycle of evidence is not enough to lower it")
+
+		third, _, _, ok := step(a, lower, now.Add(time.Minute+30*time.Second))
+		Expect(ok).To(BeTrue())
+		Expect(third).To(BeNumerically("~", 20_000, 200), "sustained, so it is adopted")
 	})
 
 	It("survives negative and NaN arrival rates", func() {
@@ -411,17 +511,14 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := atLimit()
 		rm.RequestRate = 0
 		for i := 0; i < 5; i++ {
-			_, _, src, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
-			Expect(ok).To(BeTrue())
-			// The queue is real, so the limit is measured from it — but no service
-			// rate is ever learned, so nothing is inferred from a rate comparison.
-			Expect(src).To(BeElementOf(k2SrcRateBacklog, k2SrcRateAnchored))
+			a.serviceRates.BeginCycle(now.Add(time.Duration(i) * 15 * time.Second))
+			_, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold,
+				now.Add(time.Duration(i)*15*time.Second))
+			// No completions means no service rate and no ceiling: there is nothing to
+			// measure a limit from, so the estimator declines rather than inventing one
+			// from a queue depth alone.
+			Expect(ok).To(BeFalse())
 		}
-
-		rm.QueueLength = 0
-		rm.ArrivalRate = 1
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue(), "the ceiling measured under backlog still applies")
 	})
 })
 
@@ -433,11 +530,11 @@ var _ = Describe("Bucket store — bounded growth", func() {
 		// Fill past the prune threshold with buckets nobody has touched in a day.
 		old := now.Add(-2 * HistoryEvictionTimeout)
 		for i := 0; i < BucketPruneThreshold; i++ {
-			s.ObserveCeiling(fmt.Sprintf("stale-%d", i), 1000, old)
+			ceilingCycle(s, fmt.Sprintf("stale-%d", i), []float64{1000}, old)
 		}
 		Expect(s.entries).To(HaveLen(BucketPruneThreshold))
 
-		s.ObserveCeiling("fresh", 2000, now)
+		ceilingCycle(s, "fresh", []float64{2000}, now)
 		Expect(s.entries).To(HaveLen(1), "the stale buckets went with the insert")
 		_, ok := s.Ceiling("fresh", now)
 		Expect(ok).To(BeTrue())
@@ -505,7 +602,7 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 
 	// cycle mirrors production: freeze the bucket's operating point, then compute.
 	cycle := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics, at time.Time) (int64, int64, k2Source, bool) {
-		a.serviceRates.FreezeWork(at)
+		a.serviceRates.BeginCycle(at)
 		return a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, at)
 	}
 
@@ -523,9 +620,10 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 		k2, src := run(a, atLimit(), start, 3)
 
 		// mu x W x tokensPerRequest equals the occupancy that set the ceiling, so
-		// engaging the scaling changes nothing at the point it was calibrated.
-		Expect(k2).To(Equal(int64(60_000)))
-		Expect(src).To(Equal(k2SrcRateBacklog), "still at its limit")
+		// engaging the scaling changes nothing at the point it was calibrated —
+		// whichever of the two the clamp happens to pick.
+		Expect(k2).To(BeNumerically("~", 60_000, 600))
+		Expect(src).To(BeElementOf(k2SrcRateBacklog, k2SrcRateResidence))
 	})
 
 	It("holds utilization flat when contention falls away", func() {
@@ -574,7 +672,7 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 		// Siblings report slightly different residences; they must still scale by one
 		// number, because aggregateByVariant takes the MEDIAN of per-replica values.
 		at := start.Add(5 * interval)
-		a.serviceRates.FreezeWork(at)
+		a.serviceRates.BeginCycle(at)
 		first := drained()
 		second := drained()
 		second.PodName = siblingPod
@@ -586,17 +684,24 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 		Expect(k2b).To(Equal(k2a))
 	})
 
-	It("holds at the ceiling until an operating point has been published", func() {
+	It("holds at the ceiling when there is no residence to scale by", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		// No FreezeWork call at all: nothing has been published, so there is nothing
-		// to scale by and the estimator answers with the measured ceiling.
+		// A fleet whose latency metrics are not being collected: the limit is still
+		// measurable from backlog and occupancy, but there is no operating point to
+		// scale it to, so the estimator answers with the ceiling rather than guessing.
+		blind := atLimit()
+		blind.AvgTTFT, blind.AvgITL = 0, 0
+
 		var k2 int64
 		var src k2Source
-		for i := 0; i < 3; i++ {
-			k2, _, src, _ = a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold,
-				start.Add(time.Duration(i)*interval))
+		var ok bool
+		for i := 0; i < 5; i++ {
+			at := start.Add(time.Duration(i) * interval)
+			a.serviceRates.BeginCycle(at)
+			k2, _, src, ok = a.rateAnchoredK2(blind, "m", "", 1, k1, queueThreshold, at)
 		}
-		Expect(k2).To(Equal(int64(60_000)))
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically("~", 60_000, 600))
 		Expect(src).NotTo(Equal(k2SrcRateResidence))
 	})
 })
@@ -629,7 +734,7 @@ var _ = Describe("Rate-anchored k2 operating point across siblings", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		for i := 0; i < MinServiceRateSamples+1; i++ {
 			at := start.Add(time.Duration(i) * interval)
-			a.serviceRates.FreezeWork(at)
+			a.serviceRates.BeginCycle(at)
 			_, _, _, _ = a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, at)
 		}
 
@@ -648,7 +753,7 @@ var _ = Describe("Rate-anchored k2 operating point across siblings", func() {
 		var ok bool
 		for i := 3; i < 43; i++ { // long enough for the smoothed value to settle
 			at := start.Add(time.Duration(i) * interval)
-			a.serviceRates.FreezeWork(at)
+			a.serviceRates.BeginCycle(at)
 			k2, _, src, ok = a.rateAnchoredK2(slow, "m", "", 1, k1, queueThreshold, at)
 			_, _, _, _ = a.rateAnchoredK2(fast, "m", "", 1, k1, queueThreshold, at)
 		}
@@ -670,7 +775,9 @@ var _ = Describe("Rate-anchored k2 ceiling measurement", func() {
 		rm := domain.ReplicaMetrics{
 			PodName:               "pod-a",
 			AcceleratorName:       "H100",
-			QueueLength:           12,
+			QueueLength:           12, // max_over_time: the last minute's peak
+			QueueLengthInstant:    12, // and still queueing right now
+			HasQueueLengthInstant: true,
 			RequestRate:           8.0,
 			TokensInUse:           120_000, // max_over_time: the last minute's peak
 			KvUsageInstant:        0.15,    // 60k: where it actually is now
@@ -678,16 +785,18 @@ var _ = Describe("Rate-anchored k2 ceiling measurement", func() {
 			AvgInputTokens:        1000,
 			AvgOutputTokens:       250,
 		}
-		for i := 0; i < MinServiceRateSamples+1; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0,
-				now.Add(time.Duration(i)*15*time.Second))
+		for i := 0; i <= MinServiceRateSamples+1; i++ {
+			at := now.Add(time.Duration(i) * 15 * time.Second)
+			a.serviceRates.BeginCycle(at)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, at)
 		}
 
 		// The ceiling is a running minimum, so feeding it a peak biases it high in the
 		// one direction that costs replicas.
+		a.serviceRates.BeginCycle(now.Add(time.Minute))
 		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
-		Expect(k2).To(BeNumerically("~", 60_000, 1))
+		Expect(k2).To(BeNumerically("~", 60_000, 600))
 	})
 
 	It("falls back to the averaged reading when no instantaneous one is collected", func() {
@@ -702,13 +811,15 @@ var _ = Describe("Rate-anchored k2 ceiling measurement", func() {
 			AvgInputTokens:        1000,
 			AvgOutputTokens:       250,
 		}
-		for i := 0; i < MinServiceRateSamples+1; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0,
-				now.Add(time.Duration(i)*15*time.Second))
+		for i := 0; i <= MinServiceRateSamples+1; i++ {
+			at := now.Add(time.Duration(i) * 15 * time.Second)
+			a.serviceRates.BeginCycle(at)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, at)
 		}
+		a.serviceRates.BeginCycle(now.Add(time.Minute))
 		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
-		Expect(k2).To(BeNumerically("~", 120_000, 1))
+		Expect(k2).To(BeNumerically("~", 120_000, 1200))
 	})
 })
 
@@ -744,7 +855,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		for i := 0; i < 5; i++ {
 			at := start.Add(time.Duration(i) * interval)
-			a.serviceRates.FreezeWork(at)
+			a.serviceRates.BeginCycle(at)
 			_, _, _, _ = a.rateAnchoredK2(base(), "m", "", 1, k1, queueThreshold, at)
 		}
 
@@ -757,7 +868,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 		ramp.AvgTTFT = 9.0 // W = 14 s, more than double
 
 		at := start.Add(5 * interval)
-		a.serviceRates.FreezeWork(at)
+		a.serviceRates.BeginCycle(at)
 		k2, _, _, ok := a.rateAnchoredK2(ramp, "m", "", 1, k1, queueThreshold, at)
 
 		Expect(ok).To(BeTrue())
@@ -772,7 +883,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 		s := newBucketStore()
 		at := start
 		s.ObserveWork("k", 7500, at)
-		s.FreezeWork(at)
+		s.BeginCycle(at)
 		peak, _ := s.FrozenWork("k", at)
 		Expect(peak).To(BeNumerically("~", 7500, 1))
 
@@ -783,7 +894,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 		for i := 1; i <= 3; i++ {
 			at = start.Add(time.Duration(i) * interval)
 			s.ObserveWork("k", 3750, at)
-			s.FreezeWork(at)
+			s.BeginCycle(at)
 			held, ok := s.FrozenWork("k", at)
 			Expect(ok).To(BeTrue())
 			Expect(held).To(BeNumerically("~", 7500, 1), "still inside the window")
@@ -791,7 +902,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 
 		at = start.Add(WorkWindow + interval)
 		s.ObserveWork("k", 3750, at)
-		s.FreezeWork(at)
+		s.BeginCycle(at)
 		stepped, ok := s.FrozenWork("k", at)
 		Expect(ok).To(BeTrue())
 		Expect(stepped).To(BeNumerically("~", 3750, 1), "the peak has aged out, as demand's has")
@@ -802,7 +913,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 		for i := 0; i < 200; i++ {
 			at := start.Add(time.Duration(i) * interval)
 			s.ObserveWork("k", 5000, at)
-			s.FreezeWork(at)
+			s.BeginCycle(at)
 		}
 		Expect(len(s.entries["k"].workSamples)).To(BeNumerically("<=",
 			int(WorkWindow/interval)+1), "bounded by the window, not by the run length")

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -173,11 +173,39 @@ var _ = Describe("Bucket store — token ceiling", func() {
 	})
 
 	It("separates buckets by role and by input length", func() {
-		decode := serviceRateKey("m", "H100", domain.RoleDecode, 1, 1000, 250)
-		prefill := serviceRateKey("m", "H100", domain.RolePrefill, 1, 1000, 250)
-		shortIn := serviceRateKey("m", "H100", domain.RoleDecode, 1, 300, 250)
+		decode := serviceRateKey("m", "H100", domain.RoleDecode, 1, variantShape{1000, 250})
+		prefill := serviceRateKey("m", "H100", domain.RolePrefill, 1, variantShape{1000, 250})
+		shortIn := serviceRateKey("m", "H100", domain.RoleDecode, 1, variantShape{300, 250})
 		Expect(decode).NotTo(Equal(prefill))
-		Expect(decode).NotTo(Equal(shortIn))
+		Expect(decode).NotTo(Equal(shortIn),
+			"prompt lengths get their own thresholds; 300 and 1000 are different services")
+	})
+
+	It("keys on the variant's shape, so siblings cannot land in different buckets", func() {
+		// Two replicas of one variant, their averages a few tokens either side of the
+		// 500-token input threshold — sampling noise, not different workloads. Keyed
+		// per replica they would learn independent ceilings, and aggregateByVariant's
+		// median would then blend two figures that measure different things.
+		shapes := variantShapes([]domain.ReplicaMetrics{
+			{VariantName: "v1", AvgInputTokens: 498, AvgOutputTokens: 250},
+			{VariantName: "v1", AvgInputTokens: 506, AvgOutputTokens: 250},
+			{VariantName: "v2", AvgInputTokens: 4000, AvgOutputTokens: 250},
+		})
+		Expect(shapes).To(HaveLen(2))
+		Expect(shapes["v1"].avgInput).To(BeNumerically("~", 502, 0.01))
+
+		one := serviceRateKey("m", "H100", domain.RoleBoth, 1, shapes["v1"])
+		Expect(serviceRateKey("m", "H100", domain.RoleBoth, 1, shapes["v1"])).To(Equal(one))
+		Expect(serviceRateKey("m", "H100", domain.RoleBoth, 1, shapes["v2"])).NotTo(Equal(one))
+	})
+
+	It("ignores replicas reporting no shape at all", func() {
+		shapes := variantShapes([]domain.ReplicaMetrics{
+			{VariantName: "v1", AvgInputTokens: 1000, AvgOutputTokens: 250},
+			{VariantName: "v1"}, // scraped before it served anything
+		})
+		Expect(shapes["v1"].avgInput).To(BeNumerically("~", 1000, 0.01),
+			"a replica with no data must not halve the variant's shape")
 	})
 })
 
@@ -266,6 +294,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		occupancy      = int64(64_000) // 16% of KV — the prefill-heavy regime
 	)
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	shape := variantShape{avgInput: 1000, avgOutput: 250}
 
 	atLimit := func() domain.ReplicaMetrics {
 		return domain.ReplicaMetrics{
@@ -285,7 +314,7 @@ var _ = Describe("Rate-anchored k2", func() {
 	// observed, then look at the replica. Mirrors Analyze.
 	step := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics, at time.Time) (int64, int64, k2Source, bool) {
 		a.serviceRates.BeginCycle(at)
-		return a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, at)
+		return a.rateAnchoredK2(rm, "m", "", 1, shape, k1, queueThreshold, at)
 	}
 
 	// learn drives enough cycles to establish both the service rate and the ceiling.
@@ -297,7 +326,7 @@ var _ = Describe("Rate-anchored k2", func() {
 
 	It("declines when the estimator is not enabled", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
-		_, _, _, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, shape, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -334,7 +363,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		cold.PodName = siblingPod
 		cold.QueueLength = 0
 		cold.ArrivalRate = 2.0
-		coldK2, _, coldSrc, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now.Add(time.Minute))
+		coldK2, _, coldSrc, ok := a.rateAnchoredK2(cold, "m", "", 1, shape, k1, queueThreshold, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		Expect(coldSrc).To(Equal(k2SrcRateAnchored), "not at its limit: carrying the bucket's ceiling")
 		Expect(coldK2).To(Equal(hotK2), "the median across replicas must be a no-op")
@@ -350,7 +379,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		for i, lambda := range []float64{8.0, 7.2, 8.6, 7.9, 8.3} {
 			rm.ArrivalRate = lambda
 			rm.QueueLength = 0
-			k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold,
+			k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, shape, k1, queueThreshold,
 				now.Add(time.Duration(i)*15*time.Second))
 			Expect(ok).To(BeTrue())
 			seen = append(seen, k2)
@@ -372,15 +401,21 @@ var _ = Describe("Rate-anchored k2", func() {
 		// Queue drained but arrivals still at the service rate: the replica is at its
 		// limit, and the detector says so with no queue to go on.
 		rm.QueueLength = 0
+		rm.QueueLengthInstant, rm.HasQueueLengthInstant = 0, true
 		rm.TokensInUse = 48_000
-		k2, _, src, ok := step(a, rm, now.Add(time.Minute))
+		rm.KvUsageInstant = 48_000 / float64(kvCapacity)
+		k2, ref, src, ok := step(a, rm, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog), "the arrivals path fired without a queue")
-		// The lower occupancy must NOT become the new ceiling. With no queue it is
-		// evidence the replica is keeping up, not evidence its limit has fallen —
-		// recording it would ratchet capacity down on evidence of health. (Within a
-		// per-cent: an unrefreshed ceiling relaxes upward with age.)
-		Expect(k2).To(BeNumerically("~", occupancy, float64(occupancy)*0.01))
+
+		// Capacity is held at what the replica is holding right now, so demand meets it
+		// and the fleet scales before a queue forms. Waiting for the queue would put
+		// the ~90 s a replica takes to start on top of a backlog already building.
+		Expect(k2).To(BeNumerically("~", 48_000, 1))
+
+		// The learned ceiling itself is untouched: with no queue, a lower occupancy is
+		// evidence the replica is keeping up, not evidence its limit has fallen.
+		Expect(ref).To(BeNumerically("~", occupancy, float64(occupancy)*0.01))
 	})
 
 	It("uses completions as arrivals when there is no EPP and no queue", func() {
@@ -403,7 +438,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := atLimit()
 		rm.QueueLength = 0
 		rm.ArrivalRate = 1.0
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, shape, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -411,7 +446,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := atLimit()
 		rm.TokensInUse = 0 // just became ready, KV still empty
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, shape, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -420,7 +455,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := atLimit()
 		rm.QueueLength = 1 // arrival jitter, not a limit
 		for i := 0; i < 5; i++ {
-			_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, shape, k1, queueThreshold, now)
 			Expect(ok).To(BeFalse())
 		}
 	})
@@ -479,7 +514,7 @@ var _ = Describe("Rate-anchored k2", func() {
 			rm.QueueLength = 0
 			rm.ArrivalRate = bad
 			rm.RequestRate = 0
-			k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, shape, k1, queueThreshold, now)
 			if ok {
 				Expect(k2).To(BeNumerically(">", 0))
 			}
@@ -492,7 +527,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		dec := atLimit()
 		dec.RequestRate, dec.ArrivalRate = 20, 20
 		for i := 0; i < MinServiceRateSamples+1; i++ {
-			_, _, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, k1, queueThreshold, now)
+			_, _, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, shape, k1, queueThreshold, now)
 		}
 
 		// A prefill replica of the same model on the same accelerator must not
@@ -501,7 +536,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		pre.PodName = "pod-p"
 		pre.QueueLength = 0
 		pre.ArrivalRate = 3
-		_, _, _, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		_, _, _, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, shape, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -512,7 +547,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm.RequestRate = 0
 		for i := 0; i < 5; i++ {
 			a.serviceRates.BeginCycle(now.Add(time.Duration(i) * 15 * time.Second))
-			_, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold,
+			_, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, shape, k1, queueThreshold,
 				now.Add(time.Duration(i)*15*time.Second))
 			// No completions means no service rate and no ceiling: there is nothing to
 			// measure a limit from, so the estimator declines rather than inventing one
@@ -568,6 +603,7 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 		interval       = 15 * time.Second
 	)
 	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	shape := variantShape{avgInput: 1000, avgOutput: 250}
 
 	// The numbers are Little's-law consistent, or the arithmetic below would be a
 	// coincidence rather than the property under test: a replica serving mu = 8 req/s
@@ -603,7 +639,7 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 	// cycle mirrors production: freeze the bucket's operating point, then compute.
 	cycle := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics, at time.Time) (int64, int64, k2Source, bool) {
 		a.serviceRates.BeginCycle(at)
-		return a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, at)
+		return a.rateAnchoredK2(rm, "m", "", 1, shape, k1, queueThreshold, at)
 	}
 
 	run := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics, from time.Time, n int) (int64, k2Source) {
@@ -679,8 +715,8 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 		second.AvgTTFT = 0.9
 		second.AvgITL = 0.03 // a materially longer W than pod-a's
 
-		k2a, _, _, _ := a.rateAnchoredK2(first, "m", "", 1, k1, queueThreshold, at)
-		k2b, _, _, _ := a.rateAnchoredK2(second, "m", "", 1, k1, queueThreshold, at)
+		k2a, _, _, _ := a.rateAnchoredK2(first, "m", "", 1, shape, k1, queueThreshold, at)
+		k2b, _, _, _ := a.rateAnchoredK2(second, "m", "", 1, shape, k1, queueThreshold, at)
 		Expect(k2b).To(Equal(k2a))
 	})
 
@@ -698,7 +734,7 @@ var _ = Describe("Rate-anchored k2 at the current operating point", func() {
 		for i := 0; i < 5; i++ {
 			at := start.Add(time.Duration(i) * interval)
 			a.serviceRates.BeginCycle(at)
-			k2, _, src, ok = a.rateAnchoredK2(blind, "m", "", 1, k1, queueThreshold, at)
+			k2, _, src, ok = a.rateAnchoredK2(blind, "m", "", 1, shape, k1, queueThreshold, at)
 		}
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically("~", 60_000, 600))
@@ -713,6 +749,7 @@ var _ = Describe("Rate-anchored k2 operating point across siblings", func() {
 		interval       = 15 * time.Second
 	)
 	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	shape := variantShape{avgInput: 1000, avgOutput: 250}
 
 	atLimit := func() domain.ReplicaMetrics {
 		return domain.ReplicaMetrics{
@@ -735,7 +772,7 @@ var _ = Describe("Rate-anchored k2 operating point across siblings", func() {
 		for i := 0; i < MinServiceRateSamples+1; i++ {
 			at := start.Add(time.Duration(i) * interval)
 			a.serviceRates.BeginCycle(at)
-			_, _, _, _ = a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, at)
+			_, _, _, _ = a.rateAnchoredK2(atLimit(), "m", "", 1, shape, k1, queueThreshold, at)
 		}
 
 		// One cycle, two replicas with materially different residences: 3 s and 1.2 s,
@@ -754,8 +791,8 @@ var _ = Describe("Rate-anchored k2 operating point across siblings", func() {
 		for i := 3; i < 43; i++ { // long enough for the smoothed value to settle
 			at := start.Add(time.Duration(i) * interval)
 			a.serviceRates.BeginCycle(at)
-			k2, _, src, ok = a.rateAnchoredK2(slow, "m", "", 1, k1, queueThreshold, at)
-			_, _, _, _ = a.rateAnchoredK2(fast, "m", "", 1, k1, queueThreshold, at)
+			k2, _, src, ok = a.rateAnchoredK2(slow, "m", "", 1, shape, k1, queueThreshold, at)
+			_, _, _, _ = a.rateAnchoredK2(fast, "m", "", 1, shape, k1, queueThreshold, at)
 		}
 
 		Expect(ok).To(BeTrue())
@@ -769,6 +806,7 @@ var _ = Describe("Rate-anchored k2 operating point across siblings", func() {
 
 var _ = Describe("Rate-anchored k2 ceiling measurement", func() {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	shape := variantShape{avgInput: 1000, avgOutput: 250}
 
 	It("measures the limit from the instantaneous reading, not the minute's peak", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
@@ -788,13 +826,13 @@ var _ = Describe("Rate-anchored k2 ceiling measurement", func() {
 		for i := 0; i <= MinServiceRateSamples+1; i++ {
 			at := now.Add(time.Duration(i) * 15 * time.Second)
 			a.serviceRates.BeginCycle(at)
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, at)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, shape, 320_000, 5.0, at)
 		}
 
 		// The ceiling is a running minimum, so feeding it a peak biases it high in the
 		// one direction that costs replicas.
 		a.serviceRates.BeginCycle(now.Add(time.Minute))
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, now.Add(time.Minute))
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, shape, 320_000, 5.0, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically("~", 60_000, 600))
 	})
@@ -814,10 +852,10 @@ var _ = Describe("Rate-anchored k2 ceiling measurement", func() {
 		for i := 0; i <= MinServiceRateSamples+1; i++ {
 			at := now.Add(time.Duration(i) * 15 * time.Second)
 			a.serviceRates.BeginCycle(at)
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, at)
+			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, shape, 320_000, 5.0, at)
 		}
 		a.serviceRates.BeginCycle(now.Add(time.Minute))
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, 320_000, 5.0, now.Add(time.Minute))
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, shape, 320_000, 5.0, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically("~", 120_000, 1200))
 	})
@@ -830,6 +868,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 		interval       = 15 * time.Second
 	)
 	start := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	shape := variantShape{avgInput: 1000, avgOutput: 250}
 
 	base := func() domain.ReplicaMetrics {
 		return domain.ReplicaMetrics{
@@ -856,7 +895,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 		for i := 0; i < 5; i++ {
 			at := start.Add(time.Duration(i) * interval)
 			a.serviceRates.BeginCycle(at)
-			_, _, _, _ = a.rateAnchoredK2(base(), "m", "", 1, k1, queueThreshold, at)
+			_, _, _, _ = a.rateAnchoredK2(base(), "m", "", 1, shape, k1, queueThreshold, at)
 		}
 
 		// Load steps up: more queued, more resident, and a longer residence because
@@ -869,7 +908,7 @@ var _ = Describe("Rate-anchored k2 responsiveness", func() {
 
 		at := start.Add(5 * interval)
 		a.serviceRates.BeginCycle(at)
-		k2, _, _, ok := a.rateAnchoredK2(ramp, "m", "", 1, k1, queueThreshold, at)
+		k2, _, _, ok := a.rateAnchoredK2(ramp, "m", "", 1, shape, k1, queueThreshold, at)
 
 		Expect(ok).To(BeTrue())
 		// Clamped at the measured ceiling: an inflated residence is queueing time, and

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -1,0 +1,252 @@
+package saturation_v2
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+var _ = Describe("Service rate store", func() {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	It("keeps the highest rate observed for a bucket", func() {
+		s := newServiceRateStore()
+		s.Observe("k", 4.0, now)
+		s.Observe("k", 9.0, now.Add(time.Minute))
+		s.Observe("k", 6.0, now.Add(2*time.Minute))
+
+		rate, ok := s.Rate("k", now.Add(2*time.Minute))
+		Expect(ok).To(BeTrue())
+		// Slightly under 9 because the peak decays between observations; the
+		// point is that the later, lower 6.0 did not replace it.
+		Expect(rate).To(BeNumerically("~", 9.0, 0.2))
+	})
+
+	It("ignores non-positive rates", func() {
+		s := newServiceRateStore()
+		s.Observe("k", 0, now)
+		s.Observe("k", -3, now)
+
+		_, ok := s.Rate("k", now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("reports nothing for an unknown bucket", func() {
+		_, ok := newServiceRateStore().Rate("missing", now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("decays an unrefreshed maximum", func() {
+		s := newServiceRateStore()
+		s.Observe("k", 10.0, now)
+
+		rate, ok := s.Rate("k", now.Add(ServiceRateWindow))
+		Expect(ok).To(BeTrue())
+		Expect(rate).To(BeNumerically("~", 10.0*ServiceRateDecayPerWindow, 0.01))
+	})
+
+	It("lets a fresh lower observation win over a decayed peak", func() {
+		s := newServiceRateStore()
+		s.Observe("k", 10.0, now)
+		// After a full window the peak has decayed to 7.5; 8 is now the better estimate.
+		s.Observe("k", 8.0, now.Add(ServiceRateWindow))
+
+		rate, ok := s.Rate("k", now.Add(ServiceRateWindow))
+		Expect(ok).To(BeTrue())
+		Expect(rate).To(BeNumerically("~", 8.0, 0.01))
+	})
+
+	It("stops answering past the window", func() {
+		s := newServiceRateStore()
+		s.Observe("k", 10.0, now)
+
+		_, ok := s.Rate("k", now.Add(ServiceRateWindow+time.Second))
+		Expect(ok).To(BeFalse())
+	})
+
+	It("evicts entries older than the timeout", func() {
+		s := newServiceRateStore()
+		s.Observe("fresh", 5.0, now)
+		s.Observe("stale", 5.0, now.Add(-2*time.Hour))
+
+		Expect(s.EvictStale(time.Hour, now)).To(Equal(1))
+		_, ok := s.Rate("fresh", now)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("separates buckets by input length", func() {
+		short := serviceRateKey("m", "H100", 1, 300, 300)
+		long := serviceRateKey("m", "H100", 1, 1000, 300)
+		Expect(short).NotTo(Equal(long))
+	})
+})
+
+var _ = Describe("Rate-anchored k2", func() {
+	const (
+		kvCapacity = int64(400_000)
+		k1         = int64(320_000) // 0.8 × kvCapacity
+	)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	// saturatedReplica is queueing at 16% KV — the prefill-heavy regime the
+	// occupancy-based estimator cannot express.
+	saturatedReplica := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			KvUsageInstant:        0.16,
+			TotalKvCapacityTokens: kvCapacity,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+		}
+	}
+
+	It("declines when the estimator is not enabled", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
+		_, _, _, ok := a.rateAnchoredK2(saturatedReplica(), "m", 1, k1, now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("reads 100% utilization for a replica at rate saturation", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeTrue())
+		// lambda == mu, so capacity equals current occupancy: demand/supply == 1
+		// even though only 16% of KV is in use.
+		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
+	})
+
+	It("scales capacity by the distance to saturation", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, now) // records mu = 8 req/s
+
+		// Same bucket, half the arrival rate and no backlog: twice the headroom.
+		rm.QueueLength = 0
+		rm.ArrivalRate = 4.0
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16*2, 1))
+	})
+
+	It("treats a backlogged replica as saturated when EPP provides no lambda", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		rm.ArrivalRate = 0
+
+		k2, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateBacklog))
+		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
+	})
+
+	It("falls back to completions as lambda when there is no queue and no EPP", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, now) // records mu = 8 req/s
+
+		rm.QueueLength = 0
+		rm.ArrivalRate = 0
+		rm.RequestRate = 4.0 // no queue, so completions are arrivals
+		k2, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateNoEPP))
+		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16*2, 1))
+	})
+
+	It("declines when idle and never calibrated", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		rm.QueueLength = 0 // no backlog to fall back on
+		rm.ArrivalRate = 0 // no EPP
+		rm.RequestRate = 0 // and nothing completing
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("prefers the EPP arrival rate over the fallbacks", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		_, src, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateAnchored))
+	})
+
+	It("declines when the instantaneous KV reading is missing", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		rm.KvUsageInstant = 0
+
+		_, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("clamps the ratio so a collapsed arrival rate cannot inflate capacity", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, k1, now)
+
+		rm.QueueLength = 0
+		rm.ArrivalRate = 0.0001 // mu/lambda would be 80000×
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically("<=", int64(float64(kvCapacity)*0.16*MaxRateRatio)))
+	})
+
+	It("floors the estimate so a stalled replica cannot drive capacity to zero", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := saturatedReplica()
+		rm.RequestRate = 0.01
+		rm.ArrivalRate = 50.0
+		rm.KvUsageInstant = 0.01
+
+		k2, _, _, ok := a.rateAnchoredK2(rm, "m", 1, k1, now)
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically(">=", int64(float64(k1)*MinRateAnchoredFraction)))
+	})
+})
+
+var _ = Describe("Rate-anchored k2 and the capacity store", func() {
+	const kvCapacity = int64(400_000)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	replica := func() domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			VariantName:           "v1",
+			AcceleratorName:       "H100",
+			QueueLength:           12,
+			RequestRate:           8.0,
+			ArrivalRate:           8.0,
+			KvUsageInstant:        0.16,
+			TotalKvCapacityTokens: kvCapacity,
+			AvgInputTokens:        1000,
+			AvgOutputTokens:       250,
+		}
+	}
+
+	It("marks a saturated reading as a ceiling", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		_, _, ceiling, ok := a.rateAnchoredK2(replica(), "m", 1, int64(320_000), now)
+		Expect(ok).To(BeTrue())
+		Expect(ceiling).To(BeTrue(), "lambda >= mu means the replica demonstrated this capacity")
+	})
+
+	It("does not mark a below-saturation reading as a ceiling", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := replica()
+		_, _, _, _ = a.rateAnchoredK2(rm, "m", 1, int64(320_000), now) // calibrate mu = 8
+
+		rm.QueueLength = 0
+		rm.ArrivalRate = 2.0 // well below mu: this is headroom, not a ceiling
+		_, _, ceiling, ok := a.rateAnchoredK2(rm, "m", 1, int64(320_000), now)
+		Expect(ok).To(BeTrue())
+		Expect(ceiling).To(BeFalse())
+	})
+})

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Rate-anchored k2", func() {
 	// calibrate drives enough qualifying observations to establish mu for the bucket.
 	calibrate := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics) {
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 	}
 
@@ -134,7 +134,7 @@ var _ = Describe("Rate-anchored k2", func() {
 
 	It("declines when the estimator is not enabled", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
-		_, _, _, ok := a.rateAnchoredK2(saturatedReplica(), "m", "", 1, k1, queueThreshold, now)
+		_, _, ok := a.rateAnchoredK2(saturatedReplica(), "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -142,7 +142,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
 
-		k2, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		// No mu yet, so this is the backlog path — assert the source, otherwise the
 		// numeric result is indistinguishable from the lambda path.
@@ -159,24 +159,25 @@ var _ = Describe("Rate-anchored k2", func() {
 		// ratio arithmetic exists for, and it must come from the lambda path.
 		rm.QueueLength = 0
 		rm.ArrivalRate = 8.0
-		k2, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateAnchored))
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1),
 			"capacity equals occupancy, so utilization reads 100% at 16% KV")
 	})
 
-	It("scales capacity by the distance to saturation", func() {
+	It("declines when the replica has headroom, leaving the occupancy path to answer", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
 		calibrate(a, rm) // establishes mu = 8 req/s for this bucket
 
-		// Same bucket, half the arrival rate and no backlog: twice the headroom.
+		// Same bucket, half the arrival rate and no backlog. A headroom-scaled
+		// number is not a capacity — and would be blended into the variant median
+		// alongside a backlogged sibling's real ceiling — so nothing is returned.
 		rm.QueueLength = 0
 		rm.ArrivalRate = 4.0
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16*2, 1))
+		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse())
 	})
 
 	It("treats a backlogged replica as saturated when EPP provides no lambda", func() {
@@ -184,24 +185,24 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := saturatedReplica()
 		rm.ArrivalRate = 0
 
-		k2, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog))
 		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
 	})
 
-	It("falls back to completions as lambda when there is no queue and no EPP", func() {
+	It("uses completions as lambda when there is no queue and no EPP", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
 		calibrate(a, rm) // establishes mu = 8 req/s for this bucket
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 0
-		rm.RequestRate = 4.0 // no queue, so completions are arrivals
-		k2, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		rm.RequestRate = 8.0 // no queue, so completions are arrivals; at the ceiling
+		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateNoEPP))
-		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16*2, 1))
+		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
 	})
 
 	It("declines when idle and never calibrated", func() {
@@ -210,7 +211,7 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm.QueueLength = 0 // no backlog to fall back on
 		rm.ArrivalRate = 0 // no EPP
 		rm.RequestRate = 0 // and nothing completing
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -219,13 +220,13 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := saturatedReplica()
 
 		// Before calibration the backlog itself is the only usable signal.
-		_, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateBacklog))
 
 		// Once the bucket has enough qualifying observations, lambda wins.
 		calibrate(a, rm)
-		_, src, _, ok = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, src, ok = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(src).To(Equal(k2SrcRateAnchored))
 	})
@@ -235,20 +236,19 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm := saturatedReplica()
 		rm.TokensInUse = 0
 
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("clamps the ratio so a collapsed arrival rate cannot inflate capacity", func() {
+	It("declines rather than inflating capacity when the arrival rate collapses", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := saturatedReplica()
 		calibrate(a, rm)
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = 0.0001 // mu/lambda would be 80000×
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(k2).To(BeNumerically("<=", int64(float64(kvCapacity)*0.16*MaxRateRatio)))
+		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse())
 	})
 
 	It("floors the estimate so a stalled replica cannot drive capacity to zero", func() {
@@ -258,183 +258,9 @@ var _ = Describe("Rate-anchored k2", func() {
 		rm.ArrivalRate = 50.0
 		rm.TokensInUse = int64(0.01 * float64(kvCapacity))
 
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeTrue())
 		Expect(k2).To(BeNumerically(">=", int64(float64(k1)*MinRateAnchoredFraction)))
-	})
-})
-
-var _ = Describe("Rate-anchored k2 and the capacity store", func() {
-	const (
-		kvCapacity     = int64(400_000)
-		queueThreshold = 5.0
-	)
-	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
-
-	replica := func() domain.ReplicaMetrics {
-		return domain.ReplicaMetrics{
-			VariantName:           "v1",
-			AcceleratorName:       "H100",
-			QueueLength:           12,
-			RequestRate:           8.0,
-			ArrivalRate:           8.0,
-			KvUsageInstant:        0.16,
-			TokensInUse:           int64(0.16 * float64(kvCapacity)),
-			TotalKvCapacityTokens: kvCapacity,
-			AvgInputTokens:        1000,
-			AvgOutputTokens:       250,
-		}
-	}
-
-	It("marks a saturated reading as a ceiling", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		_, _, ceiling, ok := a.rateAnchoredK2(replica(), "m", "", 1, int64(320_000), queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(ceiling).To(BeTrue(), "lambda >= mu means the replica demonstrated this capacity")
-	})
-
-	It("does not mark a below-saturation reading as a ceiling", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := replica()
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, int64(320_000), queueThreshold, now)
-		}
-
-		rm.QueueLength = 0
-		rm.ArrivalRate = 2.0 // well below mu: this is headroom, not a ceiling
-		_, _, ceiling, ok := a.rateAnchoredK2(rm, "m", "", 1, int64(320_000), queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(ceiling).To(BeFalse())
-	})
-})
-
-var _ = Describe("Rate-anchored k2 and transient queues", func() {
-	const (
-		kvCapacity     = int64(400_000)
-		k1             = int64(320_000)
-		queueThreshold = 5.0
-	)
-	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
-
-	// A replica comfortably keeping up: low occupancy, arrivals served as they come,
-	// and a single request briefly waiting from arrival jitter. mu == lambda here is
-	// flow conservation, not evidence of a ceiling, so nothing may be concluded.
-	keepingUp := func() domain.ReplicaMetrics {
-		return domain.ReplicaMetrics{
-			AcceleratorName:       "H100",
-			QueueLength:           1,
-			RequestRate:           3.0,
-			ArrivalRate:           3.0,
-			KvUsageInstant:        0.08,
-			TokensInUse:           int64(0.08 * float64(kvCapacity)),
-			TotalKvCapacityTokens: kvCapacity,
-			AvgInputTokens:        1000,
-			AvgOutputTokens:       250,
-		}
-	}
-
-	It("does not calibrate mu from a queue shallower than the threshold", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := keepingUp()
-		for i := 0; i < 5; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		}
-
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse(), "a one-deep queue is arrival jitter, not a ceiling")
-	})
-
-	It("does not declare saturation from a single deep-queue sample", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := keepingUp()
-		rm.QueueLength = 6 // one qualifying observation, below MinServiceRateSamples
-
-		_, src, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		// The backlog path still fires — a deep queue now is saturation now — but mu
-		// is not yet established, so no ratio is derived from it.
-		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateBacklog))
-	})
-})
-
-var _ = Describe("Arrival smoothing over the residence time", func() {
-	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
-
-	It("returns the first sample unchanged", func() {
-		s := newArrivalSmoother()
-		Expect(s.Smooth("pod", 10.0, 60, now)).To(Equal(10.0))
-	})
-
-	It("lags a step change instead of following it", func() {
-		s := newArrivalSmoother()
-		_ = s.Smooth("pod", 4.0, 60, now)
-
-		// One quarter of a time constant later the rate quadruples. A replica
-		// serving what arrived a residence ago has not felt this yet.
-		got := s.Smooth("pod", 16.0, 60, now.Add(15*time.Second))
-		Expect(got).To(BeNumerically(">", 4.0))
-		Expect(got).To(BeNumerically("<", 16.0))
-	})
-
-	It("converges on the new rate once a few time constants have passed", func() {
-		s := newArrivalSmoother()
-		_ = s.Smooth("pod", 4.0, 10, now)
-		got := 0.0
-		for i := 1; i <= 10; i++ {
-			got = s.Smooth("pod", 16.0, 10, now.Add(time.Duration(i)*10*time.Second))
-		}
-		Expect(got).To(BeNumerically("~", 16.0, 0.5))
-	})
-
-	It("discards a stale average rather than blending it", func() {
-		s := newArrivalSmoother()
-		_ = s.Smooth("pod", 4.0, 10, now)
-		// Well beyond the reset factor: the old value carries no information.
-		Expect(s.Smooth("pod", 16.0, 10, now.Add(time.Hour))).To(Equal(16.0))
-	})
-
-	It("passes the rate through when the residence estimate is unavailable", func() {
-		s := newArrivalSmoother()
-		_ = s.Smooth("pod", 4.0, 0, now)
-		Expect(s.Smooth("pod", 16.0, 0, now.Add(time.Second))).To(Equal(16.0))
-	})
-
-	It("keeps replicas separate", func() {
-		s := newArrivalSmoother()
-		_ = s.Smooth("a", 4.0, 60, now)
-		Expect(s.Smooth("b", 20.0, 60, now)).To(Equal(20.0))
-	})
-
-	It("evicts replicas not seen within the timeout", func() {
-		s := newArrivalSmoother()
-		_ = s.Smooth("fresh", 4.0, 60, now)
-		_ = s.Smooth("gone", 4.0, 60, now.Add(-2*time.Hour))
-		Expect(s.EvictStale(time.Hour, now)).To(Equal(1))
-	})
-})
-
-var _ = Describe("Residence estimate", func() {
-	It("is time to first token plus one ITL per output token", func() {
-		w := residenceSeconds(domain.ReplicaMetrics{
-			AvgTTFT:         2.0,
-			AvgITL:          0.02,
-			AvgOutputTokens: 250,
-		})
-		Expect(w).To(BeNumerically("~", 2.0+250*0.02, 0.001))
-	})
-
-	It("declines without latency data, leaving the arrival rate unsmoothed", func() {
-		Expect(residenceSeconds(domain.ReplicaMetrics{AvgOutputTokens: 250})).To(BeZero())
-		Expect(residenceSeconds(domain.ReplicaMetrics{AvgITL: 0.02})).To(BeZero())
-	})
-
-	It("bounds an implausible reading", func() {
-		Expect(residenceSeconds(domain.ReplicaMetrics{
-			AvgTTFT: 0, AvgITL: 0.0000001, AvgOutputTokens: 1,
-		})).To(Equal(MinResidenceSeconds))
-		Expect(residenceSeconds(domain.ReplicaMetrics{
-			AvgTTFT: 1e6, AvgITL: 1, AvgOutputTokens: 1,
-		})).To(Equal(MaxResidenceSeconds))
 	})
 })
 
@@ -467,14 +293,14 @@ var _ = Describe("Rate-anchored k2 across roles and load levels", func() {
 		// A decode replica establishes mu = 20 req/s.
 		dec := backlogged(domain.RoleDecode, 20)
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, k1, queueThreshold, now)
+			_, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, k1, queueThreshold, now)
 		}
 
 		// A prefill replica of the same model on the same accelerator must not
 		// inherit it: prefill completes at a different rate for the same requests.
 		pre := backlogged(domain.RolePrefill, 3)
 		pre.QueueLength = 0
-		_, src, _, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		_, src, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse(), "prefill has no calibration of its own yet")
 		Expect(src).To(Equal(k2Source(0)))
 	})
@@ -484,14 +310,14 @@ var _ = Describe("Rate-anchored k2 across roles and load levels", func() {
 		for _, role := range []string{domain.RolePrefill, domain.RoleDecode, domain.RoleBoth} {
 			rm := backlogged(role, 10)
 			for i := 0; i < MinServiceRateSamples; i++ {
-				_, _, _, _ = a.rateAnchoredK2(rm, "m", role, 1, k1, queueThreshold, now)
+				_, _, _ = a.rateAnchoredK2(rm, "m", role, 1, k1, queueThreshold, now)
 			}
 			rm.QueueLength = 0
-			rm.ArrivalRate = 5 // half the ceiling
-			k2, src, _, ok := a.rateAnchoredK2(rm, "m", role, 1, k1, queueThreshold, now)
+			rm.ArrivalRate = 10 // still at the ceiling for this role
+			k2, src, ok := a.rateAnchoredK2(rm, "m", role, 1, k1, queueThreshold, now)
 			Expect(ok).To(BeTrue(), "role %s", role)
 			Expect(src).To(Equal(k2SrcRateAnchored))
-			Expect(k2).To(BeNumerically(">", int64(float64(kvCapacity)*0.16)), "role %s has headroom", role)
+			Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1), "role %s", role)
 		}
 	})
 
@@ -501,7 +327,7 @@ var _ = Describe("Rate-anchored k2 across roles and load levels", func() {
 		// Calibrated conservatively at 8 req/s during a rough patch.
 		rm := backlogged(domain.RoleBoth, 8)
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
+			_, _, _ = a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
 		}
 
 		// Now running slightly past that rate with nothing queued: the replica is
@@ -509,27 +335,26 @@ var _ = Describe("Rate-anchored k2 across roles and load levels", func() {
 		rm.QueueLength = 0
 		rm.ArrivalRate = 12
 		rm.RequestRate = 12
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now.Add(time.Minute))
+		k2, _, ok := a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now.Add(time.Minute))
 		Expect(ok).To(BeTrue())
-		Expect(k2).To(BeNumerically(">=", int64(float64(kvCapacity)*0.16)),
+		Expect(k2).To(BeNumerically(">=", rm.TokensInUse),
 			"utilization must not exceed 100% for a replica with an empty queue")
 	})
 
-	It("leaves k1 as the bound when the replica has ample headroom", func() {
+	It("stays out of the way entirely when the replica has ample headroom", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := backlogged(domain.RoleBoth, 20)
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
+			_, _, _ = a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
 		}
 
-		// A quarter of the ceiling, and holding a healthy chunk of KV.
+		// A quarter of the ceiling, and holding a healthy chunk of KV: the occupancy
+		// path keeps k1 as the bound, and this estimator contributes nothing.
 		rm.QueueLength = 0
 		rm.ArrivalRate = 5
 		rm.TokensInUse = int64(0.5 * float64(kvCapacity))
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		// 0.5 × 400k × 4 = 800k > k1, so min(k1, k2) keeps the memory bound.
-		Expect(k2).To(BeNumerically(">", k1), "the memory bound should win, not be undercut")
+		_, _, ok := a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse())
 	})
 })
 
@@ -563,7 +388,7 @@ var _ = Describe("Rate-anchored k2 with degenerate or missing signals", func() {
 		rm := base()
 		rm.RequestRate = 0
 		for i := 0; i < 5; i++ {
-			_, src, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+			_, src, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
 			Expect(ok).To(BeTrue())
 			// The backlog is real, so saturation is reported — but from the queue,
 			// never from a fabricated ceiling.
@@ -572,7 +397,7 @@ var _ = Describe("Rate-anchored k2 with degenerate or missing signals", func() {
 
 		// With the queue drained there is nothing left to conclude from.
 		rm.QueueLength = 0
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		_, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -580,13 +405,13 @@ var _ = Describe("Rate-anchored k2 with degenerate or missing signals", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := base()
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = -5 // mis-scraped
 		rm.RequestRate = 0
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -594,12 +419,12 @@ var _ = Describe("Rate-anchored k2 with degenerate or missing signals", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 		rm := base()
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 
 		rm.QueueLength = 0
 		rm.ArrivalRate = math.NaN()
-		k2, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		// A NaN ratio is caught before the int64 conversion, so either the estimator
 		// declines or it returns a sane positive token count — never garbage.
 		if ok {
@@ -613,17 +438,17 @@ var _ = Describe("Rate-anchored k2 with degenerate or missing signals", func() {
 		rm := base()
 		rm.QueueLength = 0
 		rm.TokensInUse = 0 // just became ready, KV still empty
-		_, _, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("shares mu across replicas of a variant but smooths arrivals per replica", func() {
+	It("shares mu across replicas but stays silent for the idle one", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
 
 		// pod-a is backlogged and establishes the bucket's ceiling.
 		hot := base()
 		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _, _ = a.rateAnchoredK2(hot, "m", "", 1, k1, queueThreshold, now)
+			_, _, _ = a.rateAnchoredK2(hot, "m", "", 1, k1, queueThreshold, now)
 		}
 
 		// pod-b, same variant and shape, idle at a quarter of the ceiling. It gets
@@ -632,11 +457,10 @@ var _ = Describe("Rate-anchored k2 with degenerate or missing signals", func() {
 		cold.PodName = "pod-b"
 		cold.QueueLength = 0
 		cold.ArrivalRate = 2.0
-		k2, src, _, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateAnchored))
-		Expect(k2).To(BeNumerically(">", int64(float64(kvCapacity)*0.16)),
-			"an idle replica must read as having headroom, not as saturated")
+		_, _, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse(),
+			"an idle replica must contribute nothing, or its headroom would inflate "+
+				"the variant capacity median against a backlogged sibling's ceiling")
 	})
 
 	It("collapses onto one smoothing entry when replicas report no pod name", func() {

--- a/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
+++ b/internal/engines/analyzers/saturation_v2/rate_capacity_test.go
@@ -10,468 +10,386 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 )
 
-var _ = Describe("Service rate store", func() {
+var _ = Describe("Bucket store — service rate", func() {
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 
-	It("keeps the highest rate observed for a bucket", func() {
-		s := newServiceRateStore()
-		s.Observe("k", 4.0, now)
-		// three observations, so the sample floor is satisfied
-		s.Observe("k", 9.0, now.Add(time.Minute))
-		s.Observe("k", 6.0, now.Add(2*time.Minute))
+	It("keeps the highest rate observed", func() {
+		s := newBucketStore()
+		s.ObserveRate("k", 4.0, now)
+		s.ObserveRate("k", 9.0, now.Add(time.Minute))
+		s.ObserveRate("k", 6.0, now.Add(2*time.Minute))
 
 		rate, ok := s.Rate("k", now.Add(2*time.Minute))
 		Expect(ok).To(BeTrue())
-		// Slightly under 9 because the peak decays between observations; the
-		// point is that the later, lower 6.0 did not replace it.
+		// Slightly under 9 because the peak decays between observations; the point
+		// is that the later, lower 6.0 did not replace it.
 		Expect(rate).To(BeNumerically("~", 9.0, 0.2))
 	})
 
-	It("withholds an estimate until a second qualifying observation", func() {
-		s := newServiceRateStore()
-		s.Observe("k", 7.0, now)
-
+	It("withholds an estimate until a second observation", func() {
+		s := newBucketStore()
+		s.ObserveRate("k", 7.0, now)
 		_, ok := s.Rate("k", now)
-		Expect(ok).To(BeFalse(), "one observation cannot distinguish a ceiling from a slow interval")
+		Expect(ok).To(BeFalse(), "one observation cannot distinguish a limit from a slow interval")
 
-		s.Observe("k", 7.0, now)
+		s.ObserveRate("k", 7.0, now)
 		_, ok = s.Rate("k", now)
 		Expect(ok).To(BeTrue())
 	})
 
 	It("ignores non-positive rates", func() {
-		s := newServiceRateStore()
-		s.Observe("k", 0, now)
-		s.Observe("k", -3, now)
-
+		s := newBucketStore()
+		s.ObserveRate("k", 0, now)
+		s.ObserveRate("k", -3, now)
 		_, ok := s.Rate("k", now)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("reports nothing for an unknown bucket", func() {
-		_, ok := newServiceRateStore().Rate("missing", now)
-		Expect(ok).To(BeFalse())
-	})
-
-	It("decays an unrefreshed maximum", func() {
-		s := newServiceRateStore()
-		s.Observe("k", 10.0, now)
-		s.Observe("k", 10.0, now)
+	It("decays an unrefreshed rate and expires it past the window", func() {
+		s := newBucketStore()
+		s.ObserveRate("k", 10.0, now)
+		s.ObserveRate("k", 10.0, now)
 
 		rate, ok := s.Rate("k", now.Add(ServiceRateWindow))
 		Expect(ok).To(BeTrue())
 		Expect(rate).To(BeNumerically("~", 10.0*ServiceRateDecayPerWindow, 0.01))
-	})
 
-	It("lets a fresh lower observation win over a decayed peak", func() {
-		s := newServiceRateStore()
-		s.Observe("k", 10.0, now)
-		// After a full window the peak has decayed to 7.5; 8 is now the better estimate.
-		s.Observe("k", 8.0, now.Add(ServiceRateWindow))
-
-		rate, ok := s.Rate("k", now.Add(ServiceRateWindow))
-		Expect(ok).To(BeTrue())
-		Expect(rate).To(BeNumerically("~", 8.0, 0.01))
-	})
-
-	It("stops answering past the window", func() {
-		s := newServiceRateStore()
-		s.Observe("k", 10.0, now)
-		s.Observe("k", 10.0, now)
-
-		_, ok := s.Rate("k", now.Add(ServiceRateWindow+time.Second))
+		_, ok = s.Rate("k", now.Add(ServiceRateWindow+time.Second))
 		Expect(ok).To(BeFalse())
 	})
+})
 
-	It("evicts entries older than the timeout", func() {
-		s := newServiceRateStore()
-		s.Observe("fresh", 5.0, now)
-		s.Observe("fresh", 5.0, now)
-		s.Observe("stale", 5.0, now.Add(-2*time.Hour))
+var _ = Describe("Bucket store — token ceiling", func() {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 
-		Expect(s.EvictStale(time.Hour, now)).To(Equal(1))
-		_, ok := s.Rate("fresh", now)
+	It("keeps the lowest occupancy at which a limit was seen", func() {
+		s := newBucketStore()
+		s.ObserveCeiling("k", 90_000, now)
+		s.ObserveCeiling("k", 64_000, now)
+		s.ObserveCeiling("k", 80_000, now)
+
+		c, ok := s.Ceiling("k", now)
 		Expect(ok).To(BeTrue())
+		Expect(c).To(BeNumerically("~", 64_000, 1),
+			"a running minimum: the conservative reading of capacity")
 	})
 
-	It("separates buckets by input length", func() {
-		short := serviceRateKey("m", "H100", "decode", 1, 300, 300)
-		long := serviceRateKey("m", "H100", "decode", 1, 1000, 300)
-		Expect(short).NotTo(Equal(long))
+	It("relaxes upward when no fresh limit is observed", func() {
+		s := newBucketStore()
+		s.ObserveCeiling("k", 64_000, now)
+
+		c, ok := s.Ceiling("k", now.Add(ServiceRateWindow))
+		Expect(ok).To(BeTrue())
+		Expect(c).To(BeNumerically("~", 64_000*CeilingRelaxPerWindow, 1),
+			"a single pessimistic measurement must not cap the bucket forever")
+	})
+
+	It("lets a fresh higher measurement win over a relaxed one", func() {
+		s := newBucketStore()
+		s.ObserveCeiling("k", 64_000, now)
+		s.ObserveCeiling("k", 120_000, now.Add(ServiceRateWindow))
+
+		c, ok := s.Ceiling("k", now.Add(ServiceRateWindow))
+		Expect(ok).To(BeTrue())
+		Expect(c).To(BeNumerically("~", 80_000, 1), "64k relaxed to 80k, still below 120k")
+	})
+
+	It("expires past the window and evicts with the rate", func() {
+		s := newBucketStore()
+		s.ObserveCeiling("k", 64_000, now)
+		_, ok := s.Ceiling("k", now.Add(ServiceRateWindow+time.Second))
+		Expect(ok).To(BeFalse())
+
+		Expect(s.EvictStale(time.Hour, now.Add(2*time.Hour))).To(Equal(1))
+	})
+
+	It("separates buckets by role and by input length", func() {
+		decode := serviceRateKey("m", "H100", domain.RoleDecode, 1, 1000, 250)
+		prefill := serviceRateKey("m", "H100", domain.RolePrefill, 1, 1000, 250)
+		shortIn := serviceRateKey("m", "H100", domain.RoleDecode, 1, 300, 250)
+		Expect(decode).NotTo(Equal(prefill))
+		Expect(decode).NotTo(Equal(shortIn))
+	})
+})
+
+var _ = Describe("Arrival smoothing over the residence time", func() {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	It("returns the first sample unchanged", func() {
+		Expect(newArrivalSmoother().Smooth("pod", 10.0, 60, now)).To(Equal(10.0))
+	})
+
+	It("lags a step change instead of following it", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("pod", 4.0, 60, now)
+		got := s.Smooth("pod", 16.0, 60, now.Add(15*time.Second))
+		Expect(got).To(BeNumerically(">", 4.0))
+		Expect(got).To(BeNumerically("<", 16.0))
+	})
+
+	It("converges once a few time constants have passed", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("pod", 4.0, 10, now)
+		got := 0.0
+		for i := 1; i <= 10; i++ {
+			got = s.Smooth("pod", 16.0, 10, now.Add(time.Duration(i)*10*time.Second))
+		}
+		Expect(got).To(BeNumerically("~", 16.0, 0.5))
+	})
+
+	It("discards a stale average rather than blending it", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("pod", 4.0, 10, now)
+		Expect(s.Smooth("pod", 16.0, 10, now.Add(time.Hour))).To(Equal(16.0))
+	})
+
+	It("passes through when the residence estimate is unavailable", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("pod", 4.0, 0, now)
+		Expect(s.Smooth("pod", 16.0, 0, now.Add(time.Second))).To(Equal(16.0))
+	})
+
+	It("keeps replicas separate and evicts the absent", func() {
+		s := newArrivalSmoother()
+		_ = s.Smooth("a", 4.0, 60, now)
+		Expect(s.Smooth("b", 20.0, 60, now)).To(Equal(20.0))
+		_ = s.Smooth("gone", 4.0, 60, now.Add(-2*time.Hour))
+		Expect(s.EvictStale(time.Hour, now)).To(Equal(1))
+	})
+})
+
+var _ = Describe("Residence estimate", func() {
+	It("is time to first token plus one ITL per output token", func() {
+		Expect(residenceSeconds(domain.ReplicaMetrics{
+			AvgTTFT: 2.0, AvgITL: 0.02, AvgOutputTokens: 250,
+		})).To(BeNumerically("~", 2.0+250*0.02, 0.001))
+	})
+
+	It("declines without latency data", func() {
+		Expect(residenceSeconds(domain.ReplicaMetrics{AvgOutputTokens: 250})).To(BeZero())
+		Expect(residenceSeconds(domain.ReplicaMetrics{AvgITL: 0.02})).To(BeZero())
+	})
+
+	It("bounds an implausible reading", func() {
+		Expect(residenceSeconds(domain.ReplicaMetrics{AvgITL: 1e-7, AvgOutputTokens: 1})).
+			To(Equal(MinResidenceSeconds))
+		Expect(residenceSeconds(domain.ReplicaMetrics{AvgTTFT: 1e6, AvgITL: 1, AvgOutputTokens: 1})).
+			To(Equal(MaxResidenceSeconds))
 	})
 })
 
 var _ = Describe("Rate-anchored k2", func() {
 	const (
 		kvCapacity     = int64(400_000)
-		k1             = int64(320_000) // 0.8 × kvCapacity
-		queueThreshold = 5.0            // config.DefaultQueueLengthThreshold
-	)
-	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
-
-	// calibrate drives enough qualifying observations to establish mu for the bucket.
-	calibrate := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics) {
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		}
-	}
-
-	// saturatedReplica is queueing at 16% KV — the prefill-heavy regime the
-	// occupancy-based estimator cannot express.
-	saturatedReplica := func() domain.ReplicaMetrics {
-		return domain.ReplicaMetrics{
-			AcceleratorName:       "H100",
-			QueueLength:           12,
-			RequestRate:           8.0,
-			ArrivalRate:           8.0,
-			KvUsageInstant:        0.16,
-			TokensInUse:           int64(0.16 * float64(kvCapacity)),
-			TotalKvCapacityTokens: kvCapacity,
-			AvgInputTokens:        1000,
-			AvgOutputTokens:       250,
-		}
-	}
-
-	It("declines when the estimator is not enabled", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
-		_, _, ok := a.rateAnchoredK2(saturatedReplica(), "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse())
-	})
-
-	It("reads 100% utilization from the backlog before mu is calibrated", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-
-		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		// No mu yet, so this is the backlog path — assert the source, otherwise the
-		// numeric result is indistinguishable from the lambda path.
-		Expect(src).To(Equal(k2SrcRateBacklog))
-		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
-	})
-
-	It("reads 100% utilization from lambda == mu with no queue", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-		calibrate(a, rm) // mu = 8 req/s
-
-		// Arrivals exactly at the ceiling, nothing queued yet: this is the case the
-		// ratio arithmetic exists for, and it must come from the lambda path.
-		rm.QueueLength = 0
-		rm.ArrivalRate = 8.0
-		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateAnchored))
-		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1),
-			"capacity equals occupancy, so utilization reads 100% at 16% KV")
-	})
-
-	It("declines when the replica has headroom, leaving the occupancy path to answer", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-		calibrate(a, rm) // establishes mu = 8 req/s for this bucket
-
-		// Same bucket, half the arrival rate and no backlog. A headroom-scaled
-		// number is not a capacity — and would be blended into the variant median
-		// alongside a backlogged sibling's real ceiling — so nothing is returned.
-		rm.QueueLength = 0
-		rm.ArrivalRate = 4.0
-		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse())
-	})
-
-	It("treats a backlogged replica as saturated when EPP provides no lambda", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-		rm.ArrivalRate = 0
-
-		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateBacklog))
-		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
-	})
-
-	It("uses completions as lambda when there is no queue and no EPP", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-		calibrate(a, rm) // establishes mu = 8 req/s for this bucket
-
-		rm.QueueLength = 0
-		rm.ArrivalRate = 0
-		rm.RequestRate = 8.0 // no queue, so completions are arrivals; at the ceiling
-		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateNoEPP))
-		Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1))
-	})
-
-	It("declines when idle and never calibrated", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-		rm.QueueLength = 0 // no backlog to fall back on
-		rm.ArrivalRate = 0 // no EPP
-		rm.RequestRate = 0 // and nothing completing
-		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse())
-	})
-
-	It("prefers the EPP arrival rate once mu is established", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-
-		// Before calibration the backlog itself is the only usable signal.
-		_, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateBacklog))
-
-		// Once the bucket has enough qualifying observations, lambda wins.
-		calibrate(a, rm)
-		_, src, ok = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(src).To(Equal(k2SrcRateAnchored))
-	})
-
-	It("declines when the occupancy reading is missing", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-		rm.TokensInUse = 0
-
-		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse())
-	})
-
-	It("declines rather than inflating capacity when the arrival rate collapses", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-		calibrate(a, rm)
-
-		rm.QueueLength = 0
-		rm.ArrivalRate = 0.0001 // mu/lambda would be 80000×
-		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse())
-	})
-
-	It("floors the estimate so a stalled replica cannot drive capacity to zero", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := saturatedReplica()
-		rm.RequestRate = 0.01
-		rm.ArrivalRate = 50.0
-		rm.TokensInUse = int64(0.01 * float64(kvCapacity))
-
-		k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeTrue())
-		Expect(k2).To(BeNumerically(">=", int64(float64(k1)*MinRateAnchoredFraction)))
-	})
-})
-
-var _ = Describe("Rate-anchored k2 across roles and load levels", func() {
-	const (
-		kvCapacity     = int64(400_000)
 		k1             = int64(320_000)
 		queueThreshold = 5.0
+		occupancy      = int64(64_000) // 16% of KV — the prefill-heavy regime
 	)
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 
-	backlogged := func(role string, rate float64) domain.ReplicaMetrics {
-		return domain.ReplicaMetrics{
-			PodName:               "pod-" + role,
-			AcceleratorName:       "H100",
-			QueueLength:           12,
-			RequestRate:           rate,
-			ArrivalRate:           rate,
-			KvUsageInstant:        0.16,
-			TokensInUse:           int64(0.16 * float64(kvCapacity)),
-			TotalKvCapacityTokens: kvCapacity,
-			AvgInputTokens:        1000,
-			AvgOutputTokens:       250,
-		}
-	}
-
-	It("does not let one role calibrate another's ceiling", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-
-		// A decode replica establishes mu = 20 req/s.
-		dec := backlogged(domain.RoleDecode, 20)
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, k1, queueThreshold, now)
-		}
-
-		// A prefill replica of the same model on the same accelerator must not
-		// inherit it: prefill completes at a different rate for the same requests.
-		pre := backlogged(domain.RolePrefill, 3)
-		pre.QueueLength = 0
-		_, src, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse(), "prefill has no calibration of its own yet")
-		Expect(src).To(Equal(k2Source(0)))
-	})
-
-	It("calibrates each role independently", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		for _, role := range []string{domain.RolePrefill, domain.RoleDecode, domain.RoleBoth} {
-			rm := backlogged(role, 10)
-			for i := 0; i < MinServiceRateSamples; i++ {
-				_, _, _ = a.rateAnchoredK2(rm, "m", role, 1, k1, queueThreshold, now)
-			}
-			rm.QueueLength = 0
-			rm.ArrivalRate = 10 // still at the ceiling for this role
-			k2, src, ok := a.rateAnchoredK2(rm, "m", role, 1, k1, queueThreshold, now)
-			Expect(ok).To(BeTrue(), "role %s", role)
-			Expect(src).To(Equal(k2SrcRateAnchored))
-			Expect(k2).To(BeNumerically("~", float64(kvCapacity)*0.16, 1), "role %s", role)
-		}
-	})
-
-	It("does not cut capacity below what a queue-free replica is visibly handling", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-
-		// Calibrated conservatively at 8 req/s during a rough patch.
-		rm := backlogged(domain.RoleBoth, 8)
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _ = a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
-		}
-
-		// Now running slightly past that rate with nothing queued: the replica is
-		// keeping up, so capacity must not be reported below its occupancy.
-		rm.QueueLength = 0
-		rm.ArrivalRate = 12
-		rm.RequestRate = 12
-		k2, _, ok := a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now.Add(time.Minute))
-		Expect(ok).To(BeTrue())
-		Expect(k2).To(BeNumerically(">=", rm.TokensInUse),
-			"utilization must not exceed 100% for a replica with an empty queue")
-	})
-
-	It("stays out of the way entirely when the replica has ample headroom", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := backlogged(domain.RoleBoth, 20)
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _ = a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
-		}
-
-		// A quarter of the ceiling, and holding a healthy chunk of KV: the occupancy
-		// path keeps k1 as the bound, and this estimator contributes nothing.
-		rm.QueueLength = 0
-		rm.ArrivalRate = 5
-		rm.TokensInUse = int64(0.5 * float64(kvCapacity))
-		_, _, ok := a.rateAnchoredK2(rm, "m", domain.RoleBoth, 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse())
-	})
-})
-
-var _ = Describe("Rate-anchored k2 with degenerate or missing signals", func() {
-	const (
-		kvCapacity     = int64(400_000)
-		k1             = int64(320_000)
-		queueThreshold = 5.0
-	)
-	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
-
-	base := func() domain.ReplicaMetrics {
+	atLimit := func() domain.ReplicaMetrics {
 		return domain.ReplicaMetrics{
 			PodName:               "pod-a",
 			AcceleratorName:       "H100",
 			QueueLength:           12,
 			RequestRate:           8.0,
 			ArrivalRate:           8.0,
-			KvUsageInstant:        0.16,
-			TokensInUse:           int64(0.16 * float64(kvCapacity)),
+			TokensInUse:           occupancy,
 			TotalKvCapacityTokens: kvCapacity,
 			AvgInputTokens:        1000,
 			AvgOutputTokens:       250,
 		}
 	}
 
-	It("never calibrates a prefill replica that reports no completions", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		// A disaggregated prefill pod completes few or no generation tokens, so the
-		// completion-rate metric can read zero even under a deep backlog.
-		rm := base()
-		rm.RequestRate = 0
-		for i := 0; i < 5; i++ {
-			_, src, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
-			Expect(ok).To(BeTrue())
-			// The backlog is real, so saturation is reported — but from the queue,
-			// never from a fabricated ceiling.
-			Expect(src).To(Equal(k2SrcRateBacklog))
+	// learn drives enough cycles to establish both the service rate and the ceiling.
+	learn := func(a *SaturationAnalyzer, rm domain.ReplicaMetrics) {
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
+	}
 
-		// With the queue drained there is nothing left to conclude from.
-		rm.QueueLength = 0
-		_, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+	It("declines when the estimator is not enabled", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore())
+		_, _, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("declines a negative arrival rate rather than inverting the ratio", func() {
+	It("reports the current occupancy on a first overload, before anything is learned", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := base()
+		k2, src, ok := a.rateAnchoredK2(atLimit(), "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateBacklog))
+		Expect(k2).To(BeNumerically("~", float64(occupancy), 1),
+			"saturation at 16% KV is representable, which the occupancy path cannot do")
+	})
+
+	It("gives every replica of the bucket the same learned ceiling", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		hot := atLimit()
+		learn(a, hot)
+
+		hotK2, hotSrc, ok := a.rateAnchoredK2(hot, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(hotSrc).To(Equal(k2SrcRateAnchored))
+
+		// An idle sibling: different pod, no queue, a quarter of the arrival rate.
+		// It must report the SAME capacity, because capacity is a property of the
+		// bucket. aggregateByVariant takes the median of per-replica capacities, so
+		// anything load-dependent here would blend incommensurable numbers and could
+		// lift variant capacity while a sibling queues.
+		cold := atLimit()
+		cold.PodName = "pod-b"
+		cold.QueueLength = 0
+		cold.ArrivalRate = 2.0
+		coldK2, coldSrc, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(coldSrc).To(Equal(k2SrcRateAnchored))
+		Expect(coldK2).To(Equal(hotK2), "the median across replicas must be a no-op")
+	})
+
+	It("returns the same value cycle after cycle for unchanged input", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := atLimit()
+		learn(a, rm)
+
+		// Arrival rate wobbles around the service rate; capacity must not.
+		seen := make([]int64, 0, 5)
+		for i, lambda := range []float64{8.0, 7.2, 8.6, 7.9, 8.3} {
+			rm.ArrivalRate = lambda
+			rm.QueueLength = 0
+			k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold,
+				now.Add(time.Duration(i)*15*time.Second))
+			Expect(ok).To(BeTrue())
+			seen = append(seen, k2)
+		}
+		// lambda swings +-9% here. The only permitted movement is the ceiling's slow
+		// relaxation with age (CeilingRelaxPerWindow over ServiceRateWindow), which
+		// over a minute is a fraction of a percent — not a per-cycle response to load.
+		for _, v := range seen {
+			Expect(v).To(BeNumerically("~", float64(seen[0]), float64(seen[0])*0.01),
+				"a capacity that moved with lambda each cycle is an oscillation waiting to happen")
+		}
+	})
+
+	It("detects the limit from arrivals reaching the service rate, with no queue", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := atLimit()
+		for i := 0; i < MinServiceRateSamples; i++ {
+			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		}
+
+		// Queue drained but arrivals still at the ceiling, and occupancy lower than
+		// what was measured under backlog: the lower reading is now the ceiling.
+		rm.QueueLength = 0
+		rm.TokensInUse = 48_000
+		k2, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateAnchored))
+		Expect(k2).To(BeNumerically("~", 48_000, 1))
+	})
+
+	It("uses completions as arrivals when there is no EPP and no queue", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := atLimit()
 		for i := 0; i < MinServiceRateSamples; i++ {
 			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		}
 
 		rm.QueueLength = 0
-		rm.ArrivalRate = -5 // mis-scraped
-		rm.RequestRate = 0
+		rm.ArrivalRate = 0   // no EPP
+		rm.RequestRate = 8.0 // completions == arrivals with no queue
+		_, src, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(src).To(Equal(k2SrcRateAnchored))
+	})
+
+	It("declines for an idle replica in a bucket that has learned nothing", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := atLimit()
+		rm.QueueLength = 0
+		rm.ArrivalRate = 1.0
 		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("does not propagate a NaN arrival rate into capacity", func() {
+	It("declines for a cold replica with no occupancy", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := base()
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _ = a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		}
-
-		rm.QueueLength = 0
-		rm.ArrivalRate = math.NaN()
-		k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
-		// A NaN ratio is caught before the int64 conversion, so either the estimator
-		// declines or it returns a sane positive token count — never garbage.
-		if ok {
-			Expect(k2).To(BeNumerically(">", 0))
-			Expect(k2).To(BeNumerically("<=", k1))
-		}
-	})
-
-	It("declines a cold replica with no occupancy and no calibration", func() {
-		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-		rm := base()
-		rm.QueueLength = 0
+		rm := atLimit()
 		rm.TokensInUse = 0 // just became ready, KV still empty
 		_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("shares mu across replicas but stays silent for the idle one", func() {
+	It("does not let a shallow queue teach the bucket anything", func() {
 		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
-
-		// pod-a is backlogged and establishes the bucket's ceiling.
-		hot := base()
-		for i := 0; i < MinServiceRateSamples; i++ {
-			_, _, _ = a.rateAnchoredK2(hot, "m", "", 1, k1, queueThreshold, now)
+		rm := atLimit()
+		rm.QueueLength = 1 // arrival jitter, not a limit
+		for i := 0; i < 5; i++ {
+			_, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			Expect(ok).To(BeFalse())
 		}
-
-		// pod-b, same variant and shape, idle at a quarter of the ceiling. It gets
-		// the shared mu, and its own arrival history — not pod-a's.
-		cold := base()
-		cold.PodName = "pod-b"
-		cold.QueueLength = 0
-		cold.ArrivalRate = 2.0
-		_, _, ok := a.rateAnchoredK2(cold, "m", "", 1, k1, queueThreshold, now)
-		Expect(ok).To(BeFalse(),
-			"an idle replica must contribute nothing, or its headroom would inflate "+
-				"the variant capacity median against a backlogged sibling's ceiling")
 	})
 
-	It("collapses onto one smoothing entry when replicas report no pod name", func() {
-		// Documents a real limitation rather than asserting it is harmless: with
-		// PodName empty the smoother falls back to the bucket key, so two such
-		// replicas share one arrival average.
-		s := newArrivalSmoother()
-		first := s.Smooth("bucket", 4.0, 60, now)
-		second := s.Smooth("bucket", 40.0, 60, now.Add(time.Second))
-		Expect(first).To(Equal(4.0))
-		Expect(second).To(BeNumerically("<", 40.0),
-			"the second replica's rate is blended into the first's average")
+	It("floors the ceiling so a stalled replica cannot demand unbounded scale-up", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := atLimit()
+		rm.TokensInUse = 100 // stalled with a deep queue and almost nothing resident
+		k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue())
+		Expect(k2).To(BeNumerically(">=", int64(float64(k1)*MinRateAnchoredFraction)))
+	})
+
+	It("survives negative and NaN arrival rates", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		rm := atLimit()
+		learn(a, rm)
+
+		for _, bad := range []float64{-5, math.NaN(), math.Inf(1)} {
+			rm.QueueLength = 0
+			rm.ArrivalRate = bad
+			rm.RequestRate = 0
+			k2, _, ok := a.rateAnchoredK2(rm, "m", "", 1, k1, queueThreshold, now)
+			if ok {
+				Expect(k2).To(BeNumerically(">", 0))
+			}
+		}
+	})
+
+	It("keeps roles apart", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+
+		dec := atLimit()
+		dec.RequestRate, dec.ArrivalRate = 20, 20
+		for i := 0; i < MinServiceRateSamples+1; i++ {
+			_, _, _ = a.rateAnchoredK2(dec, "m", domain.RoleDecode, 1, k1, queueThreshold, now)
+		}
+
+		// A prefill replica of the same model on the same accelerator must not
+		// inherit decode's limit.
+		pre := atLimit()
+		pre.PodName = "pod-p"
+		pre.QueueLength = 0
+		pre.ArrivalRate = 3
+		_, _, ok := a.rateAnchoredK2(pre, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("never fabricates a limit for a prefill replica reporting no completions", func() {
+		a := NewSaturationAnalyzer(NewCapacityKnowledgeStore(), withRateAnchoredK2(true))
+		// A disaggregated prefill pod can report zero completions even under load.
+		rm := atLimit()
+		rm.RequestRate = 0
+		for i := 0; i < 5; i++ {
+			_, src, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+			Expect(ok).To(BeTrue())
+			// The queue is real, so the limit is measured from it — but no service
+			// rate is ever learned, so nothing is inferred from a rate comparison.
+			Expect(src).To(BeElementOf(k2SrcRateBacklog, k2SrcRateAnchored))
+		}
+
+		rm.QueueLength = 0
+		rm.ArrivalRate = 1
+		_, _, ok := a.rateAnchoredK2(rm, "m", domain.RolePrefill, 1, k1, queueThreshold, now)
+		Expect(ok).To(BeTrue(), "the ceiling measured under backlog still applies")
 	})
 })

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -50,7 +50,12 @@ type ReplicaCapacity struct {
 	ComputeBoundCapacity  int64    // k2: compute/scheduling-limited capacity
 	K2Priority            k2Source // how k2 was computed
 	EffectiveCapacity     int64    // min(k1, k2)
-	IsSaturated           bool
+	// ServiceRate is the bucket's measured requests per second per replica, or 0
+	// when nothing has been calibrated. Carried per replica only because this is
+	// where the bucket key is already in hand; every replica of a variant reports
+	// the same figure.
+	ServiceRate float64
+	IsSaturated bool
 	// ReplicaDemand is the replica's resident KV tokens — TokensInUse on the main
 	// path, kvCacheUsage * effectiveCapacity on the fallback path — plus the
 	// role-aware waiting-queue footprint: queueLength * avgInputTokens for

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -10,21 +10,23 @@ const learnedFromLive = "live"
 type k2Source int
 
 const (
-	k2SrcObserved     k2Source = iota + 1 // queue saturated: tokensInUse
-	k2SrcHistorical                       // rolling average from prior observations
-	k2SrcDerived                          // estimated from deployment args
-	k2SrcFallback                         // fallback to k1 (memory-bound)
-	k2SrcRateAnchored                     // rate-anchored: the bucket's learned token ceiling
-	k2SrcRateBacklog                      // rate-anchored: limit measured this cycle, nothing carried over
+	k2SrcObserved      k2Source = iota + 1 // queue saturated: tokensInUse
+	k2SrcHistorical                        // rolling average from prior observations
+	k2SrcDerived                           // estimated from deployment args
+	k2SrcFallback                          // fallback to k1 (memory-bound)
+	k2SrcRateAnchored                      // rate-anchored: carrying the bucket's learned token ceiling
+	k2SrcRateBacklog                       // rate-anchored: at its limit this cycle
+	k2SrcRateResidence                     // rate-anchored: ceiling scaled to this cycle's operating point
 )
 
 var k2Labels = map[k2Source]string{
-	k2SrcObserved:     "P1-obs",
-	k2SrcHistorical:   "P2-hist",
-	k2SrcDerived:      "P3-k2",
-	k2SrcFallback:     "P4-k1",
-	k2SrcRateAnchored: "RATE-learned",
-	k2SrcRateBacklog:  "RATE-now",
+	k2SrcObserved:      "P1-obs",
+	k2SrcHistorical:    "P2-hist",
+	k2SrcDerived:       "P3-k2",
+	k2SrcFallback:      "P4-k1",
+	k2SrcRateAnchored:  "RATE-learned",
+	k2SrcRateBacklog:   "RATE-now",
+	k2SrcRateResidence: "RATE-W",
 }
 
 const (

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -14,9 +14,8 @@ const (
 	k2SrcHistorical                       // rolling average from prior observations
 	k2SrcDerived                          // estimated from deployment args
 	k2SrcFallback                         // fallback to k1 (memory-bound)
-	k2SrcRateAnchored                     // rate-anchored: mu/lambda from the EPP arrival rate
-	k2SrcRateBacklog                      // rate-anchored: replica had a backlog, so it is saturated
-	k2SrcRateNoEPP                        // rate-anchored: mu/lambda with completions standing in for lambda
+	k2SrcRateAnchored                     // rate-anchored: the bucket's learned token ceiling
+	k2SrcRateBacklog                      // rate-anchored: limit measured this cycle, nothing carried over
 )
 
 var k2Labels = map[k2Source]string{
@@ -24,9 +23,8 @@ var k2Labels = map[k2Source]string{
 	k2SrcHistorical:   "P2-hist",
 	k2SrcDerived:      "P3-k2",
 	k2SrcFallback:     "P4-k1",
-	k2SrcRateAnchored: "RATE-λ",
-	k2SrcRateBacklog:  "RATE-q",
-	k2SrcRateNoEPP:    "RATE-c",
+	k2SrcRateAnchored: "RATE-learned",
+	k2SrcRateBacklog:  "RATE-now",
 }
 
 const (

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -68,6 +68,21 @@ type ReplicaCapacity struct {
 //	"short"  — avgOutput in [0, 100)
 //	"medium" — avgOutput in [100, 500)
 //	"long"   — avgOutput >= 500
+
+// classifyInputLength buckets a prompt length. Separate from classifyOutputLength
+// because the two distributions differ by an order of magnitude — see the threshold
+// constants.
+func classifyInputLength(avgInputTokens float64) string {
+	switch {
+	case avgInputTokens < ShortInputThreshold:
+		return "short"
+	case avgInputTokens < MediumInputThreshold:
+		return "medium"
+	default:
+		return "long"
+	}
+}
+
 func classifyOutputLength(avgOutputTokens float64) string {
 	switch {
 	case avgOutputTokens < ShortOutputThreshold:

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -10,17 +10,23 @@ const learnedFromLive = "live"
 type k2Source int
 
 const (
-	k2SrcObserved   k2Source = iota + 1 // queue saturated: tokensInUse
-	k2SrcHistorical                     // rolling average from prior observations
-	k2SrcDerived                        // estimated from deployment args
-	k2SrcFallback                       // fallback to k1 (memory-bound)
+	k2SrcObserved     k2Source = iota + 1 // queue saturated: tokensInUse
+	k2SrcHistorical                       // rolling average from prior observations
+	k2SrcDerived                          // estimated from deployment args
+	k2SrcFallback                         // fallback to k1 (memory-bound)
+	k2SrcRateAnchored                     // rate-anchored: mu/lambda from the EPP arrival rate
+	k2SrcRateBacklog                      // rate-anchored: replica had a backlog, so it is saturated
+	k2SrcRateNoEPP                        // rate-anchored: mu/lambda with completions standing in for lambda
 )
 
 var k2Labels = map[k2Source]string{
-	k2SrcObserved:   "P1-obs",
-	k2SrcHistorical: "P2-hist",
-	k2SrcDerived:    "P3-k2",
-	k2SrcFallback:   "P4-k1",
+	k2SrcObserved:     "P1-obs",
+	k2SrcHistorical:   "P2-hist",
+	k2SrcDerived:      "P3-k2",
+	k2SrcFallback:     "P4-k1",
+	k2SrcRateAnchored: "RATE-λ",
+	k2SrcRateBacklog:  "RATE-q",
+	k2SrcRateNoEPP:    "RATE-c",
 }
 
 const (

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -117,6 +117,7 @@ func scaleDownVariantSet(
 	onRemove func(vc domain.VariantCapacity, n int),
 ) {
 	logger := ctrl.LoggerFrom(ctx)
+	available, required, rateKnown := roleServiceRate(sortedVariants, targets)
 	for i, vc := range sortedVariants {
 		if vc.PerReplicaCapacity <= 0 {
 			continue
@@ -136,6 +137,26 @@ func scaleDownVariantSet(
 		if n > removable {
 			n = removable
 		}
+		// Rate floor: shedding must not take the role's aggregate service rate below
+		// what arrivals require. The token-space figures cannot answer this, because
+		// demand in resident tokens is measured at the current replica count and does
+		// not survive the removal being evaluated — residence rises, occupancy per
+		// replica rises with it, and past a point a queue appears from nothing.
+		// Arrivals do not move when replicas do, so the same question asked in rate
+		// space has an answer that holds. Only the aggregate is constrained; which
+		// variant gives up a replica is still the cost ordering's decision.
+		if rateKnown && vc.ServiceRatePerReplica > 0 {
+			affordable := int((available - required) / vc.ServiceRatePerReplica)
+			if affordable < 0 {
+				affordable = 0
+			}
+			if n > affordable {
+				logger.V(logging.DEBUG).Info("scale-down: held by service-rate floor",
+					"variant", vc.VariantName, "wanted", n, "allowed", affordable,
+					"availableRate", available, "requiredRate", required)
+				n = affordable
+			}
+		}
 		// cheapest-at-1: the last (cheapest) variant is protected at 1 only when no
 		// more-expensive variant still holds replicas (#1237's positional rule).
 		if i == len(sortedVariants)-1 && current-n < 1 && !anyHasReplicas(sortedVariants[:i], targets) {
@@ -145,10 +166,33 @@ func scaleDownVariantSet(
 			continue
 		}
 		targets[vc.VariantName] = current - n
+		available -= float64(n) * vc.ServiceRatePerReplica
 		onRemove(vc, n)
 		logger.V(logging.DEBUG).Info("scale-down: removed replicas",
 			"variant", vc.VariantName, "removed", n, "cost", vc.Cost)
 	}
+}
+
+// roleServiceRate sums what this role's variants can serve and what their arrivals
+// require, and reports whether the figures are complete enough to act on.
+//
+// Completeness matters: a variant holding replicas without a calibrated service rate
+// contributes nothing to the available side while its traffic still counts on the
+// required side, which would understate the role and hold replicas that are not
+// needed. Partial knowledge is treated as no knowledge.
+func roleServiceRate(variants []domain.VariantCapacity, targets map[string]int) (available, required float64, known bool) {
+	for _, vc := range variants {
+		n := targets[vc.VariantName]
+		if n <= 0 {
+			continue
+		}
+		if vc.ServiceRatePerReplica <= 0 {
+			return 0, 0, false
+		}
+		available += float64(n) * vc.ServiceRatePerReplica
+		required += vc.RequiredServiceRate
+	}
+	return available, required, required > 0
 }
 
 // sortVariantsForScaleDown orders a role's variants for cost-greedy scale-down:

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -104,6 +104,21 @@ func costGreedyRolePick(
 	return "", 0
 }
 
+// rateFloorPolicy says whether a scale-down must respect the service-rate floor.
+//
+// The routine optimizer honours it: shedding into a state arrivals cannot sustain is
+// the failure it exists to prevent. GPU rebalancing overrides it, because the whole
+// point of reclaiming a replica is that some other model needs the GPU more — a
+// variant refusing to give one up because its own traffic wants it is the argument
+// prioritisation exists to settle. The floor is a safety net for a decision nobody
+// asked for, not a veto over one that was.
+type rateFloorPolicy bool
+
+const (
+	honorRateFloor    rateFloorPolicy = true
+	overrideRateFloor rateFloorPolicy = false
+)
+
 // scaleDownVariantSet sheds replicas from sortedVariants (PRE-SORTED cost-desc,
 // cheapest last). minReplicas floor and cheapest-at-1 protection are enforced
 // here. maxRemovable returns how many replicas of vc the caller permits to remove;
@@ -113,11 +128,16 @@ func scaleDownVariantSet(
 	sortedVariants []domain.VariantCapacity,
 	targets map[string]int,
 	states map[string]domain.VariantReplicaState,
+	floorPolicy rateFloorPolicy,
 	maxRemovable func(vc domain.VariantCapacity) int,
 	onRemove func(vc domain.VariantCapacity, n int),
 ) {
 	logger := ctrl.LoggerFrom(ctx)
-	available, required, rateKnown := roleServiceRate(sortedVariants, targets)
+	var available, required float64
+	var rateKnown bool
+	if floorPolicy == honorRateFloor {
+		available, required, rateKnown = roleServiceRate(sortedVariants, targets)
+	}
 	for i, vc := range sortedVariants {
 		if vc.PerReplicaCapacity <= 0 {
 			continue
@@ -484,7 +504,7 @@ func scaleDownRoleIterated(
 			continue
 		}
 		sorted := sortVariantsForScaleDown(s, roleVCs)
-		scaleDownVariantSet(ctx, sorted, targets, states,
+		scaleDownVariantSet(ctx, sorted, targets, states, honorRateFloor,
 			func(vc domain.VariantCapacity) int {
 				return safeRemovalReplicasForRole(s, vc.VariantName, role)
 			},

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -129,6 +129,7 @@ func scaleDownVariantSet(
 	targets map[string]int,
 	states map[string]domain.VariantReplicaState,
 	floorPolicy rateFloorPolicy,
+	boundary float64,
 	maxRemovable func(vc domain.VariantCapacity) int,
 	onRemove func(vc domain.VariantCapacity, n int),
 ) {
@@ -136,7 +137,7 @@ func scaleDownVariantSet(
 	var available, required float64
 	var rateKnown bool
 	if floorPolicy == honorRateFloor {
-		available, required, rateKnown = roleServiceRate(sortedVariants, targets)
+		available, required, rateKnown = roleServiceRate(sortedVariants, targets, boundary)
 	}
 	for i, vc := range sortedVariants {
 		if vc.PerReplicaCapacity <= 0 {
@@ -200,7 +201,12 @@ func scaleDownVariantSet(
 // contributes nothing to the available side while its traffic still counts on the
 // required side, which would understate the role and hold replicas that are not
 // needed. Partial knowledge is treated as no knowledge.
-func roleServiceRate(variants []domain.VariantCapacity, targets map[string]int) (available, required float64, known bool) {
+func roleServiceRate(variants []domain.VariantCapacity, targets map[string]int,
+	boundary float64) (available, required float64, known bool) {
+	if boundary <= 0 {
+		return 0, 0, false
+	}
+	var arrivals float64
 	for _, vc := range variants {
 		n := targets[vc.VariantName]
 		if n <= 0 {
@@ -210,9 +216,22 @@ func roleServiceRate(variants []domain.VariantCapacity, targets map[string]int) 
 			return 0, 0, false
 		}
 		available += float64(n) * vc.ServiceRatePerReplica
-		required += vc.RequiredServiceRate
+		arrivals += vc.ArrivalRate
 	}
-	return available, required, required > 0
+	return available, arrivals / boundary, arrivals > 0
+}
+
+// scaleDownBoundaryOf returns the resolved scale-down boundary the engine used. It is
+// taken from the analyzer results rather than from configuration because a per-analyzer
+// override makes the global value the wrong one, and the resolved figure is what
+// produced the spare-capacity numbers this loop is acting on.
+func scaleDownBoundaryOf(s []NamedAnalyzerResult) float64 {
+	for _, nr := range s {
+		if nr.ScaleDownBoundary > 0 {
+			return nr.ScaleDownBoundary
+		}
+	}
+	return 0
 }
 
 // sortVariantsForScaleDown orders a role's variants for cost-greedy scale-down:
@@ -504,7 +523,7 @@ func scaleDownRoleIterated(
 			continue
 		}
 		sorted := sortVariantsForScaleDown(s, roleVCs)
-		scaleDownVariantSet(ctx, sorted, targets, states, honorRateFloor,
+		scaleDownVariantSet(ctx, sorted, targets, states, honorRateFloor, scaleDownBoundaryOf(s),
 			func(vc domain.VariantCapacity) int {
 				return safeRemovalReplicasForRole(s, vc.VariantName, role)
 			},

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -1108,3 +1108,82 @@ var _ = Describe("namespace constraint merge helpers", func() {
 		})
 	})
 })
+
+// The scale-down floor. Round 1 of the rate-anchored validation shed a variant from
+// two replicas to one while arrivals were unchanged and the pair was serving them
+// comfortably, and the token-space figures could not see it: demand in resident
+// tokens is measured at the current replica count and does not survive the removal
+// being evaluated.
+var _ = Describe("Service-rate floor on scale-down", func() {
+	variant := func(name string, mu, required float64) domain.VariantCapacity {
+		return domain.VariantCapacity{
+			VariantName:           name,
+			Role:                  domain.RoleBoth,
+			PerReplicaCapacity:    320_000,
+			ServiceRatePerReplica: mu,
+			RequiredServiceRate:   required,
+		}
+	}
+
+	shed := func(variants []domain.VariantCapacity, targets map[string]int, want int) map[string]int {
+		scaleDownVariantSet(context.Background(), variants, targets, nil,
+			func(vc domain.VariantCapacity) int { return want },
+			func(vc domain.VariantCapacity, n int) {})
+		return targets
+	}
+
+	It("refuses to shed below what arrivals require", func() {
+		// lambda = 24 req/s, boundary 0.60, mu = 19.5 => the role needs 40 req/s of
+		// service rate, which two replicas (39) barely miss and one (19.5) misses by
+		// half. The token model asked for one; this must hold at two.
+		targets := shed([]domain.VariantCapacity{variant("v1", 19.5, 24/0.6)},
+			map[string]int{"v1": 2}, 1)
+		Expect(targets["v1"]).To(Equal(2))
+	})
+
+	It("still sheds what the rates say is genuinely spare", func() {
+		// Four replicas against the same 40 req/s requirement: 78 available, 38 spare,
+		// and a replica is worth 19.5 — so exactly one can go. Two would leave 39,
+		// under the requirement, and the floor stops at one even though the caller
+		// asked for two.
+		targets := shed([]domain.VariantCapacity{variant("v1", 19.5, 24/0.6)},
+			map[string]int{"v1": 4}, 2)
+		Expect(targets["v1"]).To(Equal(3))
+	})
+
+	It("constrains the aggregate, not each variant, across a role", func() {
+		// Two variants on different hardware serving one stream. Shedding from the
+		// expensive one is fine while the cheap one still covers the requirement —
+		// the cost ordering decides which, the floor only decides how many.
+		fast := variant("fast", 30, 30/0.6)
+		fast.Cost = 100
+		slow := variant("slow", 10, 10/0.6)
+		slow.Cost = 10
+		targets := shed([]domain.VariantCapacity{fast, slow},
+			map[string]int{"fast": 2, "slow": 2}, 2)
+		// Available 80 against a requirement of 66.7 leaves 13.3 spare. A fast replica
+		// is worth 30 and cannot be given up; a slow one is worth 10 and can. So the
+		// expensive variant is held and the cheap one sheds — the floor inverting the
+		// cost preference, which is correct: you cannot remove capacity you need just
+		// because it is the capacity you would rather not pay for.
+		Expect(targets["fast"]).To(Equal(2))
+		Expect(targets["slow"]).To(Equal(1))
+	})
+
+	It("does nothing when any variant holding replicas has no measured rate", func() {
+		// Partial knowledge understates what the role can serve, which would hold
+		// replicas that are not needed. Treated as no knowledge.
+		known := variant("known", 19.5, 24/0.6)
+		unknown := variant("unknown", 0, 0)
+		targets := shed([]domain.VariantCapacity{known, unknown},
+			map[string]int{"known": 2, "unknown": 2}, 1)
+		Expect(targets["known"]).To(Equal(1))
+		Expect(targets["unknown"]).To(Equal(1))
+	})
+
+	It("does nothing when the estimator is off", func() {
+		targets := shed([]domain.VariantCapacity{variant("v1", 0, 0)},
+			map[string]int{"v1": 3}, 2)
+		Expect(targets["v1"]).To(Equal(1), "unchanged from the token-space decision")
+	})
+})

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -1126,7 +1126,7 @@ var _ = Describe("Service-rate floor on scale-down", func() {
 	}
 
 	shed := func(variants []domain.VariantCapacity, targets map[string]int, want int) map[string]int {
-		scaleDownVariantSet(context.Background(), variants, targets, nil,
+		scaleDownVariantSet(context.Background(), variants, targets, nil, honorRateFloor,
 			func(vc domain.VariantCapacity) int { return want },
 			func(vc domain.VariantCapacity, n int) {})
 		return targets
@@ -1179,6 +1179,18 @@ var _ = Describe("Service-rate floor on scale-down", func() {
 			map[string]int{"known": 2, "unknown": 2}, 1)
 		Expect(targets["known"]).To(Equal(1))
 		Expect(targets["unknown"]).To(Equal(1))
+	})
+
+	It("yields to GPU rebalancing, which is what prioritisation means", func() {
+		// Same state the first case holds at two replicas — but this caller is
+		// reclaiming GPUs for a model that needs them more, and the floor is a safety
+		// net for a decision nobody asked for, not a veto over one that was.
+		targets := map[string]int{"v1": 2}
+		scaleDownVariantSet(context.Background(),
+			[]domain.VariantCapacity{variant("v1", 19.5, 24/0.6)}, targets, nil, overrideRateFloor,
+			func(vc domain.VariantCapacity) int { return 1 },
+			func(vc domain.VariantCapacity, n int) {})
+		Expect(targets["v1"]).To(Equal(1))
 	})
 
 	It("does nothing when the estimator is off", func() {

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -1115,18 +1115,18 @@ var _ = Describe("namespace constraint merge helpers", func() {
 // tokens is measured at the current replica count and does not survive the removal
 // being evaluated.
 var _ = Describe("Service-rate floor on scale-down", func() {
-	variant := func(name string, mu, required float64) domain.VariantCapacity {
+	variant := func(name string, mu, lambda float64) domain.VariantCapacity {
 		return domain.VariantCapacity{
 			VariantName:           name,
 			Role:                  domain.RoleBoth,
 			PerReplicaCapacity:    320_000,
 			ServiceRatePerReplica: mu,
-			RequiredServiceRate:   required,
+			ArrivalRate:           lambda,
 		}
 	}
 
 	shed := func(variants []domain.VariantCapacity, targets map[string]int, want int) map[string]int {
-		scaleDownVariantSet(context.Background(), variants, targets, nil, honorRateFloor,
+		scaleDownVariantSet(context.Background(), variants, targets, nil, honorRateFloor, 0.6,
 			func(vc domain.VariantCapacity) int { return want },
 			func(vc domain.VariantCapacity, n int) {})
 		return targets
@@ -1136,7 +1136,7 @@ var _ = Describe("Service-rate floor on scale-down", func() {
 		// lambda = 24 req/s, boundary 0.60, mu = 19.5 => the role needs 40 req/s of
 		// service rate, which two replicas (39) barely miss and one (19.5) misses by
 		// half. The token model asked for one; this must hold at two.
-		targets := shed([]domain.VariantCapacity{variant("v1", 19.5, 24/0.6)},
+		targets := shed([]domain.VariantCapacity{variant("v1", 19.5, 24)},
 			map[string]int{"v1": 2}, 1)
 		Expect(targets["v1"]).To(Equal(2))
 	})
@@ -1146,7 +1146,7 @@ var _ = Describe("Service-rate floor on scale-down", func() {
 		// and a replica is worth 19.5 — so exactly one can go. Two would leave 39,
 		// under the requirement, and the floor stops at one even though the caller
 		// asked for two.
-		targets := shed([]domain.VariantCapacity{variant("v1", 19.5, 24/0.6)},
+		targets := shed([]domain.VariantCapacity{variant("v1", 19.5, 24)},
 			map[string]int{"v1": 4}, 2)
 		Expect(targets["v1"]).To(Equal(3))
 	})
@@ -1155,9 +1155,9 @@ var _ = Describe("Service-rate floor on scale-down", func() {
 		// Two variants on different hardware serving one stream. Shedding from the
 		// expensive one is fine while the cheap one still covers the requirement —
 		// the cost ordering decides which, the floor only decides how many.
-		fast := variant("fast", 30, 30/0.6)
+		fast := variant("fast", 30, 30)
 		fast.Cost = 100
-		slow := variant("slow", 10, 10/0.6)
+		slow := variant("slow", 10, 10)
 		slow.Cost = 10
 		targets := shed([]domain.VariantCapacity{fast, slow},
 			map[string]int{"fast": 2, "slow": 2}, 2)
@@ -1173,7 +1173,7 @@ var _ = Describe("Service-rate floor on scale-down", func() {
 	It("does nothing when any variant holding replicas has no measured rate", func() {
 		// Partial knowledge understates what the role can serve, which would hold
 		// replicas that are not needed. Treated as no knowledge.
-		known := variant("known", 19.5, 24/0.6)
+		known := variant("known", 19.5, 24)
 		unknown := variant("unknown", 0, 0)
 		targets := shed([]domain.VariantCapacity{known, unknown},
 			map[string]int{"known": 2, "unknown": 2}, 1)
@@ -1187,7 +1187,7 @@ var _ = Describe("Service-rate floor on scale-down", func() {
 		// net for a decision nobody asked for, not a veto over one that was.
 		targets := map[string]int{"v1": 2}
 		scaleDownVariantSet(context.Background(),
-			[]domain.VariantCapacity{variant("v1", 19.5, 24/0.6)}, targets, nil, overrideRateFloor,
+			[]domain.VariantCapacity{variant("v1", 19.5, 24)}, targets, nil, overrideRateFloor, 0.6,
 			func(vc domain.VariantCapacity) int { return 1 },
 			func(vc domain.VariantCapacity, n int) {})
 		Expect(targets["v1"]).To(Equal(1))

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -395,7 +395,9 @@ func reclaimRole(
 ) {
 	remaining := deltaGPUs
 	sorted := sortVariantsForScaleDown(s, variantsForRole(variants, role))
-	scaleDownVariantSet(ctx, sorted, targets, stateMap,
+	// Prioritisation wins here: this reclaim exists because another model needs the
+	// GPUs more, and the service-rate floor must not veto that.
+	scaleDownVariantSet(ctx, sorted, targets, stateMap, overrideRateFloor,
 		func(vc domain.VariantCapacity) int {
 			g := gpusPerReplicaFromState(stateMap, vc.VariantName)
 			if remaining <= 0 || g <= 0 {

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -397,7 +397,7 @@ func reclaimRole(
 	sorted := sortVariantsForScaleDown(s, variantsForRole(variants, role))
 	// Prioritisation wins here: this reclaim exists because another model needs the
 	// GPUs more, and the service-rate floor must not veto that.
-	scaleDownVariantSet(ctx, sorted, targets, stateMap, overrideRateFloor,
+	scaleDownVariantSet(ctx, sorted, targets, stateMap, overrideRateFloor, 0,
 		func(vc domain.VariantCapacity) int {
 			g := gpusPerReplicaFromState(stateMap, vc.VariantName)
 			if remaining <= 0 || g <= 0 {

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -287,6 +287,11 @@ func NewEngine(client client.Client, apiReader client.Reader, scheme *runtime.Sc
 	// when V1 is active — they're just query templates with no runtime cost.
 	registration.RegisterSaturationQueries(metricsRegistry)
 
+	// Per-pod completion rate and instantaneous KV utilization. Registered
+	// unconditionally: the rate-anchored capacity estimator needs them and must
+	// not depend on the throughput analyzer being enabled.
+	registration.RegisterRateCapacityQueries(metricsRegistry)
+
 	// Register scale-to-zero queries in the metrics registry
 	registration.RegisterScaleToZeroQueries(metricsRegistry)
 


### PR DESCRIPTION
Fixes #1500 

<!-- No issue filed yet; the "why" is below. -->

The V2 saturation analyzer models a replica's capacity as `min(k1, k2)` in KV tokens,
where `k2` — the compute bound — is recorded as `tokensInUse` at the moment the replica
was seen queueing, then averaged into a rolling history. That measures a **KV stock**
while the constraint it stands for is a **rate**, and on prefill-heavy traffic the two
are unrelated: the engine exhausts prompt-token throughput and starts queueing while KV
occupancy is still low.

In the sustained 1000/250 comparison run the WVA leg was queueing, dropping requests and
cycling replicas at **16.2% average KV utilization** — a regime the current model cannot
express, because at 16% occupancy `demand/supply` reads as abundant headroom. Three
consequences, all observed in that run:

1. `tokensInUse` comes from `max_over_time(kv_cache_usage[1m])`, a peak — whenever the
   peak exceeds `kvCacheThreshold` (0.80), `k2 >= k1` and `min(k1, k2)` returns the memory
   bound, so the compute signal never binds at all.
2. Supply is over-stated exactly when load is highest, so utilization reads low and
   `spareCapacity` grows.
3. Demand deflates faster than supply: the queue term dominates demand at peak and
   collapses the moment new replicas absorb the backlog, while `k2` stays inflated via the
   historical average. The controller sheds to one replica and the cycle repeats.

Threshold tuning does not reach this — six threshold/window/policy legs were run against
that workload and none of them broke the cycling.

This PR adds a second, rate-anchored estimator behind a build-time constant that is
**false**, so nothing changes for any user until the validation in
`docs/plans/engine/rate-anchored-k2.md` is done. The design separates two questions the
occupancy estimator conflates: **rates decide when a replica is at its limit, tokens
record what that limit is.**

## Proposed Changes

- :gift: `internal/engines/analyzers/saturation_v2/rate_capacity.go` — rate-anchored `k2`.
  A replica is at its limit when it has a backlog at least `QueueLengthThreshold` deep, or
  when its arrival rate has reached the service rate measured while it *was* backlogged; at
  that moment its resident token count is a measurement of the limit. The measurement is
  stored **per workload bucket** (model, accelerator, role, GPU count, request shape) as a
  running minimum, and every replica of the bucket reads the same value. Two properties this
  buys, both learned from earlier iterations of this code: the value is identical across
  siblings, so `aggregateByVariant`'s MEDIAN is a no-op rather than a way for an idle
  replica to lift variant capacity and turn a scale-up into a scale-down; and it does not
  move with this cycle's load, so it cannot oscillate — the stored ceiling changes only as a
  new measurement lowers the running minimum or age relaxes it upward, both slow by
  construction.
- :gift: Selected by `EnableRateAnchoredK2`, a build-time constant — deliberately not a
  ConfigMap setting, since this is under evaluation against the incumbent and is not
  something to toggle in a running cluster. With it false the stores are never allocated and
  every path in the new file returns immediately; the existing estimator is untouched.
- :gift: Two new `k2Source` values (`RATE-now`, `RATE-learned`) so the offline replay can
  tell a limit measured this cycle from one carried over.
- :broom: `internal/collector/registration/rate_capacity.go` — single definition of
  `QueryRequestRate` and `QueryKvUsageInstant` (vLLM + SGLang), registered unconditionally
  by the saturation engine. Both were previously registered only when the throughput
  analyzer was enabled; this estimator must not depend on that analyzer. Both registrars now
  use register-if-absent helpers, so either order works and neither panics on the shared
  queries. **No new PromQL** — every metric this needs is already collected.
- :broom: λ is smoothed per replica over a residence time
  (`AvgTTFT + AvgOutputTokens × AvgITL`, both already collected), because a completion
  happens one residence time after the arrival that caused it — comparing an instantaneous λ
  against a completion-derived μ would read as saturation on a replica that is coping during
  a ramp. The weight comes from the actual sample gap, so an irregular optimize interval
  does not distort it; without latency data the rate passes through unsmoothed rather than
  being averaged by a made-up constant.
- :broom: Both new stores prune themselves on insert past `BucketPruneThreshold`, since
  nothing in the engine drives eviction for the analyzer's existing stores either.
- :gift: `docs/plans/engine/rate-anchored-k2.md` — problem, design, the damping argument,
  where the two estimators actually differ (entirely in the post-drain state), guards, known
  limitations, and the validation gate that must pass before the constant is flipped.

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A while the constant is false: there is no
  reachable behavior change to assert. Unit and envtest coverage is in
  `rate_capacity_test.go` (store rate/ceiling semantics, arrival smoothing, residence time,
  role isolation, an oscillation-stability band, bounded growth) and
  `rate_capacity_integration_test.go` (what the store learns, flag-off equivalence with the
  current path, the post-drain divergence, and equal capacity for a backlogged replica and
  an idle sibling). The e2e gate belongs on the PR that flips the constant, alongside the
  cluster legs in the plan.
- [ ] **Docs PR** for any user-facing impact — N/A. A build-time constant, off; no API,
  ConfigMap field, metric or default changes.
- [ ] **Proposal PR** for any new enhancement or change to existing behavior — the design
  is in `docs/plans/engine/rate-anchored-k2.md` in this PR, and no existing behavior changes
  while the constant is false. Happy to split it into a proposal PR if maintainers would
  rather review the design separately from the code.

**Release Note**

```release-note
```

**Docs**

N/A — no user-visible impact in this PR.
