### PR TITLE
fix(throughput,saturation): correctness guards for ThroughputAnalyzer and the liveness engine

### DIFF
--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -251,7 +251,13 @@ same live-only filter.
 **Liveness.** An analyzer is live for the current cycle iff it produced a
 non-error, capacity-bearing result within the staleness window (a fixed
 multiple of the optimization interval, `analyzerLivenessStaleCycles` in
-`internal/engines/saturation/engine_v2.go`). A non-live analyzer — one that
+`internal/engines/saturation/engine_v2.go`). The resolved interval falls back
+to a 30s default whenever `Config` is absent **or** reports a non-positive
+value, so a misconfigured interval can never zero the staleness window and
+latch every analyzer non-live. An informative result with a zero-valued
+`AnalyzedAt` is treated as current (recorded as "now") rather than
+instantly-stale, so a forgotten timestamp on a future analyzer cannot
+silently disarm the veto. A non-live analyzer — one that
 has never produced a usable result, is currently erroring, or whose last
 usable result has aged past the staleness window — is excluded from the
 scale-down vote entirely: it neither vetoes nor constrains the safe-removal

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -199,6 +199,13 @@ namespaced, and model-scoped — correctly isolating traffic to a specific varia
 per-replica λ_dec in the analyzer rather than using a model-level query, which avoids the
 namespace filtering limitation of the scheduler metric.
 
+**Note on metric freshness:** the collector derives each replica's
+`ReplicaMetricsMetadata.Age`/`FreshnessStatus` from the same scrape timestamps used for the
+aggregate `wva_metrics_freshness_status` gauge — the least-fresh status across a pod's tracked
+metrics, and the age of the oldest one. `CheckModelMetrics` (`sanity.go`) flags a replica as
+`SanityIssueStaleMetrics` when `FreshnessStatus == "stale"`. This is currently detection only:
+the stale-metrics sanity issue is reported but not currently used to gate a scaling decision.
+
 ---
 
 ### Query Design Decisions
@@ -399,8 +406,10 @@ utilization k. It is calibrated independently per variant (different hardware �
 
 When `ObservationWindow.Ready()` is true (≥ 10 samples spanning ≥ 30% of the k range),
 `FitITLModel` fits A and B by ordinary least squares, minimizing `Σ(ITL_i − A·k_i − B)²`.
-The fit is accepted only when A > 0 (physically required: more concurrent requests → higher
-latency). On success, the fitted model is used for both supply and demand estimation this cycle.
+The fit is accepted only when the resulting `(A, B)` passes `validITLModel` — finite, a
+meaningfully positive slope, and positive ITL at saturation (physically required: more
+concurrent requests → higher latency). On success, the fitted model is used for both supply
+and demand estimation this cycle.
 
 ### Tier 2 — Constrained OLS
 
@@ -412,8 +421,9 @@ A = Σ((ITL_i − B) · k_i) / Σ(k_i²)
 
 This is least-squares with B fixed, applied to all replicas with k* > 0. For a single replica
 it reduces to the single-point formula `A = (ITL − B) / k*`. For multiple replicas it is
-strictly better — same OLS criterion as tier-1 but with one fewer degree of freedom.
-Accepted only when A > 0.
+strictly better — same OLS criterion as tier-1 but with one fewer degree of freedom. The
+resulting `(A, B)` is accepted through the same `validITLModel` predicate as Tier 1, so Tier 2
+cannot accept a model Tier 1 would reject.
 
 **B selection:** B is taken from `variantState.lastFittedB` when a prior successful Tier-1 fit
 exists for this variant. B reflects hardware/model characteristics (not workload shape), so it
@@ -504,7 +514,10 @@ result now only populates `VariantCapacity.TotalDemand` / `Utilization` (surface
 `λ_dec = Σ RequestRate_r × AvgOutputTokens_r`. Counts only served (completed) requests.
 
 **3. k\*-based local** (scale-up only) — when both above yield zero:
-`λ_local = Σ_r k_r* × KV_max_r / KVreq / ITL(k_r*)`.
+`λ_local = Σ_r k_r* × KV_max_r / KVreq / ITL(k_r*)`. A replica is skipped from the sum (rather
+than counted as zero) when its `KvUsageInstant` or the model's `ITLAt(KvUsageInstant)` is
+missing, non-positive, or NaN, or when `KvUsageInstant` is out of the valid `[0, 1]` range — so a
+single bad metric cannot poison the total.
 
 **Deferred:** with demand model-level, `AnalyzerInput.ArrivalRate` is the sole driver of
 `TotalDemand`'s arrival component. When EPP is absent model-wide, `ArrivalRate` is legitimately

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -201,10 +201,13 @@ namespace filtering limitation of the scheduler metric.
 
 **Note on metric freshness:** the collector derives each replica's
 `ReplicaMetricsMetadata.Age`/`FreshnessStatus` from the same scrape timestamps used for the
-aggregate `wva_metrics_freshness_status` gauge — the least-fresh status across a pod's tracked
-metrics, and the age of the oldest one. `CheckModelMetrics` (`sanity.go`) flags a replica as
-`SanityIssueStaleMetrics` when `FreshnessStatus == "stale"`. This is currently detection only:
-the stale-metrics sanity issue is reported but not currently used to gate a scaling decision.
+aggregate `wva_metrics_freshness_status` gauge — the least-fresh status across a pod's *present*
+metrics, and the age of the oldest one. Metrics that are absent by design (e.g. the EPP arrival
+rate when no EPP is deployed, or the prefix-cache metrics when prefix caching is off) leave a zero
+timestamp and are skipped rather than reported as `missing`, so a healthy replica is not
+mislabelled and a genuinely stale metric is not masked. `CheckModelMetrics` (`sanity.go`) flags a
+replica as `SanityIssueStaleMetrics` when `FreshnessStatus == "stale"`. This is currently detection
+only: the stale-metrics sanity issue is reported but not currently used to gate a scaling decision.
 
 ---
 

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -423,6 +423,19 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		requestRate         float64
 	}
 
+	// classifyTimestamp reports the freshness status of a single metric timestamp,
+	// along with its age when non-zero. A zero timestamp means the metric was never
+	// scraped for this pod and is classified "missing". Shared by trackMetricFreshness
+	// (aggregate gauge) and worstFreshnessStatus (per-replica metadata) so the two
+	// cannot drift apart.
+	classifyTimestamp := func(timestamp, collectedAt time.Time, thresholds config.FreshnessThresholds) (status string, age time.Duration, hasTimestamp bool) {
+		if timestamp.IsZero() {
+			return "missing", 0, false
+		}
+		age = collectedAt.Sub(timestamp)
+		return thresholds.DetermineStatus(age), age, true
+	}
+
 	// trackMetricFreshness determines the freshness status of metrics in podMetricData
 	// and increments the corresponding counters in the freshness status map.
 	trackMetricFreshness := func(
@@ -440,13 +453,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 
 		// Helper to track a single timestamp
 		trackTimestamp := func(timestamp time.Time) {
-			var status string
-			if timestamp.IsZero() {
-				status = "missing"
-			} else {
-				age := collectedAt.Sub(timestamp)
-				status = thresholds.DetermineStatus(age)
-			}
+			status, _, _ := classifyTimestamp(timestamp, collectedAt, thresholds)
 			freshnessMap[vaName][status]++
 		}
 
@@ -460,6 +467,43 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		trackTimestamp(data.arrivalRateTimestamp)
 		trackTimestamp(data.avgTTFTTimestamp)
 		trackTimestamp(data.avgITLTimestamp)
+	}
+
+	// freshnessSeverity orders freshness statuses from best to worst so
+	// worstFreshnessStatus can pick the single worst status across a pod's
+	// tracked timestamps.
+	freshnessSeverity := map[string]int{"fresh": 0, "stale": 1, "unavailable": 2, "missing": 3}
+
+	// worstFreshnessStatus returns the least-fresh status across data's tracked
+	// timestamps (the same set trackMetricFreshness uses) and the age of the oldest
+	// non-zero one, for the per-replica ReplicaMetricsMetadata. If any tracked metric
+	// is stale, unavailable, or missing, the replica as a whole is reported as such.
+	worstFreshnessStatus := func(data *podMetricData, collectedAt time.Time) (string, time.Duration) {
+		thresholds := config.DefaultFreshnessThresholds()
+		timestamps := []time.Time{
+			data.kvTimestamp,
+			data.queueTimestamp,
+			data.avgOutputTokensTimestamp,
+			data.avgInputTokensTimestamp,
+			data.prefixCacheHitRateTimestamp,
+			data.cacheConfigTimestamp,
+			data.arrivalRateTimestamp,
+			data.avgTTFTTimestamp,
+			data.avgITLTimestamp,
+		}
+
+		worst := "fresh"
+		var oldestAge time.Duration
+		for _, ts := range timestamps {
+			status, age, hasTimestamp := classifyTimestamp(ts, collectedAt, thresholds)
+			if hasTimestamp && age > oldestAge {
+				oldestAge = age
+			}
+			if freshnessSeverity[status] > freshnessSeverity[worst] {
+				worst = status
+			}
+		}
+		return worst, oldestAge
 	}
 
 	// Extract per-pod metrics from results
@@ -976,6 +1020,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 
 		// Track freshness for metrics in this pod
 		trackMetricFreshness(vaName, data, collectedAt, vaMetricsFreshnessStatus)
+		freshnessStatus, freshnessAge := worstFreshnessStatus(data, collectedAt)
 		metric := domain.ReplicaMetrics{
 			PodName:               podName,
 			ModelID:               modelID,
@@ -1001,8 +1046,8 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			RequestRate:           data.requestRate,
 			Metadata: &domain.ReplicaMetricsMetadata{
 				CollectedAt:     collectedAt,
-				Age:             0, // Fresh
-				FreshnessStatus: "fresh",
+				Age:             freshnessAge,
+				FreshnessStatus: freshnessStatus,
 			},
 		}
 

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -474,10 +474,19 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	// tracked timestamps.
 	freshnessSeverity := map[string]int{"fresh": 0, "stale": 1, "unavailable": 2, "missing": 3}
 
-	// worstFreshnessStatus returns the least-fresh status across data's tracked
+	// worstFreshnessStatus returns the least-fresh status across data's *present*
 	// timestamps (the same set trackMetricFreshness uses) and the age of the oldest
-	// non-zero one, for the per-replica ReplicaMetricsMetadata. If any tracked metric
-	// is stale, unavailable, or missing, the replica as a whole is reported as such.
+	// one, for the per-replica ReplicaMetricsMetadata.
+	//
+	// Absent ("missing") timestamps are skipped rather than allowed to dominate the
+	// rollup: several tracked metrics are legitimately unscraped in common
+	// deployments — arrivalRateTimestamp when no EPP is present, and the
+	// prefix-cache / cache-config timestamps when prefix caching is off. Counting
+	// those as "missing" (the worst severity) would report a healthy replica as
+	// "missing" with a near-zero Age, and — because "missing" outranks "stale" —
+	// would mask a genuinely stale driving metric from the CheckModelMetrics
+	// stale-metrics gate, which keys on FreshnessStatus == "stale". A replica with
+	// no present timestamps at all is still reported "missing".
 	worstFreshnessStatus := func(data *podMetricData, collectedAt time.Time) (string, time.Duration) {
 		thresholds := config.DefaultFreshnessThresholds()
 		timestamps := []time.Time{
@@ -494,14 +503,22 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 
 		worst := "fresh"
 		var oldestAge time.Duration
+		anyPresent := false
 		for _, ts := range timestamps {
 			status, age, hasTimestamp := classifyTimestamp(ts, collectedAt, thresholds)
-			if hasTimestamp && age > oldestAge {
+			if !hasTimestamp {
+				continue // absent-by-design metric must not dominate the rollup
+			}
+			anyPresent = true
+			if age > oldestAge {
 				oldestAge = age
 			}
 			if freshnessSeverity[status] > freshnessSeverity[worst] {
 				worst = status
 			}
+		}
+		if !anyPresent {
+			return "missing", 0
 		}
 		return worst, oldestAge
 	}

--- a/internal/collector/replica_metrics_test.go
+++ b/internal/collector/replica_metrics_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
@@ -745,7 +746,11 @@ func TestCollectReplicaMetrics_Freshness(t *testing.T) {
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	fixture := func(ts time.Time) *mockMetricsSource {
+	// fixture returns a source that reports all nine tracked metrics at timestamp
+	// ts. Any query names passed in omit are dropped from the result set, leaving
+	// their per-replica timestamps zero — used to model metrics that are absent by
+	// design (e.g. scheduler_dispatch_rate when no EPP is deployed).
+	fixture := func(ts time.Time, omit ...string) *mockMetricsSource {
 		// scheduler_dispatch_rate keys its instance by pod_name(or pod)+port (a
 		// dedicated "port" label, not the "instance" label's embedded port used by
 		// buildInstanceKey) — include "port" so it resolves to the same instance
@@ -767,7 +772,7 @@ func TestCollectReplicaMetrics_Freshness(t *testing.T) {
 		}
 		return &mockMetricsSource{
 			refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
-				return map[string]*source.MetricResult{
+				results := map[string]*source.MetricResult{
 					"kv_cache_usage":          {Values: []source.MetricValue{{Labels: podLabels, Value: 0.55, Timestamp: ts}}},
 					"queue_length":            {Values: []source.MetricValue{{Labels: podLabels, Value: 2, Timestamp: ts}}},
 					"avg_output_tokens":       {Values: []source.MetricValue{{Labels: podLabels, Value: 100, Timestamp: ts}}},
@@ -777,14 +782,18 @@ func TestCollectReplicaMetrics_Freshness(t *testing.T) {
 					"scheduler_dispatch_rate": {Values: []source.MetricValue{{Labels: podLabels, Value: 5.0, Timestamp: ts}}},
 					"avg_ttft":                {Values: []source.MetricValue{{Labels: podLabels, Value: 0.2, Timestamp: ts}}},
 					"avg_itl":                 {Values: []source.MetricValue{{Labels: podLabels, Value: 0.04, Timestamp: ts}}},
-				}, nil
+				}
+				for _, k := range omit {
+					delete(results, k)
+				}
+				return results, nil
 			},
 		}
 	}
 
-	t.Run("stale", func(t *testing.T) {
-		staleTs := time.Now().Add(-3 * time.Minute) // within [StaleThreshold, UnavailableThreshold)
-		collector := NewReplicaMetricsCollector(fixture(staleTs), k8sClient, nil, nil)
+	collect := func(src *mockMetricsSource) []domain.ReplicaMetrics {
+		t.Helper()
+		collector := NewReplicaMetricsCollector(src, k8sClient, nil, nil)
 		results, err := collector.CollectReplicaMetrics(
 			context.Background(), "test-model", "test-ns",
 			make(map[string]scaletarget.ScaleTargetAccessor),
@@ -797,8 +806,18 @@ func TestCollectReplicaMetrics_Freshness(t *testing.T) {
 		if len(results) != 1 {
 			t.Fatalf("expected exactly 1 ReplicaMetrics entry, got %d", len(results))
 		}
-		m := results[0]
-		if m.Metadata == nil || m.Metadata.FreshnessStatus != "stale" {
+		return results
+	}
+
+	const (
+		statusFresh = "fresh"
+		statusStale = "stale"
+	)
+
+	t.Run("stale", func(t *testing.T) {
+		staleTs := time.Now().Add(-3 * time.Minute) // within [StaleThreshold, UnavailableThreshold)
+		m := collect(fixture(staleTs))[0]
+		if m.Metadata == nil || m.Metadata.FreshnessStatus != statusStale {
 			t.Fatalf("expected FreshnessStatus=stale, got %+v", m.Metadata)
 		}
 		if m.Metadata.Age <= 0 {
@@ -807,23 +826,31 @@ func TestCollectReplicaMetrics_Freshness(t *testing.T) {
 	})
 
 	t.Run("fresh", func(t *testing.T) {
-		freshTs := time.Now()
-		collector := NewReplicaMetricsCollector(fixture(freshTs), k8sClient, nil, nil)
-		results, err := collector.CollectReplicaMetrics(
-			context.Background(), "test-model", "test-ns",
-			make(map[string]scaletarget.ScaleTargetAccessor),
-			make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
-			nil, make(map[string]float64),
-		)
-		if err != nil {
-			t.Fatalf("CollectReplicaMetrics: %v", err)
-		}
-		if len(results) != 1 {
-			t.Fatalf("expected exactly 1 ReplicaMetrics entry, got %d", len(results))
-		}
-		m := results[0]
-		if m.Metadata == nil || m.Metadata.FreshnessStatus != "fresh" {
+		m := collect(fixture(time.Now()))[0]
+		if m.Metadata == nil || m.Metadata.FreshnessStatus != statusFresh {
 			t.Fatalf("expected FreshnessStatus=fresh, got %+v", m.Metadata)
+		}
+	})
+
+	// A metric that is absent by design (here scheduler_dispatch_rate, unscraped
+	// when no EPP is deployed) leaves its timestamp zero. That must not make the
+	// replica "missing": the worst status is taken over present timestamps only.
+	t.Run("fresh when an absent-by-design metric leaves a zero timestamp", func(t *testing.T) {
+		m := collect(fixture(time.Now(), "scheduler_dispatch_rate"))[0]
+		if m.Metadata == nil || m.Metadata.FreshnessStatus != statusFresh {
+			t.Fatalf("expected FreshnessStatus=fresh with an absent metric, got %+v", m.Metadata)
+		}
+	})
+
+	// Because "missing" outranks "stale" in the severity order, an absent metric
+	// must not mask a genuinely stale driving metric — otherwise the rollup would
+	// report "missing" and the CheckModelMetrics stale-metrics gate (which keys on
+	// == "stale") would never fire.
+	t.Run("stale driving metric is not masked by an absent-by-design metric", func(t *testing.T) {
+		staleTs := time.Now().Add(-3 * time.Minute)
+		m := collect(fixture(staleTs, "scheduler_dispatch_rate"))[0]
+		if m.Metadata == nil || m.Metadata.FreshnessStatus != statusStale {
+			t.Fatalf("expected FreshnessStatus=stale despite an absent metric, got %+v", m.Metadata)
 		}
 	})
 }

--- a/internal/collector/replica_metrics_test.go
+++ b/internal/collector/replica_metrics_test.go
@@ -728,6 +728,106 @@ func TestCollectReplicaMetrics_ArrivalRatePerPodRetained(t *testing.T) {
 	}
 }
 
+// TestCollectReplicaMetrics_Freshness verifies that the per-replica
+// ReplicaMetricsMetadata.FreshnessStatus and Age are derived from the actual
+// metric scrape timestamps rather than hardcoded to "fresh"/0: a pod whose
+// driving metrics are old enough to cross the stale threshold is reported
+// "stale" with a non-zero Age; a pod with fresh timestamps is reported "fresh".
+func TestCollectReplicaMetrics_Freshness(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	fixture := func(ts time.Time) *mockMetricsSource {
+		// scheduler_dispatch_rate keys its instance by pod_name(or pod)+port (a
+		// dedicated "port" label, not the "instance" label's embedded port used by
+		// buildInstanceKey) — include "port" so it resolves to the same instance
+		// key ("pod-abc:8000") as every other query below.
+		podLabels := map[string]string{
+			"pod":                               "pod-abc",
+			"instance":                          "10.0.0.1:8000",
+			"port":                              "8000",
+			constants.VariantLabelPrometheusKey: "va-1",
+		}
+		// cache_config_info populates cacheConfigTimestamp only when both label
+		// values parse to positive integers (see the collector's cache-config block).
+		cacheConfigLabels := map[string]string{
+			"pod":                               "pod-abc",
+			"instance":                          "10.0.0.1:8000",
+			constants.VariantLabelPrometheusKey: "va-1",
+			"num_gpu_blocks":                    "1000",
+			"block_size":                        "16",
+		}
+		return &mockMetricsSource{
+			refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+				return map[string]*source.MetricResult{
+					"kv_cache_usage":          {Values: []source.MetricValue{{Labels: podLabels, Value: 0.55, Timestamp: ts}}},
+					"queue_length":            {Values: []source.MetricValue{{Labels: podLabels, Value: 2, Timestamp: ts}}},
+					"avg_output_tokens":       {Values: []source.MetricValue{{Labels: podLabels, Value: 100, Timestamp: ts}}},
+					"avg_input_tokens":        {Values: []source.MetricValue{{Labels: podLabels, Value: 50, Timestamp: ts}}},
+					"prefix_cache_hit_rate":   {Values: []source.MetricValue{{Labels: podLabels, Value: 0.1, Timestamp: ts}}},
+					"cache_config_info":       {Values: []source.MetricValue{{Labels: cacheConfigLabels, Value: 1, Timestamp: ts}}},
+					"scheduler_dispatch_rate": {Values: []source.MetricValue{{Labels: podLabels, Value: 5.0, Timestamp: ts}}},
+					"avg_ttft":                {Values: []source.MetricValue{{Labels: podLabels, Value: 0.2, Timestamp: ts}}},
+					"avg_itl":                 {Values: []source.MetricValue{{Labels: podLabels, Value: 0.04, Timestamp: ts}}},
+				}, nil
+			},
+		}
+	}
+
+	t.Run("stale", func(t *testing.T) {
+		staleTs := time.Now().Add(-3 * time.Minute) // within [StaleThreshold, UnavailableThreshold)
+		collector := NewReplicaMetricsCollector(fixture(staleTs), k8sClient, nil, nil)
+		results, err := collector.CollectReplicaMetrics(
+			context.Background(), "test-model", "test-ns",
+			make(map[string]scaletarget.ScaleTargetAccessor),
+			make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+			nil, make(map[string]float64),
+		)
+		if err != nil {
+			t.Fatalf("CollectReplicaMetrics: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected exactly 1 ReplicaMetrics entry, got %d", len(results))
+		}
+		m := results[0]
+		if m.Metadata == nil || m.Metadata.FreshnessStatus != "stale" {
+			t.Fatalf("expected FreshnessStatus=stale, got %+v", m.Metadata)
+		}
+		if m.Metadata.Age <= 0 {
+			t.Errorf("expected non-zero Age for stale metrics, got %v", m.Metadata.Age)
+		}
+	})
+
+	t.Run("fresh", func(t *testing.T) {
+		freshTs := time.Now()
+		collector := NewReplicaMetricsCollector(fixture(freshTs), k8sClient, nil, nil)
+		results, err := collector.CollectReplicaMetrics(
+			context.Background(), "test-model", "test-ns",
+			make(map[string]scaletarget.ScaleTargetAccessor),
+			make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+			nil, make(map[string]float64),
+		)
+		if err != nil {
+			t.Fatalf("CollectReplicaMetrics: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected exactly 1 ReplicaMetrics entry, got %d", len(results))
+		}
+		m := results[0]
+		if m.Metadata == nil || m.Metadata.FreshnessStatus != "fresh" {
+			t.Fatalf("expected FreshnessStatus=fresh, got %+v", m.Metadata)
+		}
+	})
+}
+
 // TestCollectReplicaMetrics_SGLangCacheConfig verifies the SGLang cache-config
 // pass: SGLang exposes total KV-cache token capacity directly via
 // sglang:max_total_num_tokens (queried as sglang/cache_config_info), and the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -750,6 +750,17 @@ func (c *Config) setPrometheusBaseURLForTesting(baseURL string) {
 	c.prometheus.baseURL = baseURL
 }
 
+// SetOptimizationIntervalForTest overrides the optimization interval on a test
+// Config, including to a non-positive value — Load() always sanitizes it to at
+// least MinOptimizationInterval, so this is the only way to exercise a caller's
+// handling of a Config that (however it got there) reports a non-positive
+// interval. Not for production use.
+func SetOptimizationIntervalForTest(c *Config, interval time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.infrastructure.optimizationInterval = interval
+}
+
 // --- Bootstrap State Management ---
 
 // ConfigMapsBootstrapComplete returns true once the initial ConfigMap bootstrap has completed.

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -638,11 +638,16 @@ func computeLocalDemand(metrics []domain.ReplicaMetrics, shape WorkloadShape, mo
 	}
 	var total float64
 	for _, m := range metrics {
-		if m.KvUsageInstant <= 0 || m.TotalKvCapacityTokens <= 0 {
+		if math.IsNaN(m.KvUsageInstant) || m.KvUsageInstant <= 0 || m.TotalKvCapacityTokens <= 0 {
+			continue
+		}
+		// KvUsageInstant is a KV-utilization fraction; values > 1 indicate a bad/over-committed
+		// metric. Skip rather than clamp — a single over-range replica shouldn't inflate demand.
+		if m.KvUsageInstant > 1 {
 			continue
 		}
 		itlAtK := model.ITLAt(m.KvUsageInstant)
-		if itlAtK <= 0 {
+		if math.IsNaN(itlAtK) || itlAtK <= 0 {
 			continue
 		}
 		total += m.KvUsageInstant * float64(m.TotalKvCapacityTokens) / shape.KVreq / itlAtK

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -567,7 +567,7 @@ func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variant
 	}
 	if n > 0 && sumK2 > 0 {
 		A := numerator / sumK2
-		if A > 0 {
+		if validITLModel(A, baselineB) {
 			ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("throughput analyzer: tier-2 constrained OLS fit",
 				"namespace", namespace, "modelID", modelID, "variant", variantName,
 				"A", A, "B", baselineB, "replicas", int(n),

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -3,6 +3,7 @@ package throughput
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -2031,5 +2032,44 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// Shape is derived from the healthy pod.
 			Expect(state.Shape.KVreq).To(BeNumerically(">", 0))
 		})
+	})
+})
+
+var _ = Describe("computeLocalDemand", func() {
+	shape := WorkloadShape{
+		AvgOutputTokens: 50, // above DefaultMinDecodeOLForLocalDemand
+		KVreq:           1024,
+	}
+	model := ITLModel{A: 0.073, B: 0.006}
+
+	replicaAt := func(k float64) domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{
+			KvUsageInstant:        k,
+			TotalKvCapacityTokens: 65536,
+		}
+	}
+
+	It("skips a replica with NaN KvUsageInstant but still counts the others", func() {
+		healthy := replicaAt(0.5)
+		nanReplica := replicaAt(math.NaN())
+
+		total := computeLocalDemand([]domain.ReplicaMetrics{healthy}, shape, model)
+		Expect(total).To(BeNumerically(">", 0))
+
+		withNaN := computeLocalDemand([]domain.ReplicaMetrics{healthy, nanReplica}, shape, model)
+		Expect(withNaN).To(BeNumerically("~", total, 1e-9))
+		Expect(math.IsNaN(withNaN)).To(BeFalse())
+	})
+
+	It("skips a replica with KvUsageInstant > 1", func() {
+		overRange := replicaAt(1.5)
+		total := computeLocalDemand([]domain.ReplicaMetrics{overRange}, shape, model)
+		Expect(total).To(Equal(0.0))
+	})
+
+	It("skips a replica whose model produces a NaN ITL", func() {
+		nanModel := ITLModel{A: math.NaN(), B: 0.006}
+		total := computeLocalDemand([]domain.ReplicaMetrics{replicaAt(0.5)}, shape, nanModel)
+		Expect(total).To(Equal(0.0))
 	})
 })

--- a/internal/engines/analyzers/throughput/itl_model.go
+++ b/internal/engines/analyzers/throughput/itl_model.go
@@ -26,13 +26,43 @@ func (m ITLModel) ITLAt(k float64) float64 {
 	return m.A*k + m.B
 }
 
+// validITLModel reports whether an (A, B) pair is a usable ITL model: finite,
+// meaningfully-positive slope, finite intercept, and positive ITL at saturation.
+// Shared by the Tier-1 OLS fit (FitITLModel) and the Tier-2 constrained fit
+// (resolveITLModel) so the two validation paths cannot drift apart.
+func validITLModel(a, b float64) bool {
+	// Defensive guard: NaN/+Inf a both slip past the a <= 0 check below, and a non-zero
+	// sumK can leave b finite so the b guard would not catch them. Symmetric with the b guard.
+	if math.IsNaN(a) || math.IsInf(a, 0) {
+		return false
+	}
+	// Reject flat/inverted fits. A perfectly flat line (constant ITL) is
+	// mathematically a == 0, but OLS rounding leaves tiny noise whose sign is
+	// platform-dependent (e.g. +2.6e-17 on arm64, ≤0 on amd64). Compare against a
+	// small epsilon so any slope that isn't meaningfully positive counts as flat.
+	// Real slopes in this domain are order 1e-2; noise is order 1e-17.
+	if a <= itlSlopeEpsilon {
+		return false
+	}
+	// Defensive guard: NaN/Inf b is mathematically possible with degenerate input.
+	if math.IsNaN(b) || math.IsInf(b, 0) {
+		return false
+	}
+	// Guard: ensure ITL at saturation is positive. A noisy fit can yield negative
+	// b (valid a>0), making ITLAt(DefaultKSat) near-zero and inflating supply.
+	if a*DefaultKSat+b <= 0 {
+		return false
+	}
+	return true
+}
+
 // FitITLModel fits the linear model ITL(k) = A·k + B to the observations using
 // ordinary least squares (OLS). Returns (model, true) on success.
 //
 // Returns (zero, false) when:
 //   - fewer than 2 observations are provided
 //   - k-spread across observations is zero (degenerate — no discriminating signal)
-//   - the fitted slope A ≤ 0 (inverted or flat fit — physically implausible)
+//   - the fitted (A, B) fails validITLModel (inverted/flat/non-finite/non-positive-at-saturation)
 func FitITLModel(obs []ITLObservation) (ITLModel, bool) {
 	n := float64(len(obs))
 	if n < 2 {
@@ -55,26 +85,7 @@ func FitITLModel(obs []ITLObservation) (ITLModel, bool) {
 	A := (n*sumKITL - sumK*sumITL) / denom
 	B := (sumITL - A*sumK) / n
 
-	// Defensive guard: NaN/+Inf A both slip past the A <= 0 check below, and a non-zero
-	// sumK can leave B finite so the B guard would not catch them. Symmetric with the B guard.
-	if math.IsNaN(A) || math.IsInf(A, 0) {
-		return ITLModel{}, false
-	}
-	// Reject flat/inverted fits. A perfectly flat line (constant ITL) is
-	// mathematically A == 0, but OLS rounding leaves tiny noise whose sign is
-	// platform-dependent (e.g. +2.6e-17 on arm64, ≤0 on amd64). Compare against a
-	// small epsilon so any slope that isn't meaningfully positive counts as flat.
-	// Real slopes in this domain are order 1e-2; noise is order 1e-17.
-	if A <= itlSlopeEpsilon {
-		return ITLModel{}, false
-	}
-	// Defensive guard: NaN/Inf B is mathematically possible with degenerate input.
-	if math.IsNaN(B) || math.IsInf(B, 0) {
-		return ITLModel{}, false
-	}
-	// Guard: ensure ITL at saturation is positive. A noisy OLS can yield negative
-	// B (valid A>0), making ITLAt(DefaultKSat) near-zero and inflating supply.
-	if A*DefaultKSat+B <= 0 {
+	if !validITLModel(A, B) {
 		return ITLModel{}, false
 	}
 

--- a/internal/engines/analyzers/throughput/itl_model_test.go
+++ b/internal/engines/analyzers/throughput/itl_model_test.go
@@ -1,6 +1,7 @@
 package throughput
 
 import (
+	"math"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -107,5 +108,32 @@ var _ = Describe("FitITLModel", func() {
 			Expect(ok).To(BeTrue())
 			Expect(m.ITLAt(0.85)).To(BeNumerically("~", 0.073*0.85+0.006, 1e-6))
 		})
+	})
+})
+
+var _ = Describe("validITLModel", func() {
+	It("accepts a finite, positive-slope model with positive ITL at saturation", func() {
+		Expect(validITLModel(0.073, 0.006)).To(BeTrue())
+	})
+
+	It("rejects NaN A", func() {
+		Expect(validITLModel(math.NaN(), 0.006)).To(BeFalse())
+	})
+
+	It("rejects Inf A", func() {
+		Expect(validITLModel(math.Inf(1), 0.006)).To(BeFalse())
+	})
+
+	It("rejects a flat slope (A <= itlSlopeEpsilon)", func() {
+		Expect(validITLModel(0, 0.006)).To(BeFalse())
+	})
+
+	It("rejects NaN B", func() {
+		Expect(validITLModel(0.073, math.NaN())).To(BeFalse())
+	})
+
+	It("rejects a non-positive ITL at saturation", func() {
+		// A*DefaultKSat + B <= 0 with a valid positive A.
+		Expect(validITLModel(0.01, -1.0)).To(BeFalse())
 	})
 })

--- a/internal/engines/analyzers/throughput/observation_window.go
+++ b/internal/engines/analyzers/throughput/observation_window.go
@@ -34,13 +34,13 @@ func newObservationWindow(maxSize int, maxAge time.Duration, minSamples int, min
 	}
 }
 
-// Add appends a (k, itl) observation if k ∈ [minK, maxK] and itl > 0.
-// When the window is at capacity, the oldest observation is evicted first.
-// Returns true if the observation was dropped (out of range or invalid itl)
-// so the caller can log with a reconcile-scoped logger.
+// Add appends a (k, itl) observation if k is a non-NaN value in [minK, maxK]
+// and itl > 0. When the window is at capacity, the oldest observation is
+// evicted first. Returns true if the observation was dropped (NaN/out-of-range
+// k or invalid itl) so the caller can log with a reconcile-scoped logger.
 func (w *ObservationWindow) Add(k, itl float64, ts time.Time) bool {
-	if k < w.minK || k > w.maxK {
-		return true // dropped: out of range
+	if math.IsNaN(k) || k < w.minK || k > w.maxK {
+		return true // dropped: NaN or out of range
 	}
 	if itl <= 0 || math.IsNaN(itl) {
 		return true // dropped: invalid

--- a/internal/engines/analyzers/throughput/observation_window_test.go
+++ b/internal/engines/analyzers/throughput/observation_window_test.go
@@ -41,6 +41,11 @@ var _ = Describe("ObservationWindow", func() {
 			Expect(window.Len()).To(Equal(0))
 		})
 
+		It("rejects NaN k", func() {
+			window.Add(float64NaN(), 0.040, now)
+			Expect(window.Len()).To(Equal(0))
+		})
+
 		It("rejects zero ITL", func() {
 			window.Add(0.50, 0.0, now)
 			Expect(window.Len()).To(Equal(0))

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -178,11 +178,12 @@ func (e *Engine) runAnalyzersAndScore(
 }
 
 // updateLivenessAndSetLive refreshes e.lastGoodAnalysis for this model with
-// every informative result's AnalyzedAt, then sets nr.Live on each entry in
-// place based on whether its last good analysis (if any) is within the
-// staleness window. Applies uniformly to every analyzer, including
-// saturation — no name-based exemption. After the liveness pass it runs the
-// warn-only demand-liveness detector (see detectDemandLiveness).
+// every informative result's AnalyzedAt (or the current time, as a fail-safe,
+// when an informative result carries a zero-valued AnalyzedAt), then sets
+// nr.Live on each entry in place based on whether its last good analysis (if
+// any) is within the staleness window. Applies uniformly to every analyzer,
+// including saturation — no name-based exemption. After the liveness pass it
+// runs the warn-only demand-liveness detector (see detectDemandLiveness).
 func (e *Engine) updateLivenessAndSetLive(
 	ctx context.Context,
 	namespace, modelID string,
@@ -198,9 +199,12 @@ func (e *Engine) updateLivenessAndSetLive(
 	perAnalyzer := e.lastGoodAnalysis[modelKey]
 
 	// Config is nil in unit tests that construct a minimal Engine directly
-	// (bypassing NewEngine, which panics on a nil Config in production).
+	// (bypassing NewEngine, which panics on a nil Config in production). A present
+	// Config returning a non-positive interval falls back to the same 30s default —
+	// a zero/negative interval would otherwise zero the threshold below and latch
+	// every analyzer non-live, blocking all scale-down.
 	interval := 30 * time.Second
-	if e.Config != nil {
+	if e.Config != nil && e.Config.OptimizationInterval() > 0 {
 		interval = e.Config.OptimizationInterval()
 	}
 	now := time.Now()
@@ -209,7 +213,13 @@ func (e *Engine) updateLivenessAndSetLive(
 	for i := range namedResults {
 		nr := &namedResults[i]
 		if pipeline.ResultIsInformative(*nr) {
-			perAnalyzer[nr.Name] = nr.Result.AnalyzedAt
+			at := nr.Result.AnalyzedAt
+			if at.IsZero() {
+				// Fail-safe: an informative result observed this cycle is current by
+				// definition, so a forgotten AnalyzedAt cannot silently disarm the veto.
+				at = now
+			}
+			perAnalyzer[nr.Name] = at
 		}
 		lastGood, ok := perAnalyzer[nr.Name]
 		nr.Live = ok && now.Sub(lastGood) <= threshold
@@ -324,7 +334,10 @@ func (e *Engine) detectDemandLiveness(
 //
 // Guards against an empty active set: a cycle that enumerates no models (e.g.
 // saturation config not loaded yet) must not wipe accumulated state, so pruning
-// is skipped when activeKeys is empty.
+// is skipped when activeKeys is empty. This also means a genuine all-models-removed
+// state is indistinguishable from a transient empty cycle here: those entries leak
+// until a model reappears. Accepted, bounded leak — distinguishing the two cases
+// would need a separate "models were present last cycle" signal.
 func (e *Engine) pruneLastGoodAnalysis(activeKeys map[string]bool) {
 	if len(activeKeys) == 0 || e.lastGoodAnalysis == nil {
 		return

--- a/internal/engines/saturation/engine_v2_liveness_test.go
+++ b/internal/engines/saturation/engine_v2_liveness_test.go
@@ -125,4 +125,54 @@ var _ = Describe("analyzer liveness gate (engine level)", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
 	})
+
+	It("falls back to the 30s default interval when a present Config reports a non-positive one", func() {
+		// Load() always sanitizes the interval to at least MinOptimizationInterval, so a
+		// non-positive OptimizationInterval() can only be reached via direct field
+		// manipulation (config.SetOptimizationIntervalForTest) — this guards against that
+		// Config ever reaching updateLivenessAndSetLive with a zero/negative interval, which
+		// would otherwise zero the threshold and latch every analyzer non-live.
+		fresh := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Now(),
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+			},
+		}
+		e := liveEngine(fresh)
+		e.Config = config.NewTestConfig()
+		config.SetOptimizationIntervalForTest(e.Config, 0)
+
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeTrue())
+	})
+
+	It("treats a zero-valued AnalyzedAt on an informative result as current, not instantly-stale", func() {
+		zeroTimestamp := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Time{},
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "P1-obs"}},
+			},
+		}
+		e := liveEngine(zeroTimestamp)
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeTrue())
+	})
+
+	It("leaves a non-informative result with a zero-valued AnalyzedAt excluded from liveness", func() {
+		zeroTimestampNoData := &fakeAnalyzerWithResult{
+			analyzerName: domain.SaturationAnalyzerName,
+			result: &domain.AnalyzerResult{
+				AnalyzedAt:        time.Time{},
+				VariantCapacities: []domain.VariantCapacity{{VariantName: "v", Reason: "no-data"}},
+			},
+		}
+		e := liveEngine(zeroTimestampNoData)
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namedByName(results)[domain.SaturationAnalyzerName].Live).To(BeFalse())
+	})
 })


### PR DESCRIPTION
## What

A batch of defensive correctness guards for the ThroughputAnalyzer / saturation pipeline (no behavior change on the happy path):

- **reject NaN `k`** in `ObservationWindow.Add` (a bad fit can't poison the observation window);
- **wire real per-replica metric freshness** in the collector (the staleness gate was previously inert);
- **share one ITL-model validator** across both fit tiers (removes divergent validation);
- **reject NaN / out-of-range KV usage** in `computeLocalDemand`;
- **harden the liveness engine** against a zero optimization interval and a zero `AnalyzedAt` timestamp, and extend the all-removed-vs-transient prune comment (the three follow-ups raised on the veto-liveness review).

## Testing

Unit tests per guard; `make test` full-repo green; lint 0; gofmt/build clean.

```release-note
Hardened the ThroughputAnalyzer and saturation liveness engine against NaN/out-of-range inputs, a zero optimization interval, and a zero analysis timestamp; per-replica metric freshness is now honored.
```
