### PR TITLE
fix(openshift): derive ServiceMonitor serverName from the deploy namespace

### DIFF
--- a/config/components/openshift/kustomization.yaml
+++ b/config/components/openshift/kustomization.yaml
@@ -76,6 +76,14 @@ patches:
     - op: replace
       path: /spec/endpoints/0/tlsConfig/insecureSkipVerify
       value: false
+    # serverName must match the SAN of the service-ca-issued serving cert, which
+    # is scoped to the metrics Service's actual namespace
+    # (wva-controller-manager-metrics-service.<namespace>.svc). The <namespace>
+    # segment below is only a placeholder: each openshift overlay rewrites it to
+    # its own deploy namespace via a `replacements` block, because the namespace
+    # is not known here at component-evaluation time. A stale literal here fails
+    # TLS verification and silently drops all wva_* metrics when WVA is deployed
+    # to any namespace other than the placeholder. See issue #1514.
     - op: add
       path: /spec/endpoints/0/tlsConfig/serverName
       value: wva-controller-manager-metrics-service.wva-system.svc

--- a/config/overlays/cluster-scoped/openshift/kustomization.yaml
+++ b/config/overlays/cluster-scoped/openshift/kustomization.yaml
@@ -10,3 +10,26 @@ resources:
 
 components:
 - ../../../components/openshift
+
+# Localize the ServiceMonitor's TLS serverName to this overlay's namespace. The
+# openshift component sets serverName to a placeholder
+# (wva-controller-manager-metrics-service.<namespace>.svc); the service-ca serving
+# cert's SAN is scoped to the metrics Service's real namespace, so the <namespace>
+# segment must track `namespace:` above or TLS verification fails and all wva_*
+# metrics are silently dropped (issue #1514). Sourcing the namespace here — rather
+# than in the component — is required because the namespace is unset at
+# component-evaluation time.
+replacements:
+- source:
+    kind: ServiceMonitor
+    name: wva-controller-manager-metrics-monitor
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: ServiceMonitor
+      name: wva-controller-manager-metrics-monitor
+    fieldPaths:
+    - spec.endpoints.0.tlsConfig.serverName
+    options:
+      delimiter: '.'
+      index: 1

--- a/config/overlays/namespace-scoped/openshift/kustomization.yaml
+++ b/config/overlays/namespace-scoped/openshift/kustomization.yaml
@@ -11,3 +11,26 @@ resources:
 components:
 - ../../../components/namespace-scoped/
 - ../../../components/openshift
+
+# Localize the ServiceMonitor's TLS serverName to this overlay's namespace. The
+# openshift component sets serverName to a placeholder
+# (wva-controller-manager-metrics-service.<namespace>.svc); the service-ca serving
+# cert's SAN is scoped to the metrics Service's real namespace, so the <namespace>
+# segment must track `namespace:` above or TLS verification fails and all wva_*
+# metrics are silently dropped (issue #1514). Sourcing the namespace here — rather
+# than in the component — is required because the namespace is unset at
+# component-evaluation time.
+replacements:
+- source:
+    kind: ServiceMonitor
+    name: wva-controller-manager-metrics-monitor
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: ServiceMonitor
+      name: wva-controller-manager-metrics-monitor
+    fieldPaths:
+    - spec.endpoints.0.tlsConfig.serverName
+    options:
+      delimiter: '.'
+      index: 1


### PR DESCRIPTION
## What

The `openshift` kustomize component hardcodes the metrics ServiceMonitor's TLS `serverName` to `wva-controller-manager-metrics-service.wva-system.svc`. This change derives the namespace segment from the actual deploy namespace so it stays correct when the overlay namespace is overridden.

Fixes #1514.

## Why

The OpenShift overlay uses service-ca-issued serving certs with strict verification (`insecureSkipVerify: false`). The cert's SAN is scoped to the metrics Service's **actual** namespace (`wva-controller-manager-metrics-service.<namespace>.svc`). The hardcoded literal is only correct because the shipped overlays default to `wva-system`.

When WVA is deployed to any other namespace (benchmark runs, multi-tenant clusters, per-user namespaces), Prometheus/Thanos TLS-verifies the target cert's SAN against the stale `serverName`, the handshake fails, and **all `wva_*` metrics are silently dropped**. The ServiceMonitor object itself looks healthy — downstream consumers (KEDA Prometheus triggers, prometheus-adapter HPAs reading `wva_desired_replicas`, dashboards) just see "no data", indistinguishable from a metric that was never emitted.

## How

Each `openshift` overlay now rewrites the namespace segment of `serverName` from the ServiceMonitor's own (post-transform) namespace via a kustomize `replacements` block. The namespace is unknown at component-evaluation time (`fieldPath metadata.namespace` is unset while the component is accumulated), so the replacement lives in the overlays — which own the `namespace:` value — rather than in the component. The component keeps the literal as a documented placeholder.

## Verification

`kubectl kustomize` on the shipped overlays (namespace `wva-system`) — **byte-for-byte unchanged**:

```
serverName: wva-controller-manager-metrics-service.wva-system.svc
```

Same overlay with `namespace:` overridden — `serverName` now follows (previously stayed `...wva-system.svc`):

```
# namespace: biran     -> serverName: wva-controller-manager-metrics-service.biran.svc
# namespace: prod-ns   -> serverName: wva-controller-manager-metrics-service.prod-ns.svc
```

Both `openshift` overlays and the plain `kubernetes` overlay (which uses `insecureSkipVerify: true` and has no `serverName`) build clean and are unaffected.

## Notes

- No functional change to the default `wva-system` deployment.
- `replacements` matches the ServiceMonitor by its post-`namePrefix` name (`wva-controller-manager-metrics-monitor`), consistent with how the overlays name it.

---
*Authored with AI assistance (reflected in the commit's `Co-Authored-By` trailer); reviewed and verified by me.*
