### PR TITLE
feat(observability): add OpenTelemetry tracing for the optimization pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/projectquay/golang:1.26@sha256:fe24778fb3640a23a3cdc40e50e86e06cea01d0c028bdd06550654a7e2a09df1 AS builder
+FROM quay.io/projectquay/golang:1.26@sha256:4142f907965c7a70000f34ddfcaefda9b0d61a72dff1b318946c318867f0e53d AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	prometheusutil "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/prometheus"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/crd"
 	poolutil "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/pool"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -167,6 +168,33 @@ func main() {
 		os.Exit(1)     //nolint:gocritic // exitAfterDefer: Sync() called explicitly above
 	}
 	setupLog.Info("Configuration loaded successfully")
+
+	// Tracing is opt-in: with OTEL_TRACES_EXPORTER unset (or "none") Init
+	// installs no provider, the OpenTelemetry no-op implementation stays in
+	// place, and nothing is exported.
+	tracingCfg := tracing.ConfigFromEnv()
+	tracingShutdown, err := tracing.Init(context.Background(), tracingCfg)
+	if err != nil {
+		setupLog.Error(err, "failed to initialize tracing - this is a fatal error")
+		logging.Sync() //nolint:errcheck
+		os.Exit(1)
+	}
+	// flushTracing drains pending spans. It is called on every exit path that
+	// follows, since os.Exit does not run deferred functions.
+	flushTracing := func() {
+		if err := tracingShutdown(context.Background()); err != nil {
+			setupLog.Error(err, "failed to shut down tracing cleanly")
+		}
+	}
+	if tracingCfg.Enabled() {
+		setupLog.Info("OpenTelemetry tracing enabled",
+			"exporter", tracingCfg.Exporter,
+			"serviceName", tracingCfg.ServiceName,
+			"endpoint", tracingCfg.Endpoint,
+			"sampler", tracingCfg.Sampler)
+	} else {
+		setupLog.Info("OpenTelemetry tracing disabled (set OTEL_TRACES_EXPORTER to enable)")
+	}
 
 	// Conditionally add LeaderWorkerSet scheme if CRD exists
 	lwsEnabled := crd.CheckLeaderWorkerSetCRD(restConfig, setupLog)
@@ -663,6 +691,11 @@ func main() {
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
+		flushTracing()
 		os.Exit(1)
 	}
+
+	// The manager has stopped; flush any spans still buffered by the batcher
+	// before the process exits.
+	flushTracing()
 }

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -68,6 +68,82 @@ If you see incorrect namespace groupings in per-variant panels (e.g., all varian
 
 Setting `honorLabels: false` is a security best practice that prevents scraped applications from spoofing infrastructure labels. For example, it prevents a pod from claiming to be in a different namespace via its exported metrics.
 
+## Distributed Tracing
+
+Metrics answer "how long do optimization cycles take?"; traces answer "why was *this* cycle slow, and what did it decide?". WVA can emit an OpenTelemetry trace per optimization cycle, covering collection, analysis, optimization, limiting, enforcement, and actuation.
+
+Tracing is **off by default**. When it is off, no tracer provider is installed, spans are non-recording no-ops, and nothing is exported.
+
+### Enabling
+
+Configuration uses the standard `OTEL_*` environment variables, so WVA behaves like any other OpenTelemetry application.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_TRACES_EXPORTER` | `none` | `none` disables tracing. `otlp` exports over OTLP gRPC. `console` prints spans to stdout for local debugging. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | Collector endpoint, e.g. `otel-collector.observability:4317`. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` takes precedence when both are set. |
+| `OTEL_EXPORTER_OTLP_INSECURE` | `false` | Set to `true` to disable transport security (in-cluster collector without TLS). |
+| `OTEL_SERVICE_NAME` | `llm-d-wva` | Reported as `service.name`. |
+| `OTEL_SERVICE_VERSION` | — | Reported as `service.version` when set. |
+| `OTEL_TRACES_SAMPLER` | `parentbased_always_on` | One of `always_on`, `always_off`, `traceidratio`, `parentbased_always_off`, `parentbased_traceidratio`. |
+| `OTEL_TRACES_SAMPLER_ARG` | `1.0` | Sampling ratio for the ratio-based samplers. |
+
+Add them to the controller Deployment:
+
+```yaml
+env:
+  - name: OTEL_TRACES_EXPORTER
+    value: "otlp"
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "otel-collector.observability.svc.cluster.local:4317"
+  - name: OTEL_EXPORTER_OTLP_INSECURE
+    value: "true"
+  - name: OTEL_TRACES_SAMPLER
+    value: "parentbased_traceidratio"
+  - name: OTEL_TRACES_SAMPLER_ARG
+    value: "0.1"
+```
+
+To check the wiring without a collector, set `OTEL_TRACES_EXPORTER=console` and read the spans from the controller's logs.
+
+Each trace carries the controller's identity as resource attributes: `service.name`, `service.version`, `k8s.namespace.name` (from `POD_NAMESPACE`), and `k8s.pod.name` / `service.instance.id` (from `POD_NAME`, falling back to the hostname).
+
+### Trace Structure
+
+One optimization cycle produces one trace, rooted at `reconcile`:
+
+```
+reconcile                  one optimization cycle
+├── collect                metrics and inventory collection
+│   └── prometheus_query   one PromQL query (repeated)
+├── analyze                saturation / queueing-model analysis, per model
+├── optimize               cost-aware or greedy-by-score optimizer
+├── limit                  GPU limiter clamping
+├── enforce                scale-to-zero and minimum-replica enforcement
+└── actuate                VA status updates and HPA/KEDA signals
+```
+
+Not every stage appears in every cycle. A cycle with no active VariantAutoscalings, or one where no metrics are available, ends after collection — which is itself the useful signal when scaling appears stuck.
+
+Span names are bare snake_case verbs. What emitted a span is carried by its **instrumentation scope**, which is the emitting package's import path, so the name does not repeat it:
+
+| Scope | Spans |
+|-------|-------|
+| `llm-d-wva/internal/engines/saturation` | `reconcile`, `analyze`, `optimize`, `actuate` |
+| `llm-d-wva/internal/engines/pipeline` | `optimize`, `limit`, `enforce` |
+| `llm-d-wva/internal/collector` | `collect` |
+| `llm-d-wva/internal/collector/source/prometheus` | `prometheus_query` |
+
+This matches `llm-d-router`'s convention (`llm-d-router/pkg/...` scopes with names like `prefill`, `score_prefix_cache`), so traces spanning both projects group consistently. When filtering, use scope **and** name together — `optimize` is emitted by two packages, since the V1 path builds targets in the engine while V2 runs the optimizer pipeline.
+
+Spans carry the decision context as `wva.*` attributes: `wva.model_id`, `wva.namespace`, `wva.variant_autoscaling`, `wva.mode`, `wva.analyzer`, `wva.optimizer`, `wva.limiter`, `wva.current_replicas`, `wva.desired_replicas`, `wva.decision_count`, `wva.limited_decision_count`, and `wva.query` / `wva.query_type` on Prometheus query spans.
+
+All attribute values are integers, booleans, or strings from a set the controller itself defines (analyzer, optimizer, and limiter names, Kubernetes object names, and PromQL built from registered templates with escaped parameters). Free-form user input is never attached to a span.
+
+### Not Yet Covered
+
+TLS and authentication for the OTLP exporter are not configurable yet — an in-cluster collector reached over plaintext (`OTEL_EXPORTER_OTLP_INSECURE=true`) is the supported deployment for now. Log lines do not yet carry `trace_id` / `span_id`, so jumping from a log to its trace is manual.
+
 ## Troubleshooting
 ### services "kube-prometheus-stack-grafana" not found
   - Make sure to install WVA cluster with `DEPLOY_OPERATIONAL_DASHBOARD=true` (default) as this would install Grafana.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.89.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.38.0
 	gonum.org/v1/gonum v0.17.0
 	k8s.io/apimachinery v0.34.5
 	k8s.io/client-go v0.34.5
@@ -33,7 +34,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.38.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.32.0 // indirect
@@ -85,12 +85,12 @@ require (
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
-	go.opentelemetry.io/otel v1.38.0 // indirect
+	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.38.0 // indirect
-	go.opentelemetry.io/otel/trace v1.38.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -49,6 +49,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	lwsv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -66,6 +67,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/prometheus"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturationv1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
@@ -175,7 +177,13 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	vaEventTracker map[string]bool,
 	variantCosts map[string]float64,
 ) ([]domain.ReplicaMetrics, error) {
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanCollect)
+	span.SetAttributes(tracing.ModelAttrs(modelID, namespace)...)
+	defer span.End()
+
 	replicaMetrics, err := c.collectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, variantCosts)
+	span.SetAttributes(attribute.Int(tracing.AttrReplicaMetrics, len(replicaMetrics)))
+	tracing.RecordError(span, err)
 
 	// Determine if metrics are available in this cycle
 	metricsAvailable := err == nil && len(replicaMetrics) > 0

--- a/internal/collector/source/prometheus/prometheus_source.go
+++ b/internal/collector/source/prometheus/prometheus_source.go
@@ -13,11 +13,13 @@ import (
 
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	"go.opentelemetry.io/otel/attribute"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	prometheusutil "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/prometheus"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 )
 
 // PrometheusSourceConfig contains configuration for the Prometheus source.
@@ -132,6 +134,16 @@ func (p *PrometheusSource) executeQuery(ctx context.Context, queryName string, p
 			Error:       fmt.Errorf("failed to build query: %w", err),
 		}
 	}
+
+	// The query text is built from registered templates with escaped
+	// parameters (see EscapePromQLValue above), so it is bounded and safe to
+	// record as a span attribute.
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanPrometheusQuery)
+	span.SetAttributes(
+		attribute.String(tracing.AttrQueryType, queryName),
+		attribute.String(tracing.AttrQuery, queryStr),
+	)
+	defer span.End()
 
 	// Apply query timeout
 	queryCtx := ctx

--- a/internal/collector/source/prometheus/tracing.go
+++ b/internal/collector/source/prometheus/tracing.go
@@ -1,0 +1,4 @@
+package prometheus
+
+// tracerScope is the OTel instrumentation scope for the Prometheus metrics source.
+const tracerScope = "llm-d-wva/internal/collector/source/prometheus"

--- a/internal/collector/tracing.go
+++ b/internal/collector/tracing.go
@@ -1,0 +1,4 @@
+package collector
+
+// tracerScope is the OTel instrumentation scope for metrics collection.
+const tracerScope = "llm-d-wva/internal/collector"

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -6,10 +6,12 @@ import (
 	"math"
 	"sort"
 
+	"go.opentelemetry.io/otel/attribute"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 )
 
 // CostAwareOptimizer is a per-model optimizer that minimizes total cost while
@@ -41,8 +43,19 @@ func (o *CostAwareOptimizer) Optimize(
 	requests []ModelScalingRequest,
 	constraints []*ResourceConstraints,
 ) []domain.VariantDecision {
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanOptimize)
+	span.SetAttributes(
+		attribute.String(tracing.AttrOptimizer, o.Name()),
+		attribute.Int(tracing.AttrModelCount, len(requests)),
+	)
+
 	logger := ctrl.LoggerFrom(ctx).WithName(o.Name())
 	var allDecisions []domain.VariantDecision
+
+	defer func() {
+		span.SetAttributes(attribute.Int(tracing.AttrDecisionCount, len(allDecisions)))
+		span.End()
+	}()
 
 	for _, req := range requests {
 		satEntry := saturationEntry(req.AnalyzerResults)

--- a/internal/engines/pipeline/default_limiter.go
+++ b/internal/engines/pipeline/default_limiter.go
@@ -6,9 +6,12 @@ import (
 	"maps"
 	"slices"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 )
 
 // DefaultLimiter combines an Inventory with an AllocationAlgorithm to constrain
@@ -45,10 +48,29 @@ func (l *DefaultLimiter) Name() string {
 
 // Limit applies resource constraints to scaling decisions.
 // Modifies decisions in place - may reduce TargetReplicas based on available resources.
-func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*domain.VariantDecision) error {
+func (l *DefaultLimiter) Limit(ctx context.Context, decisions []*domain.VariantDecision) (retErr error) {
 	if len(decisions) == 0 {
 		return nil
 	}
+
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanLimit)
+	span.SetAttributes(
+		attribute.String(tracing.AttrLimiter, l.Name()),
+		attribute.Int(tracing.AttrDecisionCount, len(decisions)),
+	)
+	defer func() {
+		// Report how many decisions the limiter actually clamped, so a trace
+		// shows the limiter's effect without inspecting every child span.
+		limited := 0
+		for _, d := range decisions {
+			if d != nil && d.WasLimited {
+				limited++
+			}
+		}
+		span.SetAttributes(attribute.Int(tracing.AttrLimitedCount, limited))
+		tracing.RecordError(span, retErr)
+		span.End()
+	}()
 
 	// Step 1: Refresh inventory to get latest limits from cluster
 	if err := l.inventory.Refresh(ctx); err != nil {

--- a/internal/engines/pipeline/enforcer.go
+++ b/internal/engines/pipeline/enforcer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
@@ -13,6 +14,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturationv1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 )
 
 // RequestCountFuncType is the signature for functions that retrieve the total request count
@@ -49,6 +51,14 @@ func (e *Enforcer) EnforcePolicyOnDecisions(
 	satConfig *config.SaturationScalingConfig,
 	optimizerName string,
 ) bool {
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanEnforce)
+	span.SetAttributes(append(
+		tracing.ModelAttrs(modelID, namespace),
+		attribute.Int(tracing.AttrDecisionCount, len(decisions)),
+		attribute.String(tracing.AttrOptimizer, optimizerName),
+	)...)
+	defer span.End()
+
 	logger := ctrl.LoggerFrom(ctx)
 
 	scaleToZeroEnabled := config.ResolveScaleToZeroEnabled(satConfig, scaleToZeroConfig, modelID)

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -6,10 +6,12 @@ import (
 	"math"
 	"sort"
 
+	"go.opentelemetry.io/otel/attribute"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 )
 
 // GreedyByScoreOptimizer is a multi-model optimizer for GPU-constrained
@@ -98,7 +100,17 @@ func (o *GreedyByScoreOptimizer) Optimize(
 	ctx context.Context,
 	requests []ModelScalingRequest,
 	constraints []*ResourceConstraints,
-) []domain.VariantDecision {
+) (allDecisions []domain.VariantDecision) {
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanOptimize)
+	span.SetAttributes(
+		attribute.String(tracing.AttrOptimizer, o.Name()),
+		attribute.Int(tracing.AttrModelCount, len(requests)),
+	)
+	defer func() {
+		span.SetAttributes(attribute.Int(tracing.AttrDecisionCount, len(allDecisions)))
+		span.End()
+	}()
+
 	logger := ctrl.LoggerFrom(ctx).WithName(o.Name())
 	available := mergeConstraints(constraints)
 	availableByNS := mergeNamespaceConstraints(constraints)
@@ -142,7 +154,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 
 	o.fairShareScaleUp(ctx, scaleUpWork, available, availableByNS)
 
-	allDecisions := make([]domain.VariantDecision, 0, len(scaleUpWork))
+	allDecisions = make([]domain.VariantDecision, 0, len(scaleUpWork))
 
 	for _, w := range scaleUpWork {
 		stateMap := buildStateMap(w.req.VariantStates)

--- a/internal/engines/pipeline/tracing.go
+++ b/internal/engines/pipeline/tracing.go
@@ -1,0 +1,5 @@
+package pipeline
+
+// tracerScope is the OTel instrumentation scope shared by the optimizer,
+// limiter, and enforcer stages of the scaling pipeline.
+const tracerScope = "llm-d-wva/internal/engines/pipeline"

--- a/internal/engines/pipeline/tracing_test.go
+++ b/internal/engines/pipeline/tracing_test.go
@@ -1,0 +1,229 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
+)
+
+// withRecordingTracer installs an in-memory span exporter as the global tracer
+// provider for the duration of the test and returns the exporter.
+func withRecordingTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exporter),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+	return exporter
+}
+
+// requireSpan returns the single recorded span with the given name.
+func requireSpan(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+	t.Helper()
+
+	var found []tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == name {
+			found = append(found, s)
+		}
+	}
+	require.Len(t, found, 1, "expected exactly one %q span", name)
+	return found[0]
+}
+
+// attrsOf renders a span's attributes as a string map for assertions.
+func attrsOf(span tracetest.SpanStub) map[string]string {
+	out := map[string]string{}
+	for _, kv := range span.Attributes {
+		out[string(kv.Key)] = kv.Value.Emit()
+	}
+	return out
+}
+
+// assertChildOfRoot checks that child belongs to root's trace and is its direct child.
+func assertChildOfRoot(t *testing.T, root, child tracetest.SpanStub) {
+	t.Helper()
+	assert.Equal(t, root.SpanContext.SpanID(), child.Parent.SpanID(),
+		"%q must be a direct child of the cycle root", child.Name)
+	assert.Equal(t, root.SpanContext.TraceID(), child.SpanContext.TraceID(),
+		"%q must share the cycle's trace", child.Name)
+}
+
+// tracingModelRequest builds a minimal single-variant scale-up request.
+func tracingModelRequest() ModelScalingRequest {
+	return ModelScalingRequest{
+		ModelID:   "model-a",
+		Namespace: "default",
+		Priority:  1,
+		AnalyzerResults: []NamedAnalyzerResult{{
+			Name: domain.SaturationAnalyzerName,
+			Result: &domain.AnalyzerResult{
+				RequiredCapacity: 1,
+				VariantCapacities: []domain.VariantCapacity{{
+					VariantName:        "variant-a",
+					PerReplicaCapacity: 1,
+					Cost:               1,
+					AcceleratorName:    "A100",
+				}},
+			},
+			Score:     1,
+			Remaining: 1,
+		}},
+		VariantStates: []domain.VariantReplicaState{{
+			VariantName:     "variant-a",
+			CurrentReplicas: 1,
+		}},
+	}
+}
+
+func TestOptimizersEmitOptimizeSpanUnderCycleRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		optimizer ScalingOptimizer
+	}{
+		{"cost-aware", NewCostAwareOptimizer()},
+		{"greedy-by-score", NewGreedyByScoreOptimizer()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exporter := withRecordingTracer(t)
+
+			ctx, root := tracing.Tracer(tracerScope).Start(context.Background(), tracing.SpanReconcile)
+			tc.optimizer.Optimize(ctx, []ModelScalingRequest{tracingModelRequest()}, nil)
+			root.End()
+
+			spans := exporter.GetSpans()
+			rootSpan := requireSpan(t, spans, tracing.SpanReconcile)
+			optimizeSpan := requireSpan(t, spans, tracing.SpanOptimize)
+
+			assertChildOfRoot(t, rootSpan, optimizeSpan)
+
+			attrs := attrsOf(optimizeSpan)
+			assert.Equal(t, tc.optimizer.Name(), attrs[tracing.AttrOptimizer])
+			assert.Equal(t, "1", attrs[tracing.AttrModelCount])
+			assert.Contains(t, attrs, tracing.AttrDecisionCount)
+		})
+	}
+}
+
+func TestDefaultLimiterEmitsLimitSpanUnderCycleRoot(t *testing.T) {
+	exporter := withRecordingTracer(t)
+
+	limiter := NewDefaultLimiter("test-limiter",
+		newMockInventory("test-inventory", map[string]int{"A100": 10}),
+		&mockAlgorithm{name: "test-algo"})
+
+	decisions := []*domain.VariantDecision{{
+		VariantName:     "variant-a",
+		ModelID:         "model-a",
+		Namespace:       "default",
+		AcceleratorName: "A100",
+		GPUsPerReplica:  1,
+		CurrentReplicas: 1,
+		TargetReplicas:  2,
+		Action:          domain.ActionScaleUp,
+	}}
+
+	ctx, root := tracing.Tracer(tracerScope).Start(context.Background(), tracing.SpanReconcile)
+	require.NoError(t, limiter.Limit(ctx, decisions))
+	root.End()
+
+	spans := exporter.GetSpans()
+	rootSpan := requireSpan(t, spans, tracing.SpanReconcile)
+	limitSpan := requireSpan(t, spans, tracing.SpanLimit)
+
+	assertChildOfRoot(t, rootSpan, limitSpan)
+
+	attrs := attrsOf(limitSpan)
+	assert.Equal(t, "test-limiter", attrs[tracing.AttrLimiter])
+	assert.Equal(t, "1", attrs[tracing.AttrDecisionCount])
+	assert.Contains(t, attrs, tracing.AttrLimitedCount)
+}
+
+func TestLimiterEmitsNoSpanForEmptyDecisions(t *testing.T) {
+	exporter := withRecordingTracer(t)
+
+	limiter := NewDefaultLimiter("test-limiter",
+		newMockInventory("test-inventory", map[string]int{"A100": 10}),
+		&mockAlgorithm{name: "test-algo"})
+
+	ctx, root := tracing.Tracer(tracerScope).Start(context.Background(), tracing.SpanReconcile)
+	require.NoError(t, limiter.Limit(ctx, nil))
+	root.End()
+
+	for _, s := range exporter.GetSpans() {
+		assert.NotEqual(t, tracing.SpanLimit, s.Name,
+			"an empty decision set does no work and must not open a stage span")
+	}
+}
+
+func TestEnforcerEmitsEnforceSpanUnderCycleRoot(t *testing.T) {
+	exporter := withRecordingTracer(t)
+
+	// A positive request count keeps decisions as they are; this test is about
+	// the span, not the enforcement outcome.
+	enforcer := NewEnforcer(func(context.Context, string, string, time.Duration) (float64, error) {
+		return 1, nil
+	})
+
+	decisions := []domain.VariantDecision{{
+		VariantName:     "variant-a",
+		ModelID:         "model-a",
+		Namespace:       "default",
+		Cost:            1,
+		CurrentReplicas: 1,
+		TargetReplicas:  2,
+		Action:          domain.ActionScaleUp,
+	}}
+
+	ctx, root := tracing.Tracer(tracerScope).Start(context.Background(), tracing.SpanReconcile)
+	enforcer.EnforcePolicyOnDecisions(ctx, "model-a", "default", decisions,
+		config.ScaleToZeroConfigData{}, nil, "cost-aware")
+	root.End()
+
+	spans := exporter.GetSpans()
+	rootSpan := requireSpan(t, spans, tracing.SpanReconcile)
+	enforceSpan := requireSpan(t, spans, tracing.SpanEnforce)
+
+	assertChildOfRoot(t, rootSpan, enforceSpan)
+
+	attrs := attrsOf(enforceSpan)
+	assert.Equal(t, "model-a", attrs[tracing.AttrModelID])
+	assert.Equal(t, "default", attrs[tracing.AttrNamespace])
+	assert.Equal(t, "1", attrs[tracing.AttrDecisionCount])
+	assert.Equal(t, "cost-aware", attrs[tracing.AttrOptimizer])
+}
+
+func TestStagesEmitNoSpansWhenTracingDisabled(t *testing.T) {
+	// No provider installed: the global no-op provider is what a disabled
+	// deployment runs with. Nothing may be recorded.
+	exporter := tracetest.NewInMemoryExporter()
+
+	ctx, root := tracing.Tracer(tracerScope).Start(context.Background(), tracing.SpanReconcile)
+	NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{tracingModelRequest()}, nil)
+	NewEnforcer(func(context.Context, string, string, time.Duration) (float64, error) {
+		return 1, nil
+	}).EnforcePolicyOnDecisions(ctx, "model-a", "default", nil,
+		config.ScaleToZeroConfigData{}, nil, "cost-aware")
+	root.End()
+
+	assert.False(t, root.SpanContext().IsValid(), "spans must not record while tracing is disabled")
+	assert.Empty(t, exporter.GetSpans())
+}

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,6 +51,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturationv1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
@@ -433,6 +435,12 @@ func (e *Engine) currentGPULimiter() pipeline.Limiter {
 func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	start := time.Now()
 	var modelsProcessed int
+
+	// Root span of one optimization cycle. Every stage below is a child of it,
+	// so a single trace covers collect → analyze → optimize → limit → enforce
+	// → actuate for this cycle.
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanReconcile)
+
 	defer func() {
 		status := "success"
 		if retErr != nil {
@@ -440,6 +448,10 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 		}
 		metrics.ObserveOptimizationDuration(time.Since(start).Seconds(), status)
 		metrics.SetModelsProcessed(modelsProcessed)
+
+		span.SetAttributes(attribute.Int(tracing.AttrModelCount, modelsProcessed))
+		tracing.RecordError(span, retErr)
+		span.End()
 	}()
 
 	logger := ctrl.LoggerFrom(ctx)
@@ -473,7 +485,10 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	// internal/collector/collector.go), so skipping it in quota mode loses
 	// nothing of operational value.
 	if e.Config.LimitedModeEnabled() && shouldCollectClusterInventory(e.Config) {
-		inventory, err := collector.CollectInventoryK8S(ctx, e.client)
+		collectCtx, collectSpan := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanCollect)
+		inventory, err := collector.CollectInventoryK8S(collectCtx, e.client)
+		tracing.RecordError(collectSpan, err)
+		collectSpan.End()
 		if err != nil {
 			logger.Error(err, "Failed to collect cluster inventory")
 			// do not proceed to optimization if inventory collection fails in limited mode
@@ -549,6 +564,15 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	// V1 is deprecated in favor of V2; see issue #1441 for the staged removal plan.
 	// Queueing model is activated by presence of wva-queueing-model-config ConfigMap.
 	mode := modeLabelForAnalyzer(analyzerName)
+	// Analyzer and optimizer names come from a closed set the controller
+	// defines, so they are safe as span attributes.
+	span.SetAttributes(
+		attribute.String(tracing.AttrMode, mode),
+		attribute.String(tracing.AttrAnalyzer, analyzerName),
+		attribute.String(tracing.AttrOptimizer, e.optimizer.Name()),
+		attribute.Bool(tracing.AttrScaleToZero, e.Config.ScaleToZeroEnabled()),
+		attribute.Int(tracing.AttrVariantCount, len(activeVAs)),
+	)
 	switch analyzerName {
 	case domain.QueueingModelAnalyzerName:
 		allDecisions = e.optimizeQueueingModel(ctx, modelGroups, currentAllocations)
@@ -792,6 +816,16 @@ func (e *Engine) analyzeRoleGroups(
 	currentAllocations map[string]*domain.Allocation,
 	emitSafetyNet safetyNetEmitter,
 ) []domain.VariantDecision {
+	// The V1 path performs analysis and target building together, per role
+	// group, rather than through the V2 analyzer/optimizer split. One analyze
+	// span per model keeps the stage visible on both paths.
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanAnalyze)
+	span.SetAttributes(append(
+		tracing.ModelAttrs(modelID, namespace),
+		attribute.String(tracing.AttrAnalyzer, "v1-saturation"),
+	)...)
+	defer span.End()
+
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Sub-group variants by role for P/D-aware analysis.
@@ -847,9 +881,17 @@ func (e *Engine) analyzeRoleGroups(
 			"scaleUpReason", saturationAnalysis.ScaleUpReason,
 			"scaleDownSafe", saturationAnalysis.ScaleDownSafe)
 
-		// Calculate targets and convert to decisions (transition blocking is per role group)
-		saturationTargets := roleAnalyzer.CalculateSaturationTargets(ctx, saturationAnalysis, roleStates)
-		roleDecisions := e.convertSaturationTargetsToDecisions(ctx, saturationTargets, saturationAnalysis, roleStates)
+		// Calculate targets and convert to decisions (transition blocking is per role group).
+		// Target building is the V1 equivalent of the V2 optimizer stage.
+		optimizeCtx, optimizeSpan := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanOptimize)
+		optimizeSpan.SetAttributes(append(
+			tracing.ModelAttrs(modelID, namespace),
+			attribute.String(tracing.AttrOptimizer, "v1-saturation-targets"),
+		)...)
+		saturationTargets := roleAnalyzer.CalculateSaturationTargets(optimizeCtx, saturationAnalysis, roleStates)
+		roleDecisions := e.convertSaturationTargetsToDecisions(optimizeCtx, saturationTargets, saturationAnalysis, roleStates)
+		optimizeSpan.SetAttributes(attribute.Int(tracing.AttrDecisionCount, len(roleDecisions)))
+		optimizeSpan.End()
 
 		logger.Info("Saturation-only decisions made for role group",
 			"modelID", modelID, "role", role,
@@ -1564,6 +1606,13 @@ func (e *Engine) applySaturationDecisions(
 	vaMap map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	currentAllocations map[string]*domain.Allocation,
 ) {
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanActuate)
+	span.SetAttributes(
+		attribute.Int(tracing.AttrDecisionCount, len(decisions)),
+		attribute.Int(tracing.AttrVariantCount, len(vaMap)),
+	)
+	defer span.End()
+
 	logger := ctrl.LoggerFrom(ctx)
 	// Create a map of decisions for O(1) lookup
 	// Use namespace/variantName as key to match vaMap and avoid collisions

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -24,6 +24,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +41,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 	utils "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	testutils "github.com/llm-d/llm-d-workload-variant-autoscaler/test/utils"
 )
@@ -238,6 +242,123 @@ var _ = Describe("Saturation Engine", func() {
 			// proves the variants were discovered and fed through the saturation pipeline.
 			Expect(mockPromAPI.QueryCallCounts).NotTo(BeEmpty(),
 				"engine should have queried Prometheus for at least one discovered variant")
+		})
+
+		It("should emit a single trace rooted at wva.reconcile for one optimization cycle", func() {
+			By("Installing an in-memory span exporter as the global tracer provider")
+			exporter := tracetest.NewInMemoryExporter()
+			provider := sdktrace.NewTracerProvider(
+				sdktrace.WithSyncer(exporter),
+				sdktrace.WithSampler(sdktrace.AlwaysSample()),
+			)
+			previous := otel.GetTracerProvider()
+			otel.SetTracerProvider(provider)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(previous)
+				Expect(provider.Shutdown(ctx)).To(Succeed())
+			})
+
+			By("Performing one optimization cycle over the discovered variants")
+			mockPromAPI := &testutils.MockPromAPI{
+				QueryResults: map[string]model.Value{},
+				QueryErrors:  map[string]error{},
+			}
+			sourceRegistry := source.NewSourceRegistry()
+			promSource := prometheus.NewPrometheusSource(ctx, mockPromAPI, prometheus.DefaultPrometheusSourceConfig())
+			Expect(sourceRegistry.Register("prometheus", promSource)).To(Succeed())
+
+			testConfig := config.NewTestConfig()
+			testConfig.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{"default": {}})
+
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), record.NewFakeRecorder(100),
+				sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
+			Expect(engine.optimize(ctx)).To(Succeed())
+
+			spans := exporter.GetSpans()
+			Expect(spans).NotTo(BeEmpty(), "an enabled provider must record spans for a cycle")
+
+			names := make([]string, 0, len(spans))
+			for _, s := range spans {
+				names = append(names, s.Name)
+			}
+
+			By("Producing exactly one root span, named wva.reconcile")
+			var roots tracetest.SpanStubs
+			for _, s := range spans {
+				if !s.Parent.IsValid() {
+					roots = append(roots, s)
+				}
+			}
+			Expect(roots).To(HaveLen(1),
+				"one cycle must produce exactly one root span, got %v", names)
+			Expect(roots[0].Name).To(Equal(tracing.SpanReconcile))
+
+			By("Placing every span of the cycle in the root's trace")
+			traceID := roots[0].SpanContext.TraceID()
+			for _, s := range spans {
+				Expect(s.SpanContext.TraceID()).To(Equal(traceID),
+					"span %q must belong to the cycle's trace", s.Name)
+			}
+
+			By("Recording the cycle's decision context on the root span")
+			attrs := map[string]string{}
+			for _, kv := range roots[0].Attributes {
+				attrs[string(kv.Key)] = kv.Value.Emit()
+			}
+			Expect(attrs).To(HaveKey(tracing.AttrMode))
+			Expect(attrs).To(HaveKey(tracing.AttrOptimizer))
+			Expect(attrs).To(HaveKey(tracing.AttrModelCount))
+
+			By("Emitting the collect and actuate stages within the cycle")
+			// envtest runs no kubelet, so the fixture's pods never become Ready
+			// and the mock Prometheus returns no samples. The cycle therefore
+			// collects, finds no metrics, and actuates without reaching the
+			// analyze/optimize stages. Those stages' spans are covered directly
+			// in the pipeline package's tracing tests.
+			Expect(names).To(ContainElement(tracing.SpanCollect))
+			Expect(names).To(ContainElement(tracing.SpanPrometheusQuery))
+			Expect(names).To(ContainElement(tracing.SpanActuate))
+
+			By("Attaching the actuate stage directly to the root")
+			for _, s := range spans {
+				if s.Name == tracing.SpanActuate {
+					Expect(s.Parent.SpanID()).To(Equal(roots[0].SpanContext.SpanID()))
+				}
+			}
+		})
+
+		It("should export no spans for a cycle when the provider never samples", func() {
+			// Mirrors the disabled deployment: Init installs no provider, so
+			// nothing the cycle starts is ever recorded or exported.
+			exporter := tracetest.NewInMemoryExporter()
+			provider := sdktrace.NewTracerProvider(
+				sdktrace.WithSyncer(exporter),
+				sdktrace.WithSampler(sdktrace.NeverSample()),
+			)
+			previous := otel.GetTracerProvider()
+			otel.SetTracerProvider(provider)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(previous)
+				Expect(provider.Shutdown(ctx)).To(Succeed())
+			})
+
+			mockPromAPI := &testutils.MockPromAPI{
+				QueryResults: map[string]model.Value{},
+				QueryErrors:  map[string]error{},
+			}
+			sourceRegistry := source.NewSourceRegistry()
+			promSource := prometheus.NewPrometheusSource(ctx, mockPromAPI, prometheus.DefaultPrometheusSourceConfig())
+			Expect(sourceRegistry.Register("prometheus", promSource)).To(Succeed())
+
+			testConfig := config.NewTestConfig()
+			testConfig.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{"default": {}})
+
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), record.NewFakeRecorder(100),
+				sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
+			Expect(engine.optimize(ctx)).To(Succeed())
+
+			Expect(exporter.GetSpans()).To(BeEmpty(),
+				"no spans may be exported when sampling is off")
 		})
 	})
 

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/accelerator"
@@ -14,6 +15,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/throughput"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/tracing"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
@@ -103,7 +105,15 @@ func (e *Engine) runAnalyzersAndScore(
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	schedulerQueue *domain.SchedulerQueueMetrics,
 	arrivalRate float64,
-) ([]pipeline.NamedAnalyzerResult, error) {
+) (namedResults []pipeline.NamedAnalyzerResult, retErr error) {
+	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanAnalyze)
+	span.SetAttributes(tracing.ModelAttrs(modelID, namespace)...)
+	defer func() {
+		span.SetAttributes(attribute.Int(tracing.AttrAnalyzerCount, len(namedResults)))
+		tracing.RecordError(span, retErr)
+		span.End()
+	}()
+
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Run saturation analyzer (always needed for PerReplicaCapacity).
@@ -137,7 +147,7 @@ func (e *Engine) runAnalyzersAndScore(
 
 	// Collect per-analyzer results. Saturation is first; each non-saturation
 	// analyzer is run, calibrated with its resolved thresholds, and appended.
-	namedResults := []pipeline.NamedAnalyzerResult{{
+	namedResults = []pipeline.NamedAnalyzerResult{{
 		Name:              domain.SaturationAnalyzerName,
 		Result:            baseResult,
 		Score:             scoreForAnalyzer(domain.SaturationAnalyzerName, config),

--- a/internal/engines/saturation/tracing.go
+++ b/internal/engines/saturation/tracing.go
@@ -1,0 +1,4 @@
+package saturation
+
+// tracerScope is the OTel instrumentation scope for the saturation engine.
+const tracerScope = "llm-d-wva/internal/engines/saturation"

--- a/internal/tracing/naming_test.go
+++ b/internal/tracing/naming_test.go
@@ -1,0 +1,141 @@
+package tracing
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// spanNamePattern is the project's span naming convention: a bare snake_case
+// verb phrase. The instrumentation scope, not the span name, identifies the
+// component, so dotted namespaces such as "wva.reconcile" are rejected.
+var spanNamePattern = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+
+// scopePattern is the instrumentation-scope convention: the short component
+// name, optionally followed by the emitting package's path within the repo.
+var scopePattern = regexp.MustCompile(`^llm-d-wva(/[a-z0-9]+([_a-z0-9]*))*$`)
+
+func TestSpanNameConstantsFollowConvention(t *testing.T) {
+	for _, name := range []string{
+		SpanReconcile, SpanCollect, SpanAnalyze, SpanOptimize,
+		SpanLimit, SpanEnforce, SpanActuate, SpanPrometheusQuery,
+	} {
+		assert.Regexp(t, spanNamePattern, name,
+			"span names must be bare snake_case; %q is not", name)
+	}
+}
+
+func TestSpanNamePatternRejectsOldStyleNames(t *testing.T) {
+	// Guards the guard: these are the shapes the convention exists to keep out,
+	// including the dotted names this project and llm-d-router used before
+	// standardizing. If the pattern stops rejecting them it is worthless.
+	for _, name := range []string{
+		"wva.reconcile",
+		"llm_d.pd_proxy.prefill",
+		"gateway.request_orchestration",
+		"ScorePrefixCache",
+		"score-prefix-cache",
+		"Score_Prefix_Cache",
+		"",
+	} {
+		assert.NotRegexp(t, spanNamePattern, name,
+			"%q must not be accepted as a span name", name)
+	}
+}
+
+func TestDefaultScopeFollowsConvention(t *testing.T) {
+	assert.Regexp(t, scopePattern, instrumentationName)
+}
+
+// TestSpanNamesAtCallSitesFollowConvention parses the whole module and checks
+// every literal span name passed to a Tracer's Start method.
+//
+// This is the guard that keeps the convention from eroding: a new call site
+// that hardcodes an old-style dotted name (or copies one from another project)
+// fails here rather than silently splitting dashboards that group by span name.
+func TestSpanNamesAtCallSitesFollowConvention(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	checked := 0
+
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Vendored and build output trees are not ours to police.
+			switch d.Name() {
+			case "vendor", "bin", ".git", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) < 2 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Start" {
+				return true
+			}
+			// Only Start calls on a tracer, so unrelated Start methods
+			// (tickers, managers, servers) are left alone.
+			if !strings.Contains(exprString(sel.X), "Tracer") {
+				return true
+			}
+			lit, ok := call.Args[1].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				// A constant or variable: the constant test above covers it.
+				return true
+			}
+			name, unquoteErr := strconv.Unquote(lit.Value)
+			if unquoteErr != nil {
+				return true
+			}
+			checked++
+			assert.Regexp(t, spanNamePattern, name,
+				"%s: span name %q must be bare snake_case (the scope carries the namespace)",
+				fset.Position(lit.Pos()), name)
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+
+	t.Logf("checked %d literal span names", checked)
+}
+
+// exprString renders an expression well enough to recognise a tracer receiver.
+func exprString(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return exprString(e.X) + "." + e.Sel.Name
+	case *ast.CallExpr:
+		return exprString(e.Fun)
+	default:
+		return ""
+	}
+}

--- a/internal/tracing/span.go
+++ b/internal/tracing/span.go
@@ -1,0 +1,128 @@
+package tracing
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// instrumentationName is the default OTel instrumentation scope: the short
+// component name, matching the service.name this project reports.
+//
+// Packages that emit spans override it with their own scope constant, formed as
+// "llm-d-wva/<package path>". This mirrors llm-d-router's convention
+// ("llm-d-router/pkg/..."): a short component name rather than the full Go
+// module path, followed by the emitting package's path within the repo.
+const instrumentationName = "llm-d-wva"
+
+// Span names for the stages of one optimization cycle. SpanReconcile is the
+// root; the rest are its children, in pipeline order.
+//
+// Names are bare snake_case verbs, not dotted namespaces: the instrumentation
+// scope already identifies the component that emitted the span, so repeating it
+// in the name only makes the name longer. This matches llm-d-router's
+// convention so both projects group the same way in a trace backend.
+const (
+	SpanReconcile = "reconcile"
+	SpanCollect   = "collect"
+	SpanAnalyze   = "analyze"
+	SpanOptimize  = "optimize"
+	SpanLimit     = "limit"
+	SpanEnforce   = "enforce"
+	SpanActuate   = "actuate"
+
+	// SpanPrometheusQuery is a child of SpanCollect: one PromQL query.
+	SpanPrometheusQuery = "prometheus_query"
+)
+
+// Attribute keys for the decision context carried on pipeline spans.
+//
+// Unlike span names, attribute keys are dotted and namespaced, per the
+// OpenTelemetry attribute naming convention (compare http.method, k8s.pod.name).
+//
+// Every value written under these keys is either an integer, a boolean, or a
+// string drawn from a bounded set the controller itself defines (analyzer and
+// optimizer names, accelerator types, decision reasons, Kubernetes object
+// names). Free-form, user-controlled text is never attached to a span.
+const (
+	AttrVariantAutoscaling = "wva.variant_autoscaling"
+	AttrNamespace          = "wva.namespace"
+	AttrModelID            = "wva.model_id"
+	AttrAcceleratorType    = "wva.accelerator_type"
+	AttrCurrentReplicas    = "wva.current_replicas"
+	AttrDesiredReplicas    = "wva.desired_replicas"
+	AttrAnalyzer           = "wva.analyzer"
+	AttrAnalyzerCount      = "wva.analyzer_count"
+	AttrOptimizer          = "wva.optimizer"
+	AttrLimiter            = "wva.limiter"
+	AttrMode               = "wva.mode"
+	AttrModelCount         = "wva.model_count"
+	AttrVariantCount       = "wva.variant_count"
+	AttrDecisionCount      = "wva.decision_count"
+	AttrWasLimited         = "wva.was_limited"
+	AttrLimitedCount       = "wva.limited_decision_count"
+	AttrLimitedBy          = "wva.limited_by"
+	AttrDecisionReason     = "wva.decision_reason"
+	AttrReplicaMetrics     = "wva.replica_metrics_count"
+	AttrQueryType          = "wva.query_type"
+	AttrQuery              = "wva.query"
+	AttrScaleToZero        = "wva.scale_to_zero_enabled"
+)
+
+// Tracer returns a tracer for the given instrumentation scope, defaulting to
+// instrumentationName. Emitting packages pass their own scope constant:
+//
+//	ctx, span := tracing.Tracer(tracerScope).Start(ctx, tracing.SpanOptimize)
+//	defer span.End()
+//
+// The global provider is resolved on every call, so Tracer is safe to use
+// before Init runs, and after it when tracing is disabled: the provider is then
+// the OpenTelemetry no-op implementation and the spans it returns record
+// nothing.
+func Tracer(scope ...string) trace.Tracer {
+	name := instrumentationName
+	if len(scope) > 0 && scope[0] != "" {
+		name = scope[0]
+	}
+	return otel.Tracer(name)
+}
+
+// RecordError marks span as failed and attaches err. It is a no-op when err
+// is nil, so it can be deferred over a named error return.
+func RecordError(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+// ModelAttrs returns the attributes identifying a model scope.
+func ModelAttrs(modelID, namespace string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if modelID != "" {
+		attrs = append(attrs, attribute.String(AttrModelID, modelID))
+	}
+	if namespace != "" {
+		attrs = append(attrs, attribute.String(AttrNamespace, namespace))
+	}
+	return attrs
+}
+
+// VariantAttrs returns the attributes identifying a single VariantAutoscaling
+// and its replica counts.
+func VariantAttrs(name, namespace string, current, desired int) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 4)
+	if name != "" {
+		attrs = append(attrs, attribute.String(AttrVariantAutoscaling, name))
+	}
+	if namespace != "" {
+		attrs = append(attrs, attribute.String(AttrNamespace, namespace))
+	}
+	attrs = append(attrs,
+		attribute.Int(AttrCurrentReplicas, current),
+		attribute.Int(AttrDesiredReplicas, desired),
+	)
+	return attrs
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,0 +1,268 @@
+// Package tracing provides OpenTelemetry tracing for the WVA optimization
+// pipeline: bootstrap of the global tracer provider, and helpers for starting
+// the spans that make up one optimization cycle.
+//
+// Tracing is opt-in and off by default. When it is off no tracer provider is
+// installed, so the global provider stays the OpenTelemetry no-op
+// implementation: spans are non-recording singletons, no exporter runs, and no
+// telemetry leaves the process.
+//
+// Configuration uses the standard OTEL_* environment variables so WVA behaves
+// like any other OpenTelemetry application. See docs/user-guide/monitoring.md.
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// DefaultServiceName is the service.name reported when OTEL_SERVICE_NAME is unset.
+const DefaultServiceName = "llm-d-wva"
+
+// Exporter kinds accepted by OTEL_TRACES_EXPORTER.
+const (
+	// ExporterNone disables tracing. It is the default.
+	ExporterNone = "none"
+	// ExporterOTLP exports spans over OTLP gRPC.
+	ExporterOTLP = "otlp"
+	// ExporterConsole writes spans to stdout, for local debugging.
+	ExporterConsole = "console"
+)
+
+// shutdownTimeout bounds the flush of pending spans at process exit so a
+// slow or unreachable collector cannot block shutdown indefinitely.
+const shutdownTimeout = 5 * time.Second
+
+// Config describes how the tracer provider is built. Use ConfigFromEnv to
+// populate it from the standard OpenTelemetry environment variables.
+type Config struct {
+	// Exporter selects the span exporter: ExporterNone, ExporterOTLP, or
+	// ExporterConsole. ExporterNone disables tracing entirely.
+	Exporter string
+
+	// ServiceName is reported as the service.name resource attribute.
+	ServiceName string
+
+	// ServiceVersion is reported as the service.version resource attribute.
+	// Empty means the attribute is omitted.
+	ServiceVersion string
+
+	// Endpoint is the OTLP gRPC endpoint (host:port). Empty lets the exporter
+	// fall back to its own environment-variable defaults.
+	Endpoint string
+
+	// Insecure disables transport security for the OTLP exporter. Production
+	// deployments should terminate TLS; see the hardening follow-up noted in
+	// the package documentation.
+	Insecure bool
+
+	// Sampler and SamplerArg mirror OTEL_TRACES_SAMPLER and
+	// OTEL_TRACES_SAMPLER_ARG.
+	Sampler    string
+	SamplerArg string
+
+	// Namespace and InstanceID identify this controller instance in the
+	// resource attributes.
+	Namespace  string
+	InstanceID string
+}
+
+// Enabled reports whether the configuration turns tracing on.
+func (c Config) Enabled() bool {
+	return c.Exporter != "" && !strings.EqualFold(c.Exporter, ExporterNone)
+}
+
+// ConfigFromEnv builds a Config from the standard OpenTelemetry environment
+// variables:
+//
+//	OTEL_TRACES_EXPORTER            none (default) | otlp | console
+//	OTEL_SERVICE_NAME               defaults to DefaultServiceName
+//	OTEL_SERVICE_VERSION            optional
+//	OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_ENDPOINT
+//	OTEL_EXPORTER_OTLP_INSECURE     true | false
+//	OTEL_TRACES_SAMPLER, OTEL_TRACES_SAMPLER_ARG
+//
+// The controller instance is taken from POD_NAME (or the hostname) and the
+// namespace from POD_NAMESPACE.
+func ConfigFromEnv() Config {
+	cfg := Config{
+		Exporter:       strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_EXPORTER"))),
+		ServiceName:    os.Getenv("OTEL_SERVICE_NAME"),
+		ServiceVersion: os.Getenv("OTEL_SERVICE_VERSION"),
+		Endpoint:       os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"),
+		Sampler:        strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER"))),
+		SamplerArg:     os.Getenv("OTEL_TRACES_SAMPLER_ARG"),
+		Namespace:      os.Getenv("POD_NAMESPACE"),
+		InstanceID:     os.Getenv("POD_NAME"),
+	}
+
+	if cfg.Exporter == "" {
+		cfg.Exporter = ExporterNone
+	}
+	if cfg.ServiceName == "" {
+		cfg.ServiceName = DefaultServiceName
+	}
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if insecure, err := strconv.ParseBool(os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")); err == nil {
+		cfg.Insecure = insecure
+	}
+	if cfg.InstanceID == "" {
+		// In a Pod the hostname is the Pod name, so this keeps the attribute
+		// useful without requiring a downward-API entry in the manifest.
+		if hostname, err := os.Hostname(); err == nil {
+			cfg.InstanceID = hostname
+		}
+	}
+	return cfg
+}
+
+// ShutdownFunc flushes and releases the tracer provider. It is safe to call
+// even when tracing is disabled, in which case it does nothing.
+type ShutdownFunc func(context.Context) error
+
+// Init installs the global tracer provider and W3C trace-context propagator
+// according to cfg, and returns a function that shuts them down.
+//
+// When cfg disables tracing, Init installs nothing and returns a no-op
+// shutdown, leaving the OpenTelemetry no-op provider in place.
+func Init(ctx context.Context, cfg Config) (ShutdownFunc, error) {
+	if !cfg.Enabled() {
+		return func(context.Context) error { return nil }, nil
+	}
+
+	exporter, err := newExporter(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating span exporter: %w", err)
+	}
+
+	res, err := newResource(ctx, cfg)
+	if err != nil {
+		// The exporter owns a connection; release it rather than leaking it
+		// on a failure path that never installs the provider.
+		_ = exporter.Shutdown(ctx)
+		return nil, fmt.Errorf("building tracing resource: %w", err)
+	}
+
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(newSampler(cfg)),
+	)
+
+	otel.SetTracerProvider(provider)
+	// W3C trace context and baggage, so a trace started upstream (or in
+	// llm-d-router) continues through WVA rather than starting a new one.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return func(shutdownCtx context.Context) error {
+		// Bound the flush: shutdown must not hang on an unreachable collector.
+		shutdownCtx, cancel := context.WithTimeout(shutdownCtx, shutdownTimeout)
+		defer cancel()
+		return provider.Shutdown(shutdownCtx)
+	}, nil
+}
+
+// newExporter constructs the span exporter selected by cfg.Exporter.
+func newExporter(ctx context.Context, cfg Config) (sdktrace.SpanExporter, error) {
+	switch strings.ToLower(cfg.Exporter) {
+	case ExporterConsole, "stdout":
+		return stdouttrace.New(stdouttrace.WithPrettyPrint())
+	case ExporterOTLP:
+		opts := []otlptracegrpc.Option{}
+		if cfg.Endpoint != "" {
+			opts = append(opts, otlptracegrpc.WithEndpointURL(normalizeEndpoint(cfg.Endpoint)))
+		}
+		if cfg.Insecure {
+			opts = append(opts, otlptracegrpc.WithInsecure())
+		}
+		return otlptracegrpc.New(ctx, opts...)
+	default:
+		return nil, fmt.Errorf("unsupported OTEL_TRACES_EXPORTER %q (want %q, %q, or %q)",
+			cfg.Exporter, ExporterNone, ExporterOTLP, ExporterConsole)
+	}
+}
+
+// normalizeEndpoint gives a bare host:port endpoint a scheme, since
+// WithEndpointURL requires a URL while OTEL_EXPORTER_OTLP_ENDPOINT is
+// commonly set to host:port.
+func normalizeEndpoint(endpoint string) string {
+	if strings.Contains(endpoint, "://") {
+		return endpoint
+	}
+	return "http://" + endpoint
+}
+
+// newResource describes this process to the trace backend.
+func newResource(ctx context.Context, cfg Config) (*resource.Resource, error) {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(cfg.ServiceName),
+	}
+	if cfg.ServiceVersion != "" {
+		attrs = append(attrs, semconv.ServiceVersion(cfg.ServiceVersion))
+	}
+	if cfg.Namespace != "" {
+		attrs = append(attrs, semconv.K8SNamespaceName(cfg.Namespace))
+	}
+	if cfg.InstanceID != "" {
+		attrs = append(attrs,
+			semconv.ServiceInstanceID(cfg.InstanceID),
+			semconv.K8SPodName(cfg.InstanceID),
+		)
+	}
+
+	// Merge over the default resource so the SDK's telemetry.sdk.* attributes
+	// and any OTEL_RESOURCE_ATTRIBUTES entries are preserved.
+	return resource.New(ctx,
+		resource.WithFromEnv(),
+		resource.WithTelemetrySDK(),
+		resource.WithAttributes(attrs...),
+	)
+}
+
+// newSampler maps OTEL_TRACES_SAMPLER to an SDK sampler. Unrecognized values
+// fall back to parentbased_always_on, which is the OpenTelemetry default.
+func newSampler(cfg Config) sdktrace.Sampler {
+	ratio := func(def float64) float64 {
+		if cfg.SamplerArg == "" {
+			return def
+		}
+		parsed, err := strconv.ParseFloat(cfg.SamplerArg, 64)
+		if err != nil {
+			return def
+		}
+		return parsed
+	}
+
+	switch cfg.Sampler {
+	case "always_off":
+		return sdktrace.NeverSample()
+	case "always_on":
+		return sdktrace.AlwaysSample()
+	case "traceidratio":
+		return sdktrace.TraceIDRatioBased(ratio(1.0))
+	case "parentbased_always_off":
+		return sdktrace.ParentBased(sdktrace.NeverSample())
+	case "parentbased_traceidratio":
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(ratio(1.0)))
+	default:
+		return sdktrace.ParentBased(sdktrace.AlwaysSample())
+	}
+}

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -1,0 +1,212 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestConfigFromEnvDefaults(t *testing.T) {
+	// No OTEL_* variables set: tracing must be off and the service name must
+	// fall back to the project default.
+	for _, key := range []string{
+		"OTEL_TRACES_EXPORTER", "OTEL_SERVICE_NAME", "OTEL_SERVICE_VERSION",
+		"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_INSECURE", "OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG",
+		"POD_NAMESPACE", "POD_NAME",
+	} {
+		t.Setenv(key, "")
+	}
+
+	cfg := ConfigFromEnv()
+
+	assert.Equal(t, ExporterNone, cfg.Exporter)
+	assert.False(t, cfg.Enabled(), "tracing must be off by default")
+	assert.Equal(t, DefaultServiceName, cfg.ServiceName)
+}
+
+func TestConfigFromEnvReadsStandardVariables(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "OTLP")
+	t.Setenv("OTEL_SERVICE_NAME", "wva-test")
+	t.Setenv("OTEL_SERVICE_VERSION", "v1.2.3")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "collector:4317")
+	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
+	t.Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "0.25")
+	t.Setenv("POD_NAMESPACE", "wva-system")
+	t.Setenv("POD_NAME", "wva-controller-0")
+
+	cfg := ConfigFromEnv()
+
+	// The exporter name is case-insensitive.
+	assert.Equal(t, ExporterOTLP, cfg.Exporter)
+	assert.True(t, cfg.Enabled())
+	assert.Equal(t, "wva-test", cfg.ServiceName)
+	assert.Equal(t, "v1.2.3", cfg.ServiceVersion)
+	assert.Equal(t, "collector:4317", cfg.Endpoint)
+	assert.True(t, cfg.Insecure)
+	assert.Equal(t, "traceidratio", cfg.Sampler)
+	assert.Equal(t, "0.25", cfg.SamplerArg)
+	assert.Equal(t, "wva-system", cfg.Namespace)
+	assert.Equal(t, "wva-controller-0", cfg.InstanceID)
+}
+
+func TestConfigFromEnvPrefersTracesEndpoint(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "generic:4317")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "traces:4317")
+
+	assert.Equal(t, "traces:4317", ConfigFromEnv().Endpoint)
+}
+
+func TestConfigEnabled(t *testing.T) {
+	cases := map[string]bool{
+		"":        false,
+		"none":    false,
+		"NONE":    false,
+		"otlp":    true,
+		"console": true,
+	}
+	for exporter, want := range cases {
+		assert.Equal(t, want, Config{Exporter: exporter}.Enabled(), "exporter %q", exporter)
+	}
+}
+
+func TestInitDisabledInstallsNoProvider(t *testing.T) {
+	// Capture whatever provider is installed, and assert Init leaves it alone.
+	before := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(before) })
+
+	otel.SetTracerProvider(noop.NewTracerProvider())
+
+	shutdown, err := Init(context.Background(), Config{Exporter: ExporterNone})
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+
+	_, span := Tracer().Start(context.Background(), SpanReconcile)
+	defer span.End()
+	assert.False(t, span.SpanContext().IsValid(),
+		"a disabled provider must produce non-recording spans")
+	assert.False(t, span.IsRecording())
+
+	// The no-op shutdown must succeed and be safe to call.
+	assert.NoError(t, shutdown(context.Background()))
+}
+
+func TestInitConsoleExporterInstallsProviderAndShutsDown(t *testing.T) {
+	before := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(before) })
+
+	shutdown, err := Init(context.Background(), Config{
+		Exporter:       ExporterConsole,
+		ServiceName:    "wva-test",
+		ServiceVersion: "v0.0.1",
+		Namespace:      "wva-system",
+		InstanceID:     "wva-controller-0",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+
+	_, span := Tracer().Start(context.Background(), SpanReconcile)
+	assert.True(t, span.SpanContext().IsValid(), "an enabled provider must produce recording spans")
+	span.End()
+
+	require.NoError(t, shutdown(context.Background()))
+	// Shutting down twice must not panic or error; the manager may race with
+	// an error path that also flushes.
+	assert.NoError(t, shutdown(context.Background()))
+}
+
+func TestInitRejectsUnknownExporter(t *testing.T) {
+	before := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(before) })
+
+	shutdown, err := Init(context.Background(), Config{Exporter: "kafka"})
+	require.Error(t, err)
+	assert.Nil(t, shutdown)
+	assert.Contains(t, err.Error(), "kafka")
+}
+
+func TestNewSampler(t *testing.T) {
+	cases := []struct {
+		sampler string
+		arg     string
+		want    string
+	}{
+		{"", "", sdktrace.ParentBased(sdktrace.AlwaysSample()).Description()},
+		{"always_on", "", sdktrace.AlwaysSample().Description()},
+		{"always_off", "", sdktrace.NeverSample().Description()},
+		{"traceidratio", "0.5", sdktrace.TraceIDRatioBased(0.5).Description()},
+		{"parentbased_always_off", "", sdktrace.ParentBased(sdktrace.NeverSample()).Description()},
+		{"parentbased_traceidratio", "0.1", sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1)).Description()},
+		// An unparsable ratio must not panic; it falls back to 1.0.
+		{"traceidratio", "not-a-number", sdktrace.TraceIDRatioBased(1.0).Description()},
+		// An unknown sampler name falls back to the OpenTelemetry default.
+		{"lottery", "", sdktrace.ParentBased(sdktrace.AlwaysSample()).Description()},
+	}
+
+	for _, tc := range cases {
+		got := newSampler(Config{Sampler: tc.sampler, SamplerArg: tc.arg})
+		assert.Equal(t, tc.want, got.Description(), "sampler=%q arg=%q", tc.sampler, tc.arg)
+	}
+}
+
+func TestNormalizeEndpoint(t *testing.T) {
+	assert.Equal(t, "http://collector:4317", normalizeEndpoint("collector:4317"))
+	assert.Equal(t, "https://collector:4317", normalizeEndpoint("https://collector:4317"))
+	assert.Equal(t, "http://collector:4317", normalizeEndpoint("http://collector:4317"))
+}
+
+func TestNewResourceCarriesIdentity(t *testing.T) {
+	res, err := newResource(context.Background(), Config{
+		ServiceName:    "wva-test",
+		ServiceVersion: "v9.9.9",
+		Namespace:      "wva-system",
+		InstanceID:     "wva-controller-0",
+	})
+	require.NoError(t, err)
+
+	attrs := map[string]string{}
+	for _, kv := range res.Attributes() {
+		attrs[string(kv.Key)] = kv.Value.Emit()
+	}
+
+	assert.Equal(t, "wva-test", attrs["service.name"])
+	assert.Equal(t, "v9.9.9", attrs["service.version"])
+	assert.Equal(t, "wva-system", attrs["k8s.namespace.name"])
+	assert.Equal(t, "wva-controller-0", attrs["service.instance.id"])
+	assert.Equal(t, "wva-controller-0", attrs["k8s.pod.name"])
+}
+
+func TestNewResourceOmitsEmptyOptionalAttributes(t *testing.T) {
+	res, err := newResource(context.Background(), Config{ServiceName: "wva-test"})
+	require.NoError(t, err)
+
+	for _, kv := range res.Attributes() {
+		switch string(kv.Key) {
+		case "service.version", "k8s.namespace.name", "service.instance.id", "k8s.pod.name":
+			t.Errorf("attribute %q must be omitted when unset", kv.Key)
+		}
+	}
+}
+
+func TestRecordError(t *testing.T) {
+	// RecordError on a nil error must leave the span unset; the no-op span is
+	// enough to prove it does not panic.
+	_, span := noop.NewTracerProvider().Tracer("test").Start(context.Background(), "x")
+	defer span.End()
+	RecordError(span, nil)
+}
+
+func TestTracerIsUsableBeforeInit(t *testing.T) {
+	// Tracer resolves the global provider lazily, so calling it before Init
+	// must not panic and must yield a usable (no-op) tracer.
+	tracer := Tracer()
+	require.NotNil(t, tracer)
+	_, span := tracer.Start(context.Background(), "x")
+	span.End()
+}


### PR DESCRIPTION
Fixes #1272 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add `internal/tracing`: OTel bootstrap (OTLP gRPC + console exporters, W3C propagation, graceful shutdown wired into the manager lifecycle), configured entirely through standard `OTEL_*` env vars. Off by default — with `OTEL_TRACES_EXPORTER` unset no provider is installed, so spans are no-ops and nothing is exported.
- :gift: Instrument one trace per optimization cycle, rooted at `reconcile`, with `collect` / `prometheus_query` / `analyze` / `optimize` / `limit` / `enforce` / `actuate` child spans carrying the decision context as `wva.*` attributes.
- :gift: Follow the naming convention llm-d-router standardized in llm-d/llm-d-router#1565: `llm-d-wva` service name, `llm-d-wva/<package>` instrumentation scopes, and bare snake_case span names. A test parses the module and fails on any span name that drifts from it.
- :broom: Document enablement, the trace tree, and the scope/span conventions in `docs/user-guide/monitoring.md`.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **E2E tests** for any new behavior
- [X] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
WVA can now emit OpenTelemetry traces for the optimization pipeline, producing one trace per cycle across collection, analysis, optimization, limiting, enforcement, and actuation. Tracing is off by default; enable it by setting OTEL_TRACES_EXPORTER=otlp and OTEL_EXPORTER_OTLP_ENDPOINT. See docs/user-guide/monitoring.md.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->