### PR TITLE
bump: go version from 1.25 to 1.26

### DIFF
--- a/.claude/agents/go-reuse-checker.md
+++ b/.claude/agents/go-reuse-checker.md
@@ -12,7 +12,7 @@ You are a Go library-reuse reviewer. Your job is to find new code in a PR diff t
 For each new function, method, or non-trivial code block added by the PR:
 
 1. **Understand what it does semantically** — filter a slice, compare deeply, sort keys, extract fields, deduplicate, merge maps, fan-out goroutines, etc.
-2. **Check stdlib first** — this project uses Go 1.25, which includes `slices`, `maps`, `cmp`, `sync/errgroup`, `sync/atomic`, `iter`, and the full standard library.
+2. **Check stdlib first** — this project uses Go 1.26, which includes `slices`, `maps`, `cmp`, `sync/errgroup`, `sync/atomic`, `iter`, and the full standard library.
 3. **Check the project's direct imports** (listed below) — look for the same semantic operation in an already-imported package.
 4. **When unsure**, run `go doc <package>` or `go doc <package>.<Symbol>` to check what a package actually exports before reporting.
 
@@ -20,7 +20,7 @@ Do not consult the internet. Use `go doc` for verification.
 
 ## Project imports to check (from go.mod)
 
-Standard library (Go 1.25):
+Standard library (Go 1.26):
 - `slices` — Contains, Index, Sort, SortFunc, Collect, DeleteFunc, Compact, Reverse, Max, Min, Equal, Clone, Concat
 - `maps` — Keys, Values, Clone, Copy, DeleteFunc, Collect, Insert, All
 - `cmp` — Compare, Equal, Or

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -426,7 +426,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
           cache-dependency-path: ./go.sum
       - name: Verify Go toolchain
         run: deploy/ci-e2e-openshift/verify-go-toolchain.sh

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.8.0
+          version: v2.10.0
           args: ""
 
       - name: Run make build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This document covers **WVA-specific** development setup and workflows.
 
 ### Prerequisites
 
-- Go 1.25.0+
+- Go 1.26.0+
 - Docker 17.03+
 - kubectl 1.31.0+ (or `oc` for OpenShift)
 - Kind (for local development)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/projectquay/golang:1.25@sha256:94758a6003e442ccbed85c22533306c94e3b385231f554be53962d798ec5e087 AS builder
+FROM quay.io/projectquay/golang:1.26@sha256:ee44710323a5809f03fbe9607fb6ee9229cd32d2c3cbf811616284e74a7f4725 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -753,7 +753,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
-GOLANGCI_LINT_VERSION ?= v2.8.0
+GOLANGCI_LINT_VERSION ?= v2.10.0
 HELM_VERSION ?= v3.17.1
 
 .PHONY: kustomize

--- a/docs/developer-guide/development.md
+++ b/docs/developer-guide/development.md
@@ -6,7 +6,7 @@ Guide for developers contributing to Workload-Variant-Autoscaler.
 
 ### Prerequisites
 
-- Go 1.25.0+
+- Go 1.26.0+
 - Docker 17.03+
 - kubectl 1.32.0+
 - Kind (for local testing)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llm-d/llm-d-workload-variant-autoscaler
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7


### PR DESCRIPTION
## Proposed Changes
- include go.mod
- dockerfile
- github workflow
- docs
 :broom: Update or clean up current behavior

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

```release-note
bump go version from 1.25 to 1.26
```
cc @shuynh2017 @vivekk16 