### PR TITLE
benchmark: add Wide-EP LWS scale-mechanics scenario

### DIFF
--- a/benchmark/config/scenarios/wide-ep-lws-scale-mechanics.yaml
+++ b/benchmark/config/scenarios/wide-ep-lws-scale-mechanics.yaml
@@ -1,0 +1,695 @@
+# Bounded CPU-only LeaderWorkerSet scale-mechanics scenario for WVA #1525.
+# It intentionally proves group mechanics only: one leader plus one worker per
+# group, a paused KEDA ScaledObject, and deterministic simulator metrics.
+
+# Reproducible Option 2 lifecycle for the pinned llm-d-benchmark renderer.
+#
+# Run this after standup. The ScaledObject remains paused until the exact
+# namespace-local WVA metric reaches 2. Every polling phase is bounded and
+# emits diagnostics before returning nonzero.
+#
+# ```bash
+# set -euo pipefail
+#
+# : "${NAMESPACE:=llmd-1525}"
+# : "${WVA_NAMESPACE:=workload-variant-autoscaler-system}"
+# : "${MONITORING_NAMESPACE:=workload-variant-autoscaler-monitoring}"
+# : "${PROMETHEUS_PORT:=19090}"
+# : "${POLL_INTERVAL_SECONDS:=5}"
+#
+# for required_command in kubectl curl jq grep date; do
+#   if ! command -v "${required_command}" >/dev/null 2>&1; then
+#     echo "ERROR: required command not found: ${required_command}" >&2
+#     exit 1
+#   fi
+# done
+#
+# wait_for() {
+#   local description="$1"
+#   local timeout_seconds="$2"
+#   local check_function="$3"
+#   local diagnostic_function="$4"
+#   local start_epoch
+#   local now_epoch
+#
+#   start_epoch="$(date +%s)"
+#   while ! "${check_function}"; do
+#     now_epoch="$(date +%s)"
+#     if [ "$((now_epoch - start_epoch))" -ge "${timeout_seconds}" ]; then
+#       echo "ERROR: timed out after ${timeout_seconds}s waiting for ${description}" >&2
+#       "${diagnostic_function}" >&2 || true
+#       return 1
+#     fi
+#     sleep "${POLL_INTERVAL_SECONDS}"
+#   done
+#   echo "PASS: ${description}"
+# }
+#
+# PROMETHEUS_URL="https://127.0.0.1:${PROMETHEUS_PORT}"
+# PROMETHEUS_FORWARD_LOG="/private/tmp/wva-1525-prometheus-port-forward.log"
+# PROMETHEUS_FORWARD_PID=""
+# WVA_SCALEDOBJECT_RECONCILE_QUERY="controller_runtime_reconcile_total{controller=\"scaledobject\",result=\"success\",job=\"wva-controller-manager-metrics-service\",namespace=\"${WVA_NAMESPACE}\"}"
+#
+# cleanup() {
+#   if [ -n "${PROMETHEUS_FORWARD_PID}" ]; then
+#     kill "${PROMETHEUS_FORWARD_PID}" >/dev/null 2>&1 || true
+#     wait "${PROMETHEUS_FORWARD_PID}" >/dev/null 2>&1 || true
+#   fi
+# }
+# trap cleanup EXIT INT TERM
+#
+# prom_query() {
+#   curl -ksS -G "${PROMETHEUS_URL}/api/v1/query" \
+#     --data-urlencode "query=$1"
+# }
+#
+# check_prometheus_ready() {
+#   prom_query up | jq -e \
+#     '.status == "success" and (.data.result | length) > 0' >/dev/null
+# }
+#
+# diagnose_prometheus_ready() {
+#   tail -n 80 "${PROMETHEUS_FORWARD_LOG}" 2>/dev/null || true
+#   prom_query up || true
+# }
+#
+# check_one_managed_scaledobject() {
+#   kubectl get scaledobjects.keda.sh --all-namespaces -o json | jq -e \
+#     --arg namespace "${NAMESPACE}" '
+#       [.items[] |
+#        select(.metadata.annotations["llm-d.ai/managed"] == "true")] as $managed |
+#       ($managed | length) == 1 and
+#       $managed[0].metadata.namespace == $namespace
+#     ' >/dev/null
+# }
+#
+# diagnose_managed_scaledobject() {
+#   kubectl get scaledobjects.keda.sh --all-namespaces -o yaml || true
+# }
+#
+# check_wva_scaledobject_reconcile() {
+#   prom_query "${WVA_SCALEDOBJECT_RECONCILE_QUERY}" |
+#     jq -e '
+#       .status == "success" and
+#       (.data.result | length) == 1 and
+#       ((.data.result[0].value[1] | tonumber) > 0)
+#     ' >/dev/null
+# }
+#
+# diagnose_wva_scaledobject_reconcile() {
+#   prom_query "${WVA_SCALEDOBJECT_RECONCILE_QUERY}" || true
+#   kubectl -n "${WVA_NAMESPACE}" logs \
+#     deployment/wva-controller-manager --tail=120 || true
+# }
+#
+# check_processing_model_v2() {
+#   kubectl -n "${WVA_NAMESPACE}" logs \
+#     deployment/wva-controller-manager --since=20m |
+#     grep -F 'Processing model (V2)' |
+#     grep -F "\"modelID\": \"${MODEL_ID}\"" |
+#     grep -F "\"namespace\": \"${NAMESPACE}\"" >/dev/null
+# }
+#
+# diagnose_processing_model_v2() {
+#   kubectl -n "${WVA_NAMESPACE}" logs \
+#     deployment/wva-controller-manager --since=20m --tail=160 || true
+# }
+#
+# check_lws_ready_groups() {
+#   local lws_json
+#   local pods_json
+#   local expected_pods
+#
+#   lws_json="$(kubectl -n "${NAMESPACE}" get \
+#     leaderworkersets.leaderworkerset.x-k8s.io "${LWS_NAME}" -o json)" ||
+#     return 1
+#   pods_json="$(kubectl -n "${NAMESPACE}" get pods \
+#     -l "leaderworkerset.sigs.k8s.io/name=${LWS_NAME}" -o json)" ||
+#     return 1
+#   expected_pods="$((EXPECTED_GROUPS * GROUP_SIZE))"
+#
+#   printf '%s' "${lws_json}" | jq -e \
+#     --argjson expected "${EXPECTED_GROUPS}" '
+#       .spec.replicas == $expected and
+#       .status.replicas == $expected and
+#       .status.readyReplicas == $expected
+#     ' >/dev/null || return 1
+#
+#   printf '%s' "${pods_json}" | jq -e \
+#     --argjson expected_groups "${EXPECTED_GROUPS}" \
+#     --argjson group_size "${GROUP_SIZE}" \
+#     --argjson expected_pods "${expected_pods}" '
+#       (.items | length) == $expected_pods and
+#       all(.items[];
+#         any(.status.conditions[]?;
+#           .type == "Ready" and .status == "True")) and
+#       ([.items[].metadata.labels[
+#           "leaderworkerset.sigs.k8s.io/group-index"
+#         ]] | all(. != null)) and
+#       ([.items[].metadata.labels[
+#           "leaderworkerset.sigs.k8s.io/group-index"
+#         ]] | unique | length) == $expected_groups and
+#       ([.items[].metadata.labels[
+#           "leaderworkerset.sigs.k8s.io/group-index"
+#         ]] | sort | group_by(.) | all(length == $group_size))
+#     ' >/dev/null
+# }
+#
+# diagnose_lws_ready_groups() {
+#   kubectl -n "${NAMESPACE}" get \
+#     leaderworkersets.leaderworkerset.x-k8s.io "${LWS_NAME}" -o yaml || true
+#   kubectl -n "${NAMESPACE}" get pods \
+#     -l "leaderworkerset.sigs.k8s.io/name=${LWS_NAME}" \
+#     -o wide --show-labels || true
+#   kubectl -n "${NAMESPACE}" get events \
+#     --sort-by=.lastTimestamp | tail -n 80 || true
+# }
+#
+# check_namespace_config_loaded() {
+#   kubectl -n "${WVA_NAMESPACE}" logs \
+#     deployment/wva-controller-manager --since-time="${RELOAD_AT}" |
+#     grep -F \
+#       'Updated namespace-local saturation config from ConfigMap' |
+#     grep -F \
+#       "\"ConfigMap\": {\"name\":\"wva-saturation-scaling-config\",\"namespace\":\"${NAMESPACE}\"}" |
+#     grep -F "\"namespace\": \"${NAMESPACE}\"" >/dev/null
+# }
+#
+# diagnose_namespace_config_loaded() {
+#   kubectl -n "${NAMESPACE}" get configmap \
+#     wva-saturation-scaling-config -o yaml || true
+#   kubectl -n "${WVA_NAMESPACE}" logs \
+#     deployment/wva-controller-manager \
+#     --since-time="${RELOAD_AT}" --tail=160 || true
+# }
+#
+# check_exact_desired_two() {
+#   prom_query "${QUERY}" | jq -e '
+#     .status == "success" and
+#     (.data.result | length) == 1 and
+#     .data.result[0].value[1] == "2"
+#   ' >/dev/null
+# }
+#
+# diagnose_exact_desired_two() {
+#   echo "Expected exact query: ${EXPECTED_QUERY}"
+#   prom_query "${QUERY}" || true
+#   kubectl -n "${WVA_NAMESPACE}" logs \
+#     deployment/wva-controller-manager \
+#     --since-time="${RELOAD_AT}" --tail=160 || true
+# }
+#
+# check_scaledobject_ready() {
+#   kubectl -n "${NAMESPACE}" get scaledobject.keda.sh \
+#     "${SCALEDOBJECT_NAME}" -o json |
+#     jq -e '
+#       (.metadata.annotations["autoscaling.keda.sh/paused"] == null) and
+#       any(.status.conditions[]?;
+#         .type == "Ready" and .status == "True") and
+#       any(.status.conditions[]?;
+#         .type == "Paused" and .status == "False")
+#     ' >/dev/null
+# }
+#
+# diagnose_scaledobject_ready() {
+#   kubectl -n "${NAMESPACE}" get scaledobject.keda.sh \
+#     "${SCALEDOBJECT_NAME}" -o yaml || true
+#   kubectl -n keda-system logs deployment/keda-operator \
+#     --tail=160 || true
+# }
+#
+# check_hpa_created() {
+#   HPA_NAME="$(kubectl -n "${NAMESPACE}" get scaledobject.keda.sh \
+#     "${SCALEDOBJECT_NAME}" \
+#     -o jsonpath='{.status.hpaName}' 2>/dev/null || true)"
+#   [ -n "${HPA_NAME}" ] &&
+#     kubectl -n "${NAMESPACE}" get \
+#       horizontalpodautoscaler.autoscaling "${HPA_NAME}" \
+#       >/dev/null 2>&1
+# }
+#
+# diagnose_hpa_created() {
+#   kubectl -n "${NAMESPACE}" get scaledobject.keda.sh \
+#     "${SCALEDOBJECT_NAME}" -o yaml || true
+#   kubectl -n "${NAMESPACE}" get \
+#     horizontalpodautoscalers.autoscaling -o yaml || true
+# }
+#
+# check_external_metric_visible() {
+#   kubectl get --raw \
+#     "/apis/external.metrics.k8s.io/v1beta1/namespaces/${NAMESPACE}/${EXTERNAL_METRIC_NAME}?labelSelector=${EXTERNAL_METRIC_SELECTOR_URI}" |
+#     jq -e '.items | length > 0' >/dev/null
+# }
+#
+# diagnose_external_metric_visible() {
+#   kubectl get --raw \
+#     "/apis/external.metrics.k8s.io/v1beta1/namespaces/${NAMESPACE}/${EXTERNAL_METRIC_NAME}?labelSelector=${EXTERNAL_METRIC_SELECTOR_URI}" ||
+#     true
+#   kubectl -n keda-system logs deployment/keda-operator \
+#     --tail=160 || true
+#   kubectl -n keda-system logs \
+#     deployment/keda-operator-metrics-apiserver --tail=160 || true
+# }
+#
+# check_hpa_desired_two() {
+#   kubectl -n "${NAMESPACE}" get \
+#     horizontalpodautoscaler.autoscaling "${HPA_NAME}" -o json |
+#     jq -e '.status.desiredReplicas == 2' >/dev/null
+# }
+#
+# diagnose_hpa_desired_two() {
+#   kubectl -n "${NAMESPACE}" get \
+#     horizontalpodautoscaler.autoscaling "${HPA_NAME}" -o yaml || true
+#   kubectl -n "${NAMESPACE}" describe \
+#     horizontalpodautoscaler.autoscaling "${HPA_NAME}" || true
+# }
+#
+# # The pinned renderer does not propagate arbitrary scenario namespace
+# # labels. Apply the actual opt-in label and preserve the installed
+# # Namespace YAML as evidence.
+# kubectl label namespace "${NAMESPACE}" \
+#   wva.llmd.ai/config-enabled=true --overwrite
+# kubectl get namespace "${NAMESPACE}" -o yaml |
+#   tee /private/tmp/wva-1525-installed-namespace.yaml
+#
+# if [ "$(kubectl get namespace "${NAMESPACE}" \
+#   -o jsonpath='{.metadata.labels.wva\.llmd\.ai/config-enabled}')" != \
+#   "true" ]; then
+#   echo \
+#     "ERROR: installed Namespace is missing wva.llmd.ai/config-enabled=true" \
+#     >&2
+#   exit 1
+# fi
+#
+# # The clean replay must contain exactly one managed ScaledObject
+# # cluster-wide. WVA's ScaledObject predicate handles only managed objects,
+# # so its successful-reconcile metric below is qualified by this invariant.
+# wait_for "exactly one managed ScaledObject in ${NAMESPACE}" 120 \
+#   check_one_managed_scaledobject diagnose_managed_scaledobject
+#
+# MANAGED_SCALEDOBJECT_JSON="$(kubectl get scaledobjects.keda.sh \
+#   --all-namespaces -o json |
+#   jq -c \
+#     '[.items[] |
+#       select(.metadata.annotations["llm-d.ai/managed"] == "true")][0]')"
+# SCALEDOBJECT_NAME="$(printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+#   jq -r '.metadata.name')"
+# MODEL_ID="$(printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+#   jq -r '.metadata.annotations["llm-d.ai/model-id"] // empty')"
+# LWS_NAME="$(printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+#   jq -r '.spec.scaleTargetRef.name // empty')"
+#
+# if [ -z "${SCALEDOBJECT_NAME}" ] ||
+#   [ -z "${MODEL_ID}" ] ||
+#   [ -z "${LWS_NAME}" ]; then
+#   echo \
+#     "ERROR: managed ScaledObject is missing name, model-id, or scaleTargetRef.name" \
+#     >&2
+#   printf '%s\n' "${MANAGED_SCALEDOBJECT_JSON}" >&2
+#   exit 1
+# fi
+#
+# if ! printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" | jq -e '
+#   .metadata.annotations["autoscaling.keda.sh/paused"] == "true" and
+#   .spec.scaleTargetRef.apiVersion == "leaderworkerset.x-k8s.io/v1" and
+#   .spec.scaleTargetRef.kind == "LeaderWorkerSet" and
+#   .spec.minReplicaCount == 1 and
+#   .spec.maxReplicaCount == 2
+# ' >/dev/null; then
+#   echo \
+#     "ERROR: managed ScaledObject does not match the approved paused LWS contract" \
+#     >&2
+#   printf '%s\n' "${MANAGED_SCALEDOBJECT_JSON}" >&2
+#   exit 1
+# fi
+#
+# # Inspect the installed resource rather than relying on trigger.name.
+# PROMETHEUS_TRIGGER_COUNT="$(
+#   printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+#     jq \
+#       '[.spec.triggers[]? |
+#         select(.type == "prometheus")] | length'
+# )"
+# if [ "${PROMETHEUS_TRIGGER_COUNT}" -ne 1 ]; then
+#   echo \
+#     "ERROR: expected exactly one Prometheus trigger, found ${PROMETHEUS_TRIGGER_COUNT}" \
+#     >&2
+#   printf '%s\n' "${MANAGED_SCALEDOBJECT_JSON}" >&2
+#   exit 1
+# fi
+#
+# QUERY="$(
+#   printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+#     jq -r \
+#       '[.spec.triggers[] |
+#         select(.type == "prometheus")][0].metadata.query // empty'
+# )"
+# EXPECTED_QUERY="wva_desired_replicas{variant_name=\"${LWS_NAME}\",exported_namespace=\"${NAMESPACE}\"}"
+#
+# if [ -z "${QUERY}" ]; then
+#   echo \
+#     "ERROR: the sole Prometheus trigger has an empty metadata.query" >&2
+#   exit 1
+# fi
+#
+# if [ "${QUERY}" != "${EXPECTED_QUERY}" ]; then
+#   echo \
+#     "ERROR: installed Prometheus query does not match the exact WVA contract" \
+#     >&2
+#   echo "expected: ${EXPECTED_QUERY}" >&2
+#   echo "actual:   ${QUERY}" >&2
+#   exit 1
+# fi
+#
+# GROUP_SIZE="$(kubectl -n "${NAMESPACE}" get \
+#   leaderworkersets.leaderworkerset.x-k8s.io "${LWS_NAME}" \
+#   -o jsonpath='{.spec.leaderWorkerTemplate.size}')"
+# if [ "${GROUP_SIZE}" -ne 2 ]; then
+#   echo "ERROR: expected LWS group size 2, found ${GROUP_SIZE}" >&2
+#   exit 1
+# fi
+#
+# kubectl -n "${MONITORING_NAMESPACE}" port-forward \
+#   service/kube-prometheus-stack-prometheus \
+#   "${PROMETHEUS_PORT}:9090" \
+#   >"${PROMETHEUS_FORWARD_LOG}" 2>&1 &
+# PROMETHEUS_FORWARD_PID="$!"
+#
+# wait_for "Prometheus API readiness" 120 \
+#   check_prometheus_ready diagnose_prometheus_ready
+#
+# # Current WVA exposes no direct per-namespace tracked-set log or status.
+# # On this fresh cluster, use only the narrow conjunction needed for the
+# # subsequent ConfigMap update: the sole managed ScaledObject, a successful
+# # reconciliation from WVA's own metrics service whose success path calls
+# # NamespaceTrack, and the exact Processing model (V2) observation below.
+# # A baseline wva_desired_replicas series is not used as tracking proof.
+# wait_for \
+#   "successful WVA ScaledObject reconcile for the sole managed object" 180 \
+#   check_wva_scaledobject_reconcile diagnose_wva_scaledobject_reconcile
+# wait_for \
+#   "exact WVA Processing model (V2) observation for ${MODEL_ID}/${NAMESPACE}" \
+#   180 check_processing_model_v2 diagnose_processing_model_v2
+#
+# # KEDA remains paused while the whole-group 1 -> 2 -> 1 path is proven.
+# EXPECTED_GROUPS=1
+# wait_for "initial one complete Ready LWS group" 900 \
+#   check_lws_ready_groups diagnose_lws_ready_groups
+#
+# kubectl -n "${NAMESPACE}" scale \
+#   leaderworkersets.leaderworkerset.x-k8s.io "${LWS_NAME}" --replicas=2
+# EXPECTED_GROUPS=2
+# wait_for "manual scale-up to two complete Ready LWS groups" 900 \
+#   check_lws_ready_groups diagnose_lws_ready_groups
+#
+# kubectl -n "${NAMESPACE}" scale \
+#   leaderworkersets.leaderworkerset.x-k8s.io "${LWS_NAME}" --replicas=1
+# EXPECTED_GROUPS=1
+# wait_for "manual scale-down to one complete Ready LWS group" 900 \
+#   check_lws_ready_groups diagnose_lws_ready_groups
+#
+# # Re-annotate only after qualified tracking evidence, then wait for the
+# # exact namespace-local config-loaded log. The inner ConfigMap JSON has no
+# # spaces after its colons; the outer namespace field does.
+# RELOAD_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# kubectl -n "${NAMESPACE}" annotate configmap \
+#   wva-saturation-scaling-config \
+#   "wva.llmd.ai/runtime-reload=${RELOAD_AT}" --overwrite
+#
+# wait_for "WVA namespace-local saturation ConfigMap load" 180 \
+#   check_namespace_config_loaded diagnose_namespace_config_loaded
+#
+# # Exact equality excludes every scalar fallback, including vector(2).
+# wait_for "exact Prometheus wva_desired_replicas query value 2" 300 \
+#   check_exact_desired_two diagnose_exact_desired_two
+#
+# # Only now may KEDA be fully activated.
+# kubectl -n "${NAMESPACE}" annotate scaledobject.keda.sh \
+#   "${SCALEDOBJECT_NAME}" autoscaling.keda.sh/paused-
+#
+# wait_for "ScaledObject unpaused and Ready=True" 180 \
+#   check_scaledobject_ready diagnose_scaledobject_ready
+# wait_for "KEDA-generated HPA creation" 180 \
+#   check_hpa_created diagnose_hpa_created
+#
+# HPA_JSON="$(kubectl -n "${NAMESPACE}" get \
+#   horizontalpodautoscaler.autoscaling "${HPA_NAME}" -o json)"
+#
+# if ! printf '%s' "${HPA_JSON}" | jq -e \
+#   --arg name "${LWS_NAME}" '
+#     .spec.scaleTargetRef.apiVersion ==
+#       "leaderworkerset.x-k8s.io/v1" and
+#     .spec.scaleTargetRef.kind == "LeaderWorkerSet" and
+#     .spec.scaleTargetRef.name == $name
+#   ' >/dev/null; then
+#   echo "ERROR: generated HPA does not target the exact approved LWS" >&2
+#   printf '%s\n' "${HPA_JSON}" >&2
+#   exit 1
+# fi
+#
+# EXTERNAL_METRIC_COUNT="$(
+#   printf '%s' "${HPA_JSON}" |
+#     jq \
+#       '[.spec.metrics[]? |
+#         select(.type == "External")] | length'
+# )"
+# if [ "${EXTERNAL_METRIC_COUNT}" -ne 1 ]; then
+#   echo \
+#     "ERROR: expected exactly one HPA External metric, found ${EXTERNAL_METRIC_COUNT}" \
+#     >&2
+#   printf '%s\n' "${HPA_JSON}" >&2
+#   exit 1
+# fi
+#
+# EXTERNAL_METRIC_NAME="$(
+#   printf '%s' "${HPA_JSON}" |
+#     jq -r \
+#       '[.spec.metrics[] |
+#         select(.type == "External")][0].external.metric.name // empty'
+# )"
+# if [ -z "${EXTERNAL_METRIC_NAME}" ]; then
+#   echo "ERROR: generated HPA External metric name is empty" >&2
+#   exit 1
+# fi
+# EXTERNAL_METRIC_SELECTOR_URI="$(
+#   printf '%s' "scaledobject.keda.sh/name=${SCALEDOBJECT_NAME}" |
+#     jq -sRr @uri
+# )"
+#
+# wait_for \
+#   "KEDA external metric ${EXTERNAL_METRIC_NAME} visibility" 180 \
+#   check_external_metric_visible diagnose_external_metric_visible
+# wait_for "generated HPA desiredReplicas=2" 300 \
+#   check_hpa_desired_two diagnose_hpa_desired_two
+#
+# EXPECTED_GROUPS=2
+# wait_for "KEDA/HPA scale-up to two complete Ready LWS groups" 900 \
+#   check_lws_ready_groups diagnose_lws_ready_groups
+#
+# kubectl get --raw \
+#   "/apis/leaderworkerset.x-k8s.io/v1/namespaces/${NAMESPACE}/leaderworkersets/${LWS_NAME}/scale" |
+#   jq -e \
+#     '.spec.replicas == 2 and .status.replicas == 2' >/dev/null || {
+#       echo \
+#         "ERROR: final raw LWS /scale did not report spec/status replicas 2" \
+#         >&2
+#       exit 1
+#     }
+#
+# echo \
+#   "PASS: Option 2 reproducibility lifecycle completed without a scalar fallback"
+# ```
+
+scenario:
+  - name: wide-ep-lws-scale-mechanics
+
+    model:
+      name: test-model
+      shortName: test-model
+      path: models/test-model
+      huggingfaceId: test-model
+      size: 1Gi
+      maxModelLen: 512
+      blockSize: 8
+      gpuMemoryUtilization: 0
+
+    accelerator:
+      count: 0
+      memory: 24
+
+    affinity:
+      enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+
+    images:
+      vllm:
+        repository: ghcr.io/llm-d/llm-d-inference-sim
+        tag: v0.9.0
+        pullPolicy: IfNotPresent
+
+    multinode:
+      enabled: true
+
+    modelArtifacts:
+      extraLabels:
+        llm-d.ai/accelerator-variant: cpu
+        llm-d.ai/variant: "${model.idLabel}-decode"
+
+    modelservice:
+      enabled: true
+      uriProtocol: hf
+
+      gateway:
+        className: none
+
+      routing:
+        proxy:
+          enabled: false
+
+    decode:
+      enabled: true
+      replicas: 1
+
+      accelerator:
+        count: 0
+
+      parallelism:
+        tensor: 0
+        data: 1
+        dataLocal: 1
+        workers: 2
+
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+
+      extraContainerConfig:
+        ports:
+          - name: metrics
+            containerPort: 8000
+            protocol: TCP
+
+      monitoring:
+        podmonitor:
+          enabled: true
+          portName: metrics
+          path: /metrics
+          interval: 15s
+          labels:
+            release: kube-prometheus-stack
+          relabelings:
+            - sourceLabels:
+                - __meta_kubernetes_pod_label_llm_d_ai_variant
+              targetLabel: llm_d_ai_variant
+              action: replace
+
+      vllm:
+        modelCommand: imageDefault
+        additionalFlags:
+          - --time-to-first-token=2000ms
+          - --inter-token-latency=100ms
+          - --mode=random
+          - --enable-kvcache
+          - --kv-cache-size=1
+          - --block-size=8
+          - --max-num-seqs
+          - "5"
+          - --max-model-len
+          - "512"
+          - --fake-metrics
+          - '{"kv-cache-usage":0.3,"running-requests":1,"waiting-requests":0}'
+
+    prefill:
+      enabled: false
+      replicas: 0
+
+    standalone:
+      enabled: false
+
+    extraObjects:
+      # Namespace-local V2 calibration copied from WVA's current saturation
+      # smoke path. It deterministically requests desired replicas = 2 from one
+      # Ready group without changing the cluster-global saturation policy.
+      - apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: wva-saturation-scaling-config
+          namespace: "${namespace.name}"
+          labels:
+            app.kubernetes.io/name: workload-variant-autoscaler
+        data:
+          default: |
+            analyzers:
+              - name: saturation
+                score: 1.0
+            scaleUpThreshold: 0.30
+            scaleDownBoundary: 0.20
+            kvCacheThreshold: 0.80
+            queueLengthThreshold: 50
+            kvSpareTrigger: 0.10
+            queueSpareTrigger: 5
+            enableLimiter: false
+
+      # Target/scaler structure is intentionally derived from WVA PR #1517.
+      # It starts paused so manual LWS 1 -> 2 -> 1 group scaling can run first.
+      - apiVersion: keda.sh/v1alpha1
+        kind: ScaledObject
+        metadata:
+          name: "${model.idLabel}-decode"
+          namespace: "${namespace.name}"
+          annotations:
+            autoscaling.keda.sh/paused: "true"
+            llm-d.ai/managed: "true"
+            llm-d.ai/model-id: test-model
+            llm-d.ai/variant-cost: "30.0"
+        spec:
+          scaleTargetRef:
+            apiVersion: leaderworkerset.x-k8s.io/v1
+            kind: LeaderWorkerSet
+            name: "${model.idLabel}-decode"
+          minReplicaCount: 1
+          maxReplicaCount: 2
+          pollingInterval: 5
+          cooldownPeriod: 30
+          triggers:
+            - type: prometheus
+              name: wva-desired-replicas
+              metricType: AverageValue
+              metadata:
+                serverAddress: "https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090"
+                query: 'wva_desired_replicas{variant_name="${model.idLabel}-decode",exported_namespace="${namespace.name}"}'
+                threshold: "1"
+                activationThreshold: "0"
+                unsafeSsl: "true"
+
+    storage:
+      modelPvc:
+        size: 1Gi
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: standard
+      workloadPvc:
+        size: 1Gi
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: standard
+
+    vllmCommon:
+      volumes:
+        - name: dshm
+          type: emptyDir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 256Mi
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+
+    control:
+      waitTimeout: 900
+      waitPeriod: 5

--- a/benchmark/config/scenarios/wide-ep-lws-scale-mechanics.yaml
+++ b/benchmark/config/scenarios/wide-ep-lws-scale-mechanics.yaml
@@ -1,23 +1,68 @@
-# Bounded CPU-only LeaderWorkerSet scale-mechanics scenario for WVA #1525.
-# It intentionally proves group mechanics only: one leader plus one worker per
-# group, a paused KEDA ScaledObject, and deterministic simulator metrics.
-
-# Reproducible Option 2 lifecycle for the pinned llm-d-benchmark renderer.
+# Bounded CPU-only LeaderWorkerSet live-signal scenario for WVA #1525.
 #
-# Run this after standup. The ScaledObject remains paused until the exact
-# namespace-local WVA metric reaches 2. Every polling phase is bounded and
-# emits diagnostics before returning nonzero.
+# This is the next slice after the accepted scale-mechanics slice (commit
+# 00ab8ff): WVA is not installed, the simulator's fake-metrics override is
+# removed, and KEDA's Prometheus trigger queries the simulator's own live,
+# workload-driven `vllm:num_requests_waiting` series directly. One leader
+# plus one worker per LWS group (group size 2), bounded to
+# min=1/max=2 groups. See DECISIONS.md D1-D9 and IMPLEMENTATION_BRIEF.md for
+# the full decision record; this scenario implements only the smallest
+# defensible change authorized there.
+#
+# Claims allowed / forbidden (DECISIONS.md Sections 5-6): this experiment may
+# show that a live `vllm:`-named metric can replace `wva_desired_replicas` in
+# the KEDA->HPA->LWS signal path with WVA absent, and that the raw value and
+# HPA's `desiredReplicas` are observably connected. It must NOT be read as
+# selecting `num_requests_waiting` as a production Wide-EP signal, as a
+# calibrated threshold, as real vLLM scheduler-admission fidelity, or as any
+# claim about real vLLM `engine`-label cardinality, expert imbalance,
+# DeepEP/all-to-all pressure, EPP routing, GPU cold start, or autoscaling
+# policy.
+
+# Reproducible lifecycle for the pinned llm-d-benchmark renderer.
+#
+# Run this after standup, before running the inference-perf stimulus
+# documented in benchmark/README.md:
+#
+#   llmdbenchmark --spec "${INFERENCE_PERF_SPEC}" run \
+#     -p "${NAMESPACE}" -l inference-perf -w "${INFERENCE_PERF_WORKLOAD}" \
+#     -e benchmark/experiments/wide-ep-lws-fresh-traffic.yaml \
+#     --wait-timeout 600
+#
+# `-o` is intentionally not used: `-e` supersedes it, and per WVA #1525 Track
+# A F15 the reused profile's tokenizer override
+# (`tokenizer.pretrained_model_name_or_path: gpt2`) now lives in the two
+# treatments of `benchmark/experiments/wide-ep-lws-fresh-traffic.yaml`
+# itself, because `step_05_render_profiles.py::_resolve_treatments` returns
+# from the `-e` branch before `-o`/`profile_overrides` are ever read.
+# `model.name` -- and therefore what the simulator serves as -- stays
+# `test-model`, unchanged from the accepted Slice 1 scenario; the workload
+# file is the existing Wide-EP inference-perf profile from the
+# `llm-d-benchmark` sibling repo, no new load-generation asset introduced.
+# The two-treatment run-only experiment file drives the actual load shape
+# (T1: concurrency 40 / 200 requests to trigger the KEDA->HPA->LWS 1->2
+# transition; T2: concurrency 20 / 60 requests as a freshly-created-process
+# fresh-traffic probe against the resulting two-group state) -- see WVA
+# #1525 Track A F3/F4; it supersedes the flat `concurrency_level: 2048`
+# single-stage sizing referenced by earlier drafts of this comment. The
+# ScaledObject is active (not paused) from standup, so this script both
+# starts the stimulus and observes the resulting signal chain. Every polling
+# phase is bounded and emits diagnostics before returning nonzero.
 #
 # ```bash
 # set -euo pipefail
 #
 # : "${NAMESPACE:=llmd-1525}"
-# : "${WVA_NAMESPACE:=workload-variant-autoscaler-system}"
 # : "${MONITORING_NAMESPACE:=workload-variant-autoscaler-monitoring}"
 # : "${PROMETHEUS_PORT:=19090}"
 # : "${POLL_INTERVAL_SECONDS:=5}"
+# : "${IDLE_MAX_VALUE:=5}"
+# : "${RISING_MIN_VALUE:=10}"
+# : "${POST_SCALE_SETTLE_SECONDS:=30}"
+# : "${INFERENCE_PERF_SPEC:=benchmark/config/specification/wide-ep-lws-scale-mechanics.yaml.j2}"
+# : "${INFERENCE_PERF_WORKLOAD:=guide_wide-ep-lws_1.yaml}"
 #
-# for required_command in kubectl curl jq grep date; do
+# for required_command in kubectl curl jq grep date llmdbenchmark; do
 #   if ! command -v "${required_command}" >/dev/null 2>&1; then
 #     echo "ERROR: required command not found: ${required_command}" >&2
 #     exit 1
@@ -48,9 +93,13 @@
 # PROMETHEUS_URL="https://127.0.0.1:${PROMETHEUS_PORT}"
 # PROMETHEUS_FORWARD_LOG="/private/tmp/wva-1525-prometheus-port-forward.log"
 # PROMETHEUS_FORWARD_PID=""
-# WVA_SCALEDOBJECT_RECONCILE_QUERY="controller_runtime_reconcile_total{controller=\"scaledobject\",result=\"success\",job=\"wva-controller-manager-metrics-service\",namespace=\"${WVA_NAMESPACE}\"}"
+# INFERENCE_PERF_PID=""
 #
 # cleanup() {
+#   if [ -n "${INFERENCE_PERF_PID}" ]; then
+#     kill "${INFERENCE_PERF_PID}" >/dev/null 2>&1 || true
+#     wait "${INFERENCE_PERF_PID}" >/dev/null 2>&1 || true
+#   fi
 #   if [ -n "${PROMETHEUS_FORWARD_PID}" ]; then
 #     kill "${PROMETHEUS_FORWARD_PID}" >/dev/null 2>&1 || true
 #     wait "${PROMETHEUS_FORWARD_PID}" >/dev/null 2>&1 || true
@@ -73,46 +122,29 @@
 #   prom_query up || true
 # }
 #
-# check_one_managed_scaledobject() {
-#   kubectl get scaledobjects.keda.sh --all-namespaces -o json | jq -e \
-#     --arg namespace "${NAMESPACE}" '
-#       [.items[] |
-#        select(.metadata.annotations["llm-d.ai/managed"] == "true")] as $managed |
-#       ($managed | length) == 1 and
-#       $managed[0].metadata.namespace == $namespace
-#     ' >/dev/null
+# # DECISIONS.md D1 / IMPLEMENTATION_BRIEF.md G.8: WVA must be genuinely
+# # absent, not merely un-consulted -- no wva-controller-manager Deployment
+# # anywhere in the cluster.
+# check_wva_absent() {
+#   [ "$(kubectl get deployments.apps --all-namespaces \
+#     --field-selector metadata.name=wva-controller-manager \
+#     -o json | jq '.items | length')" = "0" ]
 # }
 #
-# diagnose_managed_scaledobject() {
-#   kubectl get scaledobjects.keda.sh --all-namespaces -o yaml || true
+# diagnose_wva_absent() {
+#   kubectl get deployments.apps --all-namespaces \
+#     --field-selector metadata.name=wva-controller-manager -o yaml || true
 # }
 #
-# check_wva_scaledobject_reconcile() {
-#   prom_query "${WVA_SCALEDOBJECT_RECONCILE_QUERY}" |
-#     jq -e '
-#       .status == "success" and
-#       (.data.result | length) == 1 and
-#       ((.data.result[0].value[1] | tonumber) > 0)
-#     ' >/dev/null
+# # No WVA-managed annotation exists on this ScaledObject anymore (D1), so
+# # discovery is by namespace rather than by annotation.
+# check_one_scaledobject() {
+#   [ "$(kubectl -n "${NAMESPACE}" get scaledobjects.keda.sh \
+#     -o json | jq '.items | length')" = "1" ]
 # }
 #
-# diagnose_wva_scaledobject_reconcile() {
-#   prom_query "${WVA_SCALEDOBJECT_RECONCILE_QUERY}" || true
-#   kubectl -n "${WVA_NAMESPACE}" logs \
-#     deployment/wva-controller-manager --tail=120 || true
-# }
-#
-# check_processing_model_v2() {
-#   kubectl -n "${WVA_NAMESPACE}" logs \
-#     deployment/wva-controller-manager --since=20m |
-#     grep -F 'Processing model (V2)' |
-#     grep -F "\"modelID\": \"${MODEL_ID}\"" |
-#     grep -F "\"namespace\": \"${NAMESPACE}\"" >/dev/null
-# }
-#
-# diagnose_processing_model_v2() {
-#   kubectl -n "${WVA_NAMESPACE}" logs \
-#     deployment/wva-controller-manager --since=20m --tail=160 || true
+# diagnose_one_scaledobject() {
+#   kubectl -n "${NAMESPACE}" get scaledobjects.keda.sh -o yaml || true
 # }
 #
 # check_lws_ready_groups() {
@@ -165,49 +197,48 @@
 #     --sort-by=.lastTimestamp | tail -n 80 || true
 # }
 #
-# check_namespace_config_loaded() {
-#   kubectl -n "${WVA_NAMESPACE}" logs \
-#     deployment/wva-controller-manager --since-time="${RELOAD_AT}" |
-#     grep -F \
-#       'Updated namespace-local saturation config from ConfigMap' |
-#     grep -F \
-#       "\"ConfigMap\": {\"name\":\"wva-saturation-scaling-config\",\"namespace\":\"${NAMESPACE}\"}" |
-#     grep -F "\"namespace\": \"${NAMESPACE}\"" >/dev/null
+# # Acceptance criterion G.1: idle/baseline value must be low before the
+# # inference-perf stimulus starts. "Low" is bounded by IDLE_MAX_VALUE
+# # (default 5), well under the KEDA trigger's own uncalibrated threshold
+# # (10); a missing series (simulator has served no requests yet) also
+# # passes.
+# check_idle_metric_low() {
+#   prom_query "${QUERY}" | jq -e \
+#     --argjson max "${IDLE_MAX_VALUE}" '
+#       .status == "success" and (
+#         (.data.result | length) == 0 or
+#         ((.data.result[0].value[1] | tonumber) <= $max)
+#       )
+#     ' >/dev/null
 # }
 #
-# diagnose_namespace_config_loaded() {
-#   kubectl -n "${NAMESPACE}" get configmap \
-#     wva-saturation-scaling-config -o yaml || true
-#   kubectl -n "${WVA_NAMESPACE}" logs \
-#     deployment/wva-controller-manager \
-#     --since-time="${RELOAD_AT}" --tail=160 || true
-# }
-#
-# check_exact_desired_two() {
-#   prom_query "${QUERY}" | jq -e '
-#     .status == "success" and
-#     (.data.result | length) == 1 and
-#     .data.result[0].value[1] == "2"
-#   ' >/dev/null
-# }
-#
-# diagnose_exact_desired_two() {
-#   echo "Expected exact query: ${EXPECTED_QUERY}"
+# diagnose_idle_metric_low() {
 #   prom_query "${QUERY}" || true
-#   kubectl -n "${WVA_NAMESPACE}" logs \
-#     deployment/wva-controller-manager \
-#     --since-time="${RELOAD_AT}" --tail=160 || true
+#   kubectl -n "${NAMESPACE}" get pods -o wide || true
+# }
+#
+# # Acceptance criteria G.2/G.3: the raw Prometheus value must rise
+# # organically once inference-perf begins.
+# check_metric_rising() {
+#   prom_query "${QUERY}" | jq -e \
+#     --argjson min "${RISING_MIN_VALUE}" '
+#       .status == "success" and
+#       (.data.result | length) == 1 and
+#       ((.data.result[0].value[1] | tonumber) >= $min)
+#     ' >/dev/null
+# }
+#
+# diagnose_metric_rising() {
+#   prom_query "${QUERY}" || true
+#   kubectl -n "${NAMESPACE}" get endpoints -o wide || true
+#   kubectl -n "${NAMESPACE}" get pods -o wide || true
 # }
 #
 # check_scaledobject_ready() {
 #   kubectl -n "${NAMESPACE}" get scaledobject.keda.sh \
 #     "${SCALEDOBJECT_NAME}" -o json |
 #     jq -e '
-#       (.metadata.annotations["autoscaling.keda.sh/paused"] == null) and
-#       any(.status.conditions[]?;
-#         .type == "Ready" and .status == "True") and
-#       any(.status.conditions[]?;
-#         .type == "Paused" and .status == "False")
+#       any(.status.conditions[]?; .type == "Ready" and .status == "True")
 #     ' >/dev/null
 # }
 #
@@ -262,70 +293,51 @@
 #     horizontalpodautoscaler.autoscaling "${HPA_NAME}" -o yaml || true
 #   kubectl -n "${NAMESPACE}" describe \
 #     horizontalpodautoscaler.autoscaling "${HPA_NAME}" || true
+#   echo "raw ${QUERY} at this instant:" >&2
+#   prom_query "${QUERY}" || true
 # }
 #
-# # The pinned renderer does not propagate arbitrary scenario namespace
-# # labels. Apply the actual opt-in label and preserve the installed
-# # Namespace YAML as evidence.
-# kubectl label namespace "${NAMESPACE}" \
-#   wva.llmd.ai/config-enabled=true --overwrite
-# kubectl get namespace "${NAMESPACE}" -o yaml |
-#   tee /private/tmp/wva-1525-installed-namespace.yaml
+# # G.8/D1: WVA must be genuinely absent, not merely un-consulted, before any
+# # of the signal-path evidence below is trusted.
+# wait_for "WVA controller absent cluster-wide" 60 \
+#   check_wva_absent diagnose_wva_absent
 #
-# if [ "$(kubectl get namespace "${NAMESPACE}" \
-#   -o jsonpath='{.metadata.labels.wva\.llmd\.ai/config-enabled}')" != \
-#   "true" ]; then
-#   echo \
-#     "ERROR: installed Namespace is missing wva.llmd.ai/config-enabled=true" \
-#     >&2
-#   exit 1
-# fi
+# # Exactly one (non-WVA-managed) ScaledObject targeting this scenario's LWS.
+# wait_for "exactly one ScaledObject in ${NAMESPACE}" 120 \
+#   check_one_scaledobject diagnose_one_scaledobject
 #
-# # The clean replay must contain exactly one managed ScaledObject
-# # cluster-wide. WVA's ScaledObject predicate handles only managed objects,
-# # so its successful-reconcile metric below is qualified by this invariant.
-# wait_for "exactly one managed ScaledObject in ${NAMESPACE}" 120 \
-#   check_one_managed_scaledobject diagnose_managed_scaledobject
-#
-# MANAGED_SCALEDOBJECT_JSON="$(kubectl get scaledobjects.keda.sh \
-#   --all-namespaces -o json |
-#   jq -c \
-#     '[.items[] |
-#       select(.metadata.annotations["llm-d.ai/managed"] == "true")][0]')"
-# SCALEDOBJECT_NAME="$(printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+# SCALEDOBJECT_JSON="$(kubectl -n "${NAMESPACE}" get scaledobjects.keda.sh \
+#   -o json | jq -c '.items[0]')"
+# SCALEDOBJECT_NAME="$(printf '%s' "${SCALEDOBJECT_JSON}" |
 #   jq -r '.metadata.name')"
-# MODEL_ID="$(printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
-#   jq -r '.metadata.annotations["llm-d.ai/model-id"] // empty')"
-# LWS_NAME="$(printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+# LWS_NAME="$(printf '%s' "${SCALEDOBJECT_JSON}" |
 #   jq -r '.spec.scaleTargetRef.name // empty')"
 #
-# if [ -z "${SCALEDOBJECT_NAME}" ] ||
-#   [ -z "${MODEL_ID}" ] ||
-#   [ -z "${LWS_NAME}" ]; then
+# if [ -z "${SCALEDOBJECT_NAME}" ] || [ -z "${LWS_NAME}" ]; then
 #   echo \
-#     "ERROR: managed ScaledObject is missing name, model-id, or scaleTargetRef.name" \
-#     >&2
-#   printf '%s\n' "${MANAGED_SCALEDOBJECT_JSON}" >&2
+#     "ERROR: ScaledObject is missing name or scaleTargetRef.name" >&2
+#   printf '%s\n' "${SCALEDOBJECT_JSON}" >&2
 #   exit 1
 # fi
 #
-# if ! printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" | jq -e '
-#   .metadata.annotations["autoscaling.keda.sh/paused"] == "true" and
+# if ! printf '%s' "${SCALEDOBJECT_JSON}" | jq -e '
+#   .metadata.annotations["llm-d.ai/managed"] == null and
+#   .metadata.annotations["autoscaling.keda.sh/paused"] == null and
 #   .spec.scaleTargetRef.apiVersion == "leaderworkerset.x-k8s.io/v1" and
 #   .spec.scaleTargetRef.kind == "LeaderWorkerSet" and
 #   .spec.minReplicaCount == 1 and
 #   .spec.maxReplicaCount == 2
 # ' >/dev/null; then
 #   echo \
-#     "ERROR: managed ScaledObject does not match the approved paused LWS contract" \
+#     "ERROR: ScaledObject does not match the approved unmanaged/unpaused LWS contract" \
 #     >&2
-#   printf '%s\n' "${MANAGED_SCALEDOBJECT_JSON}" >&2
+#   printf '%s\n' "${SCALEDOBJECT_JSON}" >&2
 #   exit 1
 # fi
 #
 # # Inspect the installed resource rather than relying on trigger.name.
 # PROMETHEUS_TRIGGER_COUNT="$(
-#   printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+#   printf '%s' "${SCALEDOBJECT_JSON}" |
 #     jq \
 #       '[.spec.triggers[]? |
 #         select(.type == "prometheus")] | length'
@@ -334,17 +346,17 @@
 #   echo \
 #     "ERROR: expected exactly one Prometheus trigger, found ${PROMETHEUS_TRIGGER_COUNT}" \
 #     >&2
-#   printf '%s\n' "${MANAGED_SCALEDOBJECT_JSON}" >&2
+#   printf '%s\n' "${SCALEDOBJECT_JSON}" >&2
 #   exit 1
 # fi
 #
 # QUERY="$(
-#   printf '%s' "${MANAGED_SCALEDOBJECT_JSON}" |
+#   printf '%s' "${SCALEDOBJECT_JSON}" |
 #     jq -r \
 #       '[.spec.triggers[] |
 #         select(.type == "prometheus")][0].metadata.query // empty'
 # )"
-# EXPECTED_QUERY="wva_desired_replicas{variant_name=\"${LWS_NAME}\",exported_namespace=\"${NAMESPACE}\"}"
+# EXPECTED_QUERY="sum(vllm:num_requests_waiting{namespace=\"${NAMESPACE}\"})"
 #
 # if [ -z "${QUERY}" ]; then
 #   echo \
@@ -354,12 +366,19 @@
 #
 # if [ "${QUERY}" != "${EXPECTED_QUERY}" ]; then
 #   echo \
-#     "ERROR: installed Prometheus query does not match the exact WVA contract" \
+#     "ERROR: installed Prometheus query does not match the raw-signal contract" \
 #     >&2
 #   echo "expected: ${EXPECTED_QUERY}" >&2
 #   echo "actual:   ${QUERY}" >&2
 #   exit 1
 # fi
+# # G.8: this query contains no wva_desired_replicas reference.
+# case "${QUERY}" in
+#   *wva_desired_replicas*)
+#     echo "ERROR: installed query still references wva_desired_replicas" >&2
+#     exit 1
+#     ;;
+# esac
 #
 # GROUP_SIZE="$(kubectl -n "${NAMESPACE}" get \
 #   leaderworkersets.leaderworkerset.x-k8s.io "${LWS_NAME}" \
@@ -378,56 +397,41 @@
 # wait_for "Prometheus API readiness" 120 \
 #   check_prometheus_ready diagnose_prometheus_ready
 #
-# # Current WVA exposes no direct per-namespace tracked-set log or status.
-# # On this fresh cluster, use only the narrow conjunction needed for the
-# # subsequent ConfigMap update: the sole managed ScaledObject, a successful
-# # reconciliation from WVA's own metrics service whose success path calls
-# # NamespaceTrack, and the exact Processing model (V2) observation below.
-# # A baseline wva_desired_replicas series is not used as tracking proof.
-# wait_for \
-#   "successful WVA ScaledObject reconcile for the sole managed object" 180 \
-#   check_wva_scaledobject_reconcile diagnose_wva_scaledobject_reconcile
-# wait_for \
-#   "exact WVA Processing model (V2) observation for ${MODEL_ID}/${NAMESPACE}" \
-#   180 check_processing_model_v2 diagnose_processing_model_v2
-#
-# # KEDA remains paused while the whole-group 1 -> 2 -> 1 path is proven.
+# # One complete Ready LWS group before any load is applied.
 # EXPECTED_GROUPS=1
 # wait_for "initial one complete Ready LWS group" 900 \
 #   check_lws_ready_groups diagnose_lws_ready_groups
 #
-# kubectl -n "${NAMESPACE}" scale \
-#   leaderworkersets.leaderworkerset.x-k8s.io "${LWS_NAME}" --replicas=2
-# EXPECTED_GROUPS=2
-# wait_for "manual scale-up to two complete Ready LWS groups" 900 \
-#   check_lws_ready_groups diagnose_lws_ready_groups
+# # G.1: idle baseline, recorded before the stimulus starts.
+# wait_for "idle ${QUERY} <= ${IDLE_MAX_VALUE}" 60 \
+#   check_idle_metric_low diagnose_idle_metric_low
+# IDLE_VALUE="$(prom_query "${QUERY}" |
+#   jq -r '.data.result[0].value[1] // "0"')"
+# echo "OBSERVATION: idle ${QUERY} = ${IDLE_VALUE}"
 #
-# kubectl -n "${NAMESPACE}" scale \
-#   leaderworkersets.leaderworkerset.x-k8s.io "${LWS_NAME}" --replicas=1
-# EXPECTED_GROUPS=1
-# wait_for "manual scale-down to one complete Ready LWS group" 900 \
-#   check_lws_ready_groups diagnose_lws_ready_groups
+# # D4/G.2: bounded inference-perf stimulus, reusing the existing Wide-EP
+# # profile from the llm-d-benchmark sibling repo
+# # (workload/profiles/inference-perf/guide_wide-ep-lws_1.yaml.in). No new
+# # load generator is introduced. WVA #1525 Track A F1/F15: the actual T1/T2
+# # load shape and the tokenizer override come from the run-only
+# # `-e` experiment file, not from `-o` or a flat concurrency_level override.
+# llmdbenchmark --spec "${INFERENCE_PERF_SPEC}" run \
+#   -p "${NAMESPACE}" -l inference-perf -w "${INFERENCE_PERF_WORKLOAD}" \
+#   -e benchmark/experiments/wide-ep-lws-fresh-traffic.yaml \
+#   --wait-timeout 600 &
+# INFERENCE_PERF_PID="$!"
 #
-# # Re-annotate only after qualified tracking evidence, then wait for the
-# # exact namespace-local config-loaded log. The inner ConfigMap JSON has no
-# # spaces after its colons; the outer namespace field does.
-# RELOAD_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-# kubectl -n "${NAMESPACE}" annotate configmap \
-#   wva-saturation-scaling-config \
-#   "wva.llmd.ai/runtime-reload=${RELOAD_AT}" --overwrite
+# # G.2/G.3: the raw value must rise organically once load reaches the
+# # rendered direct ClusterIP Service (kube-proxy round-robin -- not EPP
+# # routing; DECISIONS.md D5).
+# wait_for "raw ${QUERY} rises to >= ${RISING_MIN_VALUE}" 300 \
+#   check_metric_rising diagnose_metric_rising
+# RISEN_VALUE="$(prom_query "${QUERY}" |
+#   jq -r '.data.result[0].value[1] // "no-data"')"
+# echo "OBSERVATION: risen ${QUERY} = ${RISEN_VALUE}"
 #
-# wait_for "WVA namespace-local saturation ConfigMap load" 180 \
-#   check_namespace_config_loaded diagnose_namespace_config_loaded
-#
-# # Exact equality excludes every scalar fallback, including vector(2).
-# wait_for "exact Prometheus wva_desired_replicas query value 2" 300 \
-#   check_exact_desired_two diagnose_exact_desired_two
-#
-# # Only now may KEDA be fully activated.
-# kubectl -n "${NAMESPACE}" annotate scaledobject.keda.sh \
-#   "${SCALEDOBJECT_NAME}" autoscaling.keda.sh/paused-
-#
-# wait_for "ScaledObject unpaused and Ready=True" 180 \
+# # G.4: KEDA/HPA must be consuming the live value.
+# wait_for "ScaledObject Ready=True" 180 \
 #   check_scaledobject_ready diagnose_scaledobject_ready
 # wait_for "KEDA-generated HPA creation" 180 \
 #   check_hpa_created diagnose_hpa_created
@@ -479,9 +483,18 @@
 # wait_for \
 #   "KEDA external metric ${EXTERNAL_METRIC_NAME} visibility" 180 \
 #   check_external_metric_visible diagnose_external_metric_visible
+#
+# # G.5: desiredReplicas must reach 2. Independently verify the arithmetic
+# # against the raw recorded value (ceil(observed_value / threshold) --
+# # IMPLEMENTATION_BRIEF.md G.5 guards against the AverageValue/threshold-
+# # unit mistake class caught in review on WVA PR #1517).
 # wait_for "generated HPA desiredReplicas=2" 300 \
 #   check_hpa_desired_two diagnose_hpa_desired_two
+# DESIRED_REPLICAS_VALUE="$(prom_query "${QUERY}" |
+#   jq -r '.data.result[0].value[1] // "no-data"')"
+# echo "OBSERVATION: raw ${QUERY} at desiredReplicas=2 was ${DESIRED_REPLICAS_VALUE}"
 #
+# # G.6: two complete Ready LWS groups.
 # EXPECTED_GROUPS=2
 # wait_for "KEDA/HPA scale-up to two complete Ready LWS groups" 900 \
 #   check_lws_ready_groups diagnose_lws_ready_groups
@@ -496,20 +509,39 @@
 #       exit 1
 #     }
 #
+# # G.7: post-scale signal observation only -- not a pass/fail gate
+# # (DECISIONS.md D8 does not require the signal to fall to any particular
+# # level). Allow at least one full scrape interval (15s) plus settle time
+# # before re-querying.
+# sleep "${POST_SCALE_SETTLE_SECONDS}"
+# POST_SCALE_VALUE="$(prom_query "${QUERY}" |
+#   jq -r '.data.result[0].value[1] // "no-data"')"
+# echo "OBSERVATION: post-scale (2 Ready groups) ${QUERY} = ${POST_SCALE_VALUE}"
+#
 # echo \
-#   "PASS: Option 2 reproducibility lifecycle completed without a scalar fallback"
+#   "PASS: live-signal lifecycle completed (idle=${IDLE_VALUE}, risen=${RISEN_VALUE}, at-desired-2=${DESIRED_REPLICAS_VALUE}, post-scale=${POST_SCALE_VALUE})"
 # ```
 
 scenario:
   - name: wide-ep-lws-scale-mechanics
 
+    # maxModelLen: the reused guide_wide-ep-lws_1.yaml inference-perf profile
+    # (D4) requests ~2000 input + 2000 output tokens per exchange. Per the
+    # sizing rule documented at
+    # test/e2e/fixtures/model_service_builder.go:250 ("must exceed prompt
+    # tokens + max_tokens"), max-model-len must exceed that combined length;
+    # 512 (this scenario's original value, sized for that other fixture's
+    # much shorter ~9+400 token burst-load requests) silently drops every
+    # inference-perf request instead of erroring cleanly -- reproduced
+    # directly against the simulator during implementation-time runtime
+    # validation. 4096 leaves headroom above the ~4000-token combined length.
     model:
       name: test-model
       shortName: test-model
       path: models/test-model
       huggingfaceId: test-model
       size: 1Gi
-      maxModelLen: 512
+      maxModelLen: 4096
       blockSize: 8
       gpuMemoryUtilization: 0
 
@@ -527,6 +559,23 @@ scenario:
         repository: ghcr.io/llm-d/llm-d-inference-sim
         tag: v0.9.0
         pullPolicy: IfNotPresent
+      # Bounded #1525 Track A test artifact (F13): the harness image key is
+      # distinct from images.vllm above, and 20_harness_pod.yaml.j2 defaults
+      # it to Always, forcing every fresh per-treatment harness Pod to
+      # re-check the registry. IfNotPresent alone is not sufficient
+      # reproducibility -- the operator must also pre-pull the exact image to
+      # every node and record the resolved digest before the run (F13); this
+      # scenario key only stops the redundant re-check once cached.
+      benchmark:
+        pullPolicy: IfNotPresent
+
+    # Bounded #1525 Track A test artifact (F6): disables only the generic
+    # duplicate PodMonitor (18_podmonitor.yaml.j2); the scenario-specific
+    # decode.monitoring.podmonitor below remains the single canonical scrape
+    # family. Not a production monitoring recommendation.
+    monitoring:
+      podmonitor:
+        enabled: false
 
     multinode:
       enabled: true
@@ -579,7 +628,15 @@ scenario:
           enabled: true
           portName: metrics
           path: /metrics
-          interval: 15s
+          # Bounded #1525 Track A measurement-validity artifact (F16), not a
+          # production monitoring recommendation: the 5s/4s pairing closes
+          # the Gate-2 scrape-timing race against the source-backed ~14.7s
+          # T2 first-completion time. scrapeTimeout must not exceed interval
+          # (13_ms-values.yaml.j2 passes both straight through); in-repo
+          # precedent: deploy/lib/keda-epp-guide-monitoring.values.yaml pairs
+          # scrapeInterval: 5s with scrapeTimeout: 4s.
+          interval: 5s
+          scrapeTimeout: 4s
           labels:
             release: kube-prometheus-stack
           relabelings:
@@ -595,14 +652,30 @@ scenario:
           - --inter-token-latency=100ms
           - --mode=random
           - --enable-kvcache
-          - --kv-cache-size=1
+          # --kv-cache-size: DECISIONS.md D3 said to keep this at "1"
+          # (the value validated against the short ~8-9 token burst-load
+          # fixture at test/e2e/fixtures/model_service_builder.go). Runtime
+          # validation during this implementation showed --kv-cache-size=1
+          # (1 total KV block, block-size=8) hard-fails every request whose
+          # prompt exceeds ~1 block -- reproduced directly against the
+          # simulator: a 5-token prompt succeeds, a 50-token prompt already
+          # gets "Server disconnected" on every attempt. The D4-mandated
+          # stimulus (the reused guide_wide-ep-lws_1.yaml inference-perf
+          # profile) requests ~2000-token prompts, so kv-cache-size=1 yields
+          # 0% request admission -- no queueing is observed at all, which
+          # defeats D3's own stated goal ("produce visible queueing under
+          # load"). 4096 blocks (32768 tokens of capacity) comfortably
+          # covers max-num-seqs=5 concurrent ~4096-token requests while
+          # remaining a small, bounded, CPU-test value; num_requests_waiting
+          # admission queueing is governed by --max-num-seqs=5 (unchanged),
+          # not by this value. Flagged as a deviation from D3's literal
+          # flag-freeze, not a redesign of the signal architecture.
+          - --kv-cache-size=4096
           - --block-size=8
           - --max-num-seqs
           - "5"
           - --max-model-len
-          - "512"
-          - --fake-metrics
-          - '{"kv-cache-usage":0.3,"running-requests":1,"waiting-requests":0}'
+          - "4096"
 
     prefill:
       enabled: false
@@ -611,42 +684,39 @@ scenario:
     standalone:
       enabled: false
 
-    extraObjects:
-      # Namespace-local V2 calibration copied from WVA's current saturation
-      # smoke path. It deterministically requests desired replicas = 2 from one
-      # Ready group without changing the cluster-global saturation policy.
-      - apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: wva-saturation-scaling-config
-          namespace: "${namespace.name}"
-          labels:
-            app.kubernetes.io/name: workload-variant-autoscaler
-        data:
-          default: |
-            analyzers:
-              - name: saturation
-                score: 1.0
-            scaleUpThreshold: 0.30
-            scaleDownBoundary: 0.20
-            kvCacheThreshold: 0.80
-            queueLengthThreshold: 50
-            kvSpareTrigger: 0.10
-            queueSpareTrigger: 5
-            enableLimiter: false
+    # The shared defaults size the inference-perf harness pod for a full
+    # multi-node cluster (cpu: 16, memory: 32Gi). This bounded CPU-only
+    # scenario is validated on small single-node Kind clusters (mirrors the
+    # existing decode.resources downsizing above); the harness client itself
+    # is network-bound, not compute-bound, so a much smaller request/limit
+    # is sufficient to drive the D4 inference-perf stimulus. This does not
+    # change inference-perf's load parameters (concurrency/profile), only
+    # the pod's resource envelope.
+    harness:
+      resources:
+        cpu: "2"
+        memory: 2Gi
+      # Bounded #1525 Track A test artifact (F12): authoritative bound is the
+      # --wait-timeout 600 CLI flag on the run invocation below;
+      # harness.waitTimeout mirrors it (cli.py resolution order:
+      # --wait-timeout > harness.waitTimeout > default 3600). The bound is
+      # per treatment, not per run. Honest only with the mandatory F13
+      # benchmark-image pre-pull (T1 uses ~330s of 600s).
+      waitTimeout: 600
 
-      # Target/scaler structure is intentionally derived from WVA PR #1517.
-      # It starts paused so manual LWS 1 -> 2 -> 1 group scaling can run first.
+    extraObjects:
+      # DECISIONS.md D1: WVA is not installed for this slice, so this
+      # ScaledObject carries no WVA-managed annotations and no WVA saturation
+      # ConfigMap (both removed). KEDA's Prometheus trigger below queries the
+      # simulator's own live, workload-driven `vllm:num_requests_waiting`
+      # series directly -- not a WVA-derived value -- so the ScaledObject is
+      # active (not paused) from standup: KEDA/HPA must react organically to
+      # load, per DECISIONS.md D1-D3.
       - apiVersion: keda.sh/v1alpha1
         kind: ScaledObject
         metadata:
           name: "${model.idLabel}-decode"
           namespace: "${namespace.name}"
-          annotations:
-            autoscaling.keda.sh/paused: "true"
-            llm-d.ai/managed: "true"
-            llm-d.ai/model-id: test-model
-            llm-d.ai/variant-cost: "30.0"
         spec:
           scaleTargetRef:
             apiVersion: leaderworkerset.x-k8s.io/v1
@@ -658,12 +728,26 @@ scenario:
           cooldownPeriod: 30
           triggers:
             - type: prometheus
-              name: wva-desired-replicas
+              name: vllm-num-requests-waiting
               metricType: AverageValue
               metadata:
                 serverAddress: "https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090"
-                query: 'wva_desired_replicas{variant_name="${model.idLabel}-decode",exported_namespace="${namespace.name}"}'
-                threshold: "1"
+                # Only the standard Prometheus-Operator pod-scrape label
+                # (`namespace`) is assumed to reach this series in the
+                # rendered output -- DECISIONS.md D10/F5 record that the
+                # pinned renderer drops the scenario's declared PodMonitor
+                # `labels`/`relabelings`, so no group-identifying label
+                # (e.g. `llm_d_ai_variant`) can be relied on here. `sum()`
+                # is the correct aggregation for waiting-request counts
+                # across the decode leader/worker pods in this namespace
+                # (disjoint per-pod queues; DECISIONS.md D10).
+                query: 'sum(vllm:num_requests_waiting{namespace="${namespace.name}"})'
+                # UNCALIBRATED TEST ARTIFACT (DECISIONS.md D9): "10" is
+                # chosen only to be crossable by this scenario's bounded
+                # inference-perf stimulus (concurrency 2048 against
+                # max-num-seqs=5 per decode pod). It is not a calibrated or
+                # recommended production Wide-EP threshold.
+                threshold: "10"
                 activationThreshold: "0"
                 unsafeSsl: "true"
 
@@ -691,5 +775,10 @@ scenario:
           mountPath: /dev/shm
 
     control:
-      waitTimeout: 900
+      # control.waitTimeout is inert for #1525 Track A: control.* is never
+      # read as a harness deadline (cli.py resolves only --wait-timeout and
+      # harness.waitTimeout above, per F12). Left commented out rather than
+      # removed, since some other consumer of this scenario key may still
+      # read control.* outside the harness deadline path.
+      # waitTimeout: 900
       waitPeriod: 5

--- a/benchmark/config/specification/wide-ep-lws-scale-mechanics.yaml.j2
+++ b/benchmark/config/specification/wide-ep-lws-scale-mechanics.yaml.j2
@@ -1,0 +1,14 @@
+# Bounded CPU-only LeaderWorkerSet scale-mechanics specification for WVA #1525.
+# Rendering and lifecycle are provided by the sibling llm-d-benchmark checkout.
+
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+values_file:
+  path: {{ base_dir }}/benchmark/config/templates/values/wide-ep-lws-scale-mechanics-values.yaml
+
+template_dir:
+  path: {{ base_dir }}/../llm-d-benchmark/config/templates/jinja
+
+scenario_file:
+  path: {{ base_dir }}/benchmark/config/scenarios/wide-ep-lws-scale-mechanics.yaml

--- a/benchmark/config/templates/values/wide-ep-lws-scale-mechanics-values.yaml
+++ b/benchmark/config/templates/values/wide-ep-lws-scale-mechanics-values.yaml
@@ -1,0 +1,1863 @@
+# Canonical llm-d-benchmark defaults snapshot from
+# d2bfff18f72156037fcc7903ec10563b06763885 (recorded for WVA #1525).
+# ============================================================================
+# Common Default Values for LLM-D Deployment
+# These can be completely overridden via scenarios file.
+# ============================================================================
+
+# ============================================================================
+# ANCHORS - Define reusable values here
+# ============================================================================
+_anchors:
+  # Model identifiers
+  model_name: &model_name facebook/opt-125m
+  model_short_name: &model_short_name facebook-opt-125m
+  model_path: &model_path models/facebook/opt-125m
+  model_cache_base: &model_cache_base /model-cache
+
+  # Common ports
+  vllm_port: &vllm_port 8200
+  vllm_service_port: &vllm_service_port 8000
+  ext_proc_port: &ext_proc_port 9002
+  zmq_port: &zmq_port 5557
+  rsync_port: &rsync_port 20873
+
+  # Common resource values
+  cpu_16: &cpu_16 "16"
+  cpu_4: &cpu_4 "4"
+  cpu_32: &cpu_32 "32"
+  memory_64gi: &memory_64gi 64Gi
+  memory_40gi: &memory_40gi 40Gi
+  memory_16gi: &memory_16gi 16Gi
+  memory_4gi: &memory_4gi 4Gi
+  memory_128gi: &memory_128gi 128Gi
+  memory_256gi: &memory_256gi 256Gi
+  shm_16gi: &shm_16gi 16Gi
+  shm_32gi: &shm_32gi 32Gi
+  shm_64gi: &shm_64gi 64Gi
+
+  # GPU configuration.
+  # `gpu_label_value: auto` opts into cluster-side discovery: the resolver
+  # (cluster_resource_resolver.py:_resolve_accelerator_type_labels) reads
+  # actual node labels and overrides BOTH labelKey and labelValue in the
+  # plan, so any GPU model works out of the box. Scenarios that need a
+  # specific SKU can still pin a literal value (e.g. NVIDIA-H100-80GB-HBM3).
+  gpu_label_key: &gpu_label_key nvidia.com/gpu.product
+  gpu_label_value: &gpu_label_value auto
+  gpu_memory_util: &gpu_memory_util 0.95
+
+  # Common vLLM settings
+  block_size: &block_size 64
+  max_model_len: &max_model_len 16384
+  worker_method: &worker_method spawn
+  logging_level: &logging_level INFO
+  container_home: &container_home /tmp
+  hf_home: &hf_home /tmp/huggingface
+
+  # vLLM KV Transfer config
+  kv_connector: &kv_connector NixlConnector
+  kv_role: &kv_role kv_both
+
+  # Common probe settings
+  probe_startup: &probe_startup
+    path: /health
+    failureThreshold: 60
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 5
+
+  probe_liveness: &probe_liveness
+    failureThreshold: 3
+    periodSeconds: 5
+
+  probe_readiness: &probe_readiness
+    path: /health
+    failureThreshold: 3
+    periodSeconds: 5
+
+  # Common parallelism
+  parallelism_single: &parallelism_single
+    data: 1
+    dataLocal: 1
+    tensor: 1
+    workers: 1
+
+  parallelism_4gpu: &parallelism_4gpu
+    data: 1
+    dataLocal: 1
+    tensor: 4
+    workers: 4
+
+  parallelism_8gpu: &parallelism_8gpu
+    data: 1
+    dataLocal: 1
+    tensor: 8
+    workers: 8
+
+  # Storage class: "auto"/"default" = use cluster default; set explicitly to override
+  storage_class: &storage_class auto
+
+  # Image pull policies
+  pull_always: &pull_always Always
+  pull_if_not_present: &pull_if_not_present IfNotPresent
+
+  # General versions
+  istio_version:                     &istio_version                     1.29.2
+  agentgateway_version:              &agentgateway_version              v1.3.1
+  lws_version:                       &lws_version                       0.9.0
+
+  # GAIE CRDs are still installed from the gateway-api-inference-extension
+  # release (`v1.5.0`). The router chart below replaces the legacy
+  # `inferencepool` / `standalone` charts from that release.
+  gaie_version:                      &gaie_version                      v1.5.0
+  # llm-d-router chart version (migrated off the GAIE-published
+  # `inferencepool` / `standalone` charts onto the llm-d-owned
+  # `llm-d-router-{gateway,standalone}-dev` charts in ghcr.io/llm-d/charts).
+  # Used for both the standalone and gateway router charts.
+  router_chart_version:              &router_chart_version              v0.9.0
+  vllm-openai_version:               &vllm-openai_version               v0.26.0
+  llm-d-router-endpoint-picker_version: &llm-d-router-endpoint-picker_version v0.9.0
+  llm-d-routing-sidecar_version:     &llm-d-routing-sidecar_version     v0.9.0
+  # Just use vllm-openai image for tokenizer
+  llm-d-uds-tokenizer_version:       &llm-d-uds-tokenizer_version       v0.26.0
+  llm-d-cuda_version:                &llm-d-cuda_version                v0.8.1
+  llm-d-inference-sim_version:       &llm-d-inference-sim_version       v0.10.2
+  llm-d-benchmark_version:           &llm-d-benchmark_version           v0.7.0
+
+  # Common labels
+  app_label: &app_label llm-d-benchmark-harness
+  inference_serving_label: &inference_serving_label "true"
+
+  # Preprocessing script (sourced from init container output)
+  preprocess_script: &preprocess_script /bin/true
+
+# ============================================================================
+# RESOURCE PRESETS - For different model sizes (as we get understanding...)
+#
+# Idea:
+#
+# These can be referenced in scenarios via resourcePreset: <name>
+#
+# I kind of have this implemented in the renderer. But I have not extensively
+# tested it.x
+#
+# ============================================================================
+resourcePresets:
+  small:
+    decode:
+      resources:
+        limits:
+          memory: *memory_40gi
+          cpu: *cpu_4
+        requests:
+          memory: *memory_40gi
+          cpu: *cpu_4
+      shm:
+        size: *shm_16gi
+      parallelism: *parallelism_single
+    prefill:
+      resources:
+        limits:
+          memory: *memory_40gi
+          cpu: *cpu_4
+        requests:
+          memory: *memory_40gi
+          cpu: *cpu_4
+      parallelism: *parallelism_single
+
+  medium:
+    decode:
+      resources:
+        limits:
+          memory: *memory_64gi
+          cpu: *cpu_16
+        requests:
+          memory: *memory_64gi
+          cpu: *cpu_16
+      shm:
+        size: *shm_16gi
+      parallelism: *parallelism_single
+    prefill:
+      resources:
+        limits:
+          memory: *memory_64gi
+          cpu: *cpu_16
+        requests:
+          memory: *memory_64gi
+          cpu: *cpu_16
+      parallelism: *parallelism_single
+
+  large:
+    decode:
+      resources:
+        limits:
+          memory: *memory_256gi
+          cpu: *cpu_32
+        requests:
+          memory: *memory_256gi
+          cpu: *cpu_32
+      shm:
+        size: *shm_64gi
+      parallelism: *parallelism_4gpu
+    prefill:
+      resources:
+        limits:
+          memory: *memory_256gi
+          cpu: *cpu_32
+        requests:
+          memory: *memory_256gi
+          cpu: *cpu_32
+      parallelism: *parallelism_4gpu
+
+  xlarge:
+    decode:
+      resources:
+        limits:
+          memory: *memory_256gi
+          cpu: *cpu_32
+        requests:
+          memory: *memory_256gi
+          cpu: *cpu_32
+      shm:
+        size: *shm_64gi
+      parallelism: *parallelism_8gpu
+    prefill:
+      resources:
+        limits:
+          memory: *memory_256gi
+          cpu: *cpu_32
+        requests:
+          memory: *memory_256gi
+          cpu: *cpu_32
+      parallelism: *parallelism_8gpu
+
+# ============================================================================
+# TOP-LEVEL / COMMON CONFIGURATION
+# ============================================================================
+
+# Common config block (passed through to helm chart)
+common: {}
+
+# For subchart usage
+modelservice:
+  enabled: true
+  # URI protocol for model artifacts: "pvc" (default) or "hf" (HuggingFace)
+  # When "hf", modelArtifacts.uri becomes hf://<model.huggingfaceId>
+  # When "pvc", modelArtifacts.uri becomes pvc://<storage.modelPvc.name>/<model.path>
+  uriProtocol: pvc
+
+# Override service account name (optional)
+serviceAccountOverride: ""
+
+# Global scheduler name (can be overridden per decode/prefill or standalone)
+schedulerName: default-scheduler
+
+# ============================================================================
+# NAMESPACE CONFIGURATION
+# ============================================================================
+namespace:
+  name: auto  # "auto" resolves to "llmdbench" at plan time; override via CLI --namespace
+  labels:
+    podSecurity:
+      audit: privileged
+      warn: privileged
+
+# ============================================================================
+# MODEL CONFIGURATION
+# ============================================================================
+model:
+  name: *model_name
+  shortName: *model_short_name
+  path: *model_path
+  huggingfaceId: *model_name
+  size: 1Ti
+  maxModelLen: *max_model_len
+  blockSize: *block_size
+  gpuMemoryUtilization: *gpu_memory_util
+  cacheBase: *model_cache_base
+
+# ============================================================================
+# MODEL ARTIFACTS CONFIGURATION
+# ============================================================================
+modelArtifacts:
+  # Mount path for model volume
+  mountPath: /model-cache
+  # Extra labels for model pods (in addition to llm-d.ai/inferenceServing and llm-d.ai/model)
+  extraLabels: {}
+
+# ============================================================================
+# STORAGE CONFIGURATION
+# ============================================================================
+storage:
+  # Max seconds to wait for model download job completion.
+  # Matches bash LLMDBENCH_VLLM_COMMON_PVC_DOWNLOAD_TIMEOUT default.
+  downloadTimeout: 2400
+
+  # Max retries for model download job before failing the step.
+  downloadMaxRetries: 2
+
+  workloadPvc:
+    name: workload-pvc
+    size: 20Gi
+    accessModes:
+      - ReadWriteMany
+    storageClassName: *storage_class
+
+  modelPvc:
+    name: model-pvc
+    size: 300Gi
+    accessModes:
+      - ReadWriteMany
+    storageClassName: *storage_class
+
+  # Extra PVC - only created when name is non-empty.
+  # Mirrors bash LLMDBENCH_VLLM_COMMON_EXTRA_PVC_NAME.
+  # The PVC is NOT automatically mounted; scenarios must also add matching
+  # entries to vllmCommon.volumes/volumeMounts to wire it into pods.
+  extraPvc:
+    name: ""          # Empty = skip creation (default)
+    size: 10Gi
+    accessModes:
+      - ReadWriteMany
+    volumeMode: Filesystem
+    storageClassName: *storage_class
+
+  # HostPath-backed model storage (opt-in).
+  # When enabled, a static PersistentVolume with hostPath is created and the
+  # model PVC binds to it via a matching storageClassName.  A DaemonSet
+  # downloads the model to the hostPath on every target node BEFORE the
+  # serving pods start; the regular download Job is skipped.
+  #
+  # Requirements:
+  #   - Nodes must have the hostPath directory writable.
+  #   - nodeSelector / tolerations should target the GPU nodes where
+  #     vLLM pods will schedule.
+  #   - The storageClassName does NOT need a real StorageClass object
+  #     on the cluster; static PV binding uses label matching.
+  hostPath:
+    enabled: false
+    path: /mnt/models
+    storageClassName: hostpath
+    capacity: 300Gi
+    nodeSelector: {}
+    tolerations: []
+    daemonSetTimeout: 3600
+    daemonSetName: download-model-ds
+
+# ============================================================================
+# HUGGINGFACE CONFIGURATION
+# ============================================================================
+huggingface:
+  # Auto-computed at render time based on whether a valid HF token is available.
+  # When true: the HF token secret is created, download job authenticates,
+  # and EPP/harness pods mount the secret.
+  # When false: no secret, no auth -- works for public (non-gated) models.
+  # Gated models without a token fail early at the model access check.
+  enabled: true
+  secretName: llm-d-hf-token
+  tokenKey: HF_TOKEN
+  token: ""  # Plain-text HF token; auto-detected from HF_TOKEN env var if empty
+  tokenBase64: ""  # Base64-encoded form; auto-computed when token is set from env
+
+# ============================================================================
+# IMAGE CONFIGURATION
+# ============================================================================
+#
+# Each entry has:
+#   repository:  registry path used at pod-spec render time (consumed by templates)
+#   tag:         image tag, "auto" resolves to the latest at plan time
+#   pullPolicy:  Kubernetes imagePullPolicy
+#   sourceRepo:  upstream source code repository URL (NOT consumed by templates --
+#                read by util/generate_sbom.py to build the SBOM. The registry path
+#                often differs from the source repo URL, so we record both.)
+#   sourcePath:  optional path within sourceRepo (e.g. a Dockerfile or subdir)
+#
+# Init containers (decode/prefill/standalone) can reference an entry from
+# this section via `imageKey: <entry>`, which expands to repo:tag (and
+# inherits pullPolicy when the block doesn't set its own).  See
+# `decode.initContainers` for usage.  Setting both `image` and `imageKey`
+# on the same entry is an error.
+#
+images:
+  benchmark:
+    repository: ghcr.io/llm-d/llm-d-benchmark
+    tag: *llm-d-benchmark_version
+    pullPolicy: *pull_always
+    sourceRepo: https://github.com/llm-d/llm-d-benchmark
+
+  vllm:
+#    repository: ghcr.io/llm-d/llm-d-cuda
+#    tag: *llm-d-cuda_version
+#    pullPolicy: *pull_if_not_present
+#    sourceRepo: https://github.com/llm-d/llm-d
+#    sourcePath: docker/Dockerfile.cuda
+    repository: docker.io/vllm/vllm-openai
+    tag: *vllm-openai_version
+    pullPolicy: *pull_always
+    sourceRepo: https://github.com/vllm-project/vllm
+
+  vllmOpenai:
+    repository: docker.io/vllm/vllm-openai
+    tag: *vllm-openai_version
+    pullPolicy: *pull_always
+    sourceRepo: https://github.com/vllm-project/vllm
+
+  # EPP (Endpoint Picker / Router) image -- llm-d-owned, sourced from the
+  # llm-d-router chart family.
+  routerEndpointPicker:
+    repository: ghcr.io/llm-d/llm-d-router-endpoint-picker
+    tag: *llm-d-router-endpoint-picker_version
+    pullPolicy: *pull_always
+    sourceRepo: https://github.com/llm-d/llm-d-router
+
+  routingSidecar:
+    repository: ghcr.io/llm-d/llm-d-router-disagg-sidecar
+    tag: *llm-d-routing-sidecar_version
+    pullPolicy: *pull_if_not_present
+    sourceRepo: https://github.com/llm-d/llm-d-router
+
+  udsTokenizer:
+    repository: docker.io/vllm/vllm-openai
+    tag: *llm-d-uds-tokenizer_version
+    pullPolicy: *pull_always
+    sourceRepo: https://github.com/vllm-project/vllm
+#    repository: ghcr.io/llm-d/llm-d-uds-tokenizer
+#    tag: *llm-d-uds-tokenizer_version
+#    pullPolicy: *pull_if_not_present
+#    sourceRepo: https://github.com/llm-d/llm-d-kv-cache
+#    sourcePath: services/uds_tokenizer
+
+  python:
+    repository: python
+    tag: "3.10"
+    sourceRepo: https://hub.docker.com/_/python
+
+# ============================================================================
+# HELM REPOSITORY CONFIGURATION
+# ============================================================================
+#
+# Each entry has:
+#   url:         chart repository URL used by `helm`/`helmfile` (consumed by templates)
+#   name:        optional chart name override when it differs from the key
+#   sourceRepo:  upstream source code URL (read by util/generate_sbom.py for SBOM,
+#                NOT consumed by templates)
+#
+helmRepositories:
+  istio:
+    url: https://istio-release.storage.googleapis.com/charts
+    sourceRepo: https://github.com/istio/istio
+  llmDModelservice:
+    url: https://llm-d-incubation.github.io/llm-d-modelservice/
+    sourceRepo: https://github.com/llm-d-incubation/llm-d-modelservice
+  llmDInfra:
+    url: https://llm-d-incubation.github.io/llm-d-infra/
+    sourceRepo: https://github.com/llm-d-incubation/llm-d-infra
+  agentgateway:
+    name: agentgateway
+    url: oci://cr.agentgateway.dev/charts/
+    sourceRepo: https://github.com/agentgateway/agentgateway
+  # The next entries hold metadata only -- the charts are pulled from
+  # OCI registries directly in the helmfile templates (no `url` needed for
+  # `helm repo add`). They live here so the SBOM can find the source repo.
+  #
+  # `llmDRouter` is the chart family that replaced the GAIE-published
+  # `inferencepool` and `standalone` charts. The benchmark always uses
+  # `llm-d-router-gateway-dev` (or `-standalone-dev` when
+  # gateway.className=epponly), so only the source repo metadata is held
+  # here. The chart URLs themselves are constructed in
+  # `config/templates/jinja/10_helmfile-main.yaml.j2`.
+  llmDRouter:
+    sourceRepo: https://github.com/llm-d/llm-d-router
+  # Retained for backwards-compat metadata (SBOM) but no longer used to
+  # construct chart URLs. The GAIE `inferencepool` / `standalone` charts
+  # were superseded by `llmDRouter` above.
+  inferencePool:
+    sourceRepo: https://github.com/kubernetes-sigs/gateway-api-inference-extension
+  gaie:
+    sourceRepo: https://github.com/kubernetes-sigs/gateway-api-inference-extension
+  lws:
+    sourceRepo: https://github.com/kubernetes-sigs/lws
+
+# ============================================================================
+# CHART VERSIONS
+# ============================================================================
+chartVersions:
+  istioBase: *istio_version
+  istiod: *istio_version
+  llmDInfra: auto
+  llmDModelservice: auto
+  # llm-d-router chart version (used by the standalone and gateway
+  # variants). Replaces the legacy `inferencePool` (GAIE chart) entry
+  # below for the EPP/router deploy.
+  llmDRouter: *router_chart_version
+  # Retained for backwards compatibility; no longer consumed by the helmfile
+  # template after the migration to `llmDRouter`. Kept so any scenario or
+  # downstream tooling still reading the legacy key continues to resolve.
+  inferencePool: *gaie_version
+  agentgateway: *agentgateway_version
+  lws: *lws_version
+
+# ============================================================================
+# SERVICE ACCOUNT CONFIGURATION
+# ============================================================================
+serviceAccount:
+  name: inference-perf-runner
+
+# ============================================================================
+# MONITORING CONFIGURATION
+# ============================================================================
+monitoring:
+  enabled: true
+  enableUserWorkload: true
+  podmonitor:
+    enabled: true
+  # Install PodMonitor/ServiceMonitor CRDs if they don't exist on the cluster.
+  # Set to true for clusters without Prometheus Operator (e.g., Kind, vanilla K8s).
+  # OpenShift clusters already have these CRDs via the monitoring stack.
+  installPrometheusCrds: false
+  prometheusCrdUrls:
+    - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+    - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+  metricsPath: /metrics
+  scrapeInterval: "30s"
+  metricsScrapeEnabled: false
+  # Embed downsampled per-timestamp series into the report's
+  # results.observability.components[].time_series, for interactive plotting.
+  # Only metrics in the _EMBED_TIME_SERIES allow-list (metrics_processor.py) qualify.
+  embedTimeSeries: true
+  timeSeriesMaxPoints: 256
+  # Prometheus time-series metrics retained for processing, visualization,
+  # and benchmark-report observability entries. Add new metrics here without
+  # changing the analysis code.
+  timeSeriesMetrics:
+    - vllm:kv_cache_usage_perc
+    - vllm:gpu_cache_usage_perc
+    - vllm:cpu_cache_usage_perc
+    - vllm:gpu_memory_usage_bytes
+    - vllm:cpu_memory_usage_bytes
+    - container_memory_usage_bytes
+    - DCGM_FI_DEV_GPU_UTIL
+    - DCGM_FI_DEV_POWER_USAGE
+    - vllm:num_requests_running
+    - vllm:num_requests_waiting
+    - vllm:prefix_cache_hits_total
+    - vllm:prefix_cache_queries_total
+    - vllm:external_prefix_cache_hits_total
+    - vllm:external_prefix_cache_queries_total
+    - vllm:prefix_cache_hit_rate
+    - vllm:external_prefix_cache_hit_rate
+    - vllm:nixl_xfer_time_seconds_sum
+    - vllm:nixl_xfer_time_seconds_count
+    - vllm:nixl_bytes_transferred_sum
+    - vllm:nixl_bytes_transferred_count
+    - vllm:num_preemptions_total
+    - vllm:prompt_tokens_total
+    - vllm:generation_tokens_total
+    - inference_pool_average_kv_cache_utilization
+    - inference_pool_average_queue_size
+    - inference_pool_average_running_requests
+    - inference_pool_ready_pods
+    - llm_d_epp_flow_control_pool_saturation
+    - llm_d_epp_flow_control_queue_size
+    - llm_d_epp_request_running
+
+# ============================================================================
+# ACCELERATOR CONFIGURATION
+# Supports: nvidia, intel-xpu, intel-i915, intel-xe, intel-gaudi, amd, google
+# ============================================================================
+accelerator:
+  type: nvidia
+  # Resource name for the accelerator used in limits/requests
+  # Override for non-NVIDIA GPUs (e.g. habana.ai/gaudi, amd.com/gpu)
+  resource: "nvidia.com/gpu"
+  # Runtime command fragments consumed by accelerator-neutral guide commands.
+  # Hardware profiles use these to avoid duplicating guides; a profile may
+  # additionally provide a fitting model, resource sizing, and storage defaults.
+  runtimePreamble: |
+    export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
+    export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
+  dtypeArgs: "--dtype bfloat16"
+  executionArgs: ""
+  blockSizeArgs: "--block-size $VLLM_BLOCK_SIZE"
+  memoryUtilizationArgs: "--gpu-memory-utilization $VLLM_ACCELERATOR_MEM_UTIL"
+  kvBufferDeviceJson: ""
+  # Resource names for different accelerator types (optional override)
+  # DRA drivers are tracked separately as accelerator.draDriver and are not
+  # rendered into container resource limits or requests.
+  # resources:
+  #   nvidia: "nvidia.com/gpu"
+  #   intel-i915: "gpu.intel.com/i915"
+  #   intel-xe: "gpu.intel.com/xe"
+  #   intel-gaudi: "habana.ai/gaudi"
+  #   amd: "amd.com/gpu"
+  #   google: "google.com/tpu"
+  # Environment variables specific to accelerator types (optional)
+  # env:
+  #   intel-i915:
+  #     - name: VLLM_USE_V1
+  #       value: "1"
+
+# ============================================================================
+# DYNAMIC RESOURCE ALLOCATION (DRA) - Optional
+# ============================================================================
+dra:
+  enabled: false
+  type: nvidia
+  # Keyed by accelerator type -- the chart looks the entry up by
+  # accelerator.type and builds one ResourceClaimTemplate per role.
+  # Omit `count` to let each role derive it from its own parallelism.
+  # claimTemplates:
+  #   nvidia:
+  #     name: nvidia-claim-template
+  #     class: gpu.nvidia.com
+  #     match: "exactly"
+  #     count: 1
+  #     selectors: []
+
+# ============================================================================
+# AFFINITY CONFIGURATION
+# ============================================================================
+affinity:
+  enabled: false
+  # Node selector labels (used for nodeAffinity)
+  nodeSelector: {}
+  # Example:
+  # nodeSelector:
+  #   nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+  #   topology.kubernetes.io/zone: us-east-1a
+
+  # Pod affinity rules (optional)
+  podAffinity: {}
+
+  # Pod anti-affinity rules (optional)
+  podAntiAffinity: {}
+
+# ============================================================================
+# ANNOTATIONS CONFIGURATION
+# ============================================================================
+annotations:
+  # Common annotations applied to all pods
+  common: {}
+
+  decode:
+    # Pod-level annotations
+    pod: {}
+    # Container-level annotations (if supported)
+    container: {}
+
+  prefill:
+    pod: {}
+    container: {}
+
+# ============================================================================
+# MODELSERVICE-ONLY SECTIONS: gateway / router / routing / httpRoute
+#
+# These sections (gateway, router, routing below, plus httpRoute further
+# down) are consumed ONLY on the modelservice deploy path -- standalone,
+# kustomize and fma do not read them. Scenarios MAY nest them under
+# `modelservice:` to make that scope explicit, e.g.:
+#
+#   modelservice:
+#     enabled: true
+#     gateway:
+#       className: epponly
+#     router:
+#       epp: { replicas: 2 }
+#     httpRoute:
+#       requestTimeout: "300s"
+#
+# The renderer hoists any such nested block back to the top level before the
+# resolver chain runs (RenderPlans._hoist_modelservice_sections). Templates,
+# resolvers and standup steps always read the TOP-LEVEL keys -- which is why
+# these defaults live at the top level. The flat top-level spelling in a
+# scenario is equally valid; pick one spelling per section.
+#
+# IMPORTANT: DoE experiment treatments and CLI overrides target the
+# TOP-LEVEL dotted path (e.g. `router.epp.pluginsConfigFile`,
+# `--gateway-class`), not the nested path. Precedence is
+# defaults < scenario < treatment/CLI.
+# ============================================================================
+
+# ============================================================================
+# GATEWAY CONFIGURATION
+# ============================================================================
+gateway:
+  name: infra-llmdbench-inference-gateway
+  namespace: auto  # Synced with namespace.name; resolved at plan time
+  # Gateway implementation. Supported values:
+  #   istio                      - default; istio-base + istiod control plane
+  #   agentgateway               - agentgateway-crds + agentgateway controller
+  #   gke                        - GKE-managed Gateway
+  #   data-science-gateway-class - OpenDataHub / OpenShift AI managed Gateway
+  #   epponly                    - llm-d "standalone" router topology: no
+  #                                Kubernetes Gateway is deployed, the EPP
+  #                                runs with an Envoy sidecar that serves
+  #                                HTTP directly (single-stack only).
+  #   none                       - plain ClusterIP Service to decode vLLM;
+  #                                no Gateway, EPP, Envoy, or routing proxy.
+  className: epponly
+  providerNamespace: istio-system
+  # Gateway version is derived from chartVersions.istiod at plan time
+  logLevel: error
+  # Optional: override the Gateway's HTTP listener port. When unset (default)
+  # the chart's built-in listener is used. Not supported for
+  # className: data-science-gateway-class (that class pins port 443 HTTPS+TLS).
+  # listenerPort: 80
+  service:
+    type: NodePort
+  resources:
+    limits:
+      cpu: *cpu_16
+      memory: *memory_16gi
+    requests:
+      cpu: *cpu_4
+      memory: *memory_4gi
+
+# ============================================================================
+# ROUTER CONFIGURATION
+#
+# Scenario-level keys for the llm-d-router chart. Mirrors the chart's
+# top-level `router:` shape; the 12_router-values.yaml.j2 template passes
+# this through largely unchanged, with a few benchmark-specific niceties
+# (HF token env injection, zmq port expansion into the extraContainerPorts
+# / extraServicePorts arrays, EPP image resolution from
+# `images.routerEndpointPicker`, and tokenizer.modelName fallback to
+# model.name).
+# ============================================================================
+router:
+  epp:
+    replicas: 1
+    extProcPort: *ext_proc_port
+    # Used to populate router.epp.extraContainerPorts and
+    # router.extraServicePorts with the zmq port (the EPP needs the
+    # container port for the kv-events publisher, and the service port
+    # so other pods can reach the publisher).
+    zmqPort: *zmq_port
+    pluginsConfigFile: "default-plugins.yaml"
+    # Custom plugin content to embed in router-values.yaml.
+    # Keys are filenames, values are the YAML content as literal strings.
+    # The chart expects apiVersion `llm-d.ai/v1alpha1` for the
+    # EndpointPickerConfig (the legacy `inference.networking.x-k8s.io/v1alpha1`
+    # is also accepted but deprecated).
+    # Example:
+    #   pluginsCustomConfig:
+    #     my-plugins.yaml: |
+    #       apiVersion: llm-d.ai/v1alpha1
+    #       kind: EndpointPickerConfig
+    #       ...
+    pluginsCustomConfig: {}
+    verbosity: "1"
+    # Resources are intentionally NOT set here.
+    # CI runners override this in their scenario YAML -- see
+    # config/scenarios/cicd/kind.yaml for an example.
+    # Extra volumes / mounts on the EPP container (e.g. shared dirs).
+    volumes: []
+    volumeMounts: []
+  # UDS tokenizer is a first-class chart feature. Flip
+  # `router.tokenizer.enabled: true` and the chart wires up the
+  # tokenizer container, sockets, and volumes itself. When `enabled`
+  # is true and `modelName` is unset, the template falls back to
+  # `model.name`.
+  tokenizer:
+    enabled: false
+  inferencePool:
+    failureMode: "FailOpen"
+    # Provider-specific config rendered to the values root as
+    # `provider.{gatewayClassName}.{...}` for gke/istio (epponly and
+    # agentgateway don't consume this).
+    # Example (istio):
+    #   providerConfig:
+    #     destinationRule:
+    #       trafficPolicy:
+    #         connectionPool:
+    #           http:
+    #             h2UpgradePolicy: DO_NOT_UPGRADE
+    providerConfig: {}
+  monitoring:
+    # Service-account token secret name for the Prometheus scraper.
+    # Multi-stack scenarios sharing one namespace get a per-stack
+    # rewrite of this name in render_plans to avoid Helm ownership
+    # collisions.
+    secretName: inference-gateway-sa-metrics-reader-secret
+    interval: "10s"
+    prometheus:
+      enabled: true
+      auth:
+        enabled: true
+
+# ============================================================================
+# ROUTING / PROXY CONFIGURATION
+# ============================================================================
+routing:
+  # Service port (matches routing.servicePort in helm chart)
+  servicePort: *vllm_service_port
+  connector: nixlv2
+  debugLevel: 3
+  secure: false
+
+  # Proxy configuration
+  # Image is sourced from `images.routingSidecar`; override that entry per
+  # scenario to change the version.
+  proxy:
+    enabled: true
+    imagePullPolicy: *pull_always
+    targetPort: *vllm_port
+    # TLS configuration (optional)
+    # prefillerUseTLS: false
+    # certPath: "/certs"
+    # Zap logging configuration
+    zapEncoder: json
+    zapLogLevel: debug
+    # zapDevel: false
+    # zapStacktraceLevel: error
+    # zapTimeEncoding: epoch
+
+# ============================================================================
+# HTTPROUTE CONFIGURATION
+#
+# Gateway-API HTTPRoute settings consumed by 08_httproute.yaml.j2. Applies to
+# every rule the template emits (both per-stack and shared modes).
+#
+#   requestTimeout        End-to-end request timeout the gateway enforces.
+#                         Requests exceeding it are aborted with a 502 (which
+#                         surfaces as a "connection reset by peer" on the
+#                         decode routing-proxy loopback hop). Set "0s" to
+#                         disable -- appropriate for long agentic turns.
+#   backendRequestTimeout Per-retry backend timeout; "0s" disables.
+#
+# Shared-mode-only knobs (mode/name/pathPrefix/rewriteTo) are documented in
+# the template header and read with their own defaults.
+# ============================================================================
+httpRoute:
+  requestTimeout: "300s"
+  backendRequestTimeout: "0s"
+
+# ============================================================================
+# VLLM COMMON CONFIGURATION
+# ============================================================================
+vllmCommon:
+  # Inference port used by all vLLM pods (decode, prefill, standalone).
+  # Steps reference this as the canonical port for smoketests, routes, etc.
+  # Matches bash LLMDBENCH_VLLM_COMMON_INFERENCE_PORT.
+  inferencePort: *vllm_service_port
+  host: "0.0.0.0"
+  preprocessScript: *preprocess_script
+  kvTransfer:
+    enabled: false
+    connector: *kv_connector
+    role: *kv_role
+    # Extra config passed as kv_connector_extra_config in --kv-transfer-config JSON.
+    # Used by connectors like OffloadingConnector (e.g. {num_cpu_blocks: 5000}).
+    # extraConfig:
+    #   num_cpu_blocks: 5000
+    #   cpu_bytes_to_use: 1000000000
+  # KV Events Configuration (for precise prefix cache aware routing)
+  # When enabled, adds --kv-events-config to vllm serve command
+  # Generates endpoint: tcp://<serviceName>.<namespace>.svc.cluster.local:<port>
+  # Generates topic: <topicPrefix>@$(POD_IP):$(VLLM_INFERENCE_PORT)@<model.name>
+  kvEvents:
+    enabled: false  # Set to true in scenario to enable
+    publisher: zmq
+    port: 5557
+    topicPrefix: kv
+    # serviceName: null  # Defaults to model.shortName if not specified
+  # PriorityClassName for pod scheduling priority (optional)
+  # Set to a valid PriorityClass name on the cluster, or leave empty/"none" to skip.
+  # Applied to standalone, decode, and prefill pods unless overridden per-section.
+  priorityClassName: ""
+
+  # Image pull secret name for private registries (optional)
+  # When set, adds imagePullSecrets to all pod specs.
+  pullSecret: ""
+
+  # Container HOME and HF_HOME directories.
+  # Default to /tmp which works for the standard llm-d-cuda image (runs as root).
+  # Override to /dev/shm for custom images on OpenShift where /tmp is not writable
+  # by the non-root UID assigned by restricted-v2 SCC.
+  containerHome: *container_home
+  hfHome: *hf_home
+
+  # Ephemeral storage resource for pod limits/requests (optional)
+  # Only added to pod specs when ephemeralStorage value is non-empty.
+  ephemeralStorageResource: "ephemeral-storage"
+  ephemeralStorage: ""
+
+  # Shell used to exec the vLLM startup command in every vLLM container
+  # (decode, prefill, standalone, launcher). Renders into the `command:` field
+  # of 13_ms-values.yaml.j2 and 14_standalone-deployment_yaml.j2. Override
+  # per-scenario to e.g. /bin/sh if the image lacks bash.
+  shell: "/bin/bash"
+
+  # NIXL side channel port for ZMQ-based KV transfer communication.
+  nixlSideChannelPort: "5557"
+
+  # UCX transport layer configuration for NCCL inter-node communication.
+  ucxTls: "sm,cuda_ipc,cuda_copy,tcp"
+
+  # UCX socket address transport priority.
+  ucxSockaddrTlsPriority: "tcp"
+
+  # Network resource (RDMA/InfiniBand) for pod limits/requests (optional)
+  # Only added to pod specs when both networkResource and networkNr are non-empty.
+  # Equivalent to bash LLMDBENCH_VLLM_COMMON_NETWORK_RESOURCE / _NR.
+  networkResource: ""
+  networkNr: ""
+
+  flags:
+    enforceEager: true
+    disableLogRequests: true
+    disableUvicornAccessLog: true
+    allowLongMaxModelLen: "1"
+    serverDevMode: "1"
+    # chatTemplate: null
+    # chatTemplateContentFormat: null # Format for inline chat template: string, leave null for file
+    # Additional vLLM flags (optional)
+    # enableChunkedPrefill: false
+    # maxNumBatchedTokens: null
+
+  # Volume configurations -- no defaults.
+  # Each scenario defines its own volumes and volumeMounts explicitly.
+  # Common volumes like dshm (shared memory) and shared-config (preprocess output)
+  # should be defined in the scenario YAML, not inherited from defaults.
+  # This matches the bash implementation where EXTRA_VOLUMES defaults to [].
+  volumes: []
+  volumeMounts: []
+
+# ============================================================================
+# DECODE CONFIGURATION
+# ============================================================================
+decode:
+  enabled: true
+  replicas: 1
+
+  # Autoscaling (optional)
+  autoscaling:
+    enabled: false
+    # minReplicas: 1
+    # maxReplicas: 10
+
+  # Node selector (optional - for direct nodeSelector, not affinity)
+  nodeSelector: {}
+
+  # Scheduler name override global schedulerName (optional)
+  # schedulerName: default-scheduler
+
+  # PriorityClassName override (optional - inherits from vllmCommon if not set)
+  # priorityClassName: ""
+
+  # Ephemeral storage override (optional - inherits from vllmCommon if not set)
+  # ephemeralStorage: ""
+
+  # Network resource override (optional - inherits from vllmCommon if not set)
+  # networkResource: ""
+  # networkNr: ""
+
+  # Accelerator type selection
+  acceleratorType:
+    labelKey: *gpu_label_key
+    labelValue: *gpu_label_value
+    # Use labelValues for multiple values (takes precedence over labelValue)
+    # labelValues:
+    #   - NVIDIA-H100-80GB-HBM3
+    #   - NVIDIA-A100-SXM4-80GB
+
+  # Parallelism configuration
+  parallelism: *parallelism_single
+
+  # Resource configuration
+  resources:
+    limits:
+      memory: *memory_40gi
+      cpu: *cpu_4
+      # GPU resource (optional - uncomment to explicitly request GPUs)
+      # nvidia.com/gpu: "1"
+      # DRA claims (optional)
+      # claims: {}
+    requests:
+      memory: *memory_40gi
+      cpu: *cpu_4
+      # nvidia.com/gpu: "1"
+
+  # Shared memory
+  shm:
+    size: *shm_16gi
+
+  # Probe configuration
+  probes:
+    startup: *probe_startup
+    liveness:
+      <<: *probe_liveness
+      failureThreshold: 10
+      timeoutSeconds: 15
+    readiness:
+      <<: *probe_readiness
+      failureThreshold: 10
+      timeoutSeconds: 15
+
+  # vLLM configuration
+  vllm:
+    port: *vllm_port
+    servicePort: *vllm_service_port
+    workerMultiprocMethod: *worker_method
+    loggingLevel: *logging_level
+    imagePullPolicy: *pull_if_not_present
+    customCommand: null
+    customPreprocessCommand: null
+    # Use these if wanted to use default command but add additional
+    # flags
+    additionalFlags: []
+      # - "--no-enable-log-requests"
+      # - "--max-model-len 16000"
+      # - "--tensor-parallel-size 1"
+
+  # Mount model volume
+  mountModelVolume: true
+
+  # Additional volume mounts
+  additionalVolumeMounts: []
+
+  # Additional volumes
+  additionalVolumes: []
+
+  # Extra environment variables
+  extraEnvVars: []
+  # Example:
+  # extraEnvVars:
+  #   - name: CUDA_VISIBLE_DEVICES
+  #     value: "0,1,2,3"
+  #   - name: NCCL_DEBUG
+  #     value: "INFO"
+  #   - name: MY_SECRET
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: my-secret
+  #         key: password
+
+  # Extra ports (optional)
+  # ports:
+  #   - containerPort: 8200
+  #     name: metrics
+  #     protocol: TCP
+
+  # Extra container config
+  extraContainerConfig: {}
+  # Example:
+  # extraContainerConfig:
+  #   securityContext:
+  #     privileged: true
+  #     capabilities:
+  #       add:
+  #         - IPC_LOCK
+
+  # Extra pod config
+  extraPodConfig: {}
+
+  # Init containers (optional, configured per scenario).
+  # Each entry sets `image` directly or `imageKey` (an entry name from
+  # `images.*`); if neither is set, image defaults to `images.benchmark`.
+  initContainers: []
+
+  # LWS / Multinode options (optional)
+  # hostIPC: false
+  # hostPID: false
+  # enableServiceLinks: true
+  # terminationGracePeriodSeconds: 30
+  # subGroupPolicy:
+  #   subGroupSize: 8
+  # subGroupExclusiveTopology: false
+
+  # Monitoring / PodMonitor (optional)
+  monitoring:
+    podmonitor:
+      enabled: false
+      portName: "metrics"
+      path: "/metrics"
+      interval: "30s"
+      # scrapeTimeout: "10s"
+      labels: {}
+      annotations: {}
+      relabelings: []
+      metricRelabelings: []
+
+# ============================================================================
+# PREFILL CONFIGURATION
+# ============================================================================
+prefill:
+  enabled: false
+  replicas: 0
+
+  # Autoscaling (optional)
+  autoscaling:
+    enabled: false
+    # minReplicas: 1
+    # maxReplicas: 10
+
+  # Node selector (optional)
+  nodeSelector: {}
+
+  # Scheduler name override global schedulerName (optional)
+  # schedulerName: default-scheduler
+
+  # PriorityClassName override (optional - inherits from vllmCommon if not set)
+  # priorityClassName: ""
+
+  # Ephemeral storage override (optional - inherits from vllmCommon if not set)
+  # ephemeralStorage: ""
+
+  # Network resource override (optional - inherits from vllmCommon if not set)
+  # networkResource: ""
+  # networkNr: ""
+
+  # Accelerator type selection
+  acceleratorType:
+    labelKey: *gpu_label_key
+    labelValue: *gpu_label_value
+
+  # Parallelism configuration
+  parallelism: *parallelism_single
+
+  # Resource configuration
+  resources:
+    limits:
+      memory: *memory_40gi
+      cpu: *cpu_4
+    requests:
+      memory: *memory_40gi
+      cpu: *cpu_4
+
+  # Probe configuration
+  probes:
+    startup: *probe_startup
+    liveness: *probe_liveness
+    readiness: *probe_readiness
+
+  # vLLM configuration
+  vllm:
+    port: *vllm_port
+    servicePort: *vllm_service_port
+    workerMultiprocMethod: *worker_method
+    loggingLevel: *logging_level
+    imagePullPolicy: *pull_if_not_present
+    # Use these if wanted to use default command but add additional
+    # flags
+    additionalFlags: []
+      # - "--no-enable-log-requests"
+      # - "--max-model-len 16000"
+      # - "--tensor-parallel-size 1"
+    customCommand: null
+    customPreprocessCommand: null
+
+  # Mount model volume
+  mountModelVolume: true
+
+  # Additional volume mounts
+  additionalVolumeMounts: []
+
+  # Additional volumes
+  additionalVolumes: []
+
+  # Extra environment variables
+  extraEnvVars: []
+
+  # Extra container config
+  extraContainerConfig: {}
+
+  # Extra pod config
+  extraPodConfig: {}
+
+  # Init containers (optional). See `decode.initContainers`.
+  initContainers: []
+
+
+  # Monitoring / PodMonitor (optional)
+  monitoring:
+    podmonitor:
+      enabled: false
+      portName: "metrics"
+      path: "/metrics"
+      interval: "30s"
+      labels: {}
+      annotations: {}
+      relabelings: []
+      metricRelabelings: []
+
+# ============================================================================
+# STANDALONE DEPLOYMENT CONFIGURATION
+# For simple single-model vLLM deployments without llm-d routing infrastructure
+# ============================================================================
+standalone:
+  enabled: false
+  replicas: 1
+  role: both  # Options: prefill, decode, both
+
+  # Deployment naming
+  deployment:
+    name: null  # Auto-generated if null: vllm-standalone-<model.shortName>
+
+  # Service configuration
+  service:
+    name: null  # Uses deployment name if null
+    port: 80
+    type: ClusterIP
+    # nodePort: 30080  # Only used when type: NodePort
+    # loadBalancerIP: ""  # Only used when type: LoadBalancer
+    # loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Cluster
+    # sessionAffinity: None
+    annotations: {}
+    additionalPorts: []
+    # Example:
+    # additionalPorts:
+    #   - name: metrics
+    #     port: 9090
+    #     targetPort: 9090
+
+  # Labels applied to deployment and service
+  labels:
+    stood-up-by: "auto" # Should be automatically configured to user
+    stood-up-from: llm-d-benchmark
+    stood-up-via: "standalone"
+
+  # Extra labels for pod template
+  extraPodLabels: {}
+
+  # Pod annotations
+  podAnnotations: {}
+
+  # Scheduler name override global schedulerName (optional)
+  schedulerName: default-scheduler
+
+  # PriorityClassName override (optional - inherits from vllmCommon if not set)
+  # priorityClassName: ""
+
+  # Ephemeral storage override (optional - inherits from vllmCommon if not set)
+  # ephemeralStorage: ""
+
+  # Network resource override (optional - inherits from vllmCommon if not set)
+  # networkResource: ""
+  # networkNr: ""
+
+  # Node selector (optional)
+  nodeSelector: {}
+
+  # Accelerator type selection (inherits from decode if not specified).
+  # `labelValue: auto` triggers cluster-side discovery; see the
+  # `gpu_label_value` anchor at the top of this file.
+  acceleratorType:
+    labelKey: nvidia.com/gpu.product
+    labelValue: auto
+    # labelValues:  # Use for multiple GPU types
+    #   - NVIDIA-H100-80GB-HBM3
+    #   - NVIDIA-A100-SXM4-80GB
+
+  # Image configuration (inherits from images.vllm if not specified)
+  image:
+    repository: docker.io/vllm/vllm-openai
+    tag: *vllm-openai_version
+    pullPolicy: Always
+
+  # Parallelism configuration
+  parallelism:
+    tensor: 1
+
+  # Resource configuration (inherits from decode if not specified)
+  resources:
+    limits:
+      memory: 40Gi
+      cpu: "4"
+    requests:
+      memory: 40Gi
+      cpu: "4"
+
+  # Probe configuration
+  probes:
+    startup:
+      failureThreshold: 60
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+    liveness:
+      failureThreshold: 3
+      periodSeconds: 5
+    readiness:
+      failureThreshold: 3
+      periodSeconds: 5
+
+  # vLLM configuration
+  vllm:
+    port: 8000
+    loadFormat: auto
+    modelLoaderExtraConfig: "{}"
+    workerMultiprocMethod: spawn
+    loggingLevel: INFO
+    enablePrefixCaching: false
+    preprocessCommand: /bin/true
+    customPreprocessCommand: null
+    customCommand: null
+    # How the container is launched. Mirrors decode/prefill `vllm.modelCommand`
+    # on the modelservice path.
+    #   custom       -- render `command: [<vllmCommon.shell>, -c]` plus the
+    #                   generated (or customCommand) shell script. Requires a
+    #                   shell in the server image.
+    #   imageDefault -- emit no `command:`; the image entrypoint runs and
+    #                   `args` below is passed verbatim. Required for
+    #                   distroless images, which have no shell to exec --
+    #                   e.g. llm-d-inference-sim v0.9+ ships only
+    #                   /app/llm-d-inference-sim (v0.8.2 still had bash).
+    modelCommand: custom
+    # Argument list for `modelCommand: imageDefault`. Ignored when
+    # modelCommand is `custom`. Supports ${dotted.path} substitution.
+    # Rendered as `args:`, so the image ENTRYPOINT supplies argv[0] (both
+    # server images have one: vllm-openai is `vllm serve`, inference-sim is
+    # /app/llm-d-inference-sim). For a CMD-only image with no ENTRYPOINT,
+    # make the binary the first element -- `args` replaces CMD outright.
+    args: []
+    # Example:
+    # args:
+    #   - "--model"
+    #   - "/model-cache/${model.path}"
+    #   - "--port"
+    #   - "8000"
+    #   - "--served-model-name"
+    #   - "${model.name}"
+    # Use these if wanted to use default command but add additional
+    # flags
+    additionalFlags: []
+    # Example:
+    # additionalFlags:
+    #   - "--enable-chunked-prefill"
+    #   - "--max-num-batched-tokens 8192"
+
+  # Model volume configuration
+  # NOTE: The model PVC is standalone-specific (not in vllmCommon.volumes)
+  # because modelservice handles its own model volume via the Helm chart.
+  mountModelVolume: true
+  modelMountPath: /model-cache
+  modelPvcName: model-pvc
+
+  # Launcher container (optional second container in the same pod)
+  # Mirrors bash LLMDBENCH_VLLM_STANDALONE_LAUNCHER feature.
+  # Shares the same pod volumes, env vars, and resources as the main container.
+  launcher:
+    enabled: false
+    port: 8001
+    vllmPort: 8002
+    imagePullPolicy: Always
+    # Image defaults to standalone.image if not specified
+    image:
+      repository: null  # null = inherit from standalone.image
+      tag: null          # null = inherit from standalone.image
+    customPreprocessCommand: null
+    # Custom args for the launcher. null = use default uvicorn command.
+    args: null
+    # Example custom args:
+    # args: |
+    #   uvicorn launcher:app --host 0.0.0.0 --log-level info --port 8001
+
+  # Additional volume mounts
+  additionalVolumeMounts: []
+  # Example:
+  # additionalVolumeMounts:
+  #   - name: custom-config
+  #     mountPath: /config
+  #     readOnly: true
+
+  # Additional volumes
+  additionalVolumes: []
+  # Example:
+  # additionalVolumes:
+  #   - name: custom-config
+  #     type: configMap
+  #     configMap:
+  #       name: my-config
+
+  # Extra environment variables
+  extraEnvVars: []
+  # Example:
+  # extraEnvVars:
+  #   - name: CUDA_VISIBLE_DEVICES
+  #     value: "0"
+  #   - name: MY_SECRET
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: my-secret
+  #         key: password
+
+  # Init containers (optional)
+  initContainers: []
+  # Example:
+  # initContainers:
+  #   - name: download-model
+  #     image: python:3.10
+  #     command: ["python", "-c", "print('downloading...')"]
+
+  # Extra container config (merged into container spec)
+  extraContainerConfig: {}
+  # Example:
+  # extraContainerConfig:
+  #   securityContext:
+  #     privileged: true
+
+  # Extra pod config (merged into pod spec)
+  extraPodConfig: {}
+
+# ============================================================================
+# NO-KUBERNETES (nok8s) DEPLOYMENT CONFIGURATION
+# Runs the llm-d routing stack (vLLM + EPP + Envoy) as plain docker/podman
+# containers on the local host, with NO Kubernetes cluster.  The EPP uses the
+# file-discovery plugin (reads endpoints.yaml) instead of a k8s InferencePool.
+# Wired: client -> Envoy (listenPort) -> EPP (grpcPort) -> vLLM (hostPort).
+# Opt-in via `nok8s.enabled: true` in a scenario or `-t nok8s` on the CLI.
+# ============================================================================
+nok8s:
+  enabled: false
+  # Container runtime: "docker" or "podman".
+  runtime: docker
+  # Host env var read at standup time and passed to the vLLM container so it
+  # can pull gated models from Hugging Face.
+  hfTokenEnv: HUGGING_FACE_HUB_TOKEN
+  # Host directory where rendered EPP/Envoy configs are staged and bind-mounted
+  # from (avoids sudo writes to /etc). A scenario with more than one stack
+  # gets a per-stack subdirectory appended so stacks never overwrite each
+  # other's staged configs.
+  workspaceHostDir: "~/.llmdbench/nok8s"
+  # Appended to every container name (vllm-N, epp, envoy). Filled in
+  # automatically with "-<stack>" when a scenario has more than one stack, so
+  # sibling stacks on one host don't share (and delete) each other's
+  # containers. An explicit value is preserved, but two stacks resolving to
+  # the same container name is a render error; single-stack scenarios keep
+  # the bare names.
+  nameSuffix: ""
+
+  # vLLM inference worker(s)
+  vllm:
+    image: docker.io/vllm/vllm-openai
+    tag: *vllm-openai_version
+    hostPort: 8000          # worker i is published on hostPort + i
+    containerPort: 8000
+    tensorParallel: 1       # accelerators to shard each worker across
+    # Accelerator preset for exposing the device to the container:
+    #   nvidia | amd | intel | gaudi | cpu | spyre
+    # Only NVIDIA is validated end-to-end; others follow each backend's
+    # documented device flags. Change `image` to the matching vLLM backend.
+    accelerator: nvidia
+    gpus: "all"             # nvidia only: docker --gpus value (podman uses CDI)
+    # Raw runtime device flags; overrides the accelerator preset entirely.
+    # Use for IBM Spyre/AIU or any custom device wiring, e.g.
+    #   deviceArgs: ["--device", "/dev/kfd", "--device", "/dev/dri"]
+    deviceArgs: []
+    shmSize: "20g"          # required for NCCL/RCCL when tensorParallel > 1
+    hfCacheDir: "~/.cache/huggingface"
+    # Number of independent vLLM workers (EPP load-balances across them). With
+    # replicas > 1 each worker is pinned to its own slice of `tensorParallel`
+    # GPU indices (replica i -> devices i*TP .. i*TP+TP-1) via the accelerator's
+    # visible-devices env. Total GPUs used = replicas * tensorParallel.
+    replicas: 1
+    extraArgs: []           # appended after `serve <MODEL> --tensor-parallel-size=N`
+
+  # Endpoint Picker (router brain), file-discovery mode
+  epp:
+    image: ghcr.io/llm-d/llm-d-router-endpoint-picker
+    tag: v0.9.0
+    grpcPort: 9002
+    grpcHealthPort: 9003
+    metricsPort: 9090
+    poolName: file-discovery
+    poolNamespace: default
+    configMountDir: /etc/epp
+
+  # Envoy front door
+  envoy:
+    image: docker.io/envoyproxy/envoy
+    tag: distroless-v1.33.2
+    listenPort: 8081
+    # Envoy admin interface. Envoy runs with --network host, so two stacks on
+    # one host need distinct admin ports as well as distinct listenPorts.
+    adminPort: 19000
+    configMountPath: /etc/envoy/envoy.yaml
+
+# ============================================================================
+# KUSTOMIZE DEPLOYMENT CONFIGURATION
+# Opt-in via `kustomize.enabled: true` in a scenario or `-t kustomize` on
+# the CLI. Defined here (matching modelservice/standalone/fma) so the
+# structural key is always present in merged values and template guards
+# can use `kustomize.enabled` directly.
+# ============================================================================
+kustomize:
+  enabled: false
+
+# ============================================================================
+# FMA DEPLOYMENT CONFIGURATION
+# For Fast Model Actuation
+# ============================================================================
+fma:
+  enabled: false
+  iterations: 1
+
+  # Pin FMA launchers + requester to a single GPU node. When enabled, standup
+  # (step_06) picks a GPU node with free GPUs and CPU (preferring a dedicated
+  # one), labels it <nodeLabel>=true, and sizes launchers/requesters to its free
+  # GPUs. Standup fails if no node qualifies. Off by default; opt in per-scenario
+  # (used by cicd/ocp-wva-fma-hotstart).
+  launcherNodeSelection:
+    enabled: false
+    nodeLabel: fma-hotstart
+
+  # Deployment naming
+  deployment:
+    name: null  # Auto-generated if null: vllm-standalone-<model.shortName>
+
+  # Labels applied to deployment and service
+  labels:
+    stood-up-by: "auto" # Should be automatically configured to user
+    stood-up-from: llm-d-benchmark
+    stood-up-via: "fma"
+
+  crds:
+    inferenceServerConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.4/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
+    launcherConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.4/config/crd/fma.llm-d.ai_launcherconfigs.yaml
+    launcherPopulatorConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.4/config/crd/fma.llm-d.ai_launcherpopulationpolicies.yaml
+
+  chart:
+    url: oci://ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/charts/fma-controllers
+    version: 0.6.4
+
+  image:
+    repository: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation
+    tag: v0.6.4
+    pullPolicy: IfNotPresent
+
+  requester:
+    image:
+      repository: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester
+      tag: v0.6.4
+      pullPolicy: IfNotPresent
+    probePort: 8080
+    spiPort: 8081
+    readinessProbeInitialDelay: 5
+    readinessProbePeriod: 10
+    limitsGPU: 1
+    limitsCPU: 1
+    limitsMemory: 250Mi
+
+  launcher:
+    maxInstances: 4
+    image:
+      repository: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher
+      tag: v0.6.4
+      pullPolicy: IfNotPresent
+    runtimeClassName: nvidia-legacy
+    podTemplate:
+      metadata:
+        labels:
+          stood-up-by: "auto"
+          stood-up-from: llm-d-benchmark
+          stood-up-via: "fma"
+        annotations: {}
+    customPreprocessCommands: []
+
+  dualPod:
+    sleeperLimit: 2
+    debugAcceleratorMemory: false
+
+  launcherConfigurator:
+    port: 8001
+
+  launcherPopulatorConfigurator:
+    limitsCPU: 2
+    limitsMemory: 2Gi
+    requestsCPU: 100m
+    requestsMemory: 128Mi
+
+  mountModelVolume: true
+  modelMountPath: /model-cache
+  modelPvcName: model-pvc
+
+# ============================================================================
+# DOWNLOAD JOB CONFIGURATION
+# ============================================================================
+downloadJob:
+  # Job name. Multi-stack scenarios auto-suffix this with the model ID
+  # label (render_plans._resolve_per_stack_identity) so each stack gets
+  # its own download-{model_id_label} Job and the waits don't cross-talk.
+  # Set explicitly here to opt out of the auto-suffix.
+  name: download-model
+  backoffLimit: 3
+  mountPath: /cache
+
+# ============================================================================
+# DATA ACCESS CONFIGURATION
+# ============================================================================
+dataAccess:
+  rsyncPort: *rsync_port
+  runAsUser: ~
+  nodeSelector: {}
+  tolerations: []
+
+# ============================================================================
+# LABELS
+# ============================================================================
+labels:
+  inferenceServing: *inference_serving_label
+  app: *app_label
+
+# ============================================================================
+# MULTINODE CONFIGURATION (LeaderWorkerSet)
+# ============================================================================
+multinode:
+  enabled: false
+  # When enabled, workers will be scaled by parallelism.workers
+
+# ============================================================================
+# EXTRA OBJECTS - Additional K8s resources to deploy
+# ============================================================================
+extraObjects: []
+# Example:
+# extraObjects:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: example-config
+#     data:
+#       key: value
+
+# ============================================================================
+# WVA (Workload Variant Autoscaler)
+#
+# Installed in *namespaced* mode: the controller watches only the namespace
+# it is deployed in. One controller per unique wva.namespace across rendered
+# stacks. A KEDA ScaledObject is rendered per-stack (28_wva-scaledobject.yaml.j2)
+# so a single controller can manage multiple models in the same namespace.
+# ============================================================================
+wva:
+  enabled: false
+  wellLitPath: inference-scheduling
+  # When blank, resolves to namespace.name at render time. Overridable via
+  # the third component of `--namespace deploy,harness,wva`.
+  namespace: ""
+  image:
+    repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
+    tag: auto
+  replicaCount: 1
+  # Chart-level top-level switch (v0.6.0): enables the controller Deployment.
+  controller:
+    enabled: true
+  # When true, the controller only watches the namespace it runs in.
+  namespaceScoped: true
+  metrics:
+    enabled: true
+    port: 8443
+    secure: true
+  prometheus:
+    baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+    port: 9091
+  # Only variantCost is consumed by rendering (llm-d.ai/variant-cost annotation
+  # on the KEDA ScaledObject). The controller's SLO / saturation tuning comes
+  # from the upstream overlay's ConfigMaps, not from per-model fields here --
+  # no VariantAutoscaling CR is rendered.
+  variantAutoscaling:
+    variantCost: "10.0"
+  # Drives the per-stack KEDA ScaledObject (min/maxReplicaCount, trigger
+  # threshold, HPA behavior). Named "hpa" for parity with the upstream guide.
+  hpa:
+    # Gates the smoketest's autoscaling-aware replica-range check. Does not
+    # affect rendering -- the ScaledObject is gated on wva.enabled.
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 16
+    targetAvgValue: 1
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 120
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+      scaleDown:
+        stabilizationWindowSeconds: 120
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+  vllmService:
+    enabled: true
+    nodePortMin: 30000
+    nodePortMax: 32767
+    interval: 15s
+    scheme: http
+
+# ============================================================================
+# GENERIC KEDA SCALEDOBJECTS
+# ============================================================================
+# Platform-agnostic KEDA autoscaling. Renders one ScaledObject per entry in
+# keda.scaledObjects. Works on any Kubernetes cluster (not gated on OpenShift).
+# KEDA must already be installed. The TriggerAuthentication name used by this
+# path is "keda-prometheus-auth" -- distinct from "prometheus-auth" used by
+# eppKedaSaturation below, so both paths can coexist in the same namespace.
+keda:
+  prometheus:
+    baseUrl: http://prometheus      # host only -- port is appended separately
+    port: 9090
+    authMode: none                  # "none" | "bearer-secret"
+    secretName: ""                  # pre-existing Secret in deploy namespace (bearer-secret only)
+    unsafeSsl: false
+  scaledObjects: []                 # list of ScaledObject definitions; see config/README.md
+
+# ============================================================================
+# EPP+KEDA SATURATION AUTOSCALING
+# ============================================================================
+# Direct KEDA autoscaling using EPP flow-control metrics, without WVA controller.
+# Queries llm_d_epp_flow_control_pool_saturation and llm_d_epp_request_running
+# directly (see scaledObject.triggers below).
+eppKedaSaturation:
+  enabled: false
+  namespace: ""                 # defaults to namespace.name at render time
+  prometheus:
+    baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+    port: 9091
+  epp:
+    poolName: ""                # InferencePool name; defaults to model_id_label
+    serviceLabelSelector: {}    # matchLabels for EPP Service selector
+    metricsPortName: http-metrics
+    metricsPort: 9090
+    prometheusServiceAccount: thanos-querier
+    prometheusServiceAccountNamespace: openshift-monitoring
+  scaledObject:
+    minReplicas: 1
+    maxReplicas: 10
+    pollingInterval: 15
+    unsafeSsl: true
+    # KEDA Prometheus triggers, fully defined here so new metrics/thresholds
+    # can be added without touching the Jinja. These mirror the upstream llm-d
+    # workload-autoscaling keda-epp-saturation guide; a scenario may redefine
+    # this entire list (e.g. the keda-epp-queue guide). Per entry: query
+    # (required), threshold, and optional name/metricType/activationThreshold.
+    # In `query`, ${poolName} and ${modelName} are substituted at render time.
+    triggers:
+      - name: pool-saturation
+        query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
+        threshold: "0.7"
+        activationThreshold: "0"
+      - name: running-requests
+        query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
+        threshold: "16"
+        activationThreshold: "0"
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 0
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 180  # adjust to actual pod startup time
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 300
+
+# ============================================================================
+# GATEWAY PROVIDERS
+# ============================================================================
+gatewayProviders:
+  agentgateway:
+    # Chart version managed in chartVersions.agentgateway
+    namespace: agentgateway-system
+    helmRepository: oci://cr.agentgateway.dev/charts/
+
+# ============================================================================
+# LWS (LeaderWorkerSet)
+# ============================================================================
+lws:
+  # Chart version managed in chartVersions.lws
+  namespace: lws-system
+  helmRepository: oci://registry.k8s.io/lws/charts/
+
+# ============================================================================
+# GATEWAY API CRD VERSIONS
+# ============================================================================
+gatewayApiCrd:
+  revision: v1.5.1
+  inferenceExtensionRevision: *gaie_version
+  # Install URLs for the CRD bundles. ``{revision}`` is substituted with
+  # ``revision`` / ``inferenceExtensionRevision`` above at standup time.
+  # Kept here so the URL has a single source of truth (read by
+  # llmdbenchmark/standup/steps/step_02_admin_prerequisites.py).
+  crdUrlTemplate: "github.com/kubernetes-sigs/gateway-api/config/crd?ref={revision}"
+  inferenceExtensionUrlTemplate: "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/{revision}/manifests.yaml"
+
+# ============================================================================
+# HARNESS CONFIGURATION
+# ============================================================================
+harness:
+  name: inference-perf
+  profile: sanity_random.yaml
+  executable: llm-d-benchmark.sh
+  condaEnvName: inference-perf-env
+  waitTimeout: 3600
+  loadParallelism: 1
+  podLabel: llmdbench-harness-launcher
+  debug: false
+  resources:
+    cpu: 16
+    memory: 32Gi
+  nodeSelector: {}
+  tolerations: []
+  output: local
+  inferencePerf:
+    rayonNumThreads: 4
+
+# ============================================================================
+# EXPERIMENT RUNTIME DEFAULTS
+# ============================================================================
+experiment:
+  resultsDir: /requests
+  analyzeLocally: false
+  workspaceDir: /workspace
+  datasetUrl: ""
+  datasetDir: ""
+
+# ============================================================================
+# RUN DESCRIPTION (submitter-provided; surfaces as run.description/keywords)
+# ============================================================================
+description:
+  text: ""
+  keywords: []
+
+# ============================================================================
+# CONTROL TIMEOUTS
+# ============================================================================
+control:
+  waitTimeout: 900
+  waitPeriod: 10
+  ignoreFailedValidation: true    # When true, capacity planner failures are warnings (deployment continues). Matches bash default.
+  # Name of the K8s Secret that holds the kubeconfig for in-cluster pods.
+  # Matches bash LLMDBENCH_VLLM_COMMON_CONTEXT_SECRET_NAME default.
+  contextSecretName: llmdbench-context
+
+# ============================================================================
+# RELEASE CONFIGURATION
+# ============================================================================
+release: llmdbench
+
+# ============================================================================
+# OPENSHIFT MONITORING
+# ============================================================================
+openshiftMonitoring:
+  userWorkloadMonitoringNamespace: openshift-user-workload-monitoring
+
+# ============================================================================
+# IDLE CLEANUP (Experimental)
+# Automatic GPU reclamation - scales down idle model deployments to 0 replicas
+# when no inference requests are observed over a configurable window.
+#
+# Deploys a namespace-scoped CronJob with its own ServiceAccount + RBAC.
+# Must be explicitly enabled per scenario.
+# ============================================================================
+idleCleanup:
+  enabled: false                  # Experimental: must be explicitly enabled
+  schedule: "0 * * * *"           # Cron schedule (default: hourly)
+  idleWindow: "24h"               # Scale down if zero requests in this window
+  dryRun: false                   # Log decisions without actually scaling
+  prometheusUrl: ""               # Auto-detected for OpenShift; set manually for GKE/other
+  image: ""                       # Container image for CronJob; empty = python:3.11-slim

--- a/benchmark/experiments/wide-ep-lws-fresh-traffic.yaml
+++ b/benchmark/experiments/wide-ep-lws-fresh-traffic.yaml
@@ -1,0 +1,104 @@
+# =====================================================================
+# Experiment: Wide-EP LWS fresh post-scale traffic probe (inference-perf)
+# =====================================================================
+#
+# WVA #1525 Track A bounded CPU-only proof. Runs two treatments,
+# sequentially, against a single standing deployment: T1 drives aggregate
+# `vllm:num_requests_waiting` past the unchanged KEDA threshold so
+# KEDA -> HPA -> LeaderWorkerSet scales the decode group 1 -> 2; T2, from a
+# freshly created harness Pod/process, then probes whether the new group
+# (group 1) becomes reachable to new connections while the original group
+# (group 0) also continues serving. See
+# 1525_TRACK_A_FINAL_DECISIONS.md (F1-F16) and
+# 1525_TRACK_A_IMPLEMENTATION_BRIEF.md for the full decision record; this
+# file implements only the smallest defensible change authorized there.
+#
+# Exactly one new file plus one modified scenario file are authorized for
+# this slice (F14); no third tracked source file, no setup:/standup phase,
+# no new load generator.
+#
+# Compatible harness:  inference-perf
+# Compatible workload:  guide_wide-ep-lws_1.yaml
+#                        (workload/profiles/inference-perf in the
+#                        llm-d-benchmark sibling repo; unmodified)
+#
+# Usage (run this after standup, against the wide-ep-lws-scale-mechanics
+# scenario -- see that scenario file's commented runbook for the full
+# pre-run sequence):
+#
+#   llmdbenchmark --spec "${INFERENCE_PERF_SPEC}" run \
+#     -p "${NAMESPACE}" -l inference-perf -w "${INFERENCE_PERF_WORKLOAD}" \
+#     -e benchmark/experiments/wide-ep-lws-fresh-traffic.yaml \
+#     --wait-timeout 600
+#
+# `-o` is intentionally not used: with `-e` present,
+# `step_05_render_profiles.py::_resolve_treatments` returns from the
+# `-e` branch before `context.profile_overrides` (the CLI's `-o` flag) is
+# ever read, so any `-o` value would be silently ignored (F15). The
+# tokenizer override the reused profile needs is therefore carried directly
+# in every treatment below instead.
+
+# No per-treatment retry: a retried T2 would create a second fresh Pod and
+# consume HPA scale-down stabilization margin, silently degrading a valid
+# run (F1).
+treatment_max_attempts: 1
+
+# Abort the run rather than continue past a failed treatment.
+treatment_stop_on_error: true
+
+# This is a closed-loop, non-otel_traces workload; reset_caches is
+# unsupported/inapplicable here and left at its safe default.
+reset_caches: false
+
+# summary_lifecycle_metrics.json-based failure validation is opt-in and not
+# needed: Gate 2's request accounting is done independently against the
+# Prometheus completion counters (F9).
+validate_failures: false
+
+# Deliberately no `setup:` block: a setup phase would trigger a
+# standup-to-teardown cycle per treatment and destroy the LWS 2-group scale
+# state that T2 depends on (F1).
+
+# Shared token shape and tokenizer, merged into every treatment below
+# before its own overrides (F15). Explicit per-treatment duplication of
+# load.type/load.num_workers is preferred for auditability over relying
+# solely on this block; see the two treatments.
+constants:
+  data.input_distribution.min: 512
+  data.input_distribution.max: 512
+  data.input_distribution.mean: 512
+  data.input_distribution.std_dev: 0
+  data.output_distribution.min: 128
+  data.output_distribution.max: 128
+  data.output_distribution.mean: 128
+  data.output_distribution.std_dev: 0
+  tokenizer.pretrained_model_name_or_path: gpt2
+
+treatments:
+  # T1 -- pre-scale-trigger: sized to produce initial waiting well above
+  # the unchanged KEDA threshold=10 for one group (max-num-seqs=5, 2 pods:
+  # running capacity 10, so concurrency 40 - 10 = 30 waiting), driving
+  # HPA desiredReplicas ceil(30/10)=3 clamped to maxReplicaCount=2 and the
+  # LWS 1 -> 2 scale-out (F3). num_requests: 200 is fixed; there is no
+  # N=150 fallback (F3/F13) -- benchmark-image pre-pull is a mandatory
+  # pre-run prerequisite.
+  - name: pre-scale-trigger
+    load.type: concurrent
+    load.num_workers: 1
+    load.stages.0.concurrency_level: 40
+    load.stages.0.num_requests: 200
+
+  # T2 -- post-scale-fresh-traffic: runs from a distinct, freshly created
+  # harness Pod/process (step_07_deploy_harness.py creates a new Pod per
+  # treatment; a new Pod is a new OS process, so inference-perf's
+  # session/connection pool cannot straddle the T1/T2 boundary). Probes
+  # whether the freshly Ready group 1 is reachable to these new connections
+  # while group 0 also continues serving (F4). concurrency_level: 20 is
+  # documented only as producing approximately 20 first-wave fresh
+  # connections -- never as a structural guarantee of 20 distinct TCP
+  # connections, and never as an input to PASS/FAIL (F4/F5).
+  - name: post-scale-fresh-traffic
+    load.type: concurrent
+    load.num_workers: 1
+    load.stages.0.concurrency_level: 20
+    load.stages.0.num_requests: 60


### PR DESCRIPTION
Part of #1525

## Motivation

This PR adds the first bounded scale-mechanics slice of the Wide-EP autoscaling exploration.

The goal of this slice is intentionally narrower than choosing a production autoscaling policy. It focuses on the control-plane mechanics first:

- whether a `LeaderWorkerSet` can be scaled as a whole-group unit through its `/scale` subresource;
- whether KEDA can generate an HPA that targets the LWS correctly;
- how group readiness behaves during a bounded `1 -> 2 -> 1` transition;
- whether WVA can drive the same path through its existing metrics pipeline.

Production Wide-EP signal selection, policy calibration, and accelerator-specific behavior remain follow-up work in #1525.

## Proposed Changes

The implementation keeps the WVA side limited to benchmark configuration and reuses the existing `llm-d-benchmark` machinery unchanged.

It adds:

```text
benchmark/config/specification/wide-ep-lws-scale-mechanics.yaml.j2
benchmark/config/scenarios/wide-ep-lws-scale-mechanics.yaml
benchmark/config/templates/values/wide-ep-lws-scale-mechanics-values.yaml
````

The scenario uses a CPU-only `llm-d-inference-sim` topology backed by a `LeaderWorkerSet`, starting with one LWS group containing two simulator pods.

I used #1517 as the reference for the bounded LWS ScaledObject, including its `scaleTargetRef` structure, while leaving its raw-vLLM and OpenShift-specific assumptions out of this mechanics slice.

The ScaledObject starts paused so the LWS behavior can be observed independently before KEDA is introduced into the path.

No `llm-d-benchmark` source code or WVA controller code is changed.

## Scaling Contract

For this mechanics slice, the scaler uses:

```text
metric:           wva_desired_replicas
metricType:       AverageValue
target:           1
minReplicaCount:  1
maxReplicaCount:  2
```

`wva_desired_replicas` already represents an absolute desired replica count. With an LWS target, that count represents the desired number of LWS groups rather than individual pods.

`AverageValue` is therefore intentional. Using `Value` would apply HPA proportional scaling semantics to a metric that already represents the desired replica count. In a bounded `1 -> 2` experiment, that mistake could be hidden by the replica ceiling, so the metric type is treated as part of the mechanics contract.

I then used WVA's existing test-only saturation mechanism to drive `wva_desired_replicas` to `2`, rather than selecting a production Wide-EP scaling signal.

A constant Prometheus scalar was considered only as a possible downstream-mechanics fallback during the exploration and was not needed in the final validation.

## Experiment Sequence

### Manual LWS mechanics

With KEDA paused, the LWS was first exercised directly:

```text
1 group / 2 Ready pods
        |
        | manual 1 -> 2
        v
2 complete Ready groups / 4 Ready pods
        |
        | manual 2 -> 1
        v
1 complete Ready group / 2 Ready pods
```

This isolates the LWS behavior from KEDA and confirms that the scaling unit is the complete LWS group.

### WVA-driven KEDA path

After the manual proof, the scenario establishes the WVA-driven desired count before enabling KEDA:

```text
WVA saturation stimulus
        |
        v
wva_desired_replicas = 2
        |
        v
Prometheus
        |
        v
KEDA
        |
        v
generated HPA
        |
        v
LeaderWorkerSet /scale = 2
        |
        v
2 complete Ready groups / 4 Ready pods
```

Before unpausing the ScaledObject, the exact Prometheus query used by the installed trigger is required to return one `wva_desired_replicas` series with value `2`.

After unpausing KEDA, the generated HPA targets the LWS, drives its `/scale` replica count to `2`, and the workload converges to two complete Ready groups with four Ready pods.

## Reproducibility

The first successful runtime proof exposed two pieces of state that had initially required manual intervention:

1. the workload Namespace needed the WVA opt-in label;
2. the namespace-local saturation ConfigMap needed to be re-observed after WVA started tracking the Namespace.

The underlying scaling mechanics were working, but the persistent scenario was not yet reproducible from a fresh environment without that knowledge.

The scenario lifecycle was therefore updated to make these prerequisites explicit and bounded. It now:

1. applies and verifies the WVA Namespace opt-in label;
2. waits for WVA to begin tracking the expected model and Namespace;
3. runs the paused manual `1 -> 2 -> 1` LWS proof;
4. reloads the namespace-local saturation configuration after tracking is established;
5. verifies that WVA loaded the configuration;
6. verifies that the exact Prometheus trigger query returns one series with value `2`;
7. unpauses KEDA;
8. verifies the external metric, generated HPA, LWS `/scale`, and final group readiness.

A subsequent clean replay also exposed a verification-only issue in the External Metrics API request: KEDA requires the `scaledobject.keda.sh/name=<name>` selector when querying the generated external metric. The assertion now derives the installed ScaledObject name and includes that selector explicitly.

## Validation

The final validation was performed from a brand-new CPU-only Kind environment with:

```text
Kubernetes:       v1.35.0
KEDA:             2.19.0
LeaderWorkerSet:  0.8.0
modelservice:     v0.4.15
```

The clean replay confirmed:

* one initial LWS group with two Ready pods;
* manual `1 -> 2` scaling to two complete groups and four Ready pods;
* manual `2 -> 1` scaling back to one complete group and two Ready pods;
* WVA producing `wva_desired_replicas = 2`;
* the exact Prometheus trigger query returning one series with value `2` before KEDA activation;
* an unpaused and Ready ScaledObject;
* a generated HPA targeting the LWS;
* the KEDA external metric reaching `2`;
* HPA current and desired replicas reaching `2/2`;
* raw LWS `/scale` reporting spec/status `2/2`;
* two complete Ready LWS groups with four Ready pods;
* no scalar fallback;
* no undocumented intervention during the final replay;
* successful cleanup.

`git diff --check` also passes.

## Scope

This PR provides scale-mechanics evidence, not a production Wide-EP autoscaling policy.

The remaining exploration still needs real Wide-EP evidence around signal semantics, accelerator cold-start behavior, prefill and decode scaling policy, latency calibration, rank normalization, and ultimately continuous autoscaling, right-sizing, or scale-to-zero.

### Pre-review Checklist

* [x] **E2E tests** for any new behavior — validated through the clean fresh-Kind replay described above
* [x] **Docs PR** for any user-facing impact — N/A; benchmark exploration only
* [x] **Proposal PR** for any new enhancement or change to existing behavior — N/A; this implements the accepted first mechanics slice from #1525

