### PR TITLE
refactor(pipeline): derive the per-model anchor on demand; add analyzer enablement

### DIFF
--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -37,8 +37,8 @@ over it via shared free functions in `internal/engines/pipeline/`.
                            ▼
 ┌──────────────────────────────────────────────────────────┐
 │ Engine: run analyzers, build per-analyzer slice          │
-│ Saturation V2 (always first), then each registered       │
-│ non-saturation analyzer in registration order:           │
+│ Saturation V2 (always run — the (a)/identity carrier),   │
+│ then each registered non-saturation analyzer:            │
 │   • skip if Enabled:false                                │
 │   • Analyze(ctx, input) → *AnalyzerResult                │
 │   • applyUniversalThreshold(result, scaleUp, scaleDown)  │
@@ -161,9 +161,15 @@ no entry at all does not run and is not included in the result slice,
 exactly as if `enabled: false` had been set. This prevents a
 registered-but-unconfigured analyzer from returning `SpareCapacity=0` and
 silently vetoing scale-down, since the per-role scale-down decision requires
-every analyzer in the slice to agree. Saturation is exempt from this gate —
-it is always run, independent of `analyzers` config, because the engine
-identifies it by name before this check applies.
+every voting analyzer in the slice to agree. Saturation is always run
+regardless of `analyzers` config — the engine identifies it by name and
+appends it as the identity/(a) carrier that supplies per-variant metadata
+(`Cost`, `AcceleratorName`, `Role`) for every configured variant. Its *vote*,
+however, is opt-in like any other analyzer's: saturation votes in the combine
+math only in the default single-analyzer config (no explicit `analyzers` list)
+or when its name is explicitly enabled. A `[throughput]`-only config leaves
+saturation present as a non-voting carrier — it is pruned from the voting
+subset (`votingResults`) and neither vetoes nor constrains scale-down.
 
 ---
 
@@ -234,9 +240,14 @@ analyzer-written values are discarded.
 6. Each result is wrapped in a `NamedAnalyzerResult{Name, Result, Score,
    Remaining, Spare}` and appended to the `[]NamedAnalyzerResult` slice.
    `Remaining = RC` and `Spare = SC` after the post-step.
-7. Saturation is always first. Its `VariantCapacities` entries carry `Cost`,
-   `AcceleratorName`, and `Role` used downstream by the optimizer and
-   enforcer.
+7. Saturation supplies the (a)/identity fields. Its `VariantCapacities`
+   entries carry `Cost`, `AcceleratorName`, and `Role` for every configured
+   variant. The optimizer does not read these off the saturation entry
+   directly: the anchor it consumes is a per-variant merge (`bindingAnchor`,
+   derived on demand) that takes the (a) identity fields from saturation and
+   the (b) sizing fields (`PerReplicaCapacity`, demand) from whichever
+   analyzer binds — saturation when it votes, otherwise the sole enabled
+   non-saturation analyzer. Slice position is not significant.
 
 ---
 
@@ -282,17 +293,23 @@ capacity — so this reason-based check, not an engine-level error signal, is
 what actually detects a durably-broken analyzer.
 
 Within the multi-analyzer engine path (`runAnalyzersAndScore`), this
-liveness filter applies uniformly to every registered analyzer, including
+liveness filter applies uniformly to every *voting* analyzer, including
 saturation's own token-capacity signal — there is no name-based exemption
-inside the scale-down gate. (Saturation's separate role as the shared
-metrics-collection layer — cache size, replica cost, etc., feeding every
-analyzer and the cost optimizer — is unaffected; that collection either
-succeeds for everyone or, if it fails, every analyzer ends up non-live and
-the safety floor below applies.) The queueing-model optimize path
-(`optimizeQueueingModel`) is a separate, older code path that does not yet
-run through this liveness tracking; its `NamedAnalyzerResult` sets `Live:
-true` statically so it keeps scaling down as before. It will pick up real
-liveness tracking when it becomes a first-class multi-analyzer participant.
+inside the scale-down gate. The gate runs over the voting subset
+(`votingResults`, the ballot entries whose analyzer is enabled this cycle):
+saturation is subject to it exactly when it votes (default single-analyzer
+config, or when its name is explicitly enabled), and a non-voting saturation
+carrier is excluded from the vote just like any other disabled analyzer.
+(Saturation's separate role as the shared metrics-collection layer — cache
+size, replica cost, etc., feeding every analyzer and the cost optimizer — is
+unaffected; that collection either succeeds for everyone or, if it fails,
+every analyzer ends up non-live and the safety floor below applies.) The
+queueing-model optimize path is no longer dispatched: when a queueing-model
+ConfigMap is present the engine refuses that path — it logs an error and holds
+each model at its last-good replica count for the cycle rather than running
+the older, un-tracked optimizer. The path's code is retained but parked;
+re-enabling it is a separate follow-up that would make the queueing model a
+first-class, liveness-tracked multi-analyzer participant.
 
 Liveness reflects whether an analyzer has a current *capacity* (supply-side)
 signal — it does not gate on the *demand* signal. A falsely-low demand value
@@ -327,10 +344,46 @@ apply to scale-up — a non-live analyzer contributes `Remaining == 0`
 (from `RequiredCapacity == 0`), which is already harmless to the max-across-
 analyzers formula.
 
-The saturation entry in the slice is also the keeper of per-variant metadata
-(`Cost`, `AcceleratorName`, `Role`) that the optimizer reads from
-`VariantCapacities`. Future work will extract per-variant metadata collection
-out of the saturation result so each analyzer owns only its own signals.
+The optimizer never reads per-variant metadata straight off the saturation
+entry. It consumes an **anchor** built on demand by `bindingAnchor`: a fresh,
+per-variant `AnalyzerResult` merged by `VariantName` from the (a)/identity
+fields (`Cost`, `AcceleratorName`, `Role`, replica counts) that saturation
+supplies for every configured variant, plus the (b)/sizing fields
+(`PerReplicaCapacity`, demand) from whichever analyzer binds. Nothing is
+stored — the merge is recomputed each time it is needed — and when nothing
+can bind (an empty ballot, no enabled-and-live-and-informative analyzer, or an
+ambiguous set of binding candidates) `bindingAnchor` returns `nil` and the
+optimizer holds that model unchanged for the cycle.
+
+### Scale-from-zero and zero-replica variants
+
+The throughput analyzer computes per-replica capacity from *live* replica
+metrics, so a variant that has scaled to zero produces no capacity row and
+would drop out of the anchor merge — leaving it unselectable for a proactive
+scale-up. To keep a returning variant selectable, the throughput analyzer
+emits a per-replica-capacity-only fallback (`Reason: "T-sfz"`) for any variant
+it observed live earlier, carrying that variant's persisted last-good
+per-replica supply. It emits only the (b)/sizing field: `Cost`,
+`AcceleratorName`, and `Role` remain saturation's (a)/identity, supplied
+through the merge. A variant the throughput analyzer has never seen gets no
+fallback — its `PerReplicaCapacity` stays zero and it is not proactively
+selectable; the reactive `scalefromzero` engine still covers genuine
+cold-starts. The persisted supply self-expires on the analyzer's idle window
+(the observation-max-age eviction, ~60 min), so a long-idle variant degrades
+back to the never-seen case on its own.
+
+**Known limitation.** `Cost` always comes from saturation's (a)/identity, and
+saturation reports `Cost = 0` for a variant currently at zero replicas. A
+returning variant therefore has a cost-efficiency of `0 / PerReplicaCapacity`
+and ranks cheapest, so the cost optimizer picks it first on scale-up. This is
+a pre-existing saturation behavior — it affects every config with a returning
+zero-replica variant, and resolving it means fixing that separate saturation
+`Cost = 0` behavior, which is out of scope here. Scale-from-zero still
+functions (the variant is selected, if eagerly); only cost *priority* is
+affected. Because no cooldown or grace period exists in the cost optimizer,
+the choice can flap while load oscillates across the scale-up/scale-down
+boundary, or persist as a costlier-than-ideal allocation while load stays
+high. That flapping gap is pre-existing and not introduced by this mechanism.
 
 ---
 

--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -251,20 +251,28 @@ throughput, SLO) can be plugged in without the engine package knowing the
 concrete type. Each cycle the engine iterates every registered analyzer in
 registration order and invokes its `Analyze` method.
 
-> **Scope note.** Saturation drives every scaling decision on its own.
-> Non-saturation analyzers are registered and invoked, but their results
-> are **not yet consumed** — combine semantics and per-analyzer score
-> consumption land in a follow-up PR (`multi-analyzer-optimizer`). The
-> hooks below are wired so that follow-up can hang its behavior off them
-> without further engine changes.
+> **Scope note.** Saturation drives scaling decisions only when it votes. The
+> engine runs every enabled analyzer and derives the decision anchor on demand
+> from the ballot, so three configurations follow from the `analyzers` list
+> alone:
+> - *default* (no `analyzers` list) → saturation is the sole voter and binder;
+>   behavior is unchanged from single-analyzer operation.
+> - `[saturation, throughput]` → both vote; saturation binds the anchor.
+> - `[throughput]` only → throughput binds the anchor; saturation still runs as
+>   the identity/(a) carrier but does not vote.
+>
+> Saturation always runs to supply per-variant identity metadata regardless of
+> which config is active; what the `analyzers` list changes is whether it
+> *votes*.
 
 ### Registering Analyzers
 
 Pre-registered:
 
 - The V2 saturation analyzer is pre-registered by `NewEngine` under
-  `interfaces.SaturationAnalyzerName`. It always runs and drives the
-  optimizer.
+  `interfaces.SaturationAnalyzerName`. It always runs — supplying the
+  identity/(a) carrier — but drives the optimizer only when it votes (the
+  default config, or when its name is enabled).
 
 External analyzers are registered from `cmd/main.go` via:
 
@@ -453,13 +461,18 @@ The asymmetry — anticipated supply for scale-up, steady-state `TotalSupply` fo
 
 **Per-analyzer threshold overrides.** `analyzers[].scaleUpThreshold` / `analyzers[].scaleDownBoundary` are resolved per analyzer: a per-entry override takes precedence over the model-level global. The resolved pair is applied uniformly at model level and every role for that analyzer. An opt-out flag for analyzers with non-universal calibration math is deferred to a follow-up.
 
-### Saturation Always Runs
+### Saturation as the Identity Carrier
 
-The saturation analyzer executes on every cycle regardless of any future
-`enabled` flag — its `VariantCapacities` carry `Cost` and `AcceleratorName`
-required by the optimizer for variant selection and GPU accounting. On
-this branch saturation's `RequiredCapacity` and `SpareCapacity` are the
-only signals the optimizer consumes.
+The saturation analyzer executes on every cycle regardless of the `analyzers`
+config — its `VariantCapacities` carry the (a)/identity fields (`Cost`,
+`AcceleratorName`, `Role`, replica counts) the optimizer needs for variant
+selection and GPU accounting, for every configured variant including those at
+zero replicas. Running is unconditional; *voting* is opt-in. Saturation
+contributes its `RequiredCapacity` / `SpareCapacity` to the combine math only
+when it votes — the default single-analyzer config, or when its name is
+enabled. In a `[throughput]`-only config it is present purely as the identity
+carrier: it supplies (a) for the anchor merge but is pruned from the voting
+subset and neither drives scale-up nor vetoes scale-down.
 
 ### Resilience
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -114,6 +114,7 @@ const (
 	K8SEventMetricsUnavailable                = "MetricsUnavailable"
 	K8SEventScaledToZero                      = "ScaledToZero"
 	K8SEventOptimizationFailed                = "OptimizationFailed"
+	K8SEventOptimizationRefused               = "OptimizationRefused"
 	K8SEventUnattributedReadyPods             = "UnattributedReadyPods"
 	K8SEventThroughputAnalyzerRestartRequired = "ThroughputAnalyzerRestartRequired"
 	EnforcerPolicyTypeScaleToZero             = "scale_to_zero"

--- a/internal/domain/analyzer.go
+++ b/internal/domain/analyzer.go
@@ -148,7 +148,8 @@ type VariantCapacity struct {
 	// variant's per-replica capacity was computed. Empty for analyzers that
 	// do not set it. Saturation V2 uses "P0-store", "P1-obs", "P2-hist",
 	// "P3-k2", "P4-k1", "no-data", "error". Throughput uses "T1-ols",
-	// "T2-pinned", "T2-default", "T2-failed".
+	// "T2-pinned", "T2-default", "T2-failed", and "T-sfz" (scale-from-zero:
+	// persisted last-good per-replica supply for a variant now at zero replicas).
 	Reason string
 
 	// TotalCapacity is ReplicaCount × PerReplicaCapacity.

--- a/internal/engines/analyzers/queueingmodel/analyzer.go
+++ b/internal/engines/analyzers/queueingmodel/analyzer.go
@@ -285,6 +285,12 @@ func (a *QueueingModelAnalyzer) computeAllVariantCapacities(
 			VariantName:     variantName,
 			AcceleratorName: variantAccel[variantName],
 			Cost:            variantCost[variantName],
+			// Role must be carried: consumers canonicalize a blank role to
+			// domain.RoleBoth, which on a disaggregated model collapses prefill and
+			// decode into one bucket and lets the optimizer shed them
+			// interchangeably. This path is parked (the engine refuses to dispatch
+			// it today), so this is here for whoever re-enables it.
+			Role:            variantState.Role,
 			ReplicaCount:    readyCount,
 			PendingReplicas: variantState.PendingReplicas,
 
@@ -386,6 +392,7 @@ func (a *QueueingModelAnalyzer) computeAllVariantCapacities(
 			VariantName:     variantName,
 			AcceleratorName: variantAccel[variantName],
 			Cost:            variantCost[variantName], // TODO: multiply by numReplicas?
+			Role:            variantState.Role,        // see errorVariantCapacity above
 			ReplicaCount:    readyCount,
 			PendingReplicas: variantState.PendingReplicas,
 

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -390,13 +390,20 @@ func (a *ThroughputAnalyzer) Analyze(
 	// live before, emit a PRC-only capacity carrying its persisted last-good
 	// per-replica supply. That keeps a previously-live variant proactively selectable
 	// for scale-from-zero without fabricating a baseline for one TA has never sized.
-	// Cost, AcceleratorName, Role, and ReplicaCount are deliberately left unset: they
-	// are identity fields the anchor merge sources from the saturation entry for the
-	// same variant, not values TA is entitled to emit. A never-seen variant (no
-	// persisted supply) gets nothing, so its per-replica capacity stays zero and it is
-	// not proactively selectable; the reactive scale-from-zero engine covers genuine
-	// cold-starts. Persisted supply self-expires on the same idle window as the rest
-	// of the per-variant state, so a long-idle variant degrades to the never-seen case.
+	// Cost, AcceleratorName, and ReplicaCount are deliberately left unset: they are
+	// identity fields the anchor merge sources from the saturation entry for the same
+	// variant, not values TA is entitled to emit. Role is the exception and must be
+	// carried: this slice is consumed by distributeDemandByRole and
+	// aggregateRoleCapacities below, before any anchor merge runs, and both
+	// canonicalize an empty role to domain.RoleBoth. On a disaggregated model a
+	// blank-role entry would therefore manufacture a phantom "both" bucket — which
+	// dilutes each role's demand share and leaves the paired allocator unable to pick
+	// a variant for it — so the persisted role is emitted, exactly as the live loop
+	// above does. A never-seen variant (no persisted supply) gets nothing, so its
+	// per-replica capacity stays zero and it is not proactively selectable; the
+	// reactive scale-from-zero engine covers genuine cold-starts. Persisted supply
+	// self-expires on the same idle window as the rest of the per-variant state, so a
+	// long-idle variant degrades to the never-seen case.
 	for _, vs := range input.VariantStates {
 		if _, alreadyLive := byVariant[vs.VariantName]; alreadyLive {
 			continue
@@ -408,6 +415,7 @@ func (a *ThroughputAnalyzer) Analyze(
 		}
 		variantCapacities = append(variantCapacities, domain.VariantCapacity{
 			VariantName:        vs.VariantName,
+			Role:               st.role,
 			PerReplicaCapacity: st.lastPerReplicaSupply,
 			Reason:             itlReasonScaleFromZero,
 		})

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -382,6 +382,37 @@ func (a *ThroughputAnalyzer) Analyze(
 		})
 	}
 
+	// Scale-from-zero complement: the loop above keys off byVariant, which only has
+	// entries for variants with live replicas this cycle, so a variant that has
+	// scaled to zero contributes nothing and is not a selectable candidate. Iterate
+	// the full variant list (input.VariantStates enumerates every configured variant,
+	// zero-replica included) and, for a variant absent from byVariant that TA saw
+	// live before, emit a PRC-only capacity carrying its persisted last-good
+	// per-replica supply. That keeps a previously-live variant proactively selectable
+	// for scale-from-zero without fabricating a baseline for one TA has never sized.
+	// Cost, AcceleratorName, Role, and ReplicaCount are deliberately left unset: they
+	// are identity fields the anchor merge sources from the saturation entry for the
+	// same variant, not values TA is entitled to emit. A never-seen variant (no
+	// persisted supply) gets nothing, so its per-replica capacity stays zero and it is
+	// not proactively selectable; the reactive scale-from-zero engine covers genuine
+	// cold-starts. Persisted supply self-expires on the same idle window as the rest
+	// of the per-variant state, so a long-idle variant degrades to the never-seen case.
+	for _, vs := range input.VariantStates {
+		if _, alreadyLive := byVariant[vs.VariantName]; alreadyLive {
+			continue
+		}
+		key := variantKey(input.Namespace, input.ModelID, vs.VariantName)
+		st, ok := a.variantStates[key]
+		if !ok || st.lastPerReplicaSupply <= 0 {
+			continue
+		}
+		variantCapacities = append(variantCapacities, domain.VariantCapacity{
+			VariantName:        vs.VariantName,
+			PerReplicaCapacity: st.lastPerReplicaSupply,
+			Reason:             itlReasonScaleFromZero,
+		})
+	}
+
 	// Model-level supply totals computed from the per-variant slice.
 	// TotalAnticipatedSupply is published so the engine's post-step can compute RC/SC.
 	totalSupply := aggregation.SumTotalSupply(variantCapacities)
@@ -522,8 +553,9 @@ func (a *ThroughputAnalyzer) getOrCreateVariantState(key string) *variantState {
 //     k* = 0 (idle) carry no ITL signal and are excluded.
 //
 // When replicas are present but all are idle (k* = 0), both tiers fail and we return (zero, false).
-// A future tier-3 (knowledge store) path for the scale-from-zero case will be added once Analyze()
-// is extended to iterate variants with state but no current replica metrics.
+// A variant that has dropped to zero replicas is handled separately by the scale-from-zero
+// complement in Analyze(), which re-emits the persisted last-good per-replica supply rather than
+// re-deriving an ITL model here; resolveITLModel is only consulted for variants with live replicas.
 //
 // Must be called with a.mu held.
 func (a *ThroughputAnalyzer) resolveITLModel(ctx context.Context, state *variantState, metrics []domain.ReplicaMetrics, namespace, modelID, variantName string) (ITLModel, string, bool) {

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -2178,11 +2178,13 @@ var _ = Describe("ThroughputAnalyzer — scale-from-zero PRC-only complement", f
 		Expect(ok).To(BeTrue())
 		Expect(vc.PerReplicaCapacity).To(BeNumerically("~", persisted, 1e-9))
 		Expect(vc.Reason).To(Equal(itlReasonScaleFromZero))
-		// PRC only: identity fields (Cost/AcceleratorName/Role/ReplicaCount) are the
-		// anchor merge's job to source from the saturation analyzer, not TA's.
+		// PRC only: identity fields (Cost/AcceleratorName/ReplicaCount) are the anchor
+		// merge's job to source from the saturation analyzer, not TA's. Role is the
+		// exception — it is consumed by the role aggregation inside this same Analyze
+		// call, before any merge, so TA must carry it.
 		Expect(vc.Cost).To(Equal(0.0))
 		Expect(vc.AcceleratorName).To(Equal(""))
-		Expect(vc.Role).To(Equal(""))
+		Expect(vc.Role).To(Equal(domain.RoleBoth))
 		Expect(vc.ReplicaCount).To(Equal(0))
 	})
 
@@ -2206,5 +2208,101 @@ var _ = Describe("ThroughputAnalyzer — scale-from-zero PRC-only complement", f
 		result := analyzeAtZero("v1")
 		_, ok := capFor(result, "v1")
 		Expect(ok).To(BeFalse())
+	})
+
+	// A scale-from-zero entry on a disaggregated model must carry its real role.
+	// distributeDemandByRole and aggregateRoleCapacities both canonicalize an empty
+	// role to domain.RoleBoth, and they run on this same slice inside Analyze —
+	// before any anchor merge could fill the role in. A blank-role entry therefore
+	// manufactures a "both" bucket alongside prefill/decode, which (a) splits the
+	// model-level decode demand across one more role than exists, and (b) leaves the
+	// paired allocator with a role no anchor variant can satisfy.
+	Context("on a disaggregated (P/D) model", func() {
+		// makePreviouslyLiveWithRole is makePreviouslyLive for a variant whose role is
+		// not "both", so the persisted state carries that role into the zero cycle.
+		makePreviouslyLiveWithRole := func(variant, role string) {
+			injectWindowObs(analyzer, ctx, modelID, namespace, variant, il, ol, prefix, kvMax, B, kValues)
+			_, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: []domain.ReplicaMetrics{liveReplica(variant, 5)},
+				ArrivalRate:    5,
+				VariantStates:  []domain.VariantReplicaState{{VariantName: variant, CurrentReplicas: 1, Role: role}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			st, ok := analyzer.VariantState(modelID, namespace, variant)
+			Expect(ok).To(BeTrue())
+			Expect(st.PerReplicaSupply).To(BeNumerically(">", 0))
+		}
+
+		It("emits the persisted role, so a zero-replica decode variant does not manufacture a phantom 'both' bucket", func() {
+			makePreviouslyLiveWithRole("v-decode", domain.RoleDecode)
+			makePreviouslyLiveWithRole("v-prefill", domain.RolePrefill)
+
+			// v-prefill stays live; v-decode drops to zero replicas this cycle.
+			result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: []domain.ReplicaMetrics{liveReplica("v-prefill", 5)},
+				ArrivalRate:    5,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "v-decode", CurrentReplicas: 0, Role: domain.RoleDecode},
+					{VariantName: "v-prefill", CurrentReplicas: 1, Role: domain.RolePrefill},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			vc, ok := capFor(result, "v-decode")
+			Expect(ok).To(BeTrue())
+			Expect(vc.Reason).To(Equal(itlReasonScaleFromZero))
+			Expect(vc.Role).To(Equal(domain.RoleDecode))
+
+			// The role breakdown stays exactly {prefill, decode} — no "both" key.
+			Expect(result.RoleCapacities).NotTo(BeNil())
+			Expect(result.RoleCapacities).To(HaveKey(domain.RoleDecode))
+			Expect(result.RoleCapacities).NotTo(HaveKey(domain.RoleBoth))
+		})
+
+		It("does not dilute per-role decode demand when a decode variant is at zero replicas", func() {
+			makePreviouslyLiveWithRole("v-decode-a", domain.RoleDecode)
+			makePreviouslyLiveWithRole("v-decode-b", domain.RoleDecode)
+			makePreviouslyLiveWithRole("v-prefill", domain.RolePrefill)
+
+			analyzeWith := func(states []domain.VariantReplicaState, live []domain.ReplicaMetrics) *domain.AnalyzerResult {
+				result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+					ModelID:        modelID,
+					Namespace:      namespace,
+					ReplicaMetrics: live,
+					ArrivalRate:    5,
+					VariantStates:  states,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				return result
+			}
+
+			// Baseline: only the live decode variant is configured at all.
+			baseline := analyzeWith(
+				[]domain.VariantReplicaState{
+					{VariantName: "v-decode-a", CurrentReplicas: 1, Role: domain.RoleDecode},
+					{VariantName: "v-prefill", CurrentReplicas: 1, Role: domain.RolePrefill},
+				},
+				[]domain.ReplicaMetrics{liveReplica("v-decode-a", 5), liveReplica("v-prefill", 5)},
+			)
+
+			// Same traffic, but a second decode variant sits at zero replicas. It joins
+			// the decode role rather than adding a role, so decode's share is unchanged.
+			withZero := analyzeWith(
+				[]domain.VariantReplicaState{
+					{VariantName: "v-decode-a", CurrentReplicas: 1, Role: domain.RoleDecode},
+					{VariantName: "v-decode-b", CurrentReplicas: 0, Role: domain.RoleDecode},
+					{VariantName: "v-prefill", CurrentReplicas: 1, Role: domain.RolePrefill},
+				},
+				[]domain.ReplicaMetrics{liveReplica("v-decode-a", 5), liveReplica("v-prefill", 5)},
+			)
+
+			Expect(baseline.RoleCapacities[domain.RoleDecode].TotalDemand).To(BeNumerically(">", 0))
+			Expect(withZero.RoleCapacities[domain.RoleDecode].TotalDemand).To(
+				BeNumerically("~", baseline.RoleCapacities[domain.RoleDecode].TotalDemand, 1e-9))
+		})
 	})
 })

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -2073,3 +2073,138 @@ var _ = Describe("computeLocalDemand", func() {
 		Expect(total).To(Equal(0.0))
 	})
 })
+
+// Test 7 — scale-from-zero PRC-only complement.
+//
+// Analyze()'s primary per-variant loop keys off live ReplicaMetrics, so a variant
+// that has dropped to zero replicas produces no rows and would silently vanish from
+// the capacity ballot. The scale-from-zero complement re-emits a PRC-only
+// VariantCapacity for a *previously-live* variant, carrying its persisted last-good
+// per-replica supply. A never-seen variant (no persisted supply) emits nothing, and
+// once idle-window eviction drops the persisted state the variant degrades back to
+// the never-seen case on its own.
+var _ = Describe("ThroughputAnalyzer — scale-from-zero PRC-only complement", func() {
+	const (
+		il     = 5000.0
+		ol     = 200.0
+		prefix = 0.1
+		kvMax  = int64(1024000)
+		A      = 0.073
+		B      = 0.006
+	)
+	// 10 points spanning [0.20, 0.65], spread 0.45 ≥ DefaultMinKSpread: OLS-ready.
+	kValues := []float64{0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65}
+
+	var (
+		analyzer  *ThroughputAnalyzer
+		ctx       context.Context
+		modelID   string
+		namespace string
+	)
+
+	BeforeEach(func() {
+		analyzer = NewThroughputAnalyzer()
+		ctx = context.Background()
+		modelID = "llama3-8b"
+		namespace = "default"
+	})
+
+	// liveReplica drives a single healthy replica at k=0.50 so a live Analyze cycle
+	// computes and persists a positive last-good per-replica supply for the variant.
+	liveReplica := func(variant string, arrivalRate float64) domain.ReplicaMetrics {
+		const k = 0.50
+		return domain.ReplicaMetrics{
+			VariantName:           variant,
+			KvCacheUsage:          k,
+			KvUsageInstant:        k,
+			AvgITL:                A*k + B,
+			AvgInputTokens:        il,
+			AvgOutputTokens:       ol,
+			PrefixCacheHitRate:    prefix,
+			TotalKvCapacityTokens: kvMax,
+			ArrivalRate:           arrivalRate,
+		}
+	}
+
+	// makePreviouslyLive runs one OLS-ready live Analyze cycle for the variant so the
+	// analyzer persists a positive lastPerReplicaSupply, and returns that value.
+	makePreviouslyLive := func(variant string) float64 {
+		injectWindowObs(analyzer, ctx, modelID, namespace, variant, il, ol, prefix, kvMax, B, kValues)
+		_, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+			ModelID:        modelID,
+			Namespace:      namespace,
+			ReplicaMetrics: []domain.ReplicaMetrics{liveReplica(variant, 5)},
+			ArrivalRate:    5,
+			VariantStates:  []domain.VariantReplicaState{{VariantName: variant, CurrentReplicas: 1, Role: domain.RoleBoth}},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		st, ok := analyzer.VariantState(modelID, namespace, variant)
+		Expect(ok).To(BeTrue())
+		Expect(st.PerReplicaSupply).To(BeNumerically(">", 0))
+		return st.PerReplicaSupply
+	}
+
+	// analyzeAtZero runs an Analyze cycle with the named variants present only in
+	// VariantStates at zero live replicas (no ReplicaMetrics rows).
+	analyzeAtZero := func(variants ...string) *domain.AnalyzerResult {
+		states := make([]domain.VariantReplicaState, 0, len(variants))
+		for _, v := range variants {
+			states = append(states, domain.VariantReplicaState{VariantName: v, CurrentReplicas: 0, Role: domain.RoleBoth})
+		}
+		result, err := analyzer.Analyze(ctx, domain.AnalyzerInput{
+			ModelID:       modelID,
+			Namespace:     namespace,
+			VariantStates: states,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return result
+	}
+
+	capFor := func(result *domain.AnalyzerResult, variant string) (domain.VariantCapacity, bool) {
+		for _, vc := range result.VariantCapacities {
+			if vc.VariantName == variant {
+				return vc, true
+			}
+		}
+		return domain.VariantCapacity{}, false
+	}
+
+	It("re-emits a PRC-only capacity carrying the persisted supply for a previously-live variant now at zero replicas", func() {
+		persisted := makePreviouslyLive("v1")
+
+		result := analyzeAtZero("v1")
+
+		vc, ok := capFor(result, "v1")
+		Expect(ok).To(BeTrue())
+		Expect(vc.PerReplicaCapacity).To(BeNumerically("~", persisted, 1e-9))
+		Expect(vc.Reason).To(Equal(itlReasonScaleFromZero))
+		// PRC only: identity fields (Cost/AcceleratorName/Role/ReplicaCount) are the
+		// anchor merge's job to source from the saturation analyzer, not TA's.
+		Expect(vc.Cost).To(Equal(0.0))
+		Expect(vc.AcceleratorName).To(Equal(""))
+		Expect(vc.Role).To(Equal(""))
+		Expect(vc.ReplicaCount).To(Equal(0))
+	})
+
+	It("emits nothing for a never-seen variant with no persisted supply", func() {
+		// v2 is present in VariantStates but was never analyzed live.
+		result := analyzeAtZero("v2")
+		_, ok := capFor(result, "v2")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("degrades a previously-live variant to the never-seen (no-emission) case after idle-window eviction", func() {
+		makePreviouslyLive("v1")
+
+		// Advance the analyzer clock past 2×DefaultObservationMaxAge with an empty
+		// Observe: the eviction sweep drops v1's persisted state.
+		analyzer.Observe(ctx, time.Now().Add(2*DefaultObservationMaxAge+time.Minute), modelID, namespace, nil)
+		_, stillThere := analyzer.VariantState(modelID, namespace, "v1")
+		Expect(stillThere).To(BeFalse())
+
+		// A subsequent zero-replica cycle now sees v1 as never-seen → no emission.
+		result := analyzeAtZero("v1")
+		_, ok := capFor(result, "v1")
+		Expect(ok).To(BeFalse())
+	})
+})

--- a/internal/engines/analyzers/throughput/constants.go
+++ b/internal/engines/analyzers/throughput/constants.go
@@ -110,10 +110,15 @@ const (
 	// the current window's lifetime.
 	DefaultGPSMismatchClearThreshold = 3
 
-	// itlReason* are the values set on VariantCapacity.Reason by resolveITLModel.
-	// They appear in the "analyzer-result" structured log line.
+	// itlReason* are the values set on VariantCapacity.Reason. The first four are
+	// set by resolveITLModel; itlReasonScaleFromZero is set by the scale-from-zero
+	// complement. They appear in the "analyzer-result" structured log line.
 	itlReasonT1OLS     = "T1-ols"     // tier-1: OLS fit from live observations
 	itlReasonT2Default = "T2-default" // tier-2: constrained OLS with default B baseline
 	itlReasonT2Pinned  = "T2-pinned"  // tier-2: constrained OLS with previously fitted B
 	itlReasonT2Failed  = "T2-failed"  // all paths exhausted; no model for this cycle
+	// itlReasonScaleFromZero marks the PRC-only VariantCapacity emitted for a
+	// previously-live variant now at zero replicas: its per-replica capacity is the
+	// persisted last-good value, not a fresh fit. Not produced by resolveITLModel.
+	itlReasonScaleFromZero = "T-sfz"
 )

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -84,17 +84,161 @@ func applyAllocation(s []NamedAnalyzerResult, v string, n int) {
 	}
 }
 
-// saturationEntry returns the saturation analyzer's result from s, or nil if not present.
-// The saturation entry is the keeper of per-variant metadata (Cost, AcceleratorName, Role,
-// replica counts) that the optimizer uses for variant selection and GPU accounting.
-// TODO: remove the sat_v2 special role once all analyzers populate variant metadata.
-func saturationEntry(s []NamedAnalyzerResult) *domain.AnalyzerResult {
-	for _, e := range s {
-		if e.Name == domain.SaturationAnalyzerName {
-			return e.Result
+// bindingAnchor derives the per-model anchor on demand from the ballot s. The
+// anchor is the topology carrier the optimizer selects variants and accounts
+// GPUs against. It merges identity/(a) fields from the saturation entry —
+// per variant: AcceleratorName, Cost, Role, ReplicaCount, PendingReplicas; at
+// the model level: ModelID, Namespace, AnalyzedAt — with sizing/(b) fields from
+// the binding analyzer — per variant: PerReplicaCapacity, Reason, TotalDemand,
+// Utilization; at the model level: TotalSupply, TotalDemand, Utilization,
+// TotalAnticipatedSupply, RequiredCapacity, SpareCapacity, RoleCapacities —
+// keyed by VariantName. TotalCapacity is recomputed, not copied. Returns nil
+// when nothing can bind; the optimizer then holds for this model (the nil-guard
+// at each call site is that per-model hold).
+//
+// The binding analyzer (the (b)/sizing source) is:
+//   - saturation, when it votes and is live+informative (the default and the
+//     saturation+throughput case — merging saturation with itself is the
+//     identity, which is why the characterization goldens hold);
+//   - otherwise the sole enabled+live+informative non-saturation entry (the
+//     throughput-only case);
+//   - otherwise none → return nil.
+//
+// If more than one non-saturation analyzer is enabled+live+informative, this PR
+// does not define which binds; rather than guess, the model is treated as
+// unbindable and nil is returned.
+//
+// Per-variant (b)-fallback: where the binding analyzer omits a variant the (a)
+// carrier lists, the (demand, PerReplicaCapacity) pair must come from a single
+// source. Saturation's own (b) is the fallback ONLY when saturation votes
+// (satNR.Enabled) — saturation is then both the demand and the PRC source, so
+// the pair stays consistent. Under a throughput-only config (saturation present
+// as the (a) carrier but not voting) a variant the binding analyzer omits gets
+// PerReplicaCapacity = 0 and is not proactively selectable; genuine cold-starts
+// fall to the reactive scale-from-zero engine. The (a) carrier is captured up
+// front, before any voting-set prune, so the fallback source is available even
+// when saturation is non-voting.
+//
+// Builds fresh literals throughout — it never mutates the source Results or
+// their VariantCapacities slices/elements.
+func bindingAnchor(s []NamedAnalyzerResult) *domain.AnalyzerResult {
+	// (a) carrier: the saturation entry. It may be present even when it does not
+	// vote (throughput-only config), so it is located by name, not by vote.
+	var satNR *NamedAnalyzerResult
+	for i := range s {
+		if s[i].Name == domain.SaturationAnalyzerName && s[i].Result != nil {
+			satNR = &s[i]
+			break
 		}
 	}
-	return nil
+
+	// Select the binding (b)/sizing analyzer.
+	var binding *NamedAnalyzerResult
+	switch {
+	case satNR != nil && satNR.Enabled && satNR.Live && ResultIsInformative(*satNR):
+		// Saturation binds whenever it votes (default / saturation+throughput).
+		binding = satNR
+	default:
+		// Otherwise the sole enabled+live+informative non-saturation entry binds.
+		for i := range s {
+			if s[i].Name == domain.SaturationAnalyzerName {
+				continue
+			}
+			if s[i].Enabled && s[i].Live && ResultIsInformative(s[i]) {
+				if binding != nil {
+					// >1 non-saturation binding candidate is not a config this PR
+					// defines; do not guess which binds — hold this model instead.
+					return nil
+				}
+				binding = &s[i]
+			}
+		}
+	}
+	if binding == nil {
+		return nil
+	}
+
+	// Identity/(a) carrier: saturation when present; with no saturation entry at
+	// all (not a config this PR defines) fall back to binding so the merge stays
+	// well-defined.
+	aCarrier := binding
+	if satNR != nil {
+		aCarrier = satNR
+	}
+	// Whether saturation votes — gates the per-variant (b)-fallback below.
+	satEnabled := satNR != nil && satNR.Enabled
+
+	// Model-level fields: identity from the (a) carrier, sizing from binding.
+	anchor := &domain.AnalyzerResult{
+		AnalyzerName:           binding.Result.AnalyzerName,
+		ModelID:                aCarrier.Result.ModelID,
+		Namespace:              aCarrier.Result.Namespace,
+		AnalyzedAt:             aCarrier.Result.AnalyzedAt,
+		TotalSupply:            binding.Result.TotalSupply,
+		TotalDemand:            binding.Result.TotalDemand,
+		Utilization:            binding.Result.Utilization,
+		TotalAnticipatedSupply: binding.Result.TotalAnticipatedSupply,
+		RequiredCapacity:       binding.Result.RequiredCapacity,
+		SpareCapacity:          binding.Result.SpareCapacity,
+		RoleCapacities:         binding.Result.RoleCapacities,
+	}
+
+	// Per-variant merge: iterate the (a) carrier's complete variant list (it emits
+	// every configured variant), take (a) from it and (b) from the binding
+	// analyzer for the same VariantName.
+	bByName := make(map[string]domain.VariantCapacity, len(binding.Result.VariantCapacities))
+	for _, vc := range binding.Result.VariantCapacities {
+		bByName[vc.VariantName] = vc
+	}
+	merged := make([]domain.VariantCapacity, 0, len(aCarrier.Result.VariantCapacities))
+	for _, a := range aCarrier.Result.VariantCapacities {
+		out := domain.VariantCapacity{
+			VariantName:     a.VariantName,
+			AcceleratorName: a.AcceleratorName,
+			Cost:            a.Cost,
+			Role:            a.Role,
+			ReplicaCount:    a.ReplicaCount,
+			PendingReplicas: a.PendingReplicas,
+		}
+		if b, ok := bByName[a.VariantName]; ok {
+			out.PerReplicaCapacity = b.PerReplicaCapacity
+			out.Reason = b.Reason
+			out.TotalDemand = b.TotalDemand
+			out.Utilization = b.Utilization
+		} else if satEnabled {
+			// Enablement-gated fallback: saturation votes, so its own (b) is a
+			// consistent (demand, PRC) source. aCarrier is saturation here.
+			out.PerReplicaCapacity = a.PerReplicaCapacity
+			out.Reason = a.Reason
+			out.TotalDemand = a.TotalDemand
+			out.Utilization = a.Utilization
+		}
+		// else: throughput-only, binding analyzer omits this variant, no persisted
+		// throughput PRC → PerReplicaCapacity stays 0 → not proactively selectable.
+
+		// TotalCapacity is recomputed (not copied) so the invariant
+		// TotalCapacity == ReplicaCount × PerReplicaCapacity holds by construction.
+		out.TotalCapacity = float64(out.ReplicaCount) * out.PerReplicaCapacity
+		merged = append(merged, out)
+	}
+	anchor.VariantCapacities = merged
+	return anchor
+}
+
+// votingResults returns the sub-slice of the ballot whose analyzers vote in the
+// combine (RC/SC) math this cycle. Non-voting entries (e.g. a saturation entry
+// present only as the (a) carrier in a throughput-only config) are excluded.
+// The anchor build (bindingAnchor) reads the FULL ballot, not this pruned view.
+// In the default and saturation+throughput configs every entry is Enabled, so
+// this returns the same combine input set as the raw ballot.
+func votingResults(s []NamedAnalyzerResult) []NamedAnalyzerResult {
+	out := make([]NamedAnalyzerResult, 0, len(s))
+	for _, e := range s {
+		if e.Enabled {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // prcForVariant returns the PerReplicaCapacity for variant v in result r.

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -186,10 +186,7 @@ func bindingAnchor(s []NamedAnalyzerResult) *domain.AnalyzerResult {
 	// Per-variant merge: iterate the (a) carrier's complete variant list (it emits
 	// every configured variant), take (a) from it and (b) from the binding
 	// analyzer for the same VariantName.
-	bByName := make(map[string]domain.VariantCapacity, len(binding.Result.VariantCapacities))
-	for _, vc := range binding.Result.VariantCapacities {
-		bByName[vc.VariantName] = vc
-	}
+	bByName := buildCapacityMap(binding.Result.VariantCapacities)
 	merged := make([]domain.VariantCapacity, 0, len(aCarrier.Result.VariantCapacities))
 	for _, a := range aCarrier.Result.VariantCapacities {
 		out := domain.VariantCapacity{

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -320,6 +320,75 @@ var _ = Describe("analyzer helpers", func() {
 			Expect(ok).To(BeTrue(), "rescale must resolve a single accelerator type from the merged anchor")
 			Expect(accType).To(Equal("A100"))
 		})
+
+		// Test 4 — degenerate ballots produce no anchor (the per-model hold).
+		// bindingAnchor returns nil whenever nothing can bind; each optimizer's
+		// nil-anchor guard then holds the model (no decision this cycle) rather
+		// than indexing into an empty or unbindable ballot. These pin the three
+		// nil paths that back the "empty / no-live-analyzer ballot is graceful"
+		// behaviour: no index panic on an empty ballot, and a deliberate hold
+		// when no single analyzer can bind.
+		It("returns nil for an empty ballot", func() {
+			Expect(bindingAnchor(nil)).To(BeNil())
+			Expect(bindingAnchor([]NamedAnalyzerResult{})).To(BeNil())
+		})
+
+		It("returns nil when no enabled+live+informative analyzer is present", func() {
+			// Saturation and throughput are both present, enabled, and informative,
+			// but neither is live this cycle → no binder → hold the model.
+			sat := NamedAnalyzerResult{
+				Name:    domain.SaturationAnalyzerName,
+				Enabled: true,
+				Live:    false,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: domain.SaturationAnalyzerName,
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", ReplicaCount: 1, PerReplicaCapacity: 100.0, Reason: "P1-obs"},
+					},
+				},
+			}
+			ta := NamedAnalyzerResult{
+				Name:    "throughput",
+				Enabled: true,
+				Live:    false,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: "throughput",
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", PerReplicaCapacity: 200.0, Reason: "T1-ols"},
+					},
+				},
+			}
+			Expect(bindingAnchor([]NamedAnalyzerResult{sat, ta})).To(BeNil())
+		})
+
+		It("returns nil for an ambiguous multi-binder (two non-saturation live analyzers)", func() {
+			// No saturation entry; two distinct non-saturation analyzers are each
+			// enabled+live+informative. This PR does not define which one binds, so
+			// bindingAnchor refuses to guess and holds the model.
+			ta := NamedAnalyzerResult{
+				Name:    "throughput",
+				Enabled: true,
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: "throughput",
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", PerReplicaCapacity: 200.0, Reason: "T1-ols"},
+					},
+				},
+			}
+			lat := NamedAnalyzerResult{
+				Name:    "latency",
+				Enabled: true,
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: "latency",
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", PerReplicaCapacity: 150.0, Reason: "L1-obs"},
+					},
+				},
+			}
+			Expect(bindingAnchor([]NamedAnalyzerResult{ta, lat})).To(BeNil())
+		})
 	})
 
 	Describe("ResultIsInformative", func() {

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -31,6 +31,7 @@ func makeNamed(name string, rc, sc float64, vcs ...any) NamedAnalyzerResult {
 		Remaining: rc,
 		Spare:     sc,
 		Live:      true,
+		Enabled:   true,
 	}
 }
 
@@ -63,19 +64,261 @@ var _ = Describe("analyzer helpers", func() {
 		})
 	})
 
-	Describe("saturationEntry", func() {
-		It("returns the saturation result from the slice", func() {
-			satResult := &domain.AnalyzerResult{RequiredCapacity: 42}
-			s := []NamedAnalyzerResult{
-				{Name: domain.SaturationAnalyzerName, Result: satResult},
-				makeNamed("ta", 10, 0),
+	Describe("bindingAnchor", func() {
+		// Test 1 — merged-anchor construction (non-vacuous).
+		// A two-entry ballot where saturation is the (a)/identity carrier and a
+		// live throughput analyzer is the (b)/sizing binder. The merged anchor must
+		// take identity (accelerator, cost, replica count, model ID) from
+		// saturation and sizing (PRC, reason, model-level RC) from throughput, and
+		// recompute TotalCapacity. The fixtures make the anchor differ from
+		// ballot[0] (saturation) in both analyzer name and PRC, so an implementation
+		// that merely returned the saturation entry would fail — proving the merge.
+		It("merges (a) identity from saturation with (b) sizing from the binding analyzer", func() {
+			sat := NamedAnalyzerResult{
+				Name:    domain.SaturationAnalyzerName,
+				Enabled: false, // present as the (a) carrier, not voting
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName:     domain.SaturationAnalyzerName,
+					ModelID:          "m1",
+					Namespace:        "ns1",
+					RequiredCapacity: 999, // must NOT surface (sizing comes from binding)
+					VariantCapacities: []domain.VariantCapacity{{
+						VariantName:        "v1",
+						AcceleratorName:    "A100",
+						Cost:               10.0,
+						Role:               domain.RoleBoth,
+						ReplicaCount:       2,
+						PerReplicaCapacity: 100.0, // sat's own (b) — must NOT surface for v1
+						Reason:             "P1-obs",
+						TotalDemand:        150.0,
+					}},
+				},
 			}
-			Expect(saturationEntry(s)).To(BeIdenticalTo(satResult))
+			ta := NamedAnalyzerResult{
+				Name:    "throughput",
+				Enabled: true,
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName:     "throughput",
+					ModelID:          "ignored", // identity comes from the (a) carrier
+					RequiredCapacity: 50,
+					VariantCapacities: []domain.VariantCapacity{{
+						VariantName:        "v1",
+						PerReplicaCapacity: 200.0, // binding (b) — this is what surfaces
+						Reason:             "T1-ols",
+						TotalDemand:        300.0,
+					}},
+				},
+			}
+			s := []NamedAnalyzerResult{sat, ta}
+
+			anchor := bindingAnchor(s)
+			Expect(anchor).NotTo(BeNil())
+			// Non-vacuous: the anchor is a fresh merge, not either source Result.
+			Expect(anchor).NotTo(BeIdenticalTo(s[0].Result))
+			Expect(anchor).NotTo(BeIdenticalTo(s[1].Result))
+
+			// Model-level: identity from saturation, sizing from binding.
+			Expect(anchor.AnalyzerName).To(Equal("throughput"))
+			Expect(anchor.ModelID).To(Equal("m1"))
+			Expect(anchor.Namespace).To(Equal("ns1"))
+			Expect(anchor.RequiredCapacity).To(Equal(50.0))
+
+			Expect(anchor.VariantCapacities).To(HaveLen(1))
+			vc := anchor.VariantCapacities[0]
+			Expect(vc.VariantName).To(Equal("v1"))
+			// (a) from saturation
+			Expect(vc.AcceleratorName).To(Equal("A100"))
+			Expect(vc.Cost).To(Equal(10.0))
+			Expect(vc.ReplicaCount).To(Equal(2))
+			// (b) from binding (throughput)
+			Expect(vc.PerReplicaCapacity).To(Equal(200.0))
+			Expect(vc.Reason).To(Equal("T1-ols"))
+			// TotalCapacity recomputed = ReplicaCount(a) × PerReplicaCapacity(b)
+			Expect(vc.TotalCapacity).To(Equal(400.0))
 		})
 
-		It("returns nil when saturation is absent", func() {
-			s := []NamedAnalyzerResult{makeNamed("ta", 10, 0)}
-			Expect(saturationEntry(s)).To(BeNil())
+		// Test 2 — per-variant (b)-fallback + ordering.
+		// The (a) carrier (saturation) lists v1+v2; the binding analyzer lists only
+		// v1. Variant ordering follows the (a) carrier. For v2 (omitted by the
+		// binder) the fallback depends on whether saturation votes:
+		//   - saturation enabled (but non-binding here because non-live): its own
+		//     (b) is a consistent (demand, PRC) source, so v2 resolves from it;
+		//   - saturation not enabled (throughput-only): no consistent fallback, so
+		//     v2's PRC stays 0 and it is not proactively selectable.
+		It("falls back to saturation's own (b) for an omitted variant when saturation votes", func() {
+			sat := NamedAnalyzerResult{
+				Name:    domain.SaturationAnalyzerName,
+				Enabled: true,  // votes → fallback source is consistent
+				Live:    false, // non-live → does not bind; throughput binds
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: domain.SaturationAnalyzerName,
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", ReplicaCount: 1, PerReplicaCapacity: 100.0, Reason: "P1-obs"},
+						{VariantName: "v2", ReplicaCount: 1, PerReplicaCapacity: 110.0, Reason: "P1-obs"},
+					},
+				},
+			}
+			ta := NamedAnalyzerResult{
+				Name:    "throughput",
+				Enabled: true,
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: "throughput",
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", PerReplicaCapacity: 200.0, Reason: "T1-ols"},
+					},
+				},
+			}
+			anchor := bindingAnchor([]NamedAnalyzerResult{sat, ta})
+			Expect(anchor).NotTo(BeNil())
+			Expect(anchor.VariantCapacities).To(HaveLen(2))
+			// Ordering follows the (a) carrier (saturation): v1 then v2.
+			Expect(anchor.VariantCapacities[0].VariantName).To(Equal("v1"))
+			Expect(anchor.VariantCapacities[1].VariantName).To(Equal("v2"))
+			// v1 sized by the binding analyzer.
+			Expect(anchor.VariantCapacities[0].PerReplicaCapacity).To(Equal(200.0))
+			Expect(anchor.VariantCapacities[0].Reason).To(Equal("T1-ols"))
+			// v2 omitted by the binder → falls back to saturation's own (b).
+			Expect(anchor.VariantCapacities[1].PerReplicaCapacity).To(Equal(110.0))
+			Expect(anchor.VariantCapacities[1].Reason).To(Equal("P1-obs"))
+		})
+
+		It("leaves an omitted variant at PRC=0 under a throughput-only (non-voting saturation) config", func() {
+			sat := NamedAnalyzerResult{
+				Name:    domain.SaturationAnalyzerName,
+				Enabled: false, // throughput-only: saturation carries (a) but does not vote
+				Live:    false,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: domain.SaturationAnalyzerName,
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", ReplicaCount: 1, PerReplicaCapacity: 100.0, Reason: "P1-obs"},
+						{VariantName: "v2", ReplicaCount: 1, PerReplicaCapacity: 110.0, Reason: "P1-obs"},
+					},
+				},
+			}
+			ta := NamedAnalyzerResult{
+				Name:    "throughput",
+				Enabled: true,
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: "throughput",
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", PerReplicaCapacity: 200.0, Reason: "T1-ols"},
+					},
+				},
+			}
+			anchor := bindingAnchor([]NamedAnalyzerResult{sat, ta})
+			Expect(anchor).NotTo(BeNil())
+			Expect(anchor.VariantCapacities).To(HaveLen(2))
+			// v2 has no consistent fallback source → PRC stays 0 (reactive
+			// scale-from-zero owns cold-start).
+			Expect(anchor.VariantCapacities[1].VariantName).To(Equal("v2"))
+			Expect(anchor.VariantCapacities[1].PerReplicaCapacity).To(Equal(0.0))
+			Expect(anchor.VariantCapacities[1].TotalCapacity).To(Equal(0.0))
+		})
+
+		// Test 3 — no source mutation (aliasing guard).
+		// bindingAnchor must build fresh VariantCapacity literals; mutating the
+		// returned anchor must not write through to either source Result.
+		It("does not mutate the source Results' VariantCapacities", func() {
+			sat := NamedAnalyzerResult{
+				Name:    domain.SaturationAnalyzerName,
+				Enabled: false,
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: domain.SaturationAnalyzerName,
+					ModelID:      "m1",
+					VariantCapacities: []domain.VariantCapacity{{
+						VariantName:        "v1",
+						AcceleratorName:    "A100",
+						Cost:               10.0,
+						ReplicaCount:       2,
+						PerReplicaCapacity: 100.0,
+						TotalCapacity:      200.0,
+					}},
+				},
+			}
+			ta := NamedAnalyzerResult{
+				Name:    "throughput",
+				Enabled: true,
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: "throughput",
+					VariantCapacities: []domain.VariantCapacity{{
+						VariantName:        "v1",
+						PerReplicaCapacity: 200.0,
+						Reason:             "T1-ols",
+						TotalCapacity:      400.0,
+					}},
+				},
+			}
+			s := []NamedAnalyzerResult{sat, ta}
+
+			anchor := bindingAnchor(s)
+			Expect(anchor).NotTo(BeNil())
+			Expect(anchor.VariantCapacities).To(HaveLen(1))
+
+			// Mutate the merged output; the sources must be unaffected.
+			anchor.VariantCapacities[0].PerReplicaCapacity = 9999.0
+			anchor.VariantCapacities[0].AcceleratorName = "MUTATED"
+
+			Expect(sat.Result.VariantCapacities[0].AcceleratorName).To(Equal("A100"))
+			Expect(sat.Result.VariantCapacities[0].PerReplicaCapacity).To(Equal(100.0))
+			Expect(sat.Result.VariantCapacities[0].TotalCapacity).To(Equal(200.0))
+			Expect(ta.Result.VariantCapacities[0].PerReplicaCapacity).To(Equal(200.0))
+			Expect(ta.Result.VariantCapacities[0].TotalCapacity).To(Equal(400.0))
+		})
+
+		// Rescale read-source characterization. The rescale path resolves the
+		// model's accelerator type via singleAccType(bindingAnchor(...).VariantCapacities).
+		// Under a throughput-only config the throughput analyzer binds (it is the
+		// sole voting+live member) but leaves AcceleratorName empty; the accelerator
+		// identity comes from saturation's (a) contribution through the merge. This
+		// pins the wiring so a later change that repoints the read at the raw binding
+		// result (which has no AcceleratorName) can't silently drop the model from
+		// rescale. Throughput-only rescale *correctness* is a later change; this only
+		// freezes the read-source.
+		It("resolves the accelerator type via the merged anchor when the binding analyzer omits it", func() {
+			sat := NamedAnalyzerResult{
+				Name:    domain.SaturationAnalyzerName,
+				Enabled: false, // throughput-only: saturation carries (a) but does not vote
+				Live:    false,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: domain.SaturationAnalyzerName,
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", AcceleratorName: "A100", ReplicaCount: 1, PerReplicaCapacity: 100.0, Reason: "P1-obs"},
+					},
+				},
+			}
+			ta := NamedAnalyzerResult{
+				Name:    "throughput",
+				Enabled: true,
+				Live:    true,
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: "throughput",
+					VariantCapacities: []domain.VariantCapacity{
+						// AcceleratorName deliberately empty — throughput does not set it.
+						{VariantName: "v1", PerReplicaCapacity: 200.0, Reason: "T1-ols"},
+					},
+				},
+			}
+			s := []NamedAnalyzerResult{sat, ta}
+
+			anchor := bindingAnchor(s)
+			Expect(anchor).NotTo(BeNil())
+			Expect(anchor.VariantCapacities).To(HaveLen(1))
+			// Throughput binds the sizing (PRC=200), confirming it is the binder.
+			Expect(anchor.VariantCapacities[0].PerReplicaCapacity).To(Equal(200.0))
+			// Accelerator identity survives via saturation's (a), even though the
+			// binding analyzer's own result left it empty.
+			Expect(anchor.VariantCapacities[0].AcceleratorName).To(Equal("A100"))
+
+			// The exact expression the rescale path uses to key its GPU budgets.
+			accType, ok := singleAccType(anchor.VariantCapacities)
+			Expect(ok).To(BeTrue(), "rescale must resolve a single accelerator type from the merged anchor")
+			Expect(accType).To(Equal("A100"))
 		})
 	})
 
@@ -130,6 +373,7 @@ func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float
 		Remaining: pRC, // P-scope after initDisaggregatedRemaining
 		RoleSpare: map[string]float64{"prefill": pSC, "decode": dSC},
 		Live:      true,
+		Enabled:   true,
 	}
 }
 

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -45,24 +45,25 @@ func (o *CostAwareOptimizer) Optimize(
 	var allDecisions []domain.VariantDecision
 
 	for _, req := range requests {
-		satEntry := saturationEntry(req.AnalyzerResults)
-		if satEntry == nil {
+		anchor := bindingAnchor(req.AnalyzerResults)
+		if anchor == nil {
 			continue
 		}
 
 		stateMap := buildStateMap(req.VariantStates)
-		vcMap := buildCapacityMap(satEntry.VariantCapacities)
+		vcMap := buildCapacityMap(anchor.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
 		// Unified dispatch: one path for all models via (model, role) math.
 		// Non-disaggregated uses synthetic "both" role; disaggregated uses actual roles.
-		s := req.AnalyzerResults
+		// Combine (RC/SC) math consumes only the voting subset of the ballot.
+		s := votingResults(req.AnalyzerResults)
 		roles, ps := initRoleState(s)
 		if anyRoleNeedsScaleUp(ps, roles) {
-			allocateForModelPaired(ctx, s, satEntry.VariantCapacities, stateMap, nil, targets,
+			allocateForModelPaired(ctx, s, anchor.VariantCapacities, stateMap, nil, targets,
 				costGreedyRolePick, ps, roles)
 		} else {
-			scaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
+			scaleDownRoleIterated(ctx, s, anchor.VariantCapacities, targets, stateMap)
 		}
 
 		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "cost-aware")
@@ -248,12 +249,12 @@ func buildDecisionsWithOptimizer(
 	optimizerName string,
 ) []domain.VariantDecision {
 	decisions := make([]domain.VariantDecision, 0, len(targets))
-	// satEntry carries the model-level RequiredCapacity/SpareCapacity computed by
+	// anchor carries the model-level RequiredCapacity/SpareCapacity computed by
 	// applyUniversalThreshold; per-variant Utilization is on each VariantCapacity.
 	// These feed the saturation gauges (utilization/required/spare). SpareCapacity is
 	// additionally an input to the GPU limiter's GreedyBySaturation ordering, so setting
 	// it here also makes that ordering reflect real spare tokens on V2 (it was 0 before).
-	satEntry := saturationEntry(req.AnalyzerResults)
+	anchor := bindingAnchor(req.AnalyzerResults)
 	for name, target := range targets {
 		state := stateMap[name]
 		vc := vcMap[name]
@@ -300,13 +301,13 @@ func buildDecisionsWithOptimizer(
 		// For P/D-disaggregated models use the variant's per-role capacity; otherwise
 		// fall back to the model-level totals.
 		decision.Utilization = vc.Utilization
-		if satEntry != nil {
-			reqCap, spareCap := satEntry.RequiredCapacity, satEntry.SpareCapacity
+		if anchor != nil {
+			reqCap, spareCap := anchor.RequiredCapacity, anchor.SpareCapacity
 			role := state.Role
 			if role == "" {
 				role = domain.RoleBoth
 			}
-			if rc, ok := satEntry.RoleCapacities[role]; ok {
+			if rc, ok := anchor.RoleCapacities[role]; ok {
 				reqCap, spareCap = rc.RequiredCapacity, rc.SpareCapacity
 			}
 			decision.RequiredCapacity = reqCap

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 // withSatEntry adds a single-saturation AnalyzerResults to req, initialised from r.
-// Used by test fixtures so CostAwareOptimizer can find the saturation entry.
+// Used by test fixtures so the optimizer's binding anchor resolves to the
+// saturation entry. Enabled marks it as a voting member of the ballot; Live
+// lets it bind as the anchor (the engine populates both in production).
 func withSatEntry(r *domain.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
 	if r != nil {
 		req.AnalyzerResults = []NamedAnalyzerResult{{
@@ -20,6 +22,7 @@ func withSatEntry(r *domain.AnalyzerResult, req ModelScalingRequest) ModelScalin
 			Result:    r,
 			Remaining: r.RequiredCapacity,
 			Spare:     r.SpareCapacity,
+			Enabled:   true,
 			Live:      true,
 		}}
 	}
@@ -745,6 +748,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
+					Enabled:   true,
 					Live:      true,
 				}}
 			}
@@ -838,6 +842,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
+					Enabled:   true,
 					Live:      true,
 				}}
 			}
@@ -887,6 +892,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					Result:    r,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
+					Enabled:   true,
 					Live:      true,
 				}}
 			}

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -43,7 +43,7 @@ func (o *GreedyByScoreOptimizer) Name() string {
 type modelWork struct {
 	req       ModelScalingRequest
 	s         []NamedAnalyzerResult  // working slice; Remaining/Spare decremented in place
-	satEntry  *domain.AnalyzerResult // variant metadata keeper (Cost, AcceleratorName, Role)
+	anchor    *domain.AnalyzerResult // merged per-model anchor (topology + sizing); see bindingAnchor
 	ps        RolePairedState        // picker-local per-role demand (from initRoleState)
 	roles     []string               // active roles for this model
 	remaining float64                // fair-share priority metric (negative = fully satisfied)
@@ -122,16 +122,17 @@ func (o *GreedyByScoreOptimizer) Optimize(
 		if handled[modelKey(req)] {
 			continue
 		}
-		satEntry := saturationEntry(req.AnalyzerResults)
-		if satEntry == nil {
+		anchor := bindingAnchor(req.AnalyzerResults)
+		if anchor == nil {
 			continue
 		}
 
-		s := req.AnalyzerResults
+		// Combine (RC/SC) math consumes only the voting subset of the ballot.
+		s := votingResults(req.AnalyzerResults)
 		roles, ps := initRoleState(s)
 		fsv := fairShareValue(req.Priority, s, ps, roles)
 		if anyRoleNeedsScaleUp(ps, roles) || fsv > 0 {
-			w := o.buildScaleUpWork(req, satEntry, s, ps, roles, fsv)
+			w := o.buildScaleUpWork(req, anchor, s, ps, roles, fsv)
 			if w != nil {
 				scaleUpWork = append(scaleUpWork, w)
 			}
@@ -146,7 +147,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 
 	for _, w := range scaleUpWork {
 		stateMap := buildStateMap(w.req.VariantStates)
-		vcMap := buildCapacityMap(w.satEntry.VariantCapacities)
+		vcMap := buildCapacityMap(w.anchor.VariantCapacities)
 		decisions := buildDecisionsWithOptimizer(w.req, stateMap, vcMap, w.targets, "greedy-by-score")
 		logger.V(logging.DEBUG).Info("Greedy-by-score optimizer decisions (scale-up)",
 			"modelID", w.req.ModelID,
@@ -155,19 +156,20 @@ func (o *GreedyByScoreOptimizer) Optimize(
 	}
 
 	for _, req := range otherRequests {
-		satEntry := saturationEntry(req.AnalyzerResults)
-		if satEntry == nil {
+		anchor := bindingAnchor(req.AnalyzerResults)
+		if anchor == nil {
 			continue
 		}
 
 		stateMap := buildStateMap(req.VariantStates)
-		vcMap := buildCapacityMap(satEntry.VariantCapacities)
+		vcMap := buildCapacityMap(anchor.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
 		// Unified scale-down path via scaleDownRoleIterated.
-		s := req.AnalyzerResults
+		// Combine (RC/SC) math consumes only the voting subset of the ballot.
+		s := votingResults(req.AnalyzerResults)
 		_, _ = initRoleState(s) // populates RoleSpare for all roles
-		scaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
+		scaleDownRoleIterated(ctx, s, anchor.VariantCapacities, targets, stateMap)
 
 		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "greedy-by-score")
 		logger.V(logging.DEBUG).Info("Greedy-by-score optimizer decisions (other)",
@@ -181,14 +183,14 @@ func (o *GreedyByScoreOptimizer) Optimize(
 }
 
 // buildScaleUpWork creates a single work unit for a scale-up request.
-func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest, satEntry *domain.AnalyzerResult, s []NamedAnalyzerResult, ps RolePairedState, roles []string, fsv float64) *modelWork {
+func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest, anchor *domain.AnalyzerResult, s []NamedAnalyzerResult, ps RolePairedState, roles []string, fsv float64) *modelWork {
 	if fsv <= 0 {
 		return nil
 	}
 	return &modelWork{
 		req:       req,
 		s:         s,
-		satEntry:  satEntry,
+		anchor:    anchor,
 		ps:        ps,
 		roles:     roles,
 		remaining: fsv,
@@ -306,7 +308,7 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	// Unified path: fairShareRolePick behind the RolePickFn interface.
 	// α logic removed in commit 3.
 	pick := fairShareRolePick(target, w.s, w.roles)
-	allocateForModelPaired(ctx, w.s, w.satEntry.VariantCapacities, stateMap, effAvail,
+	allocateForModelPaired(ctx, w.s, w.anchor.VariantCapacities, stateMap, effAvail,
 		w.targets, pick, ps, w.roles)
 
 	// Reconcile: apply what was consumed (before − after) to the cluster-wide

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -837,6 +837,8 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						Score:     1.0, // explicit: mirrors engine-populated value
 						Remaining: rA.RequiredCapacity,
 						Spare:     rA.SpareCapacity,
+						Enabled:   true,
+						Live:      true,
 					}},
 					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
@@ -852,6 +854,8 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						Score:     1.0, // explicit: mirrors engine-populated value
 						Remaining: rB.RequiredCapacity,
 						Spare:     rB.SpareCapacity,
+						Enabled:   true,
+						Live:      true,
 					}},
 					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
@@ -907,6 +911,8 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 							Result:    rA,
 							Score:     1.0,
 							Remaining: rA.RequiredCapacity,
+							Enabled:   true,
+							Live:      true,
 						},
 						{
 							Name:  "throughput",
@@ -915,6 +921,8 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 							// its RC signal adds to the fair-share weight.
 							Result:    &domain.AnalyzerResult{RequiredCapacity: 20000},
 							Remaining: 20000,
+							Enabled:   true,
+							Live:      true,
 						},
 					},
 					VariantStates: []domain.VariantReplicaState{
@@ -930,6 +938,8 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						Result:    rB,
 						Score:     1.0,
 						Remaining: rB.RequiredCapacity,
+						Enabled:   true,
+						Live:      true,
 					}},
 					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
@@ -1321,6 +1331,8 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						Score:     1.0,
 						Remaining: r.RequiredCapacity,
 						Spare:     r.SpareCapacity,
+						Enabled:   true,
+						Live:      true,
 					}},
 					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "pf", CurrentReplicas: 2, GPUsPerReplica: 2},
@@ -1371,6 +1383,8 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						Score:     1.0,
 						Remaining: r.RequiredCapacity,
 						Spare:     r.SpareCapacity,
+						Enabled:   true,
+						Live:      true,
 					}},
 					VariantStates: []domain.VariantReplicaState{
 						{VariantName: "pf", CurrentReplicas: 1, GPUsPerReplica: 2},

--- a/internal/engines/pipeline/optimizer_characterization_test.go
+++ b/internal/engines/pipeline/optimizer_characterization_test.go
@@ -108,3 +108,134 @@ var _ = Describe("Anchor refactor characterization goldens (sat-v2-only)", func(
 		})
 	})
 })
+
+// Commit 2 — aggregated (RoleBoth) optimizer goldens: scenarios A1-A4.
+var _ = Describe("Commit 2 — aggregated (RoleBoth) optimizer goldens", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	It("A1: single-variant scale-up — demand exceeds capacity", func() {
+		build := func() ModelScalingRequest {
+			r := &domain.AnalyzerResult{
+				ModelID:          "a1",
+				Namespace:        "default",
+				RequiredCapacity: 15000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.71},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID:   "a1",
+				Namespace: "default",
+				Priority:  1,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "v", CurrentReplicas: 2, GPUsPerReplica: 1},
+				},
+			})
+		}
+		// captured from main@9906dac5: ceil(15000/10000)=2 additional -> 2+2=4.
+		want := map[string]goldenDecision{
+			"v": {Replicas: 4, RequiredCapacity: 15000, SpareCapacity: 0, Utilization: 0.71},
+		}
+		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
+		gs := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, unlimitedConstraints("A100"))
+		Expect(ca[0].TargetReplicas).To(BeNumerically(">", 2), "non-vacuity: scale-up must actually run")
+		expectDecisionSet(ca, want)
+		expectDecisionSet(gs, want)
+	})
+
+	It("A2: single-variant scale-down — cheapest/only variant protected at 1", func() {
+		build := func() ModelScalingRequest {
+			r := &domain.AnalyzerResult{
+				ModelID:       "a2",
+				Namespace:     "default",
+				SpareCapacity: 30000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000, Utilization: 0.05},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID:   "a2",
+				Namespace: "default",
+				Priority:  1,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "v", CurrentReplicas: 3, GPUsPerReplica: 1},
+				},
+			})
+		}
+		// captured from main@9906dac5: floor(30000/10000)=3 would remove all
+		// replicas, but the sole (always-cheapest) variant is protected at 1.
+		want := map[string]goldenDecision{
+			"v": {Replicas: 1, RequiredCapacity: 0, SpareCapacity: 30000, Utilization: 0.05},
+		}
+		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
+		gs := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
+		Expect(ca[0].TargetReplicas).To(BeNumerically("<", 3), "non-vacuity: scale-down must actually run")
+		expectDecisionSet(ca, want)
+		expectDecisionSet(gs, want)
+	})
+
+	It("A3: no-op / at-target — no demand and no spare, nothing changes", func() {
+		build := func() ModelScalingRequest {
+			r := &domain.AnalyzerResult{
+				ModelID:   "a3",
+				Namespace: "default",
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.4},
+					{VariantName: "v2", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000, Utilization: 0.55},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID:   "a3",
+				Namespace: "default",
+				Priority:  1,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "v1", CurrentReplicas: 2, GPUsPerReplica: 1},
+					{VariantName: "v2", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			})
+		}
+		// This golden is *supposed* to be vacuous (every target == current) — that
+		// is the property being frozen: no spurious churn absent demand or spare.
+		want := map[string]goldenDecision{
+			"v1": {Replicas: 2, RequiredCapacity: 0, SpareCapacity: 0, Utilization: 0.4},
+			"v2": {Replicas: 1, RequiredCapacity: 0, SpareCapacity: 0, Utilization: 0.55},
+		}
+		expectDecisionSet(NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil), want)
+		expectDecisionSet(NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, unlimitedConstraints("A100", "H100")), want)
+	})
+
+	It("A4: multi-variant cost tie-break — cheapest absorbs demand", func() {
+		build := func() ModelScalingRequest {
+			r := &domain.AnalyzerResult{
+				ModelID:          "a4",
+				Namespace:        "default",
+				RequiredCapacity: 5000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.6},
+					{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000, Utilization: 0.3},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID:   "a4",
+				Namespace: "default",
+				Priority:  1,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "cheap", CurrentReplicas: 2, GPUsPerReplica: 1},
+					{VariantName: "expensive", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			})
+		}
+		// captured from main@9906dac5: cost-efficiency cheap=5/10000=0.0005 <
+		// expensive=15/20000=0.00075 -> cheap absorbs all demand: ceil(5000/10000)=1.
+		want := map[string]goldenDecision{
+			"cheap":     {Replicas: 3, RequiredCapacity: 5000, SpareCapacity: 0, Utilization: 0.6},
+			"expensive": {Replicas: 1, RequiredCapacity: 5000, SpareCapacity: 0, Utilization: 0.3},
+		}
+		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
+		gs := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, unlimitedConstraints("A100", "H100"))
+		expectDecisionSet(ca, want)
+		expectDecisionSet(gs, want)
+	})
+})

--- a/internal/engines/pipeline/optimizer_characterization_test.go
+++ b/internal/engines/pipeline/optimizer_characterization_test.go
@@ -1,0 +1,110 @@
+package pipeline
+
+// Anchor-refactor characterization goldens.
+//
+// These tests capture the CURRENT (main) behavior of the sat-v2-only optimizer
+// path as literal expected values ("goldens"). They exist to prove design
+// invariant #7 of the anchor refactor: when exactly one analyzer votes
+// (today's default config), the refactored pipeline must produce the same
+// decisions as today. The same file rides unchanged onto the anchor-refactor
+// branch as its ship gate.
+//
+// Every case here is single-analyzer, sat-v2-only (one NamedAnalyzerResult
+// named domain.SaturationAnalyzerName). Because the expected values are
+// captured from current code, every test in this file passes by construction
+// against main — a red test here means the fixture is wrong, not that
+// production code is buggy.
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+// goldenDecision is the subset of domain.VariantDecision fields the anchor
+// refactor repoints and this branch freezes: target replica count,
+// RequiredCapacity, SpareCapacity, and Utilization.
+type goldenDecision struct {
+	Replicas         int
+	RequiredCapacity float64
+	SpareCapacity    float64
+	Utilization      float64
+}
+
+// expectDecisionSet asserts got matches want as a SET keyed by VariantName,
+// never by slice order or slice equality: Optimize's per-decision content is
+// deterministic but its output slice order is not (map iteration in
+// buildDecisionsWithOptimizer, unstable sort in sortByRemainingDesc).
+func expectDecisionSet(got []domain.VariantDecision, want map[string]goldenDecision) {
+	gm := make(map[string]domain.VariantDecision, len(got))
+	gotNames := make([]string, 0, len(got))
+	for _, d := range got {
+		gm[d.VariantName] = d
+		gotNames = append(gotNames, d.VariantName)
+	}
+	wantNames := make([]string, 0, len(want))
+	for n := range want {
+		wantNames = append(wantNames, n)
+	}
+	Expect(gotNames).To(ConsistOf(wantNames), "decision-set variant names must match the golden")
+
+	for name, w := range want {
+		d := gm[name]
+		Expect(d.TargetReplicas).To(Equal(w.Replicas), "variant %q: TargetReplicas", name)
+		Expect(d.RequiredCapacity).To(BeNumerically("~", w.RequiredCapacity, 1e-9), "variant %q: RequiredCapacity", name)
+		Expect(d.SpareCapacity).To(BeNumerically("~", w.SpareCapacity, 1e-9), "variant %q: SpareCapacity", name)
+		Expect(d.Utilization).To(BeNumerically("~", w.Utilization, 1e-9), "variant %q: Utilization", name)
+	}
+}
+
+// unlimitedConstraints emulates "no GPU limit" for GreedyByScoreOptimizer,
+// which treats absent/empty constraints as zero (deny), not unlimited —
+// mirrors the pattern in optimizer_equivalence_test.go.
+func unlimitedConstraints(types ...string) []*ResourceConstraints {
+	pools := map[string]ResourcePool{}
+	for _, t := range types {
+		pools[t] = ResourcePool{Limit: 1_000_000}
+	}
+	return []*ResourceConstraints{{Pools: pools}}
+}
+
+var _ = Describe("Anchor refactor characterization goldens (sat-v2-only)", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	Context("harness smoke test", func() {
+		It("freezes a trivial no-op decision (proves the harness itself)", func() {
+			// No demand (RequiredCapacity=0) and no spare (SpareCapacity=0): neither
+			// optimizer has a reason to change the target. This exercises the
+			// harness plumbing (fixture -> Optimize -> expectDecisionSet) without
+			// depending on any allocation math.
+			build := func() ModelScalingRequest {
+				r := &domain.AnalyzerResult{
+					ModelID:   "smoke",
+					Namespace: "default",
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.5},
+					},
+				}
+				return withSatEntry(r, ModelScalingRequest{
+					ModelID:   "smoke",
+					Namespace: "default",
+					Priority:  1,
+					VariantStates: []domain.VariantReplicaState{
+						{VariantName: "v", CurrentReplicas: 2, GPUsPerReplica: 1},
+					},
+				})
+			}
+			want := map[string]goldenDecision{
+				"v": {Replicas: 2, RequiredCapacity: 0, SpareCapacity: 0, Utilization: 0.5},
+			}
+
+			expectDecisionSet(NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil), want)
+			expectDecisionSet(NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, unlimitedConstraints("A100")), want)
+		})
+	})
+})

--- a/internal/engines/pipeline/optimizer_characterization_test.go
+++ b/internal/engines/pipeline/optimizer_characterization_test.go
@@ -140,7 +140,11 @@ var _ = Describe("Commit 2 — aggregated (RoleBoth) optimizer goldens", func() 
 		}
 		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
 		gs := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, unlimitedConstraints("A100"))
-		Expect(ca[0].TargetReplicas).To(BeNumerically(">", 2), "non-vacuity: scale-up must actually run")
+		caTargets := make(map[string]int, len(ca))
+		for _, d := range ca {
+			caTargets[d.VariantName] = d.TargetReplicas
+		}
+		Expect(caTargets["v"]).To(BeNumerically(">", 2), "non-vacuity: scale-up must actually run")
 		expectDecisionSet(ca, want)
 		expectDecisionSet(gs, want)
 	})
@@ -171,7 +175,11 @@ var _ = Describe("Commit 2 — aggregated (RoleBoth) optimizer goldens", func() 
 		}
 		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
 		gs := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
-		Expect(ca[0].TargetReplicas).To(BeNumerically("<", 3), "non-vacuity: scale-down must actually run")
+		caTargets := make(map[string]int, len(ca))
+		for _, d := range ca {
+			caTargets[d.VariantName] = d.TargetReplicas
+		}
+		Expect(caTargets["v"]).To(BeNumerically("<", 3), "non-vacuity: scale-down must actually run")
 		expectDecisionSet(ca, want)
 		expectDecisionSet(gs, want)
 	})
@@ -279,7 +287,12 @@ var _ = Describe("Commit 3 — disaggregated (P/D) optimizer goldens", func() {
 			"decode-v":  {Replicas: 3, RequiredCapacity: 20000, SpareCapacity: 0, Utilization: 0.45},
 		}
 		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
-		Expect(ca[0].TargetReplicas).To(BeNumerically(">", 1), "non-vacuity: scale-up must actually run")
+		caTargets := make(map[string]int, len(ca))
+		for _, d := range ca {
+			caTargets[d.VariantName] = d.TargetReplicas
+		}
+		Expect(caTargets["prefill-v"]).To(BeNumerically(">", 1), "non-vacuity: prefill scale-up must actually run")
+		Expect(caTargets["decode-v"]).To(BeNumerically(">", 1), "non-vacuity: decode scale-up must actually run")
 		expectDecisionSet(ca, wantCA)
 
 		// GreedyByScore distributes proportionally to per-role demand rather than

--- a/internal/engines/pipeline/optimizer_characterization_test.go
+++ b/internal/engines/pipeline/optimizer_characterization_test.go
@@ -343,3 +343,54 @@ var _ = Describe("Commit 3 — disaggregated (P/D) optimizer goldens", func() {
 		expectDecisionSet(gs, want)
 	})
 })
+
+// Commit 4 — quota-constrained optimizer golden: scenario C1.
+//
+// CostAwareOptimizer ignores ResourceConstraints entirely (unlimited mode —
+// see its doc comment), so quota/GPU-limiting behavior only exists on
+// GreedyByScoreOptimizer. C1 is a GreedyByScoreOptimizer-only golden.
+var _ = Describe("Commit 4 — quota-constrained optimizer golden", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	It("C1: namespace quota caps a model's allocation below cluster-unconstrained demand", func() {
+		build := func() ModelScalingRequest {
+			r := &domain.AnalyzerResult{
+				ModelID:          "c1",
+				Namespace:        "team-a",
+				RequiredCapacity: 50000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.9},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID:   "c1",
+				Namespace: "team-a",
+				Priority:  1,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2},
+				},
+			})
+		}
+		quotaConstraints := []*ResourceConstraints{
+			{
+				Pools:          map[string]ResourcePool{"A100": {Limit: 100}},
+				NamespacePools: map[string]map[string]ResourcePool{"team-a": {"A100": {Limit: 4, Used: 2}}},
+			},
+		}
+
+		// captured from main@9906dac5: team-a has 2 free GPUs (cap 4 - used 2) =
+		// room for exactly one more 2-GPU replica, well below cluster-unconstrained
+		// demand of ceil(50000/10000)=5 additional replicas.
+		want := map[string]goldenDecision{
+			"v": {Replicas: 2, RequiredCapacity: 50000, SpareCapacity: 0, Utilization: 0.9},
+		}
+		constrained := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, quotaConstraints)
+		unconstrained := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, unlimitedConstraints("A100"))
+
+		Expect(constrained[0].TargetReplicas).To(BeNumerically("<", unconstrained[0].TargetReplicas),
+			"non-vacuity: the namespace budget must actually bind below unconstrained demand")
+		expectDecisionSet(constrained, want)
+	})
+})

--- a/internal/engines/pipeline/optimizer_characterization_test.go
+++ b/internal/engines/pipeline/optimizer_characterization_test.go
@@ -239,3 +239,107 @@ var _ = Describe("Commit 2 — aggregated (RoleBoth) optimizer goldens", func() 
 		expectDecisionSet(gs, want)
 	})
 })
+
+// Commit 3 — disaggregated (P/D) optimizer goldens: scenarios B1-B2.
+var _ = Describe("Commit 3 — disaggregated (P/D) optimizer goldens", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	It("B1: paired scale-up — equal prefill/decode demand", func() {
+		build := func() ModelScalingRequest {
+			r := &domain.AnalyzerResult{
+				ModelID:          "b1",
+				Namespace:        "default",
+				RequiredCapacity: 20000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "prefill-v", Role: "prefill", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.65},
+					{VariantName: "decode-v", Role: "decode", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000, Utilization: 0.45},
+				},
+				RoleCapacities: map[string]domain.RoleCapacity{
+					"prefill": {Role: "prefill", RequiredCapacity: 20000, TotalDemand: 20000},
+					"decode":  {Role: "decode", RequiredCapacity: 20000, TotalDemand: 20000},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID:       "b1",
+				Namespace:     "default",
+				Priority:      1,
+				Disaggregated: true,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "prefill-v", Role: "prefill", CurrentReplicas: 1, GPUsPerReplica: 2},
+					{VariantName: "decode-v", Role: "decode", CurrentReplicas: 1, GPUsPerReplica: 2},
+				},
+			})
+		}
+		// captured from main@9906dac5: alpha=20000/20000=1; n_P=ceil(20000/10000)=2;
+		// n_D=ceil(1x20000/10000)=2 -> both roles committed jointly (1+2 each).
+		wantCA := map[string]goldenDecision{
+			"prefill-v": {Replicas: 3, RequiredCapacity: 20000, SpareCapacity: 0, Utilization: 0.65},
+			"decode-v":  {Replicas: 3, RequiredCapacity: 20000, SpareCapacity: 0, Utilization: 0.45},
+		}
+		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
+		Expect(ca[0].TargetReplicas).To(BeNumerically(">", 1), "non-vacuity: scale-up must actually run")
+		expectDecisionSet(ca, wantCA)
+
+		// GreedyByScore distributes proportionally to per-role demand rather than
+		// jointly committing a paired (n_P, n_D) — a different algorithm, so it is
+		// pinned as its own golden rather than asserted equal to CostAware's.
+		wantGS := map[string]goldenDecision{
+			"prefill-v": {Replicas: 3, RequiredCapacity: 20000, SpareCapacity: 0, Utilization: 0.65},
+			"decode-v":  {Replicas: 3, RequiredCapacity: 20000, SpareCapacity: 0, Utilization: 0.45},
+		}
+		gs := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, unlimitedConstraints("A100"))
+		expectDecisionSet(gs, wantGS)
+	})
+
+	It("B2: role-scoped scale-down — expensive prefill fully removed, cheap prefill protected", func() {
+		build := func() ModelScalingRequest {
+			r := &domain.AnalyzerResult{
+				ModelID:       "b2",
+				Namespace:     "default",
+				SpareCapacity: 20000, // model-level; unused in the disaggregated path
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "cheap-p", Role: "prefill", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.2},
+					{VariantName: "expensive-p", Role: "prefill", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.1},
+					{VariantName: "decode-v", Role: "decode", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000, Utilization: 0.3},
+				},
+				RoleCapacities: map[string]domain.RoleCapacity{
+					"prefill": {Role: "prefill", SpareCapacity: 20000, TotalDemand: 10000},
+					"decode":  {Role: "decode", SpareCapacity: 10000, TotalDemand: 10000},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID:       "b2",
+				Namespace:     "default",
+				Priority:      1,
+				Disaggregated: true,
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "cheap-p", Role: "prefill", CurrentReplicas: 2, GPUsPerReplica: 1},
+					{VariantName: "expensive-p", Role: "prefill", CurrentReplicas: 2, GPUsPerReplica: 1},
+					{VariantName: "decode-v", Role: "decode", CurrentReplicas: 3, GPUsPerReplica: 1},
+				},
+			})
+		}
+		// captured from main@9906dac5: prefill sheds cost-desc — expensive-p first,
+		// floor(20000/10000)=2 removes it fully; cheap-p is protected as the last
+		// prefill variant with replicas. decode sheds floor(10000/10000)=1.
+		want := map[string]goldenDecision{
+			"cheap-p":     {Replicas: 2, RequiredCapacity: 0, SpareCapacity: 20000, Utilization: 0.2},
+			"expensive-p": {Replicas: 0, RequiredCapacity: 0, SpareCapacity: 20000, Utilization: 0.1},
+			"decode-v":    {Replicas: 2, RequiredCapacity: 0, SpareCapacity: 10000, Utilization: 0.3},
+		}
+		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
+		gs := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
+
+		caTargets := make(map[string]int, len(ca))
+		for _, d := range ca {
+			caTargets[d.VariantName] = d.TargetReplicas
+		}
+		Expect(caTargets["expensive-p"]).To(BeNumerically("<", 2), "non-vacuity: prefill scale-down must actually run")
+		Expect(caTargets["decode-v"]).To(BeNumerically("<", 3), "non-vacuity: decode scale-down must actually run")
+
+		expectDecisionSet(ca, want)
+		expectDecisionSet(gs, want)
+	})
+})

--- a/internal/engines/pipeline/optimizer_combine_characterization_test.go
+++ b/internal/engines/pipeline/optimizer_combine_characterization_test.go
@@ -1,0 +1,115 @@
+package pipeline
+
+// Two-analyzer combine characterization golden (saturation + throughput).
+//
+// The single-analyzer goldens (optimizer_characterization_test.go) freeze the
+// single-analyzer, sat-v2-only decision set. This file adds the companion
+// two-voting-entry case: a ballot with BOTH saturation and throughput enabled,
+// exercised through the full combine (RC/SC) path. It freezes the resulting
+// decision SET (keyed by VariantName, same shape as the single-analyzer
+// goldens) so the combine arithmetic stays identical to the current
+// (pre-refactor) main behavior when two analyzers vote.
+//
+// Expected values are captured from main@9906dac5 by hand-tracing the combine
+// path (the same method used for the single-analyzer goldens). A red test here
+// means the refactor changed multi-analyzer combine behavior — which the
+// single-vote-equivalence invariant forbids from extending to the two-vote case.
+//
+// Fixture constraint: every variant is live (>=1 current replica). This keeps
+// the later throughput-side proactive-capacity complement (which only emits for
+// previously-live-now-zero variants) a no-op for this fixture, so the golden
+// stays valid across that change too.
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+var _ = Describe("Anchor refactor combine characterization goldens (saturation + throughput)", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	It("freezes the two-analyzer scale-up decision set (throughput demand dominates)", func() {
+		// A [saturation, throughput] ballot, both voting (Enabled) and live.
+		// Saturation binds the anchor (identity + sizing); throughput contributes
+		// only to the combine's cross-analyzer bottleneck. Single non-disaggregated
+		// variant "v" with 2 live replicas (satisfies the all-live constraint).
+		//
+		//   saturation: RC=5000  -> ceil(5000/10000)  = 1 additional replica
+		//   throughput: RC=25000 -> ceil(25000/10000) = 3 additional replicas
+		//
+		// The scale-up bottleneck is the cross-analyzer MAX, so throughput drives
+		// the joint commit to +3 -> target 5. RequiredCapacity/SpareCapacity/
+		// Utilization come from the saturation-bound anchor (RC=5000, SC=0, u=0.8).
+		build := func() ModelScalingRequest {
+			sat := &domain.AnalyzerResult{
+				ModelID:          "combine",
+				Namespace:        "default",
+				RequiredCapacity: 5000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000, Utilization: 0.8, Reason: "P1-obs"},
+				},
+			}
+			ta := &domain.AnalyzerResult{
+				ModelID:          "combine",
+				Namespace:        "default",
+				RequiredCapacity: 25000,
+				VariantCapacities: []domain.VariantCapacity{
+					{VariantName: "v", PerReplicaCapacity: 10000, Reason: "T1-ols"},
+				},
+			}
+			return ModelScalingRequest{
+				ModelID:   "combine",
+				Namespace: "default",
+				Priority:  1,
+				AnalyzerResults: []NamedAnalyzerResult{
+					{
+						Name:      domain.SaturationAnalyzerName,
+						Result:    sat,
+						Score:     1.0,
+						Remaining: sat.RequiredCapacity,
+						Spare:     sat.SpareCapacity,
+						Enabled:   true,
+						Live:      true,
+					},
+					{
+						Name:      "throughput",
+						Result:    ta,
+						Score:     1.0,
+						Remaining: ta.RequiredCapacity,
+						Spare:     ta.SpareCapacity,
+						Enabled:   true,
+						Live:      true,
+					},
+				},
+				VariantStates: []domain.VariantReplicaState{
+					{VariantName: "v", CurrentReplicas: 2, GPUsPerReplica: 1},
+				},
+			}
+		}
+		// captured from main@9906dac5: cross-analyzer bottleneck MAX(1, 3)=3
+		// additional -> 2+3=5; anchor (saturation-bound) RC=5000, SC=0, u=0.8.
+		want := map[string]goldenDecision{
+			"v": {Replicas: 5, RequiredCapacity: 5000, SpareCapacity: 0, Utilization: 0.8},
+		}
+
+		ca := NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, nil)
+		gs := NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{build()}, unlimitedConstraints("A100"))
+
+		// Non-vacuity: saturation alone would scale to 3 (ceil(5000/10000)=1
+		// additional); the throughput vote must actually drive the target higher.
+		caTargets := make(map[string]int, len(ca))
+		for _, d := range ca {
+			caTargets[d.VariantName] = d.TargetReplicas
+		}
+		Expect(caTargets["v"]).To(BeNumerically(">", 3), "non-vacuity: the throughput vote must lift the target above saturation-alone")
+
+		expectDecisionSet(ca, want)
+		expectDecisionSet(gs, want)
+	})
+})

--- a/internal/engines/pipeline/optimizer_hold_test.go
+++ b/internal/engines/pipeline/optimizer_hold_test.go
@@ -1,0 +1,63 @@
+package pipeline
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+// Test 4 (optimizer facet) — a request whose ballot yields no anchor is held
+// gracefully. bindingAnchor returns nil for that request, so each optimizer's
+// nil-anchor guard skips the model: it produces no decision and never indexes
+// into the empty or unbindable ballot (the empty-ballot regression). The
+// engine's unconditional applySaturationDecisions then re-affirms the model's
+// last-good replicas and emits the scaling metric — that hold-and-emit path is
+// exercised end-to-end in the saturation engine's queueing-model refusal test.
+var _ = Describe("optimizer hold on an unbindable ballot", func() {
+	ctx := context.Background()
+
+	// unbindableRequest builds a request with real variant state but a ballot
+	// that cannot bind: a lone throughput entry that is enabled and informative
+	// but not live, so bindingAnchor returns nil. VariantStates is populated so
+	// the request is non-trivial — the guard must skip on the nil anchor, not on
+	// an empty request set.
+	unbindableRequest := func() ModelScalingRequest {
+		return ModelScalingRequest{
+			ModelID:   "m1",
+			Namespace: "ns1",
+			AnalyzerResults: []NamedAnalyzerResult{{
+				Name:    "throughput",
+				Enabled: true,
+				Live:    false, // not live → no binder → nil anchor
+				Result: &domain.AnalyzerResult{
+					AnalyzerName: "throughput",
+					VariantCapacities: []domain.VariantCapacity{
+						{VariantName: "v1", PerReplicaCapacity: 200.0, Reason: "T1-ols"},
+					},
+				},
+			}},
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "v1", CurrentReplicas: 2, DesiredReplicas: 2, GPUsPerReplica: 1, Role: domain.RoleBoth},
+			},
+		}
+	}
+
+	It("CostAwareOptimizer produces no decision and does not panic", func() {
+		var decisions []domain.VariantDecision
+		Expect(func() {
+			decisions = NewCostAwareOptimizer().Optimize(ctx, []ModelScalingRequest{unbindableRequest()}, nil)
+		}).NotTo(Panic())
+		Expect(decisions).To(BeEmpty())
+	})
+
+	It("GreedyByScoreOptimizer produces no decision and does not panic", func() {
+		var decisions []domain.VariantDecision
+		Expect(func() {
+			decisions = NewGreedyByScoreOptimizer().Optimize(ctx, []ModelScalingRequest{unbindableRequest()}, nil)
+		}).NotTo(Panic())
+		Expect(decisions).To(BeEmpty())
+	})
+})

--- a/internal/engines/pipeline/optimizer_interfaces.go
+++ b/internal/engines/pipeline/optimizer_interfaces.go
@@ -34,6 +34,14 @@ type NamedAnalyzerResult struct {
 	// error state, never analyzed) cannot block scale-down. Recovery is automatic: a
 	// fresh informative result makes it live again on the next cycle.
 	Live bool
+
+	// Enabled indicates the analyzer votes in the combine (RC/SC) math for this cycle.
+	// Saturation is present as the identity/(a) carrier even when it does not vote
+	// (e.g. a throughput-only config), so "present in the ballot" != "votes".
+	// Set by the engine each cycle. votingResults prunes the ballot to Enabled
+	// entries before combine math; the anchor build (bindingAnchor) reads the full
+	// ballot so a non-voting saturation entry can still supply (a)/fallback (b).
+	Enabled bool
 }
 
 // ModelScalingRequest bundles the analyzer result with variant state for one model.
@@ -41,7 +49,7 @@ type NamedAnalyzerResult struct {
 type ModelScalingRequest struct {
 	ModelID         string
 	Namespace       string
-	AnalyzerResults []NamedAnalyzerResult // per-analyzer slice; saturation entry is always first
+	AnalyzerResults []NamedAnalyzerResult // per-analyzer slice; order is not significant (see bindingAnchor / votingResults)
 	VariantStates   []domain.VariantReplicaState
 	Priority        float64 // Model priority (default 1.0)
 	Disaggregated   bool    // true when model has prefill+decode variants

--- a/internal/engines/pipeline/optimizer_scale_from_zero_test.go
+++ b/internal/engines/pipeline/optimizer_scale_from_zero_test.go
@@ -1,0 +1,99 @@
+package pipeline
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+)
+
+// Test 10 — scale-from-zero selection under a throughput-only ([TA]) ballot.
+//
+// End-to-end companion to the throughput analyzer's scale-from-zero complement:
+// the analyzer re-emits a PRC-only VariantCapacity for a previously-live variant
+// now at zero replicas, and the pipeline must consume it. The saturation entry is
+// present only as the (a)/identity carrier (not voting), so bindingAnchor merges
+// its per-variant identity (Cost/AcceleratorName/Role/ReplicaCount) with the
+// throughput analyzer's per-replica capacity. A previously-live-now-zero variant
+// then has a positive merged PerReplicaCapacity and is a viable scale-up target,
+// while a never-seen variant the throughput analyzer did not emit stays at
+// PerReplicaCapacity 0 and is skipped — the picker selects by viability, not by
+// cost ranking (the never-seen decoy here is strictly cheaper).
+var _ = Describe("scale-from-zero selection under a throughput-only ballot", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	// taOnlyBallot builds a [TA]-only ballot for one model:
+	//   - saturation entry present as the (a) carrier only (Enabled:false): it emits
+	//     both variants' identity (cost/accelerator/role/replica-count) but does not
+	//     vote or bind.
+	//   - throughput entry as the sole voting+binding analyzer: model-level demand
+	//     (Remaining) drives scale-up; VariantCapacities is the PRC-only emission for
+	//     the previously-live variant only.
+	taOnlyBallot := func(demand float64) ModelScalingRequest {
+		satIdentity := &domain.AnalyzerResult{
+			ModelID:    "m",
+			Namespace:  "default",
+			AnalyzedAt: time.Now(),
+			VariantCapacities: []domain.VariantCapacity{
+				// previously-live-now-zero: identity carrier, no PRC of its own.
+				{VariantName: "revived", AcceleratorName: "H100", Cost: 10.0, Role: "", ReplicaCount: 0},
+				// never-seen-now-zero: strictly cheaper, but TA emits no PRC for it.
+				{VariantName: "cold", AcceleratorName: "A100", Cost: 5.0, Role: "", ReplicaCount: 0},
+			},
+		}
+		taResult := &domain.AnalyzerResult{
+			AnalyzerName:     "throughput",
+			ModelID:          "m",
+			Namespace:        "default",
+			AnalyzedAt:       time.Now(),
+			RequiredCapacity: demand,
+			VariantCapacities: []domain.VariantCapacity{
+				// PRC-only scale-from-zero emission (mirrors the analyzer's T-sfz row).
+				{VariantName: "revived", PerReplicaCapacity: 12000, Reason: "T-sfz"},
+			},
+		}
+		return ModelScalingRequest{
+			ModelID:   "m",
+			Namespace: "default",
+			VariantStates: []domain.VariantReplicaState{
+				{VariantName: "revived", CurrentReplicas: 0},
+				{VariantName: "cold", CurrentReplicas: 0},
+			},
+			AnalyzerResults: []NamedAnalyzerResult{
+				{
+					Name:    domain.SaturationAnalyzerName,
+					Result:  satIdentity,
+					Enabled: false, // (a) carrier only — does not vote or bind
+					Live:    false,
+				},
+				{
+					Name:      "throughput",
+					Result:    taResult,
+					Remaining: demand,
+					Enabled:   true,
+					Live:      true,
+				},
+			},
+		}
+	}
+
+	It("raises the previously-live variant above zero and skips the never-seen one", func() {
+		requests := []ModelScalingRequest{taOnlyBallot(12000)}
+
+		dm := decisionMap(NewCostAwareOptimizer().Optimize(ctx, requests, nil))
+
+		Expect(dm).To(HaveKey("revived"))
+		// ceil(12000 / 12000) = 1 replica added from zero — selected as the viable
+		// scale-from-zero source despite being the more expensive variant.
+		Expect(dm["revived"].TargetReplicas).To(BeNumerically(">", 0))
+		// The cheaper never-seen variant has no per-replica capacity → not selectable.
+		Expect(dm["cold"].TargetReplicas).To(Equal(0))
+	})
+})

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -222,11 +222,11 @@ func (o *GreedyByScoreOptimizer) applyRescale(
 	}
 	groups := make(map[groupKey][]ModelScalingRequest)
 	for _, req := range requests {
-		satEntry := saturationEntry(req.AnalyzerResults)
-		if satEntry == nil {
+		anchor := bindingAnchor(req.AnalyzerResults)
+		if anchor == nil {
 			continue
 		}
-		accType, ok := singleAccType(satEntry.VariantCapacities)
+		accType, ok := singleAccType(anchor.VariantCapacities)
 		if !ok {
 			continue // multi-accelerator (incl. P/D spanning types): deferred
 		}
@@ -339,21 +339,21 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	targetGPUs int,
 	freeThisCycle *int,
 ) []domain.VariantDecision {
-	satEntry := saturationEntry(req.AnalyzerResults)
+	anchor := bindingAnchor(req.AnalyzerResults)
 	stateMap := buildStateMap(req.VariantStates)
-	vcMap := buildCapacityMap(satEntry.VariantCapacities)
+	vcMap := buildCapacityMap(anchor.VariantCapacities)
 	targets := initTargets(req.VariantStates)
 
 	// Split the model's GPU target across its roles by role demand (a P/D model
 	// must keep both roles served), then reclaim/fill each role toward its share.
 	// A non-disaggregated model has the single synthetic "both" role.
-	roles := modelRolesOnType(satEntry.VariantCapacities, accType)
+	roles := modelRolesOnType(anchor.VariantCapacities, accType)
 	curByRole := make(map[string]int, len(roles))
 	demByRole := make(map[string]int, len(roles))
 	floorByRole := make(map[string]int, len(roles))
 	for _, role := range roles {
 		curByRole[role] = roleCurrentGPUs(req, accType, role)
-		demByRole[role] = roleDemandGPUs(satEntry, stateMap, accType, role)
+		demByRole[role] = roleDemandGPUs(anchor, stateMap, accType, role)
 		floorByRole[role] = roleFloorGPUs(req, accType, role)
 	}
 	tgtByRole := distributeGPUsByWeight(targetGPUs, roles, demByRole, curByRole, floorByRole)
@@ -362,13 +362,15 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 		rt, rc := tgtByRole[role], curByRole[role]
 		switch {
 		case rt < rc:
-			reclaimRole(ctx, req.AnalyzerResults, satEntry.VariantCapacities, role, stateMap, targets, rc-rt)
+			// Combine (RC/SC) math (scale-down score-weighted tie-break) consumes only
+			// the voting subset of the ballot; the anchor supplies the variant topology.
+			reclaimRole(ctx, votingResults(req.AnalyzerResults), anchor.VariantCapacities, role, stateMap, targets, rc-rt)
 		case rt > rc:
 			want := rt - rc
 			if want > *freeThisCycle {
 				want = *freeThisCycle
 			}
-			*freeThisCycle -= fillRole(satEntry.VariantCapacities, role, stateMap, targets, want)
+			*freeThisCycle -= fillRole(anchor.VariantCapacities, role, stateMap, targets, want)
 		}
 	}
 
@@ -462,13 +464,13 @@ func singleAccType(vcs []domain.VariantCapacity) (string, bool) {
 // modelCurrentGPUs sums CurrentReplicas x GPUsPerReplica over the model's variants
 // on accType.
 func modelCurrentGPUs(req ModelScalingRequest, accType string) int {
-	satEntry := saturationEntry(req.AnalyzerResults)
-	if satEntry == nil {
+	anchor := bindingAnchor(req.AnalyzerResults)
+	if anchor == nil {
 		return 0
 	}
 	stateMap := buildStateMap(req.VariantStates)
 	total := 0
-	for _, vc := range satEntry.VariantCapacities {
+	for _, vc := range anchor.VariantCapacities {
 		if vc.AcceleratorName != accType {
 			continue
 		}
@@ -483,14 +485,14 @@ func rescaleInputsForGroup(reqs []ModelScalingRequest, accType string, budget in
 	inputs := make([]rescaleInput, 0, len(reqs))
 	sumDemandGPUs := 0
 	for _, req := range reqs {
-		satEntry := saturationEntry(req.AnalyzerResults)
-		if satEntry == nil {
+		anchor := bindingAnchor(req.AnalyzerResults)
+		if anchor == nil {
 			continue
 		}
 		stateMap := buildStateMap(req.VariantStates)
 
 		floorGPUs, maxGPUs, maxBounded := 0, 0, true
-		for _, vc := range satEntry.VariantCapacities {
+		for _, vc := range anchor.VariantCapacities {
 			if vc.AcceleratorName != accType {
 				continue
 			}
@@ -506,7 +508,7 @@ func rescaleInputsForGroup(reqs []ModelScalingRequest, accType string, budget in
 			}
 		}
 
-		demandGPUs := modelDemandGPUs(satEntry, stateMap, accType)
+		demandGPUs := modelDemandGPUs(anchor, stateMap, accType)
 		capGPUs := demandGPUs
 		if maxBounded {
 			capGPUs = min(capGPUs, maxGPUs)
@@ -518,7 +520,7 @@ func rescaleInputsForGroup(reqs []ModelScalingRequest, accType string, budget in
 		inputs = append(inputs, rescaleInput{
 			ID:        modelKey(req),
 			Priority:  req.Priority,
-			Demand:    satEntry.TotalDemand,
+			Demand:    anchor.TotalDemand,
 			FloorGPUs: floorGPUs,
 			CapGPUs:   capGPUs,
 		})
@@ -529,10 +531,10 @@ func rescaleInputsForGroup(reqs []ModelScalingRequest, accType string, budget in
 
 // modelDemandGPUs is the model's demand-in-GPUs summed across its roles on accType
 // (a P/D model needs GPUs for both prefill and decode).
-func modelDemandGPUs(satEntry *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType string) int {
+func modelDemandGPUs(anchor *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType string) int {
 	total := 0
-	for _, role := range modelRolesOnType(satEntry.VariantCapacities, accType) {
-		total += roleDemandGPUs(satEntry, stateMap, accType, role)
+	for _, role := range modelRolesOnType(anchor.VariantCapacities, accType) {
+		total += roleDemandGPUs(anchor, stateMap, accType, role)
 	}
 	return total
 }
@@ -540,16 +542,16 @@ func modelDemandGPUs(satEntry *domain.AnalyzerResult, stateMap map[string]domain
 // roleDemandGPUs converts a role's token demand to a GPU count via the role's most
 // cost-efficient variant's per-replica capacity. The synthetic "both" role uses the
 // model-level TotalDemand; a P/D role uses its RoleCapacities demand.
-func roleDemandGPUs(satEntry *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType, role string) int {
-	demand := satEntry.TotalDemand
+func roleDemandGPUs(anchor *domain.AnalyzerResult, stateMap map[string]domain.VariantReplicaState, accType, role string) int {
+	demand := anchor.TotalDemand
 	if role != domain.RoleBoth {
-		if rc, ok := satEntry.RoleCapacities[role]; ok {
+		if rc, ok := anchor.RoleCapacities[role]; ok {
 			demand = rc.TotalDemand
 		}
 	}
 	best := 0.0
 	bestGPUs := 1
-	for _, vc := range sortByCostEfficiencyAsc(variantsForRole(variantsOnType(satEntry.VariantCapacities, accType), role)) {
+	for _, vc := range sortByCostEfficiencyAsc(variantsForRole(variantsOnType(anchor.VariantCapacities, accType), role)) {
 		if vc.PerReplicaCapacity <= 0 {
 			continue
 		}
@@ -586,13 +588,13 @@ func modelRolesOnType(vcs []domain.VariantCapacity, accType string) []string {
 
 // roleCurrentGPUs sums CurrentReplicas x GPUsPerReplica over a role's variants on accType.
 func roleCurrentGPUs(req ModelScalingRequest, accType, role string) int {
-	satEntry := saturationEntry(req.AnalyzerResults)
-	if satEntry == nil {
+	anchor := bindingAnchor(req.AnalyzerResults)
+	if anchor == nil {
 		return 0
 	}
 	stateMap := buildStateMap(req.VariantStates)
 	total := 0
-	for _, vc := range variantsForRole(variantsOnType(satEntry.VariantCapacities, accType), role) {
+	for _, vc := range variantsForRole(variantsOnType(anchor.VariantCapacities, accType), role) {
 		total += stateMap[vc.VariantName].CurrentReplicas * gpusPerReplicaFromState(stateMap, vc.VariantName)
 	}
 	return total
@@ -601,13 +603,13 @@ func roleCurrentGPUs(req ModelScalingRequest, accType, role string) int {
 // roleFloorGPUs sums minReplicas x GPUsPerReplica over a role's variants on accType —
 // the GPUs that must stay allocated to the role regardless of the weighted split.
 func roleFloorGPUs(req ModelScalingRequest, accType, role string) int {
-	satEntry := saturationEntry(req.AnalyzerResults)
-	if satEntry == nil {
+	anchor := bindingAnchor(req.AnalyzerResults)
+	if anchor == nil {
 		return 0
 	}
 	stateMap := buildStateMap(req.VariantStates)
 	total := 0
-	for _, vc := range variantsForRole(variantsOnType(satEntry.VariantCapacities, accType), role) {
+	for _, vc := range variantsForRole(variantsOnType(anchor.VariantCapacities, accType), role) {
 		st := stateMap[vc.VariantName]
 		if st.MinReplicas != nil && *st.MinReplicas > 0 {
 			total += *st.MinReplicas * gpusPerReplicaFromState(stateMap, vc.VariantName)

--- a/internal/engines/pipeline/rescale.go
+++ b/internal/engines/pipeline/rescale.go
@@ -340,6 +340,15 @@ func (o *GreedyByScoreOptimizer) rescaleModelDecisions(
 	freeThisCycle *int,
 ) []domain.VariantDecision {
 	anchor := bindingAnchor(req.AnalyzerResults)
+	// applyRescale drops anchor-less requests before grouping, so this is
+	// unreachable today. Guard it anyway, as every other bindingAnchor call site
+	// does: the anchor is now derived per call rather than read from a stored
+	// field, and it returns nil for a stale, non-informative, or ambiguously bound
+	// ballot — a much wider set of inputs than the old "entry absent" case. A
+	// dereference here would panic the optimize goroutine.
+	if anchor == nil {
+		return nil
+	}
 	stateMap := buildStateMap(req.VariantStates)
 	vcMap := buildCapacityMap(anchor.VariantCapacities)
 	targets := initTargets(req.VariantStates)

--- a/internal/engines/pipeline/rescale_test.go
+++ b/internal/engines/pipeline/rescale_test.go
@@ -1,6 +1,8 @@
 package pipeline
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -146,5 +148,30 @@ var _ = Describe("roleDemandGPUs", func() {
 			"A-v": {VariantName: "A-v", GPUsPerReplica: 1},
 		}
 		Expect(roleDemandGPUs(sat, stateMap, "A100", domain.RoleBoth)).To(Equal(9))
+	})
+})
+
+var _ = Describe("rescaleModelDecisions", func() {
+	// applyRescale drops anchor-less requests before grouping, so production never
+	// reaches this function with a nil anchor. The guard exists because the anchor
+	// is derived per call rather than read from a stored field, and now comes back
+	// nil for a stale, non-informative, or ambiguously bound ballot — a far wider
+	// set of inputs than the old "entry absent" case. Pin it directly: without the
+	// guard the next line dereferences the anchor and panics the optimize goroutine.
+	It("returns no decisions instead of panicking when the ballot yields no anchor", func() {
+		o := NewGreedyByScoreOptimizer()
+		free := 4
+
+		var decisions []domain.VariantDecision
+		Expect(func() {
+			// Empty ballot → bindingAnchor returns nil.
+			decisions = o.rescaleModelDecisions(
+				context.Background(),
+				ModelScalingRequest{ModelID: "A", Namespace: "ns"},
+				"A100", 8, &free,
+			)
+		}).NotTo(Panic())
+		Expect(decisions).To(BeEmpty())
+		Expect(free).To(Equal(4), "a request with no anchor must not consume the cycle's free GPUs")
 	})
 })

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -550,12 +550,20 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	// V1 is deprecated in favor of V2; see issue #1441 for the staged removal plan.
 	// Queueing model is activated by presence of wva-queueing-model-config ConfigMap.
 	mode := modeLabelForAnalyzer(analyzerName)
+	// optimizationRefused marks a cycle in which the engine declined to run the
+	// configured optimize path at all, as opposed to running it and finding nothing
+	// to change. It is threaded into applySaturationDecisions so the held VAs report
+	// the hold instead of reporting a healthy no-op — without it, an operator whose
+	// cluster has stopped autoscaling entirely sees OptimizationReady=True on every
+	// VA and has only the controller log to go on.
+	optimizationRefused := false
 	switch analyzerName {
 	case domain.QueueingModelAnalyzerName:
 		// Refuse the queueing-model path loudly and leave allDecisions empty; the
 		// unconditional applySaturationDecisions below then holds each model at its
 		// last-good replicas and still emits the scaling metric this cycle.
 		e.refuseQueueingModel(ctx, modelGroups)
+		optimizationRefused = true
 	case domain.SaturationAnalyzerName:
 		allDecisions = e.optimizeV2(ctx, modelGroups, currentAllocations)
 	default:
@@ -572,7 +580,7 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	} else {
 		logger.Info("No scaling decisions to apply, updating VA status with metrics")
 	}
-	e.applySaturationDecisions(ctx, allDecisions, vaMap, currentAllocations)
+	e.applySaturationDecisions(ctx, allDecisions, vaMap, currentAllocations, optimizationRefused)
 
 	logger.Info("Optimization completed successfully",
 		"mode", mode,
@@ -622,6 +630,31 @@ func (e *Engine) recordEvent(
 	e.Recorder.Event(va, eventType, reason, message)
 	if e.vaEventTracker != nil {
 		e.vaEventTracker[key] = true
+	}
+}
+
+// optimizationRefusedMessage is the single message used for both the
+// TypeOptimizationReady condition and the K8s event raised when the engine
+// declines to run the configured optimize path. Keeping it a constant (rather
+// than a per-cycle formatted string) lets the API server's event aggregator
+// collapse repeat emissions into one entry with a rising count.
+const optimizationRefusedMessage = "Optimization refused for the configured analyzer; replicas held at last-good value"
+
+// recordOptimizationRefusedEvent raises the refusal Warning on every variant the
+// engine is holding. It is called from the refusing dispatch path, ahead of
+// applySaturationDecisions, so the refusal wins each VA's one-event-per-cycle
+// budget over lower-priority notices.
+func (e *Engine) recordOptimizationRefusedEvent(
+	modelGroups map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+) {
+	if e.Recorder == nil {
+		return
+	}
+	for _, modelVAs := range modelGroups {
+		for i := range modelVAs {
+			e.recordEvent(&modelVAs[i], corev1.EventTypeWarning,
+				constants.K8SEventOptimizationRefused, optimizationRefusedMessage)
+		}
 	}
 }
 
@@ -1562,11 +1595,15 @@ func (e *Engine) prepareModelData(
 }
 
 // applySaturationDecisions updates VA status and emits metrics based on Saturation decisions.
+// refused reports that the engine declined to run the configured optimize path this
+// cycle, so an absent decision means "held at last-good replicas", not "ran and found
+// nothing to change"; the two are reported differently on TypeOptimizationReady.
 func (e *Engine) applySaturationDecisions(
 	ctx context.Context,
 	decisions []domain.VariantDecision,
 	vaMap map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	currentAllocations map[string]*domain.Allocation,
+	refused bool,
 ) {
 	logger := ctrl.LoggerFrom(ctx)
 	// Create a map of decisions for O(1) lookup
@@ -1633,17 +1670,27 @@ func (e *Engine) applySaturationDecisions(
 			// Fallback for new VAs without prior status or collected metrics:
 			// resolve accelerator from deployment nodeSelector/nodeAffinity or VA label,
 			// and use current deployment replicas as target to avoid unintended scaling.
-			if !constants.IsAcceleratorResolved(acceleratorName) {
+			//
+			// The scale target is consulted whenever EITHER is missing, not only when
+			// the accelerator is unresolved. targetReplicas is still 0 here if the VA
+			// has no prior DesiredOptimizedAlloc — currentAllocations above is never
+			// populated — and emitting a desired-replicas of 0 for a variant we are
+			// merely holding tells KEDA/HPA to scale it to zero. Reading the live
+			// scale target holds it at what it is actually running, including a
+			// legitimate 0.
+			if !constants.IsAcceleratorResolved(acceleratorName) || targetReplicas == 0 {
 				scaleTargetName := updateVa.GetScaleTargetName()
 				if scaleTargetName != "" {
 					var scaleTarget scaletarget.ScaleTargetAccessor
 					var err error
 					if scaleTarget, err = scaletarget.FetchScaleTarget(ctx, e.client, va.Name, va.Spec.ScaleTargetRef.Kind, scaleTargetName, va.Namespace); err == nil {
-						acceleratorName = accel.GetAcceleratorNameFromScaleTarget(&updateVa, scaleTarget)
+						if !constants.IsAcceleratorResolved(acceleratorName) {
+							acceleratorName = accel.GetAcceleratorNameFromScaleTarget(&updateVa, scaleTarget)
+						}
 						if targetReplicas == 0 && scaleTarget.GetReplicas() != nil {
 							targetReplicas = int(*scaleTarget.GetReplicas())
 						}
-					} else {
+					} else if !constants.IsAcceleratorResolved(acceleratorName) {
 						// If scaleTarget fetch fails, try VA label directly
 						acceleratorName = accel.GetAcceleratorNameFromScaleTarget(&updateVa, nil)
 					}
@@ -1696,28 +1743,46 @@ func (e *Engine) applySaturationDecisions(
 		updateVa.Status.Actuation.Applied = false // Reset applied status until Actuator handles it (if needed)
 
 		// Set condition based on decision characteristics (or lack thereof)
-		if hasDecision {
-			switch {
-			case decision.SafetyOverride:
-				llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
-					llmdVariantAutoscalingV1alpha1.TypeOptimizationReady,
-					metav1.ConditionTrue,
-					"SaturationSafetyOverride",
-					"saturation safety override: "+reason)
-			case decision.SaturationOnly:
-				llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
-					llmdVariantAutoscalingV1alpha1.TypeOptimizationReady,
-					metav1.ConditionTrue,
-					"SaturationOnlyMode",
-					fmt.Sprintf("saturation-only decision: %s (target: %d replicas)", reason, targetReplicas))
-			default:
-				llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
-					llmdVariantAutoscalingV1alpha1.TypeOptimizationReady,
-					metav1.ConditionTrue,
-					llmdVariantAutoscalingV1alpha1.ReasonOptimizationSucceeded,
-					fmt.Sprintf("Hybrid mode: %s (target: %d replicas)", reason, targetReplicas))
-			}
-		} else {
+		switch {
+		case hasDecision && decision.SafetyOverride:
+			llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
+				llmdVariantAutoscalingV1alpha1.TypeOptimizationReady,
+				metav1.ConditionTrue,
+				"SaturationSafetyOverride",
+				"saturation safety override: "+reason)
+		case hasDecision && decision.SaturationOnly:
+			llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
+				llmdVariantAutoscalingV1alpha1.TypeOptimizationReady,
+				metav1.ConditionTrue,
+				"SaturationOnlyMode",
+				fmt.Sprintf("saturation-only decision: %s (target: %d replicas)", reason, targetReplicas))
+		case hasDecision:
+			llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
+				llmdVariantAutoscalingV1alpha1.TypeOptimizationReady,
+				metav1.ConditionTrue,
+				llmdVariantAutoscalingV1alpha1.ReasonOptimizationSucceeded,
+				fmt.Sprintf("Hybrid mode: %s (target: %d replicas)", reason, targetReplicas))
+		case refused:
+			// The optimize path was refused, so this VA is frozen at its last-good
+			// replica count for as long as the configuration stands, and must not
+			// report the healthy steady-state reason the default arm sets.
+			//
+			// Like every other arm of this switch, the condition is set on a copy
+			// that is discarded at the end of the iteration: variants are
+			// synthesized in-memory, so there is no CRD status to patch and
+			// nothing in the tree reads TypeOptimizationReady back. It is kept
+			// here for consistency with its siblings and for whenever status
+			// reporting is wired up again. The operator-visible half of this
+			// signal is the Warning event, raised by the refusing path itself
+			// (recordOptimizationRefusedEvent) ahead of this loop so it claims
+			// each VA's one-event-per-cycle slot before lesser notices such as an
+			// unresolved accelerator.
+			llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
+				llmdVariantAutoscalingV1alpha1.TypeOptimizationReady,
+				metav1.ConditionFalse,
+				llmdVariantAutoscalingV1alpha1.ReasonOptimizationRefused,
+				optimizationRefusedMessage)
+		default:
 			// No active decision (just refreshing)
 			llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
 				llmdVariantAutoscalingV1alpha1.TypeOptimizationReady,

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -207,10 +207,11 @@ type Engine struct {
 
 	// analyzersSnapshot is the frozen, registration-ordered view that
 	// runAnalyzersAndScore iterates. Built from analyzers in StartOptimizeLoop
-	// before the goroutine launches. Saturation always runs and drives scaling
-	// decisions; other registered analyzers are invoked but their results are
-	// not consumed yet — combine and per-analyzer threshold logic lands in
-	// follow-up PRs.
+	// before the goroutine launches. Saturation always runs to supply the
+	// identity/(a) carrier; each enabled analyzer's result is consumed — it
+	// votes in the combine math and may bind the anchor. Iteration order is not
+	// significant: the anchor is derived on demand and the combine consumes only
+	// the voting subset.
 	analyzersSnapshot []analyzerEntry
 
 	// started transitions to true in StartOptimizeLoop. Late RegisterAnalyzer

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -551,7 +551,10 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	mode := modeLabelForAnalyzer(analyzerName)
 	switch analyzerName {
 	case domain.QueueingModelAnalyzerName:
-		allDecisions = e.optimizeQueueingModel(ctx, modelGroups, currentAllocations)
+		// Refuse the queueing-model path loudly and leave allDecisions empty; the
+		// unconditional applySaturationDecisions below then holds each model at its
+		// last-good replicas and still emits the scaling metric this cycle.
+		e.refuseQueueingModel(ctx, modelGroups)
 	case domain.SaturationAnalyzerName:
 		allDecisions = e.optimizeV2(ctx, modelGroups, currentAllocations)
 	default:

--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -83,6 +83,10 @@ func (e *Engine) optimizeQueueingModel(
 				Score:     1.0, // QM path: single analyzer, no per-entry score config
 				Remaining: result.RequiredCapacity,
 				Spare:     result.SpareCapacity,
+				// Enabled is statically true: the queueing-model path runs a single
+				// analyzer, so it is always the voting member and the anchor's
+				// binding/(a) carrier for this model.
+				Enabled: true,
 				// Live is statically true: the queueing-model path is not yet a
 				// per-analyzer-liveness participant (it doesn't run through
 				// updateLivenessAndSetLive), so it must not be caught by the

--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -2,6 +2,7 @@ package saturation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -14,6 +15,38 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
 )
+
+// refuseQueueingModel is the dispatch target selected when a queueing-model
+// ConfigMap is present. The queueing-model optimize path (optimizeQueueingModel,
+// below) is deferred — it is not yet a first-class voting analyzer in the
+// multi-analyzer engine — so the engine refuses to dispatch it rather than
+// silently running the parked path or silently falling through to the
+// saturation-only / V1 path (either would mask a misconfiguration). It logs an
+// error and produces no decisions; the dispatch case leaves the decision set
+// empty, so the caller's unconditional applySaturationDecisions re-affirms each
+// model's last-good replica count and still emits the HPA/KEDA scaling metric
+// this cycle — affected models are held in place rather than dropped. To
+// re-enable the path later, restore the dispatch to optimizeQueueingModel.
+func (e *Engine) refuseQueueingModel(
+	ctx context.Context,
+	modelGroups map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Error(
+		errors.New("queueing-model optimization path is disabled"),
+		"refusing to dispatch the queueing-model path; enable the saturation and/or throughput analyzers instead",
+		"modelGroups", len(modelGroups),
+	)
+}
+
+// optimizeQueueingModel and the two helpers below (runQueueingModelAnalysis,
+// buildQMConfig) are no longer dispatched — refuseQueueingModel replaced them at
+// the engine's dispatch switch. They are retained in-tree as a deferred design
+// direction (a queueing-model-driven analyzer), parked until the multi-analyzer
+// engine can host it as a first-class voting analyzer. The blank reference below
+// keeps this parked call-subtree reachable so the unused linter does not flag it;
+// drop the reference when the path is re-dispatched.
+var _ = (*Engine).optimizeQueueingModel
 
 // optimizeQueueingModel runs the queueing model-based analysis path.
 // Follows the same three-stage pattern as optimizeV2:

--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -27,6 +27,14 @@ import (
 // model's last-good replica count and still emits the HPA/KEDA scaling metric
 // this cycle — affected models are held in place rather than dropped. To
 // re-enable the path later, restore the dispatch to optimizeQueueingModel.
+//
+// The hold is reported as well as logged: a Warning event is raised on every
+// held variant here, and the caller's refused flag drives
+// TypeOptimizationReady=False/OptimizationRefused on each one (vestigial today
+// — nothing reads that condition back, see applySaturationDecisions). Without
+// the event, a cluster that has stopped autoscaling entirely is
+// indistinguishable from a healthy idle one, with a repeating controller log
+// line as the only evidence.
 func (e *Engine) refuseQueueingModel(
 	ctx context.Context,
 	modelGroups map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
@@ -37,6 +45,7 @@ func (e *Engine) refuseQueueingModel(
 		"refusing to dispatch the queueing-model path; enable the saturation and/or throughput analyzers instead",
 		"modelGroups", len(modelGroups),
 	)
+	e.recordOptimizationRefusedEvent(modelGroups)
 }
 
 // optimizeQueueingModel and the two helpers below (runQueueingModelAnalysis,

--- a/internal/engines/saturation/engine_queueing_model_test.go
+++ b/internal/engines/saturation/engine_queueing_model_test.go
@@ -12,8 +12,8 @@ import (
 
 // withQMEntry builds a ModelScalingRequest whose single AnalyzerResults entry
 // mirrors the shape optimizeQueueingModel constructs in engine_queueing_model.go
-// (Name: SaturationAnalyzerName, Live: true statically), without going through
-// the full prepareModelData collection pipeline.
+// (Name: SaturationAnalyzerName, Enabled: true and Live: true statically), without
+// going through the full prepareModelData collection pipeline.
 func withQMEntry(r *domain.AnalyzerResult, req pipeline.ModelScalingRequest) pipeline.ModelScalingRequest {
 	req.AnalyzerResults = []pipeline.NamedAnalyzerResult{{
 		Name:      domain.SaturationAnalyzerName,
@@ -21,6 +21,7 @@ func withQMEntry(r *domain.AnalyzerResult, req pipeline.ModelScalingRequest) pip
 		Score:     1.0,
 		Remaining: r.RequiredCapacity,
 		Spare:     r.SpareCapacity,
+		Enabled:   true,
 		Live:      true,
 	}}
 	return req
@@ -58,7 +59,8 @@ var _ = Describe("Queueing model path stays live under the liveness gate", func(
 		dm := decisionsByVariant(decisions)
 
 		// Spare=25000, PRC=10000 → floor(25000/10000)=2 removable; would be 0
-		// (no scale-down at all) if the QM entry were left at the Live zero-value.
+		// (no scale-down at all) if the QM entry were left at the Enabled/Live
+		// zero-values, since the anchor would then fail to bind.
 		Expect(dm["v1"].TargetReplicas).To(Equal(1))
 	})
 })

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
@@ -295,6 +296,24 @@ var _ = Describe("Saturation Engine", func() {
 			// silently ran V2/V1 instead of refusing.
 			Expect(mockPromAPI.QueryCallCounts).To(BeEmpty(),
 				"a refused queueing-model cycle must not query Prometheus (no V2/V1 fall-through)")
+
+			By("Verifying the hold is surfaced to operators as a Warning event")
+			// The held variants are synthesized in-memory, so their
+			// TypeOptimizationReady=False/OptimizationRefused condition is set on a
+			// copy with no API object to read back. The event is the observable
+			// half of the same signal, and the one that must not regress to
+			// silence: without it, a cluster whose autoscaling has stopped
+			// entirely looks identical to a healthy idle one.
+			var refusedEvent string
+			for len(fakeRecorder.Events) > 0 {
+				e := <-fakeRecorder.Events
+				if strings.Contains(e, constants.K8SEventOptimizationRefused) {
+					refusedEvent = e
+					break
+				}
+			}
+			Expect(refusedEvent).To(ContainSubstring(v1.EventTypeWarning),
+				"the refusal must raise a Warning event on the held variants")
 		})
 	})
 

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -21,9 +21,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
@@ -238,6 +243,58 @@ var _ = Describe("Saturation Engine", func() {
 			// proves the variants were discovered and fed through the saturation pipeline.
 			Expect(mockPromAPI.QueryCallCounts).NotTo(BeEmpty(),
 				"engine should have queried Prometheus for at least one discovered variant")
+		})
+
+		It("refuses the queueing-model path loudly and holds, rather than silently running V2/V1", func() {
+			By("Using a mock Prometheus API that records every query")
+			mockPromAPI := &testutils.MockPromAPI{
+				QueryResults: map[string]model.Value{},
+				QueryErrors:  map[string]error{},
+			}
+
+			sourceRegistry := source.NewSourceRegistry()
+			promSource := prometheus.NewPrometheusSource(ctx, mockPromAPI, prometheus.DefaultPrometheusSourceConfig())
+			sourceRegistry.Register("prometheus", promSource) // nolint:errcheck
+
+			// Saturation config present (as in the V2 test above) plus a
+			// queueing-model ConfigMap. Presence of the QM "default" entry routes the
+			// dispatch to the refusal path regardless of the saturation analyzerName.
+			testConfig := config.NewTestConfig()
+			testConfig.UpdateSaturationConfig(map[string]config.SaturationScalingConfig{
+				"default": {},
+			})
+			testConfig.UpdateQMAnalyzerConfig(map[string]domain.QueueingModelScalingConfig{
+				"default": {},
+			})
+			fakeRecorder := record.NewFakeRecorder(100)
+			engine := NewEngine(k8sClient, k8sClient, k8sClient.Scheme(), fakeRecorder, sourceRegistry, testConfig, pipeline.NewNoOpLimiter("test"))
+
+			By("Running the optimization loop with an observed logger")
+			// A Ginkgo It cannot call zapObserverCtx (it needs *testing.T), so build
+			// the observed-logger context inline.
+			core, recorded := observer.New(zapcore.InfoLevel)
+			observedCtx := logr.NewContext(ctx, zapr.NewLogger(zap.New(core)))
+			err := engine.optimize(observedCtx)
+
+			By("Verifying the loop completed without error (models are held, not dropped)")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the queueing-model path was refused, not silently dispatched")
+			var refused bool
+			for _, e := range recorded.All() {
+				if strings.Contains(e.Message, "refusing to dispatch the queueing-model path") {
+					refused = true
+					break
+				}
+			}
+			Expect(refused).To(BeTrue(), "the engine must log the explicit queueing-model refusal")
+
+			By("Verifying no fall-through to the saturation (V2) or V1 path")
+			// The refusal path never calls prepareModelData, so it issues no
+			// Prometheus queries. A non-empty QueryCallCounts would mean the engine
+			// silently ran V2/V1 instead of refusing.
+			Expect(mockPromAPI.QueryCallCounts).To(BeEmpty(),
+				"a refused queueing-model cycle must not query Prometheus (no V2/V1 fall-through)")
 		})
 	})
 

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -146,6 +146,20 @@ func (e *Engine) runAnalyzersAndScore(
 	// but pruned from the voting subset by votingResults.
 	satVotes := len(config.Analyzers) == 0 || effectiveEnabled(domain.SaturationAnalyzerName, config)
 
+	// An explicit analyzer list that omits saturation is a supported configuration,
+	// but it is also a real change in safety posture and easy to arrive at without
+	// meaning to. Saturation stops contributing to the combine, so it can no longer
+	// veto a scale-down: a demand-driven analyzer reading zero demand (EPP not
+	// scraped for a window, say) will shed replicas with nothing holding it back,
+	// even while saturation itself sees KV cache near capacity. Say so plainly
+	// rather than leaving it to the docs.
+	if !satVotes {
+		logger.Info("saturation analyzer is absent from the configured analyzer list: it will not vote and cannot veto scale-down for this model",
+			"modelID", modelID,
+			"namespace", namespace,
+		)
+	}
+
 	// Collect per-analyzer results. Each entry carries its Enabled tag; order is
 	// not significant. Saturation is appended first purely as a code artifact (it
 	// is the (a) carrier), tagged Enabled: satVotes; each enabled non-saturation

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -90,9 +90,13 @@ const analyzerLivenessStaleCycles = 3
 //
 // The engine applies applyUniversalThreshold to every analyzer (saturation and
 // all registered non-saturation analyzers) and collects the calibrated results
-// into a per-analyzer slice returned to the optimizer. Saturation is always the
-// first entry; it is the keeper of per-variant metadata (Cost, AcceleratorName,
-// Role) until a future pre-analysis-extraction PR separates that concern.
+// into a per-analyzer slice returned to the optimizer. Each entry is tagged with
+// its enablement (Enabled — whether it votes in the combine RC/SC math this
+// cycle) and liveness (Live). Order is not significant: the anchor is derived on
+// demand from the ballot (bindingAnchor), and combine math consumes only the
+// voting subset (votingResults). Saturation is always appended as the
+// identity/(a) carrier — it supplies per-variant metadata (Cost, AcceleratorName,
+// Role) for every configured variant — but it votes only when enabled.
 func (e *Engine) runAnalyzersAndScore(
 	ctx context.Context,
 	modelID, namespace string,
@@ -135,8 +139,18 @@ func (e *Engine) runAnalyzersAndScore(
 		ArrivalRate:    arrivalRate,
 	}
 
-	// Collect per-analyzer results. Saturation is first; each non-saturation
-	// analyzer is run, calibrated with its resolved thresholds, and appended.
+	// Whether saturation votes in the combine (RC/SC) math this cycle. It always
+	// votes in the default single-analyzer config (no explicit analyzer list) and
+	// otherwise votes only when its name is enabled. When it does not vote it is
+	// still appended below as the identity/(a) carrier — present in the ballot,
+	// but pruned from the voting subset by votingResults.
+	satVotes := len(config.Analyzers) == 0 || effectiveEnabled(domain.SaturationAnalyzerName, config)
+
+	// Collect per-analyzer results. Each entry carries its Enabled tag; order is
+	// not significant. Saturation is appended first purely as a code artifact (it
+	// is the (a) carrier), tagged Enabled: satVotes; each enabled non-saturation
+	// analyzer is run, calibrated with its resolved thresholds, and appended
+	// tagged Enabled: true.
 	namedResults := []pipeline.NamedAnalyzerResult{{
 		Name:              domain.SaturationAnalyzerName,
 		Result:            baseResult,
@@ -145,9 +159,13 @@ func (e *Engine) runAnalyzersAndScore(
 		Spare:             baseResult.SpareCapacity,
 		ScaleUpThreshold:  satUp,
 		ScaleDownBoundary: satDown,
+		Enabled:           satVotes,
 	}}
 	for _, entry := range e.analyzersSnapshot {
 		if entry.name == domain.SaturationAnalyzerName {
+			// Reuse guard, not a decision gate: saturation is already appended
+			// above (as the (a) carrier). Its vote is decided by satVotes there,
+			// not by skipping it here.
 			continue
 		}
 		if !effectiveEnabled(entry.name, config) {
@@ -167,6 +185,7 @@ func (e *Engine) runAnalyzersAndScore(
 			Spare:             result.SpareCapacity,
 			ScaleUpThreshold:  up,
 			ScaleDownBoundary: down,
+			Enabled:           true,
 		})
 	}
 	e.updateLivenessAndSetLive(ctx, namespace, modelID, namedResults)

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -400,8 +400,10 @@ func resolveThresholds(analyzerName string, cfg config.SaturationScalingConfig) 
 // not yet defaulted). An analyzer registered in code but ABSENT from cfg.Analyzers
 // does NOT participate — this prevents a registered-but-unconfigured analyzer (e.g.
 // throughput) from returning SpareCapacity=0 and silently vetoing scale-down.
-// Saturation is exempt: it is guarded by the SaturationAnalyzerName check upstream
-// (engine_v2.go ~L136) before effectiveEnabled is ever called.
+// Saturation is handled separately: it is always appended as the identity/(a)
+// carrier, and whether it votes is decided by satVotes, which consults this
+// function for the saturation name. The per-analyzer loop skips the saturation
+// name as a reuse guard (so it is not appended twice), not as a decision gate.
 func effectiveEnabled(analyzerName string, cfg config.SaturationScalingConfig) bool {
 	for _, aw := range cfg.Analyzers {
 		if aw.EffectiveType() == analyzerName {

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -508,21 +508,26 @@ func applyUniversalThreshold(r *domain.AnalyzerResult, scaleUp, scaleDown float6
 func computeCurrentGPUUsage(requests []pipeline.ModelScalingRequest) map[string]int {
 	usage := make(map[string]int)
 	for _, req := range requests {
-		var satEntry *domain.AnalyzerResult
+		// The saturation result is the per-variant identity carrier (VariantName,
+		// AcceleratorName, topology) and is present in every ballot even when
+		// saturation does not vote. Current physical GPU usage is a topology lookup
+		// (CurrentReplicas × GPUs-per-replica), not a voting or ordering decision, so
+		// it reads that carrier directly by name.
+		var satCarrier *domain.AnalyzerResult
 		for _, e := range req.AnalyzerResults {
 			if e.Name == domain.SaturationAnalyzerName {
-				satEntry = e.Result
+				satCarrier = e.Result
 				break
 			}
 		}
-		if satEntry == nil {
+		if satCarrier == nil {
 			continue
 		}
 		stateMap := make(map[string]domain.VariantReplicaState, len(req.VariantStates))
 		for _, s := range req.VariantStates {
 			stateMap[s.VariantName] = s
 		}
-		for _, vc := range satEntry.VariantCapacities {
+		for _, vc := range satCarrier.VariantCapacities {
 			state := stateMap[vc.VariantName]
 			gpusPerReplica := state.GPUsPerReplica
 			if gpusPerReplica <= 0 {
@@ -547,21 +552,23 @@ func computeCurrentGPUUsageByNamespace(requests []pipeline.ModelScalingRequest) 
 			perType = make(map[string]int)
 			usage[req.Namespace] = perType
 		}
-		var satEntry *domain.AnalyzerResult
+		// Topology lookup of the always-present saturation identity carrier (see
+		// computeCurrentGPUUsage); not a voting or ordering decision.
+		var satCarrier *domain.AnalyzerResult
 		for _, e := range req.AnalyzerResults {
 			if e.Name == domain.SaturationAnalyzerName {
-				satEntry = e.Result
+				satCarrier = e.Result
 				break
 			}
 		}
-		if satEntry == nil {
+		if satCarrier == nil {
 			continue
 		}
 		stateMap := make(map[string]domain.VariantReplicaState, len(req.VariantStates))
 		for _, s := range req.VariantStates {
 			stateMap[s.VariantName] = s
 		}
-		for _, vc := range satEntry.VariantCapacities {
+		for _, vc := range satCarrier.VariantCapacities {
 			state := stateMap[vc.VariantName]
 			gpusPerReplica := state.GPUsPerReplica
 			if gpusPerReplica <= 0 {

--- a/internal/engines/saturation/engine_v2_enablement_test.go
+++ b/internal/engines/saturation/engine_v2_enablement_test.go
@@ -1,0 +1,106 @@
+package saturation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/throughput"
+)
+
+// The Enabled tag runAnalyzersAndScore puts on each ballot entry is what decides
+// which analyzers vote in the combine math: votingResults prunes the ballot to the
+// enabled subset, and the anchor is derived from what survives. The three
+// configurations below are the ones the developer guide documents as supported, so
+// they are pinned here at the layer that actually derives Enabled from config.
+// Pipeline-level tests hand-construct NamedAnalyzerResult.Enabled and so cannot
+// catch a regression in this wiring.
+
+// noAnalyzerListCfg is the default configuration: no explicit analyzer list, which
+// is the shipped single-analyzer (saturation-only) shape.
+var noAnalyzerListCfg = config.SaturationScalingConfig{
+	ScaleUpThreshold:  0.85,
+	ScaleDownBoundary: 0.70,
+}
+
+// bothAnalyzersCfg names saturation and throughput explicitly, so both vote.
+var bothAnalyzersCfg = config.SaturationScalingConfig{
+	ScaleUpThreshold:  0.85,
+	ScaleDownBoundary: 0.70,
+	Analyzers: []config.AnalyzerScoreConfig{
+		{Name: domain.SaturationAnalyzerName},
+		{Name: throughput.AnalyzerName},
+	},
+}
+
+// saturationSilencedWarnings returns the warning emitted when an explicit analyzer
+// list leaves saturation out, isolating it from the routine per-analyzer INFO lines.
+func saturationSilencedWarnings(logs *observer.ObservedLogs) []observer.LoggedEntry {
+	var out []observer.LoggedEntry
+	for _, e := range logs.All() {
+		if strings.Contains(e.Message, "cannot veto scale-down") {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Default config (no analyzer list): saturation is the sole analyzer and votes.
+func TestRunAnalyzersAndScore_DefaultConfigSaturationVotes(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+	e := demandLivenessEngine(informativeSat(), throughputAnalyzer(1000))
+
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, noAnalyzerListCfg, nil, nil, nil, nil, 0)
+	require.NoError(t, err)
+
+	byName := namedByName(results)
+	assert.True(t, byName[domain.SaturationAnalyzerName].Enabled,
+		"saturation must vote in the default no-analyzer-list configuration")
+	// Throughput is not opted in, so it is not run and contributes no entry.
+	assert.NotContains(t, byName, throughput.AnalyzerName,
+		"an analyzer absent from the list must not be run")
+	assert.Empty(t, saturationSilencedWarnings(logs),
+		"the default configuration must not warn about saturation being silenced")
+}
+
+// Throughput-only list: saturation stays on the ballot as the identity carrier but
+// does not vote, and the loss of its scale-down veto is called out in the log.
+func TestRunAnalyzersAndScore_ThroughputOnlySilencesSaturationVote(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+	e := demandLivenessEngine(informativeSat(), throughputAnalyzer(1000))
+
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, enabledThroughputCfg, nil, nil, nil, nil, 0)
+	require.NoError(t, err)
+
+	byName := namedByName(results)
+	require.Contains(t, byName, domain.SaturationAnalyzerName,
+		"saturation must remain on the ballot as the identity/(a) carrier even when it does not vote")
+	assert.False(t, byName[domain.SaturationAnalyzerName].Enabled,
+		"saturation must not vote when an explicit analyzer list omits it")
+	assert.True(t, byName[throughput.AnalyzerName].Enabled,
+		"a listed analyzer must vote")
+	assert.Len(t, saturationSilencedWarnings(logs), 1,
+		"silencing saturation's vote must be logged: it removes the scale-down veto")
+}
+
+// Both analyzers listed: both vote.
+func TestRunAnalyzersAndScore_BothAnalyzersVote(t *testing.T) {
+	ctx, logs := zapObserverCtx(t)
+	e := demandLivenessEngine(informativeSat(), throughputAnalyzer(1000))
+
+	results, err := e.runAnalyzersAndScore(ctx, "m", "ns", nil, bothAnalyzersCfg, nil, nil, nil, nil, 0)
+	require.NoError(t, err)
+
+	byName := namedByName(results)
+	assert.True(t, byName[domain.SaturationAnalyzerName].Enabled,
+		"saturation must vote when it is named in the analyzer list")
+	assert.True(t, byName[throughput.AnalyzerName].Enabled,
+		"throughput must vote when it is named in the analyzer list")
+	assert.Empty(t, saturationSilencedWarnings(logs),
+		"saturation is voting here, so nothing should warn about its veto")
+}

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -16,6 +16,8 @@ import (
 
 // withSatEntryV2 adds a single-saturation AnalyzerResults to req from r.
 // Mirrors the helper in cost_aware_optimizer_test.go for use in the saturation package.
+// Enabled marks it as a voting ballot member; Live lets it bind as the anchor
+// (the engine populates both in production).
 func withSatEntryV2(r *domain.AnalyzerResult, req pipeline.ModelScalingRequest) pipeline.ModelScalingRequest {
 	if r != nil {
 		req.AnalyzerResults = []pipeline.NamedAnalyzerResult{{
@@ -23,6 +25,7 @@ func withSatEntryV2(r *domain.AnalyzerResult, req pipeline.ModelScalingRequest) 
 			Result:    r,
 			Remaining: r.RequiredCapacity,
 			Spare:     r.SpareCapacity,
+			Enabled:   true,
 			Live:      true,
 		}}
 	}

--- a/internal/variant/types.go
+++ b/internal/variant/types.go
@@ -145,6 +145,11 @@ const (
 	ReasonInvalidConfiguration = "InvalidConfiguration"
 	// ReasonSkippedProcessing indicates VA was skipped during processing
 	ReasonSkippedProcessing = "SkippedProcessing"
+	// ReasonOptimizationRefused indicates the engine declined to run the configured
+	// optimize path at all, so replicas are held at their last-good value. Unlike
+	// ReasonOptimizationSucceeded with no scaling change, this is a standing state
+	// that persists until the configuration is corrected.
+	ReasonOptimizationRefused = "OptimizationRefused"
 
 	// ReasonTargetFound indicates the scale target was successfully resolved
 	ReasonTargetFound = "TargetFound"


### PR DESCRIPTION
## Summary

Reshapes the multi-analyzer optimizer pipeline so the per-model **anchor** (the topology/identity carrier used for sizing and sorting) is **derived on demand** from the analyzer ballot rather than pre-computed and stored. The engine passes the enabled-analyzer list as the ballot; a getter merges, per variant (keyed by variant name), the identity/metadata from the saturation carrier with the sizing fields from the binding analyzer. This is the structural groundwork for running additional analyzers (e.g. the throughput analyzer) alongside saturation. It is **single-vote only** (0 or 1 enabled analyzers) and changes **zero combine arithmetic** — the multi-analyzer combine lands in a stacked follow-up.

## What changes

- **Ballot enablement tag** — analyzer results carry an `Enabled` flag; the pipeline builds the ballot from the enabled set.
- **On-demand anchor** — derived by a getter via a per-variant merge; no anchor field is persisted on the request.
- **Analyzer enablement** — three configs: saturation-only (default, unchanged), throughput-analyzer-only (saturation as a non-voting topology carrier), both-enabled (two-vote path turned on by the follow-up).
- **Queueing-model path** — the optimizer now refuses the queueing-model optimize path (holds, no-op) instead of dispatching it; folding QM in as a first-class voting analyzer is deferred.
- **Scale-from-zero** — the throughput analyzer emits a per-replica-capacity-only signal for previously-live zero-replica variants.
- **Developer guide** updated for the on-demand anchor + saturation-as-carrier model.

## Behavior / compatibility

Default saturation-only decisions are **byte-for-byte unchanged**, frozen by the characterization goldens in this diff (decision-set identity keyed by variant name). Opt-in: nothing beyond saturation is enabled by default.

## Testing

Characterization golden harness + aggregated (RoleBoth), disaggregated (P/D), and quota-constrained goldens, plus the two-analyzer combine characterization spec — all green after every commit. `make test` / `make lint` / `go build` / `gofmt` clean; DCO signed.

## Stacking / ordering

The bottom 5 commits are the characterization goldens (also proposed standalone as #1513). This branch was rebased onto current `main` before #1513 merged, so those goldens ride in this diff; once #1513 merges, a rebase drops them and this PR reduces to the 5 refactor commits. A follow-up PR (stacked on this branch) adds the multi-analyzer combine, the combine-arithmetic fixes, per-iteration dynamic re-binding, and liveness/notation hardening.
