### PR TITLE
fix: Inject trace_id/span_id into structured logs

### DIFF
--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -68,6 +68,52 @@ If you see incorrect namespace groupings in per-variant panels (e.g., all varian
 
 Setting `honorLabels: false` is a security best practice that prevents scraped applications from spoofing infrastructure labels. For example, it prevents a pod from claiming to be in a different namespace via its exported metrics.
 
+## Trace-Log Correlation
+
+When OpenTelemetry tracing is enabled, every log line emitted inside an active span carries the IDs of that span, so a log line can be resolved to the exact trace of the reconcile cycle that produced it, and a trace can be resolved back to its logs.
+
+| Field | Description |
+|-------|-------------|
+| `trace_id` | 32-hex-character ID of the trace the log line belongs to. Shared by every span and every log line of one reconcile cycle. |
+| `span_id` | 16-hex-character ID of the innermost active span (for example the `wva.optimize` stage), not the root span. |
+
+The field names follow the OpenTelemetry log data model, which is what Grafana Loki, Tempo, and Jaeger expect by default.
+
+A correlated log line looks like this:
+
+```json
+{"level":"info","ts":"2026-02-11T09:14:22.417Z","logger":"controller","msg":"Optimization completed","variantAutoscaling":"default/vllm-llama-3-8b","desiredReplicas":4,"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7"}
+```
+
+To jump from a log line to its trace in Grafana, add a derived field to the Loki data source that maps `trace_id` to the Tempo/Jaeger data source:
+
+```yaml
+jsonData:
+  derivedFields:
+    - name: TraceID
+      matcherType: label
+      matcherRegex: trace_id
+      url: '${__value.raw}'
+      datasourceUid: tempo
+```
+
+When tracing is disabled, no span is active, and log output is exactly as it is without this feature: the fields are omitted rather than emitted empty.
+
+### Instrumenting New Code
+
+Start spans through `internal/tracing` rather than calling a tracer directly, so span creation and logger enrichment cannot drift apart:
+
+```go
+ctx, span := tracing.StartSpan(ctx, "wva.optimize")
+defer span.End()
+
+// Every log.FromContext / ctrl.LoggerFrom caller downstream of this ctx,
+// in this function and in everything it calls, is correlated automatically.
+log.FromContext(ctx).Info("Optimization completed")
+```
+
+Log through the context logger (`log.FromContext(ctx)` or `ctrl.LoggerFrom(ctx)`) rather than the package-level `ctrl.Log`; the latter has no context, so its lines cannot be correlated.
+
 ## Troubleshooting
 ### services "kube-prometheus-stack-grafana" not found
   - Make sure to install WVA cluster with `DEPLOY_OPERATIONAL_DASHBOARD=true` (default) as this would install Grafana.

--- a/go.mod
+++ b/go.mod
@@ -85,12 +85,12 @@ require (
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
-	go.opentelemetry.io/otel v1.38.0 // indirect
+	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.38.0 // indirect
-	go.opentelemetry.io/otel/trace v1.38.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,0 +1,94 @@
+// Package tracing bridges OpenTelemetry span context and the
+// controller-runtime context logger. Starting a span through this package
+// enriches the logger stored in the context with the active trace and span
+// IDs, so every downstream log.FromContext / ctrl.LoggerFrom caller emits
+// correlated log lines without any change of its own.
+//
+// The fields are named trace_id and span_id, matching the OpenTelemetry log
+// data model and the derived-field defaults of backends such as Grafana
+// Tempo/Loki and Jaeger.
+//
+// When tracing is not configured the global provider returns non-recording
+// spans whose span context is invalid; in that case the logger is left
+// untouched and log output is unchanged.
+package tracing
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// TraceIDKey is the log field carrying the active trace ID.
+	TraceIDKey = "trace_id"
+
+	// SpanIDKey is the log field carrying the active span ID.
+	SpanIDKey = "span_id"
+)
+
+// instrumentationName identifies this project as the instrumentation scope of
+// the spans it produces.
+const instrumentationName = "github.com/llm-d/llm-d-workload-variant-autoscaler"
+
+// baseLoggerKey is the context key under which the logger as it was before
+// trace fields were added is kept. Re-deriving from that logger keeps nested
+// spans from appending a second trace_id/span_id pair to the same line.
+type baseLoggerKey struct{}
+
+// Tracer returns the tracer used for all spans emitted by this project. It
+// resolves against the global provider on every call, so it is safe to use
+// before the provider is installed.
+func Tracer() trace.Tracer {
+	return otel.Tracer(instrumentationName)
+}
+
+// StartSpan starts a span named name and returns a context carrying both the
+// span and a logger enriched with the span's trace and span IDs. The caller
+// must end the returned span.
+//
+// Use it in place of a direct tracer.Start so span creation and logger
+// enrichment cannot drift apart:
+//
+//	ctx, span := tracing.StartSpan(ctx, "wva.reconcile")
+//	defer span.End()
+func StartSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	ctx, span := Tracer().Start(ctx, name, opts...)
+	return ContextWithTraceLogger(ctx), span
+}
+
+// ContextWithTraceLogger enriches the logger in ctx with the IDs of the span
+// ctx already carries. It returns ctx unchanged when there is no valid span
+// context, which is the case whenever tracing is disabled. Use it at entry
+// points where the span was started elsewhere, such as a context extracted
+// from an incoming request; code that starts its own span should call
+// StartSpan instead.
+func ContextWithTraceLogger(ctx context.Context) context.Context {
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		return ctx
+	}
+
+	base, ok := ctx.Value(baseLoggerKey{}).(logr.Logger)
+	if !ok {
+		base = log.FromContext(ctx)
+		ctx = context.WithValue(ctx, baseLoggerKey{}, base)
+	}
+	return log.IntoContext(ctx, LoggerWithSpanContext(base, spanCtx))
+}
+
+// LoggerWithSpanContext returns logger with the trace and span IDs of spanCtx
+// attached. An invalid span context leaves logger unchanged, so no empty
+// fields are ever emitted.
+func LoggerWithSpanContext(logger logr.Logger, spanCtx trace.SpanContext) logr.Logger {
+	if !spanCtx.IsValid() {
+		return logger
+	}
+	return logger.WithValues(
+		TraceIDKey, spanCtx.TraceID().String(),
+		SpanIDKey, spanCtx.SpanID().String(),
+	)
+}

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -1,0 +1,183 @@
+package tracing
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TestMain installs a recording tracer provider for the whole package so
+// StartSpan produces valid span contexts. Cases that exercise the
+// tracing-disabled path use an explicit noop tracer instead.
+func TestMain(m *testing.M) {
+	tp := sdktrace.NewTracerProvider()
+	otel.SetTracerProvider(tp)
+	code := m.Run()
+	_ = tp.Shutdown(context.Background())
+	os.Exit(code)
+}
+
+// capturingLogger returns a logger that records every rendered line and the
+// slice it records into.
+func capturingLogger() (logr.Logger, *[]string) {
+	lines := &[]string{}
+	logger := funcr.New(func(prefix, args string) {
+		*lines = append(*lines, prefix+" "+args)
+	}, funcr.Options{})
+	return logger, lines
+}
+
+// field renders the key/value pair the way funcr does, for substring
+// assertions against captured lines.
+func field(key, value string) string {
+	return `"` + key + `"="` + value + `"`
+}
+
+func TestStartSpanEnrichesContextLogger(t *testing.T) {
+	logger, lines := capturingLogger()
+	ctx := log.IntoContext(context.Background(), logger)
+
+	ctx, span := StartSpan(ctx, "wva.reconcile")
+	defer span.End()
+
+	spanCtx := span.SpanContext()
+	require.True(t, spanCtx.IsValid(), "expected a valid span context from the recording provider")
+
+	log.FromContext(ctx).Info("reconciling")
+
+	require.Len(t, *lines, 1)
+	assert.Contains(t, (*lines)[0], field(TraceIDKey, spanCtx.TraceID().String()))
+	assert.Contains(t, (*lines)[0], field(SpanIDKey, spanCtx.SpanID().String()))
+}
+
+func TestStartSpanPreservesExistingLoggerValues(t *testing.T) {
+	logger, lines := capturingLogger()
+	ctx := log.IntoContext(context.Background(), logger.WithValues("variantAutoscaling", "vllm-llama"))
+
+	ctx, span := StartSpan(ctx, "wva.optimize")
+	defer span.End()
+
+	log.FromContext(ctx).Info("optimizing")
+
+	require.Len(t, *lines, 1)
+	assert.Contains(t, (*lines)[0], field("variantAutoscaling", "vllm-llama"))
+	assert.Contains(t, (*lines)[0], field(SpanIDKey, span.SpanContext().SpanID().String()))
+}
+
+func TestNestedSpansReplaceTraceFields(t *testing.T) {
+	logger, lines := capturingLogger()
+	ctx := log.IntoContext(context.Background(), logger)
+
+	ctx, parent := StartSpan(ctx, "wva.reconcile")
+	defer parent.End()
+
+	ctx, child := StartSpan(ctx, "wva.collect")
+	defer child.End()
+
+	require.NotEqual(t, parent.SpanContext().SpanID(), child.SpanContext().SpanID())
+
+	log.FromContext(ctx).Info("collecting")
+
+	require.Len(t, *lines, 1)
+	line := (*lines)[0]
+
+	// The child's IDs win, and the parent's are not left behind as a second
+	// pair of fields on the same line.
+	assert.Contains(t, line, field(SpanIDKey, child.SpanContext().SpanID().String()))
+	assert.NotContains(t, line, field(SpanIDKey, parent.SpanContext().SpanID().String()))
+	assert.Equal(t, 1, strings.Count(line, `"`+SpanIDKey+`"`))
+	assert.Equal(t, 1, strings.Count(line, `"`+TraceIDKey+`"`))
+
+	// Both spans belong to the same trace.
+	assert.Equal(t, parent.SpanContext().TraceID(), child.SpanContext().TraceID())
+	assert.Contains(t, line, field(TraceIDKey, child.SpanContext().TraceID().String()))
+}
+
+func TestContextWithTraceLoggerIsIdempotent(t *testing.T) {
+	logger, lines := capturingLogger()
+	ctx := log.IntoContext(context.Background(), logger)
+
+	ctx, span := StartSpan(ctx, "wva.analyze")
+	defer span.End()
+
+	ctx = ContextWithTraceLogger(ctx)
+	log.FromContext(ctx).Info("analyzing")
+
+	require.Len(t, *lines, 1)
+	assert.Equal(t, 1, strings.Count((*lines)[0], `"`+TraceIDKey+`"`))
+	assert.Equal(t, 1, strings.Count((*lines)[0], `"`+SpanIDKey+`"`))
+}
+
+func TestTracingDisabledLeavesLogsUnchanged(t *testing.T) {
+	logger, lines := capturingLogger()
+	baseCtx := log.IntoContext(context.Background(), logger)
+
+	// A noop tracer is what the global provider hands out when tracing is
+	// not configured: the span context it produces is invalid.
+	ctx, span := noop.NewTracerProvider().Tracer("test").Start(baseCtx, "wva.reconcile")
+	defer span.End()
+	require.False(t, span.SpanContext().IsValid())
+
+	enriched := ContextWithTraceLogger(ctx)
+	assert.Equal(t, ctx, enriched, "context must be returned unchanged when there is no valid span")
+
+	log.FromContext(enriched).Info("reconciling")
+
+	require.Len(t, *lines, 1)
+	assert.NotContains(t, (*lines)[0], TraceIDKey)
+	assert.NotContains(t, (*lines)[0], SpanIDKey)
+}
+
+func TestContextWithTraceLoggerWithoutSpan(t *testing.T) {
+	logger, lines := capturingLogger()
+	ctx := log.IntoContext(context.Background(), logger)
+
+	assert.Equal(t, ctx, ContextWithTraceLogger(ctx))
+
+	log.FromContext(ContextWithTraceLogger(ctx)).Info("no span here")
+
+	require.Len(t, *lines, 1)
+	assert.NotContains(t, (*lines)[0], TraceIDKey)
+	assert.NotContains(t, (*lines)[0], SpanIDKey)
+}
+
+func TestLoggerWithSpanContextInvalid(t *testing.T) {
+	logger, lines := capturingLogger()
+
+	LoggerWithSpanContext(logger, trace.SpanContext{}).Info("no fields")
+
+	require.Len(t, *lines, 1)
+	assert.NotContains(t, (*lines)[0], TraceIDKey)
+	assert.NotContains(t, (*lines)[0], SpanIDKey)
+}
+
+func TestLoggerWithSpanContextValid(t *testing.T) {
+	logger, lines := capturingLogger()
+
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+	require.NoError(t, err)
+
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	})
+
+	LoggerWithSpanContext(logger, spanCtx).Info("correlated")
+
+	require.Len(t, *lines, 1)
+	assert.Contains(t, (*lines)[0], field(TraceIDKey, "4bf92f3577b34da6a3ce929d0e0e4736"))
+	assert.Contains(t, (*lines)[0], field(SpanIDKey, "00f067aa0ba902b7"))
+}


### PR DESCRIPTION
Fixes #1273 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Inject trace_id/span_id into structured logs for trace-log correlation
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
