### PR TITLE
fix(crd): restart when KEDA or LWS CRDs are installed after startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -177,7 +177,8 @@ func main() {
 		}
 		setupLog.Info("LeaderWorkerSet CRD detected - support enabled")
 	} else {
-		setupLog.Info("LeaderWorkerSet CRD not found - support disabled (Deployment-only mode)")
+		setupLog.Info("LeaderWorkerSet CRD not found - support disabled (Deployment-only mode); " +
+			"support requires a controller restart, which happens automatically if the CRD is installed later")
 	}
 
 	// Detect KEDA for annotation-based ScaledObject discovery
@@ -185,11 +186,27 @@ func main() {
 	if kedaEnabled {
 		setupLog.Info("KEDA ScaledObject CRD detected - annotation-based ScaledObject discovery enabled")
 	} else {
-		setupLog.Info("KEDA ScaledObject CRD not found - annotation-based discovery limited to HPAs")
+		setupLog.Info("KEDA ScaledObject CRD not found - annotation-based discovery limited to HPAs; " +
+			"support requires a controller restart, which happens automatically if the CRD is installed later")
 	}
 	// Gate the pod locator's ScaledObject lookups on KEDA availability. Set before
 	// the saturation engine goroutine constructs its locator.
 	locator.SetKEDAEnabled(kedaEnabled)
+
+	crdTargets := []crd.Target{
+		{
+			CRDName:       "leaderworkersets.leaderworkerset.x-k8s.io",
+			GroupVersion:  "leaderworkerset.x-k8s.io/v1",
+			Kind:          "LeaderWorkerSet",
+			PresentAtBoot: lwsEnabled,
+		},
+		{
+			CRDName:       "scaledobjects.keda.sh",
+			GroupVersion:  "keda.sh/v1alpha1",
+			Kind:          "ScaledObject",
+			PresentAtBoot: kedaEnabled,
+		},
+	}
 
 	tlsOpts := []func(*tls.Config){
 		func(c *tls.Config) {
@@ -611,6 +628,11 @@ func main() {
 		setupLog.Info("Coordinator disabled (experimental feature; set EXPERIMENTAL_COORDINATOR_ENABLED=true to enable)")
 	}
 
+	if err := mgr.Add(crd.NewWatcher(restConfig, crdTargets)); err != nil {
+		setupLog.Error(err, "unable to add CRD watcher to manager")
+		os.Exit(1)
+	}
+
 	if metricsCertWatcher != nil {
 		setupLog.Info("Adding metrics certificate watcher to manager")
 		if err := mgr.Add(metricsCertWatcher); err != nil {
@@ -662,6 +684,10 @@ func main() {
 	}
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		if errors.Is(err, crd.ErrRestartRequired) {
+			setupLog.Info("restarting to enable support for a CRD installed after startup", "reason", err.Error())
+			os.Exit(1)
+		}
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -104,6 +104,11 @@ func main() {
 	configFilePath := flag.String("config-file", "", "Path to the YAML configuration file. "+
 		"When set, the main configuration is read from this file instead of a Kubernetes ConfigMap.")
 
+	disableCRDAutoRestart := flag.Bool("disable-crd-auto-restart", false,
+		"Disable automatically restarting the controller when an optional CRD (KEDA ScaledObject or "+
+			"LeaderWorkerSet) is installed after startup. When set, enabling support for a CRD installed "+
+			"later requires a manual controller restart.")
+
 	flag.String("metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -168,6 +173,12 @@ func main() {
 	}
 	setupLog.Info("Configuration loaded successfully")
 
+	restartNote := "support requires a controller restart, which happens automatically if the CRD is installed later"
+	if *disableCRDAutoRestart {
+		restartNote = "support requires a manual controller restart after the CRD is installed " +
+			"(automatic restart disabled via --disable-crd-auto-restart)"
+	}
+
 	// Conditionally add LeaderWorkerSet scheme if CRD exists
 	lwsEnabled := crd.CheckLeaderWorkerSetCRD(restConfig, setupLog)
 	if lwsEnabled {
@@ -177,8 +188,7 @@ func main() {
 		}
 		setupLog.Info("LeaderWorkerSet CRD detected - support enabled")
 	} else {
-		setupLog.Info("LeaderWorkerSet CRD not found - support disabled (Deployment-only mode); " +
-			"support requires a controller restart, which happens automatically if the CRD is installed later")
+		setupLog.Info("LeaderWorkerSet CRD not found - support disabled (Deployment-only mode); " + restartNote)
 	}
 
 	// Detect KEDA for annotation-based ScaledObject discovery
@@ -186,8 +196,7 @@ func main() {
 	if kedaEnabled {
 		setupLog.Info("KEDA ScaledObject CRD detected - annotation-based ScaledObject discovery enabled")
 	} else {
-		setupLog.Info("KEDA ScaledObject CRD not found - annotation-based discovery limited to HPAs; " +
-			"support requires a controller restart, which happens automatically if the CRD is installed later")
+		setupLog.Info("KEDA ScaledObject CRD not found - annotation-based discovery limited to HPAs; " + restartNote)
 	}
 	// Gate the pod locator's ScaledObject lookups on KEDA availability. Set before
 	// the saturation engine goroutine constructs its locator.
@@ -628,7 +637,10 @@ func main() {
 		setupLog.Info("Coordinator disabled (experimental feature; set EXPERIMENTAL_COORDINATOR_ENABLED=true to enable)")
 	}
 
-	if err := mgr.Add(crd.NewWatcher(restConfig, crdTargets)); err != nil {
+	if *disableCRDAutoRestart {
+		setupLog.Info("Automatic restart on post-startup CRD installation is disabled " +
+			"(--disable-crd-auto-restart); install-then-restart must be performed manually")
+	} else if err := mgr.Add(crd.NewWatcher(restConfig, crdTargets)); err != nil {
 		setupLog.Error(err, "unable to add CRD watcher to manager")
 		os.Exit(1)
 	}

--- a/internal/utils/crd/watcher.go
+++ b/internal/utils/crd/watcher.go
@@ -1,0 +1,94 @@
+package crd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+)
+
+var ErrRestartRequired = errors.New("CRD installed after startup, controller restart required")
+
+const defaultProbeInterval = time.Minute
+
+type Target struct {
+	CRDName       string
+	GroupVersion  string
+	Kind          string
+	PresentAtBoot bool
+}
+
+type probeFunc func(groupVersion, kind string, logger logr.Logger) (bool, error)
+
+type Watcher struct {
+	targets  []Target
+	probe    probeFunc
+	interval time.Duration
+}
+
+var _ manager.LeaderElectionRunnable = (*Watcher)(nil)
+
+func NewWatcher(restConfig *rest.Config, targets []Target) *Watcher {
+	return &Watcher{
+		targets: targets,
+		probe: func(groupVersion, kind string, logger logr.Logger) (bool, error) {
+			return DetectCRDInstalled(restConfig, groupVersion, kind, logger)
+		},
+		interval: defaultProbeInterval,
+	}
+}
+
+func (w *Watcher) NeedLeaderElection() bool { return false }
+
+func (w *Watcher) Start(ctx context.Context) error {
+	logger := ctrl.LoggerFrom(ctx).WithName("crd-watcher")
+
+	pending := make([]Target, 0, len(w.targets))
+	for _, t := range w.targets {
+		if !t.PresentAtBoot {
+			pending = append(pending, t)
+		}
+	}
+	if len(pending) == 0 {
+		logger.V(logging.DEBUG).Info("all optional CRDs present at startup, CRD probe idle")
+		<-ctx.Done()
+		return nil
+	}
+
+	for _, t := range pending {
+		logger.V(logging.DEBUG).Info("probing for post-startup CRD installation",
+			"crd", t.CRDName, "groupVersion", t.GroupVersion, "kind", t.Kind, "interval", w.interval)
+	}
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			for _, t := range pending {
+				installed, err := w.probe(t.GroupVersion, t.Kind, logger)
+				if err != nil {
+					logger.V(logging.DEBUG).Info("discovery probe failed, will retry",
+						"crd", t.CRDName, "error", err)
+					continue
+				}
+				if !installed {
+					continue
+				}
+				logger.Info("CRD available after controller startup, restarting to enable support",
+					"crd", t.CRDName, "groupVersion", t.GroupVersion, "kind", t.Kind)
+				return fmt.Errorf("%w: %s", ErrRestartRequired, t.CRDName)
+			}
+		}
+	}
+}

--- a/internal/utils/crd/watcher_test.go
+++ b/internal/utils/crd/watcher_test.go
@@ -1,0 +1,166 @@
+package crd
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	testCRDName      = "scaledobjects.keda.sh"
+	testGroupVersion = "keda.sh/v1alpha1"
+	testKind         = "ScaledObject"
+)
+
+func absentTarget() Target {
+	return Target{
+		CRDName:       testCRDName,
+		GroupVersion:  testGroupVersion,
+		Kind:          testKind,
+		PresentAtBoot: false,
+	}
+}
+
+func TestWatcher_NeedLeaderElectionIsFalse(t *testing.T) {
+	w := &Watcher{}
+	if w.NeedLeaderElection() {
+		t.Error("NeedLeaderElection() = true, want false")
+	}
+}
+
+func TestWatcher_AllTargetsPresentAtBootStaysIdle(t *testing.T) {
+	present := absentTarget()
+	present.PresentAtBoot = true
+
+	w := &Watcher{
+		targets:  []Target{present},
+		interval: time.Millisecond,
+		probe: func(string, string, logr.Logger) (bool, error) {
+			t.Error("probe must not run when every target was present at boot")
+			return true, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Start(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() = %v, want nil on context cancellation", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+func TestWatcher_StartReturnsRestartRequiredOnDetection(t *testing.T) {
+	w := &Watcher{
+		targets:  []Target{absentTarget()},
+		interval: time.Millisecond,
+		probe: func(string, string, logr.Logger) (bool, error) {
+			return true, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := w.Start(ctx)
+	if !errors.Is(err, ErrRestartRequired) {
+		t.Fatalf("Start() = %v, want ErrRestartRequired", err)
+	}
+	if !errors.Is(err, ErrRestartRequired) || err.Error() != ErrRestartRequired.Error()+": "+testCRDName {
+		t.Errorf("Start() = %q, want the CRD name appended", err)
+	}
+}
+
+func TestWatcher_StartKeepsProbingWhileAbsent(t *testing.T) {
+	var calls atomic.Int32
+	w := &Watcher{
+		targets:  []Target{absentTarget()},
+		interval: time.Millisecond,
+		probe: func(string, string, logr.Logger) (bool, error) {
+			calls.Add(1)
+			return false, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	if err := w.Start(ctx); err != nil {
+		t.Errorf("Start() = %v, want nil while the CRD stays absent", err)
+	}
+	if calls.Load() < 2 {
+		t.Errorf("probe ran %d times, want repeated probing", calls.Load())
+	}
+}
+
+func TestWatcher_StartKeepsProbingAfterProbeError(t *testing.T) {
+	var calls atomic.Int32
+	w := &Watcher{
+		targets:  []Target{absentTarget()},
+		interval: time.Millisecond,
+		probe: func(string, string, logr.Logger) (bool, error) {
+			if calls.Add(1) < 3 {
+				return false, errors.New("discovery unavailable")
+			}
+			return true, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := w.Start(ctx); !errors.Is(err, ErrRestartRequired) {
+		t.Fatalf("Start() = %v, want ErrRestartRequired after transient probe errors", err)
+	}
+}
+
+func TestWatcher_StartProbesEveryPendingTarget(t *testing.T) {
+	lws := Target{
+		CRDName:      "leaderworkersets.leaderworkerset.x-k8s.io",
+		GroupVersion: "leaderworkerset.x-k8s.io/v1",
+		Kind:         "LeaderWorkerSet",
+	}
+	keda := absentTarget()
+
+	seen := make(chan string, 8)
+	w := &Watcher{
+		targets:  []Target{lws, keda},
+		interval: time.Millisecond,
+		probe: func(groupVersion, _ string, _ logr.Logger) (bool, error) {
+			select {
+			case seen <- groupVersion:
+			default:
+			}
+			return false, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start() = %v, want nil", err)
+	}
+	close(seen)
+
+	probed := map[string]bool{}
+	for gv := range seen {
+		probed[gv] = true
+	}
+	for _, want := range []string{lws.GroupVersion, keda.GroupVersion} {
+		if !probed[want] {
+			t.Errorf("group version %q was never probed", want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1461

## Summary

This change enables KEDA and LeaderWorkerSet support to become active when those CRDs are installed after the controller has already started. Today both are probed once at startup, so installing either one later leaves that support disabled until someone manually restarts the pod. This is easy to hit in GitOps or bootstrap flows, where component ordering is not guaranteed.

## Changes Made

This change adds `internal/utils/crd/watcher.go`. The `Watcher` type is a manager `Runnable` that probes discovery once a minute for the group-versions that were absent at boot, using the same `DetectCRDInstalled` function the startup path already calls. Targets present at boot are filtered out, and probe errors are retried rather than read as absence. On detection it returns an error wrapping `ErrRestartRequired`, which shuts the manager down so the Deployment restarts the controller with correct wiring. `NeedLeaderElection()` returns false so every replica restarts rather than leaving standbys stale.

In `cmd/main.go`, the change builds the targets from the existing `lwsEnabled` and `kedaEnabled` results, registers the watcher, matches `ErrRestartRequired` in the `mgr.Start` error path so the restart is not logged as `problem running manager`, and rewords the two "CRD not found" startup lines. It adds no dependencies and no RBAC.

## Test evidence

```
$ make test
ok   .../internal/utils/crd   0.471s   coverage: 77.4% of statements

$ make lint
0 issues.
```

Seven new unit tests in `internal/utils/crd`. `make test-e2e-smoke` on kind passed 15 of 15. The feature also fired on its own during `make deploy-e2e-infra`, which installs WVA before KEDA: the controller detected the CRD one interval after boot, restarted, and came back with ScaledObject discovery enabled.

## Notes

- **Exit code.** Non-zero, as suggested fix 2 specifies. Exiting zero would report `Completed` rather than `Error`, and I am happy to switch.
- **Install ordering.** `deploy/install.sh` installs WVA before KEDA, so a fresh `make deploy-e2e-infra` now restarts the controller about a minute in. This is harmless, but it makes the restart routine rather than exceptional on the project's own install path. Fixing the ordering there is the better long-term answer, and it is out of scope here.

### Pre-review Checklist

- [x] **E2E tests** for any new behavior. Verified on kind; no new spec added.
- [ ] **Docs PR** for any user-facing impact. N/A, covered by the release note.
- [ ] **Proposal PR** for any new enhancement or change to existing behavior. N/A, implements #1461.

```release-note
WVA now detects KEDA and LeaderWorkerSet CRDs that are installed after the controller has started. Previously, installing either CRD afterwards left the corresponding support silently disabled until the controller was manually restarted. The controller now restarts itself once the newly installed API is served.
```
