### PR TITLE
test(throughput): cover ITL-model / demand / supply guard branches

### DIFF
--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -2097,4 +2097,20 @@ var _ = Describe("computeLocalDemand", func() {
 		total := computeLocalDemand([]domain.ReplicaMetrics{replicaAt(0.5)}, shape, nanModel)
 		Expect(total).To(Equal(0.0))
 	})
+
+	It("skips a replica with non-positive TotalKvCapacityTokens", func() {
+		noCapacity := replicaAt(0.5)
+		noCapacity.TotalKvCapacityTokens = 0
+		total := computeLocalDemand([]domain.ReplicaMetrics{noCapacity}, shape, model)
+		Expect(total).To(Equal(0.0))
+	})
+
+	It("skips a replica whose model produces a finite non-positive ITL", func() {
+		// B negative enough that A*k+B <= 0 at k=0.5 without A or B being NaN/Inf —
+		// distinct from the existing NaN-ITL case, which uses a NaN model coefficient.
+		negativeITLModel := ITLModel{A: 0.01, B: -0.1}
+		Expect(negativeITLModel.ITLAt(0.5)).To(BeNumerically("<=", 0), "fixture sanity check")
+		total := computeLocalDemand([]domain.ReplicaMetrics{replicaAt(0.5)}, shape, negativeITLModel)
+		Expect(total).To(Equal(0.0))
+	})
 })

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -558,10 +558,11 @@ var _ = Describe("ThroughputAnalyzer", func() {
 		})
 
 		It("resolveITLModel returns T2-failed when the computed fit is rejected by validITLModel", func() {
-			// AvgITL below the pinned baseline (DefaultBaselineITLSec = 0.006) at k=0.5 produces
-			// numerator = (0.001 - 0.006) * 0.5 = -0.0025, sumK2 = 0.25 → A = -0.01 (negative,
-			// inverted slope) — a real Tier-2 fit is computed (n=1, sumK2>0) but validITLModel
-			// rejects it, unlike the existing "all idle" test which never reaches the fit at all.
+			// AvgITL below the constant baseline B (DefaultBaselineITLSec = 0.006, default path) at
+			// k=0.5 produces numerator = (0.001 - 0.006) * 0.5 = -0.0025, sumK2 = 0.25 → A = -0.01
+			// (negative, inverted slope) — a real Tier-2 fit is computed (n=1, sumK2>0) but
+			// validITLModel rejects it, unlike the existing "all idle" test which never reaches the
+			// fit at all.
 			belowBaseline := domain.ReplicaMetrics{
 				VariantName: "v1", KvUsageInstant: 0.5, KvCacheUsage: 0.5,
 				AvgITL: 0.001, AvgInputTokens: 5000, AvgOutputTokens: 200,

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -2100,8 +2100,11 @@ var _ = Describe("computeLocalDemand", func() {
 	})
 
 	It("skips a replica with non-positive TotalKvCapacityTokens", func() {
+		// Negative, not zero: the accumulated term is KvUsageInstant × capacity / KVreq / ITL, so
+		// a zero capacity contributes 0 whether or not the guard fires. Only a negative capacity
+		// makes the unguarded contribution non-zero, so only it pins the skip.
 		noCapacity := replicaAt(0.5)
-		noCapacity.TotalKvCapacityTokens = 0
+		noCapacity.TotalKvCapacityTokens = -65536
 		total := computeLocalDemand([]domain.ReplicaMetrics{noCapacity}, shape, model)
 		Expect(total).To(Equal(0.0))
 	})
@@ -2125,11 +2128,16 @@ var _ = Describe("computeVariantSupply", func() {
 	}
 
 	It("aggregates supply across KV-capable replicas", func() {
+		// Differing capacities keep perReplica from being a copy of total, and the third replica
+		// carries no KV capacity so nKV (2) differs from len(metrics) (3) — that is what pins the
+		// mean to the KV-capable count rather than to the replica count.
 		total, perReplica, nKV := computeVariantSupply(
-			[]domain.ReplicaMetrics{replicaWithCap(65536)}, shape, itlSat)
-		Expect(nKV).To(Equal(1))
-		Expect(total).To(BeNumerically(">", 0))
-		Expect(perReplica).To(BeNumerically("~", total, 1e-9)) // single replica → mean == total
+			[]domain.ReplicaMetrics{replicaWithCap(65536), replicaWithCap(131072), replicaWithCap(0)},
+			shape, itlSat)
+		Expect(nKV).To(Equal(2))
+		// Σ_r DefaultKSat × KV_max_r / KVreq / itlSat over the KV-capable replicas.
+		Expect(total).To(BeNumerically("~", DefaultKSat*(65536+131072)/shape.KVreq/itlSat, 1e-6))
+		Expect(perReplica).To(BeNumerically("~", total/2, 1e-9))
 	})
 
 	It("skips a replica with non-positive TotalKvCapacityTokens", func() {

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -556,6 +556,31 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			Expect(ok).To(BeFalse())
 			Expect(reason).To(Equal(itlReasonT2Failed))
 		})
+
+		It("resolveITLModel returns T2-failed when the computed fit is rejected by validITLModel", func() {
+			// AvgITL below the pinned baseline (DefaultBaselineITLSec = 0.006) at k=0.5 produces
+			// numerator = (0.001 - 0.006) * 0.5 = -0.0025, sumK2 = 0.25 → A = -0.01 (negative,
+			// inverted slope) — a real Tier-2 fit is computed (n=1, sumK2>0) but validITLModel
+			// rejects it, unlike the existing "all idle" test which never reaches the fit at all.
+			belowBaseline := domain.ReplicaMetrics{
+				VariantName: "v1", KvUsageInstant: 0.5, KvCacheUsage: 0.5,
+				AvgITL: 0.001, AvgInputTokens: 5000, AvgOutputTokens: 200,
+				PrefixCacheHitRate: 0.1, TotalKvCapacityTokens: 1024000,
+			}
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, []domain.ReplicaMetrics{belowBaseline})
+
+			_, reason, ok := analyzer.resolveITLModel(ctx,
+				func() *variantState {
+					analyzer.mu.Lock()
+					defer analyzer.mu.Unlock()
+					return analyzer.variantStates[variantKey(namespace, modelID, "v1")]
+				}(),
+				[]domain.ReplicaMetrics{belowBaseline},
+				namespace, modelID, "v1",
+			)
+			Expect(ok).To(BeFalse())
+			Expect(reason).To(Equal(itlReasonT2Failed))
+		})
 	})
 
 	Describe("Analyze — idle replicas produce no signal", func() {

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -2115,3 +2115,28 @@ var _ = Describe("computeLocalDemand", func() {
 		Expect(total).To(Equal(0.0))
 	})
 })
+
+var _ = Describe("computeVariantSupply", func() {
+	shape := WorkloadShape{KVreq: 1024}
+	const itlSat = 0.05
+
+	replicaWithCap := func(capTokens int64) domain.ReplicaMetrics {
+		return domain.ReplicaMetrics{TotalKvCapacityTokens: capTokens}
+	}
+
+	It("aggregates supply across KV-capable replicas", func() {
+		total, perReplica, nKV := computeVariantSupply(
+			[]domain.ReplicaMetrics{replicaWithCap(65536)}, shape, itlSat)
+		Expect(nKV).To(Equal(1))
+		Expect(total).To(BeNumerically(">", 0))
+		Expect(perReplica).To(BeNumerically("~", total, 1e-9)) // single replica → mean == total
+	})
+
+	It("skips a replica with non-positive TotalKvCapacityTokens", func() {
+		total, perReplica, nKV := computeVariantSupply(
+			[]domain.ReplicaMetrics{replicaWithCap(0)}, shape, itlSat)
+		Expect(nKV).To(Equal(0))
+		Expect(total).To(Equal(0.0))
+		Expect(perReplica).To(Equal(0.0))
+	})
+})

--- a/internal/engines/analyzers/throughput/itl_model_test.go
+++ b/internal/engines/analyzers/throughput/itl_model_test.go
@@ -132,6 +132,10 @@ var _ = Describe("validITLModel", func() {
 		Expect(validITLModel(0.073, math.NaN())).To(BeFalse())
 	})
 
+	It("rejects Inf B", func() {
+		Expect(validITLModel(0.073, math.Inf(1))).To(BeFalse())
+	})
+
 	It("rejects a non-positive ITL at saturation", func() {
 		// A*DefaultKSat + B <= 0 with a valid positive A.
 		Expect(validITLModel(0.01, -1.0)).To(BeFalse())


### PR DESCRIPTION
## What

Adds unit-test coverage for several already-shipped defensive guards in the ThroughputAnalyzer
that were flagged as untested during the #1503 review. **Test-only — no production code changes.**

During the #1503 review, @ev-shindin noted three untested guard branches (and left them as optional
follow-ups). This PR covers those three plus one adjacent supply-path gap found while adding them:

- **`validITLModel` — `Inf B` rejection.** Symmetric with the already-tested `Inf A` case; the
  `math.IsInf(b, 0)` branch was previously uncovered.
- **Tier-2 fit rejection in `resolveITLModel`.** A single below-baseline replica produces a
  negative slope that `validITLModel` rejects, exercising the `n>0 && sumK2>0` fit-then-reject
  path — distinct from the existing "all replicas idle" (`n==0`) test, which never reaches the fit.
- **`computeLocalDemand` skip guards.** Non-positive `TotalKvCapacityTokens`, and a finite (non-NaN)
  negative predicted ITL — distinct from the existing NaN-coefficient case.
- **`computeVariantSupply` direct coverage.** The same non-positive-capacity guard on the supply
  path, previously only exercised indirectly through an `Analyze`-level test. Adds a direct
  aggregate case plus the skip case.

Each new spec was verified to be non-vacuous (it fails if the guard is removed) and to reach its
intended branch by control-flow + arithmetic, not just a green suite. No behavior changed; no new
test failed against current code, so no latent bug was uncovered.

## Testing

- `make test` — PASS (throughput package coverage 93.2% → 93.4%)
- `make lint` — 0 issues
- `go test ./internal/engines/analyzers/throughput/... -race` — PASS
- `go build ./...` — clean · `gofmt` — clean

## Notes

The matching capacity/ITL guards in `checkVariantGPSMismatch` (a diagnostic-only path) remain a
known coverage gap, intentionally left for a separate follow-up.

```release-note
NONE
```
