### PR TITLE
fix(coordinator): include namespace label in Prometheus queue metric queries

### DIFF
--- a/internal/coordinator/plugins/gpurebalance/plugin.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin.go
@@ -22,7 +22,7 @@ import (
 const (
 	AnnotationInferencePool = "llm-d.ai/epp-inference-pool"
 	gpuQuotaResource        = "requests.nvidia.com/gpu"
-	eppQueueMetric          = `sum(inference_extension_flow_control_queue_size{inference_pool=%q})`
+	eppQueueMetric          = `sum(inference_extension_flow_control_queue_size{inference_pool=%q, namespace=%q})`
 	displayKindHPA          = "HorizontalPodAutoscaler"
 	displayKindScaledObject = "ScaledObject"
 )
@@ -145,7 +145,7 @@ func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns str
 	// Query EPP queue depth per pool (best-effort; default to 0 on error).
 	queues := make([]float64, len(entries))
 	for i, e := range entries {
-		q, err := p.queryQueue(ctx, e.pool)
+		q, err := p.queryQueue(ctx, ns, e.pool)
 		if err != nil {
 			log.V(1).Info("Queue query failed, using 0", "pool", e.pool, "err", err)
 		} else {
@@ -246,14 +246,10 @@ func (p *Plugin) namespaceGPUQuota(ctx context.Context, ns string) (int64, error
 	return 0, nil
 }
 
-func (p *Plugin) queryQueue(ctx context.Context, inferencePool string) (float64, error) {
-	// TODO: the query filters only by inference_pool name with no namespace label.
-	// If two namespaces each have a pool with the same name (e.g. "model-a"), the
-	// sum includes both, inflating the queue reading for each namespace's allocation
-	// decision. Fix: include a namespace label in the query if the EPP emits one,
-	// or scope the metric series by passing the namespace as an additional matcher.
-
-	query := fmt.Sprintf(eppQueueMetric, inferencePool)
+// queryQueue returns the instantaneous queue depth for an inference pool in the
+// given namespace from Prometheus, or 0 if no metric vector was returned.
+func (p *Plugin) queryQueue(ctx context.Context, namespace, inferencePool string) (float64, error) {
+	query := fmt.Sprintf(eppQueueMetric, inferencePool, namespace)
 	result, _, err := p.promAPI.Query(ctx, query, time.Now())
 	if err != nil {
 		return 0, err

--- a/internal/coordinator/plugins/gpurebalance/plugin_test.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin_test.go
@@ -25,21 +25,34 @@ import (
 )
 
 // stubPromAPI implements promv1.API with only Query stubbed.
-// Pool→queue values are matched by searching the query string for the pool name.
+// Pool→queue values are matched by searching the query string for the pool name
+// or "namespace:pool" key.
 type stubPromAPI struct {
 	promv1.API
-	queues map[string]float64
-	errs   map[string]error
+	queues    map[string]float64
+	errs      map[string]error
+	lastQuery string
 }
 
 func (s *stubPromAPI) Query(_ context.Context, query string, _ time.Time, _ ...promv1.Option) (model.Value, promv1.Warnings, error) {
-	for pool, err := range s.errs {
-		if strings.Contains(query, pool) {
+	s.lastQuery = query
+	for key, err := range s.errs {
+		if strings.Contains(key, ":") {
+			parts := strings.SplitN(key, ":", 2)
+			if strings.Contains(query, `namespace="`+parts[0]+`"`) && strings.Contains(query, `inference_pool="`+parts[1]+`"`) {
+				return nil, nil, err
+			}
+		} else if strings.Contains(query, key) {
 			return nil, nil, err
 		}
 	}
-	for pool, q := range s.queues {
-		if strings.Contains(query, pool) {
+	for key, q := range s.queues {
+		if strings.Contains(key, ":") {
+			parts := strings.SplitN(key, ":", 2)
+			if strings.Contains(query, `namespace="`+parts[0]+`"`) && strings.Contains(query, `inference_pool="`+parts[1]+`"`) {
+				return model.Vector{{Value: model.SampleValue(q)}}, nil, nil
+			}
+		} else if strings.Contains(query, key) {
 			return model.Vector{{Value: model.SampleValue(q)}}, nil, nil
 		}
 	}
@@ -714,5 +727,68 @@ func TestSetMaxReplicas_GivesUpAfterMaxRetries(t *testing.T) {
 	}
 	if got := getMaxReplicas(t, c, hpa); got != 5 {
 		t.Errorf("maxReplicas = %d, want 5 (unchanged)", got)
+	}
+}
+
+// TestRebalance_NamespaceIsolation verifies that pools with the same name
+// in different namespaces do not interfere with each other's queue readings.
+func TestRebalance_NamespaceIsolation(t *testing.T) {
+	// ns1: pool "model-a" queue=50, pool "model-b" queue=50, quota=10 → model-a=5, model-b=5
+	// ns2: pool "model-a" queue=200, pool "model-c" queue=0, quota=10 → model-a=9, model-c=1
+	hpaA1 := makeHPA("model-a", "ns1", "model-a", 1)
+	hpaB1 := makeHPA("model-b", "ns1", "model-b", 1)
+	hpaA2 := makeHPA("model-a", "ns2", "model-a", 1)
+	hpaC2 := makeHPA("model-c", "ns2", "model-c", 1)
+
+	p, c := newPlugin(t,
+		map[string]float64{
+			"ns1:model-a": 50,
+			"ns1:model-b": 50,
+			"ns2:model-a": 200,
+			"ns2:model-c": 0,
+		},
+		nil,
+		hpaA1, hpaB1, hpaA2, hpaC2,
+		makeGPUQuota("q-ns1", "ns1", 10),
+		makeGPUQuota("q-ns2", "ns2", 10),
+	)
+
+	if err := p.Tick(context.Background(), []client.Object{hpaA1, hpaB1, hpaA2, hpaC2}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := getMaxReplicas(t, c, hpaA1); got != 5 {
+		t.Errorf("ns1/model-a maxReplicas = %d, want 5", got)
+	}
+	if got := getMaxReplicas(t, c, hpaB1); got != 5 {
+		t.Errorf("ns1/model-b maxReplicas = %d, want 5", got)
+	}
+	if got := getMaxReplicas(t, c, hpaA2); got != 9 {
+		t.Errorf("ns2/model-a maxReplicas = %d, want 9", got)
+	}
+	if got := getMaxReplicas(t, c, hpaC2); got != 1 {
+		t.Errorf("ns2/model-c maxReplicas = %d, want 1", got)
+	}
+}
+
+// TestQueryQueue_IncludesNamespace verifies that queryQueue includes both
+// inference_pool and namespace matchers in the Prometheus PromQL expression.
+func TestQueryQueue_IncludesNamespace(t *testing.T) {
+	stub := &stubPromAPI{
+		queues: map[string]float64{
+			"prod:llm-service": 42.0,
+		},
+	}
+	p := New(nil, stub)
+	val, err := p.queryQueue(context.Background(), "prod", "llm-service")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != 42.0 {
+		t.Errorf("got %v, want 42.0", val)
+	}
+	expected := `sum(inference_extension_flow_control_queue_size{inference_pool="llm-service", namespace="prod"})`
+	if stub.lastQuery != expected {
+		t.Errorf("query = %q, want %q", stub.lastQuery, expected)
 	}
 }


### PR DESCRIPTION
## Description

Fixes #1426.

When `rebalanceNamespace` queries Prometheus queue depths via `queryQueue`, the metric query template `eppQueueMetric` only filtered by `inference_pool=%q` without scoping by namespace. In multi-namespace deployments where inference pools in different namespaces share the same name (e.g., `model-a`), Prometheus returns the aggregated sum across all namespaces, causing cross-namespace metric collisions and skewed replica allocations.

This PR updates `eppQueueMetric` to include `namespace=%q`, passes the target namespace `ns` from `rebalanceNamespace` into `queryQueue`, and updates `queryQueue`'s signature and implementation accordingly.

## Changes

- `internal/coordinator/plugins/gpurebalance/plugin.go`:
  - Updated `eppQueueMetric` to `sum(inference_extension_flow_control_queue_size{inference_pool=%q, namespace=%q})`.
  - Updated `rebalanceNamespace` to pass `ns` to `p.queryQueue(ctx, ns, e.pool)`.
  - Updated `queryQueue(ctx context.Context, namespace, inferencePool string)` to format both parameters.
- `internal/coordinator/plugins/gpurebalance/plugin_test.go`:
  - Enhanced `stubPromAPI.Query` to support namespace-scoped queries.
  - Added `TestRebalance_NamespaceIsolation` asserting that identical pool names in distinct namespaces are isolated without metric bleed.
  - Added `TestQueryQueue_IncludesNamespace` validating that the generated PromQL query contains both `inference_pool` and `namespace` matchers.

## Verification

- Unit tests in `internal/coordinator/plugins/gpurebalance` passing with 100% diff statement coverage.
- Code formatted with `gofmt`.
