### PR TITLE
test(e2e): add Coordinator gpu-rebalance e2e coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ NUM_PROMPTS          ?= 3000
 ENVIRONMENT                 ?= kind-emulator
 USE_SIMULATOR               ?= true
 SCALE_TO_ZERO_ENABLED       ?= false
+COORDINATOR_ENABLED         ?= false
+COORDINATOR_INTERVAL        ?= 5s
 DEPLOY_ALERTING_RULES       ?= false
 SCALER_BACKEND              ?= keda  # keda (ScaledObject) or none (skip, use pre-installed backend)
 LLM_D_ROUTER_VERSION        ?= v0.9.0
@@ -209,6 +211,8 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + EPP; no model server 
 		ENVIRONMENT=$(ENVIRONMENT) \
 		SCALER_BACKEND=$(SCALER_BACKEND) \
 		ENABLE_SCALE_TO_ZERO=$(SCALE_TO_ZERO_ENABLED) \
+		ENABLE_COORDINATOR=$(COORDINATOR_ENABLED) \
+		COORDINATOR_INTERVAL=$(COORDINATOR_INTERVAL) \
 		DEPLOY_ALERTING_RULES=$(DEPLOY_ALERTING_RULES) \
 		WVA_IMAGE_REPO=$$IMAGE_REPO \
 		WVA_IMAGE_TAG=$$IMAGE_TAG \
@@ -219,6 +223,8 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + EPP; no model server 
 		ENVIRONMENT=$(ENVIRONMENT) \
 		SCALER_BACKEND=$(SCALER_BACKEND) \
 		ENABLE_SCALE_TO_ZERO=$(SCALE_TO_ZERO_ENABLED) \
+		ENABLE_COORDINATOR=$(COORDINATOR_ENABLED) \
+		COORDINATOR_INTERVAL=$(COORDINATOR_INTERVAL) \
 		DEPLOY_ALERTING_RULES=$(DEPLOY_ALERTING_RULES) \
 		./deploy/install.sh; \
 	fi
@@ -252,6 +258,7 @@ test-e2e-smoke: ## Run smoke e2e tests
 	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
+	COORDINATOR_ENABLED=$(COORDINATOR_ENABLED) \
 	DEPLOY_ALERTING_RULES=$(DEPLOY_ALERTING_RULES) \
 	SCALER_BACKEND=keda \
 	MODEL_ID=$(MODEL_ID) \
@@ -276,6 +283,7 @@ test-e2e-full: ## Run full e2e test suite
 	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
+	COORDINATOR_ENABLED=$(COORDINATOR_ENABLED) \
 	DEPLOY_ALERTING_RULES=$(DEPLOY_ALERTING_RULES) \
 	SCALER_BACKEND=keda \
 	KEDA_NAMESPACE=$(E2E_KEDA_NAMESPACE) \
@@ -312,6 +320,7 @@ test-e2e-multi-controller: ## Run multi-controller e2e tests
 	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
+	COORDINATOR_ENABLED=$(COORDINATOR_ENABLED) \
 	DEPLOY_ALERTING_RULES=$(DEPLOY_ALERTING_RULES) \
 	SCALER_BACKEND=$(SCALER_BACKEND) \
 	MODEL_ID=$(MODEL_ID) \
@@ -327,6 +336,43 @@ test-e2e-multi-controller: ## Run multi-controller e2e tests
 # Convenience target that deploys infra + runs multi-controller tests.
 .PHONY: test-e2e-multi-controller-with-setup
 test-e2e-multi-controller-with-setup: deploy-e2e-infra test-e2e-multi-controller
+
+# Runs the Coordinator / gpu-rebalance subset. The Coordinator is read once at
+# manager startup, so it needs its own deploy with COORDINATOR_ENABLED=true and
+# therefore its own job — the "coordinator" label is deliberately outside the
+# "full" filter so the saturation-path specs never run against a cluster with the
+# Coordinator ticking.
+.PHONY: test-e2e-coordinator
+test-e2e-coordinator: ## Run Coordinator (gpu-rebalance) e2e tests
+	@echo "Running Coordinator e2e tests..."
+	$(eval FOCUS_ARGS := $(if $(FOCUS),-ginkgo.focus="$(FOCUS)",))
+	$(eval SKIP_ARGS := $(if $(SKIP),-ginkgo.skip="$(SKIP)",))
+	KUBECONFIG=$(KUBECONFIG) \
+	ENVIRONMENT=$(ENVIRONMENT) \
+	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
+	LLMD_NAMESPACE=$(E2E_EMULATED_LLMD_NAMESPACE) \
+	MONITORING_NAMESPACE=$(E2E_MONITORING_NAMESPACE) \
+	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
+	USE_SIMULATOR=$(USE_SIMULATOR) \
+	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
+	COORDINATOR_ENABLED=$(COORDINATOR_ENABLED) \
+	DEPLOY_ALERTING_RULES=$(DEPLOY_ALERTING_RULES) \
+	SCALER_BACKEND=keda \
+	MODEL_ID=$(MODEL_ID) \
+	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
+		-ginkgo.label-filter="coordinator" $(FOCUS_ARGS) $(SKIP_ARGS); \
+	TEST_EXIT_CODE=$$?; \
+	echo ""; \
+	echo "=========================================="; \
+	echo "Test execution completed. Exit code: $$TEST_EXIT_CODE"; \
+	echo "=========================================="; \
+	exit $$TEST_EXIT_CODE
+
+# Convenience target that deploys Coordinator-enabled infra + runs the Coordinator tests.
+.PHONY: test-e2e-coordinator-with-setup
+test-e2e-coordinator-with-setup:
+	COORDINATOR_ENABLED=true SCALER_BACKEND=keda $(MAKE) deploy-e2e-infra
+	COORDINATOR_ENABLED=true $(MAKE) test-e2e-coordinator
 
 # Convenience target that deploys KEDA infra + runs full test suite.
 # Set DELETE_CLUSTER=true to delete Kind cluster after tests (default: keep cluster for debugging).

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -41,6 +41,15 @@ CONTROLLER_INSTANCE=${CONTROLLER_INSTANCE:-""}
 
 ENABLE_SCALE_TO_ZERO=${ENABLE_SCALE_TO_ZERO:-true}
 
+# EXPERIMENTAL: opt in to the Coordinator (gpu-rebalance). Off by default — the
+# manager reads EXPERIMENTAL_COORDINATOR_ENABLED once at startup, so infra_wva.sh
+# patches wva-manager-config before the manager becomes Ready. Only the dedicated
+# Coordinator e2e job should set this; leaving it on would have the Coordinator
+# rewriting replica ceilings underneath the saturation-path specs.
+ENABLE_COORDINATOR=${ENABLE_COORDINATOR:-false}
+COORDINATOR_INTERVAL=${COORDINATOR_INTERVAL:-5s}
+export ENABLE_COORDINATOR COORDINATOR_INTERVAL
+
 # Prometheus Configuration
 PROM_CA_CERT_PATH=${PROM_CA_CERT_PATH:-"/tmp/prometheus-ca.crt"}
 PROMETHEUS_SECRET_NAME=${PROMETHEUS_SECRET_NAME:-"prometheus-web-tls"}

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -166,6 +166,31 @@ EOF
             -p "$(jq -n --arg cfg "$updated_config" '{data:{"config.yaml":$cfg}}')"
     fi
 
+    if [ "${ENABLE_COORDINATOR:-false}" = "true" ]; then
+        log_info "Enabling Coordinator in WVA ConfigMap (ENABLE_COORDINATOR=true)..."
+        # Same approach as scale-to-zero above: patch data["config.yaml"] in place
+        # with yq. The Coordinator flag is read once at manager startup, so this
+        # must land before the readiness wait below — a later patch would need a
+        # rollout restart and would race any specs already running.
+        #
+        # COORDINATOR_INTERVAL is shortened from the 15s default so a rebalance
+        # tick lands well inside the e2e Eventually windows.
+        local current_coord_config
+        current_coord_config=$(kubectl get configmap wva-manager-config -n "$WVA_NS" \
+            -o jsonpath='{.data.config\.yaml}')
+        if [ -z "$current_coord_config" ]; then
+            log_error "ConfigMap wva-manager-config has no data['config.yaml'] key"
+        fi
+
+        local updated_coord_config
+        updated_coord_config=$(echo "$current_coord_config" \
+            | yq '.EXPERIMENTAL_COORDINATOR_ENABLED = "true"' \
+            | yq ".COORDINATOR_INTERVAL = \"${COORDINATOR_INTERVAL:-5s}\"")
+
+        kubectl patch configmap wva-manager-config -n "$WVA_NS" --type=merge \
+            -p "$(jq -n --arg cfg "$updated_coord_config" '{data:{"config.yaml":$cfg}}')"
+    fi
+
     # Wait for WVA to be ready
     log_info "Waiting for WVA controller to be ready..."
     if kubectl wait --for=condition=Ready pod -l "$WVA_CONTROLLER_LABEL_SELECTOR" -n "$WVA_NS" --timeout=60s; then

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -166,6 +166,24 @@ This deploys:
 
 When `ENABLE_SCALE_TO_ZERO=true` (set by `make deploy-e2e-infra` when `SCALE_TO_ZERO_ENABLED=true`), **`install-epp.sh`** enables the **flowControl feature gate** on the EPP so it exposes `inference_extension_flow_control_queue_size`. The **InferenceObjective** `e2e-default` is created by the scale-from-zero tests (`test/e2e/fixtures`), not by the install scripts.
 
+### Coordinator (gpu-rebalance) tests
+
+The Coordinator is experimental and off by default. It reads `EXPERIMENTAL_COORDINATOR_ENABLED` **once at manager startup**, so it cannot be toggled per-spec — a mid-suite ConfigMap patch would need a rollout restart and would race any specs already running. Instead `deploy/lib/infra_wva.sh` yq-patches `EXPERIMENTAL_COORDINATOR_ENABLED=true` (plus a shorter `COORDINATOR_INTERVAL`) into `wva-manager-config` **before** the manager becomes Ready, gated on `ENABLE_COORDINATOR=true`.
+
+Because of that, the Coordinator specs run in their own job, under the `coordinator` Ginkgo label — deliberately outside the `full` filter, so the saturation-path specs are never exercised against a cluster with the Coordinator rewriting replica ceilings underneath them:
+
+```bash
+make test-e2e-coordinator-with-setup
+```
+
+or, against infrastructure you already deployed with `COORDINATOR_ENABLED=true`:
+
+```bash
+COORDINATOR_ENABLED=true make test-e2e-coordinator
+```
+
+The specs skip themselves with an explanatory message when `COORDINATOR_ENABLED` is false, so running them against a normally-deployed cluster reports a skip rather than a confusing failure.
+
 **Install script tuning (optional, same variables as `deploy/install.sh`):**
 
 - **`SKIP_HELM_REPO_UPDATE`**: When set to **`true`**, `helm repo update` is skipped during installs (faster, less network churn). Default runs `helm repo update` to refresh repo indexes.

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -14,6 +14,13 @@ type E2EConfig struct {
 	// ("scale-to-zero" via HPAScaleToZero). Distinct from scale-from-zero (scale up from zero replicas).
 	ScaleToZeroEnabled bool
 
+	// CoordinatorEnabled: env COORDINATOR_ENABLED — the deploy set
+	// EXPERIMENTAL_COORDINATOR_ENABLED=true in wva-manager-config before the manager
+	// became Ready (see deploy/lib/infra_wva.sh). The manager reads that flag once at
+	// startup, so it cannot be toggled per-spec; specs that need the Coordinator
+	// running must Skip when this is false.
+	CoordinatorEnabled bool
+
 	// Timeouts (seconds unless noted)
 	PodReadyTimeout int // Wait for deployment/model pods ready
 	ScaleUpTimeout  int // Long reconcile / scale-from-zero / job completion
@@ -37,6 +44,7 @@ func LoadConfigFromEnv() E2EConfig {
 		SharedConfig: testconfig.LoadSharedConfig(),
 
 		ScaleToZeroEnabled: testconfig.GetEnvBool("SCALE_TO_ZERO_ENABLED", false),
+		CoordinatorEnabled: testconfig.GetEnvBool("COORDINATOR_ENABLED", false),
 
 		PodReadyTimeout: testconfig.GetEnvInt("POD_READY_TIMEOUT", 300), // 5 minutes
 		ScaleUpTimeout:  testconfig.GetEnvInt("SCALE_UP_TIMEOUT", 600),  // 10 minutes

--- a/test/e2e/coordinator_gpu_rebalance_test.go
+++ b/test/e2e/coordinator_gpu_rebalance_test.go
@@ -1,0 +1,235 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
+)
+
+// Coordinator / gpu-rebalance coverage.
+//
+// The Coordinator reads EXPERIMENTAL_COORDINATOR_ENABLED once at manager startup, so
+// it cannot be toggled per-spec. The deploy sets it (deploy/lib/infra_wva.sh, gated on
+// ENABLE_COORDINATOR) before the manager becomes Ready, and this suite carries its own
+// "coordinator" label so it runs in a dedicated job — the saturation-path specs are
+// never exercised against a cluster with the Coordinator ticking.
+//
+// Acceptance case: two managed ScaledObjects sharing one namespace GPU ResourceQuota.
+// gpu-rebalance reserves each scaler's effective minimum, then splits what is left by
+// EPP queue-depth weight, giving any rounding remainder to the highest-weight pool.
+// With both queues at zero the weights are equal, so the ceilings must come out even.
+const (
+	coordNamespaceQuotaName = "coordinator-e2e-gpu-quota"
+
+	// coordGPUQuota is chosen so the expected split is exact rather than
+	// rounding-dependent: two scalers with effectiveMin=1 reserve 2, leaving 6 to
+	// divide by weight 0.5 each, so each ceiling is 1 + 3 = 4 with no remainder to
+	// hand out. A quota that did not divide evenly would make the assertion depend
+	// on which pool won the remainder, which is not what this case is pinning.
+	coordGPUQuota = int64(8)
+
+	coordScalerAName = "coordinator-e2e-a"
+	coordScalerBName = "coordinator-e2e-b"
+	coordPoolAName   = "coordinator-e2e-pool-a"
+	coordPoolBName   = "coordinator-e2e-pool-b"
+
+	coordScalerMinReplicas = int32(1)
+	// Seeded away from the expected post-rebalance value so a passing assertion
+	// proves the Coordinator wrote the ceiling, rather than it having been correct
+	// from creation.
+	coordScalerInitialMax = int32(1)
+
+	coordExpectedCeiling = int32(4)
+)
+
+var _ = Describe("Coordinator - gpu-rebalance", Label("coordinator"), Ordered, func() {
+	var (
+		quotaTimeout  time.Duration
+		pollInterval  time.Duration
+		createdScaler []string
+	)
+
+	BeforeAll(func() {
+		if !cfg.CoordinatorEnabled {
+			Skip("This suite requires the Coordinator to be enabled at deploy time: " +
+				"run `make test-e2e-coordinator-with-setup`, or deploy with COORDINATOR_ENABLED=true " +
+				"so EXPERIMENTAL_COORDINATOR_ENABLED is set before the manager starts.")
+		}
+
+		quotaTimeout = time.Duration(cfg.EventuallyStandardSec) * time.Second
+		pollInterval = time.Duration(cfg.PollIntervalSec) * time.Second
+
+		By(fmt.Sprintf("creating a %d-GPU ResourceQuota in %s", coordGPUQuota, cfg.LLMDNamespace))
+		Expect(fixtures.EnsureGPUResourceQuota(
+			ctx, crClient, cfg.LLMDNamespace, coordNamespaceQuotaName, coordGPUQuota,
+		)).To(Succeed())
+
+		promURL := fixtures.PrometheusURLFor(cfg.MonitoringNS)
+
+		for _, s := range []struct{ name, pool string }{
+			{coordScalerAName, coordPoolAName},
+			{coordScalerBName, coordPoolBName},
+		} {
+			By("creating scale target and managed ScaledObject for " + s.name)
+			Expect(createCoordinatorScaleTarget(s.name)).To(Succeed())
+
+			Expect(fixtures.EnsureScaledObject(
+				ctx, crClient,
+				cfg.LLMDNamespace, s.name, s.name, s.name,
+				coordScalerMinReplicas, coordScalerInitialMax,
+				cfg.MonitoringNS,
+				fixtures.WithScaledObjectCoordinatorManaged(s.pool, promURL),
+			)).To(Succeed())
+
+			createdScaler = append(createdScaler, s.name)
+		}
+	})
+
+	AfterAll(func() {
+		if !cfg.CoordinatorEnabled {
+			return
+		}
+		for _, name := range createdScaler {
+			Expect(fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, name)).To(Succeed())
+			Expect(deleteCoordinatorScaleTarget(name)).To(Succeed())
+		}
+		Expect(fixtures.DeleteGPUResourceQuota(
+			ctx, crClient, cfg.LLMDNamespace, coordNamespaceQuotaName,
+		)).To(Succeed())
+	})
+
+	It("selects both managed ScaledObjects", func() {
+		// Guards the selection contract the rest of the suite rests on: a ScaledObject
+		// is only rebalanced when it is annotated managed and does not carry a
+		// wva_desired_replicas trigger. If the fixture regressed to the default
+		// WVA trigger, the Coordinator would silently skip both objects and the split
+		// assertion below would fail for a reason that has nothing to do with the split.
+		for _, name := range []string{coordScalerAName, coordScalerBName} {
+			so := &kedav1alpha1.ScaledObject{}
+			Expect(crClient.Get(ctx, client.ObjectKey{
+				Namespace: cfg.LLMDNamespace,
+				Name:      name + "-so",
+			}, so)).To(Succeed())
+
+			Expect(so.Annotations).To(HaveKeyWithValue("llm-d.ai/managed", "true"))
+			Expect(so.Annotations).To(HaveKey("llm-d.ai/epp-inference-pool"))
+
+			for _, t := range so.Spec.Triggers {
+				Expect(t.Metadata["query"]).ToNot(ContainSubstring("wva_desired_replicas"),
+					"a wva_desired_replicas trigger excludes the ScaledObject from Coordinator control")
+			}
+		}
+	})
+
+	It("splits the GPU quota evenly when every pool queue is zero", func() {
+		// No load is driven against either pool, so both EPP queue depths are zero and
+		// the plugin falls back to equal weights. Asserting on both objects together
+		// (rather than one Eventually each) keeps the check honest: the invariant is
+		// that the ceilings are equal *and* sum to the quota at the same instant, not
+		// that each one passed through the right value at some point.
+		Eventually(func(g Gomega) {
+			maxA := currentMaxReplicas(g, coordScalerAName)
+			maxB := currentMaxReplicas(g, coordScalerBName)
+
+			g.Expect(maxA).To(Equal(coordExpectedCeiling),
+				"pool A ceiling should be quota/2 once reserved minimums are returned")
+			g.Expect(maxB).To(Equal(coordExpectedCeiling),
+				"pool B ceiling should be quota/2 once reserved minimums are returned")
+			g.Expect(int64(maxA+maxB)).To(Equal(coordGPUQuota),
+				"the Coordinator must never hand out more ceiling than the namespace quota")
+		}, quotaTimeout, pollInterval).Should(Succeed())
+	})
+
+	It("keeps the combined ceiling within the quota after it shrinks", func() {
+		// Halving the quota exercises the reserve-then-distribute path in the shrink
+		// direction: minimums (1 each) are still reserved, leaving 2 to split evenly,
+		// so both ceilings land on 2. This is the case that catches a plugin that only
+		// ever ratchets ceilings upward.
+		const shrunkQuota = int64(4)
+		const shrunkCeiling = int32(2)
+
+		By("shrinking the ResourceQuota to 4 GPUs")
+		Expect(fixtures.EnsureGPUResourceQuota(
+			ctx, crClient, cfg.LLMDNamespace, coordNamespaceQuotaName, shrunkQuota,
+		)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			maxA := currentMaxReplicas(g, coordScalerAName)
+			maxB := currentMaxReplicas(g, coordScalerBName)
+
+			g.Expect(maxA).To(Equal(shrunkCeiling))
+			g.Expect(maxB).To(Equal(shrunkCeiling))
+			g.Expect(int64(maxA + maxB)).To(Equal(shrunkQuota))
+		}, quotaTimeout, pollInterval).Should(Succeed())
+	})
+
+	// Asymmetric ceilings under uneven EPP queue depth are the other half of #1458's
+	// acceptance criteria. Driving that needs real EPP flow-control queue depth, which
+	// means binding these pool annotations to live inference pools and pushing burst
+	// load through one of them rather than the standalone scale targets used above.
+	// Left pending deliberately rather than asserted against a fabricated metric, so
+	// the shape is visible and reviewable without claiming coverage it does not have.
+	PIt("gives the busier pool a higher ceiling under uneven EPP queue depth", func() {})
+})
+
+// currentMaxReplicas reads the ScaledObject's configured ceiling. It reads spec rather
+// than the KEDA-generated HPA because gpu-rebalance patches maxReplicaCount on the
+// ScaledObject; the HPA is downstream and would add KEDA's reconcile latency to every
+// assertion.
+func currentMaxReplicas(g Gomega, name string) int32 {
+	so := &kedav1alpha1.ScaledObject{}
+	g.Expect(crClient.Get(ctx, client.ObjectKey{
+		Namespace: cfg.LLMDNamespace,
+		Name:      name + "-so",
+	}, so)).To(Succeed())
+	g.Expect(so.Spec.MaxReplicaCount).ToNot(BeNil(), "ScaledObject %s has no maxReplicaCount", name)
+	return *so.Spec.MaxReplicaCount
+}
+
+// createCoordinatorScaleTarget stands up a minimal Deployment for a ScaledObject to
+// point at. gpu-rebalance only reads and patches the ScaledObject's replica bounds, so
+// the target never has to serve traffic — but KEDA will not admit a ScaledObject whose
+// scaleTargetRef does not resolve, and an unadmitted object is a confusing thing to
+// assert against. The pod requests no GPU, so it is unaffected by the GPU ResourceQuota.
+func createCoordinatorScaleTarget(name string) error {
+	replicas := coordScalerMinReplicas
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cfg.LLMDNamespace,
+			Labels:    map[string]string{"test-resource": "true", "app": name},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(replicas),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: ptr.To(int64(0)),
+					Containers: []corev1.Container{{
+						Name:            "pause",
+						Image:           "registry.k8s.io/pause:3.10",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+					}},
+				},
+			},
+		},
+	}
+	return client.IgnoreAlreadyExists(crClient.Create(ctx, deploy))
+}
+
+func deleteCoordinatorScaleTarget(name string) error {
+	return client.IgnoreNotFound(crClient.Delete(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cfg.LLMDNamespace},
+	}))
+}

--- a/test/e2e/coordinator_gpu_rebalance_test.go
+++ b/test/e2e/coordinator_gpu_rebalance_test.go
@@ -155,6 +155,14 @@ var _ = Describe("Coordinator - gpu-rebalance", Label("coordinator"), Ordered, f
 		// direction: minimums (1 each) are still reserved, leaving 2 to split evenly,
 		// so both ceilings land on 2. This is the case that catches a plugin that only
 		// ever ratchets ceilings upward.
+		//
+		// Unlike the even-split case above, this one lands a *downgrade*, so it does
+		// not appear within a single Coordinator tick once the damping in #1427 is in
+		// place: a lower ceiling must persist for several consecutive ticks before it
+		// is written. At the deploy-time COORDINATOR_INTERVAL of 5s that is well
+		// inside EventuallyStandardSec, so the assertion holds either way — but do not
+		// tighten this timeout to a single interval on the assumption that a ceiling
+		// change is always immediate. Increases are; decreases deliberately are not.
 		const shrunkQuota = int64(4)
 		const shrunkCeiling = int32(2)
 

--- a/test/e2e/fixtures/resource_quota_builder.go
+++ b/test/e2e/fixtures/resource_quota_builder.go
@@ -1,0 +1,75 @@
+package fixtures
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GPUQuotaResource is the ResourceQuota key the gpu-rebalance plugin reads to size
+// a namespace's GPU budget. It mirrors the plugin's gpuQuotaResource constant.
+const GPUQuotaResource = "requests.nvidia.com/gpu"
+
+func resourceQuotaRef(namespace, name string) *corev1.ResourceQuota {
+	return &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func buildGPUResourceQuota(namespace, name string, gpus int64) *corev1.ResourceQuota {
+	return &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{"test-resource": defaultTestResourceLabelValue},
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName(GPUQuotaResource): *resource.NewQuantity(gpus, resource.DecimalSI),
+			},
+		},
+	}
+}
+
+// EnsureGPUResourceQuota creates or replaces a ResourceQuota capping the namespace's
+// GPU requests, which is what gpu-rebalance divides across managed scalers.
+//
+// The quota is deliberately scoped to requests.nvidia.com/gpu only. Adding pod or CPU
+// limits here would make the quota admission controller reject the spec's workloads
+// for unrelated reasons and turn a rebalance assertion into a scheduling failure.
+func EnsureGPUResourceQuota(ctx context.Context, crClient client.Client, namespace, name string, gpus int64) error {
+	obj := buildGPUResourceQuota(namespace, name, gpus)
+	existing := resourceQuotaRef(namespace, name)
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+
+	err := crClient.Get(ctx, key, existing)
+	switch {
+	case errors.IsNotFound(err):
+		return crClient.Create(ctx, obj)
+	case err != nil:
+		return fmt.Errorf("check existing ResourceQuota %s/%s: %w", namespace, name, err)
+	}
+
+	existing.Spec = obj.Spec
+	if err := crClient.Update(ctx, existing); err != nil {
+		return fmt.Errorf("update ResourceQuota %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// DeleteGPUResourceQuota removes the ResourceQuota. Idempotent; ignores NotFound.
+func DeleteGPUResourceQuota(ctx context.Context, crClient client.Client, namespace, name string) error {
+	err := crClient.Delete(ctx, resourceQuotaRef(namespace, name))
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("delete ResourceQuota %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}

--- a/test/e2e/fixtures/scaled_object_builder.go
+++ b/test/e2e/fixtures/scaled_object_builder.go
@@ -19,6 +19,12 @@ import (
 const (
 	scaledObjectSuffix = "-so"
 
+	// coordinatorInferencePoolAnnotation mirrors gpurebalance.AnnotationInferencePool.
+	// It is duplicated rather than imported so the e2e fixtures keep depending only on
+	// internal/annotations, and so a rename in the plugin surfaces here as a failing
+	// selection assertion rather than a silently-still-compiling test.
+	coordinatorInferencePoolAnnotation = "llm-d.ai/epp-inference-pool"
+
 	kindLeaderWorkerSet = "LeaderWorkerSet"
 	kindDeployment      = "Deployment"
 	apiVersionLWS       = "leaderworkerset.x-k8s.io/v1"
@@ -77,6 +83,45 @@ func WithScaledObjectWVAAnnotations(modelID, cost string) ScaledObjectOption {
 		so.Annotations[annotations.ModelID] = modelID
 		so.Annotations[annotations.VariantCost] = cost
 	}
+}
+
+// WithScaledObjectCoordinatorManaged makes the ScaledObject a gpu-rebalance target.
+//
+// The Coordinator selects a ScaledObject only when it is annotated managed AND does
+// not carry a wva_desired_replicas trigger — a ScaledObject driven by WVA's own
+// desired-replicas signal is deliberately left alone (see IsScaledObjectUnderControl).
+// The default builder installs exactly that trigger, so this option replaces the
+// trigger list with a constant-value Prometheus trigger, and adds the inference-pool
+// annotation the plugin uses to look up the pool's EPP queue depth.
+func WithScaledObjectCoordinatorManaged(pool, prometheusURL string) ScaledObjectOption {
+	return func(so *kedav1alpha1.ScaledObject) {
+		if so.Annotations == nil {
+			so.Annotations = make(map[string]string)
+		}
+		so.Annotations[annotations.Managed] = "true"
+		so.Annotations[coordinatorInferencePoolAnnotation] = pool
+
+		so.Spec.Triggers = []kedav1alpha1.ScaleTriggers{
+			{
+				Type: "prometheus",
+				Name: "coordinator-e2e-constant",
+				Metadata: map[string]string{
+					"serverAddress":       prometheusURL,
+					"query":               "vector(1)",
+					"threshold":           "1",
+					"activationThreshold": "0",
+					"metricType":          "Value",
+					"unsafeSsl":           "true",
+				},
+			},
+		}
+	}
+}
+
+// PrometheusURLFor returns the in-cluster Prometheus address the ScaledObject
+// builder uses, so specs can pass it to WithScaledObjectCoordinatorManaged.
+func PrometheusURLFor(monitoringNamespace string) string {
+	return "https://kube-prometheus-stack-prometheus." + monitoringNamespace + ".svc.cluster.local:9090"
 }
 
 // CreateScaledObject creates a KEDA ScaledObject for WVA. Fails if it already exists.


### PR DESCRIPTION
## What this PR does

Adds e2e coverage for the Coordinator's `gpu-rebalance` plugin, per #1458.

Following @mamy-CS's guidance on the issue, the Coordinator is toggled at **deploy time** rather than per-spec. It reads `EXPERIMENTAL_COORDINATOR_ENABLED` once at manager startup, so a runtime toggle would need a ConfigMap patch plus a rollout restart mid-suite and would race the other specs. This mirrors the existing scale-from-zero pattern:

- `deploy/lib/infra_wva.sh` yq-patches `EXPERIMENTAL_COORDINATOR_ENABLED="true"` and a shorter `COORDINATOR_INTERVAL` into `wva-manager-config`, **before** the `kubectl wait --for=condition=Ready`, gated on `ENABLE_COORDINATOR=true`.
- `deploy/install.sh` defaults and exports `ENABLE_COORDINATOR=false` / `COORDINATOR_INTERVAL=5s`.
- `Makefile` gains `COORDINATOR_ENABLED` / `COORDINATOR_INTERVAL`, plus `test-e2e-coordinator` and `test-e2e-coordinator-with-setup`.
- `test/e2e/config.go` surfaces it as `cfg.CoordinatorEnabled`; the specs `Skip()` with an explanatory message when it is false.

The specs carry their own `coordinator` Ginkgo label, deliberately **outside** the `full && !smoke && !flaky` filter, and run from their own target — so the saturation-path specs are never exercised against a cluster with the Coordinator rewriting replica ceilings underneath them.

## Coverage

The acceptance-criteria case: two managed ScaledObjects sharing one namespace GPU `ResourceQuota`.

1. **Selection contract.** Asserts both objects are annotated managed *and* carry no `wva_desired_replicas` trigger. This one is load-bearing: the default `buildScaledObject` fixture installs exactly that trigger, and `IsScaledObjectUnderControl` excludes objects that have it — so without a distinct fixture option the Coordinator would silently skip both and the split assertion would fail for an unrelated reason. Hence the new `WithScaledObjectCoordinatorManaged`.
2. **Even split when every pool queue is zero.** Both ceilings equal, and their sum equals the quota, checked in the same `Eventually` so the invariant holds at one instant rather than each value merely having passed through at some point.
3. **Shrinking quota.** Halving the quota re-derives lower ceilings — the case that catches a plugin that only ever ratchets upward.

The quota is 8 so the expected split is exact rather than rounding-dependent: two scalers at `effectiveMin=1` reserve 2, leaving 6 to split at weight 0.5, giving 1 + 3 = 4 each with no remainder to hand to the highest-weight pool.

Also adds a `ResourceQuota` fixture (none existed), scoped to `requests.nvidia.com/gpu` only — adding pod/CPU limits would make the quota admission controller reject the spec's workloads for unrelated reasons and turn a rebalance assertion into a scheduling failure.

## Deliberately left out

**Asymmetric ceilings under uneven EPP queue depth** is the other half of the acceptance criteria and is committed as a `PIt` rather than asserted. Driving it needs real flow-control queue depth, which means binding these pool annotations to live inference pools and pushing burst load through one of them, instead of the standalone scale targets used here. I did not want to assert it against a fabricated metric and claim coverage the test does not have.

@mamy-CS — two questions on that:
1. Would you rather I wire it to the sglang emulator pools in this PR, or land the deterministic cases first and do the load-driven one as the follow-up?
2. For the CI side, I wired `ENABLE_COORDINATOR` so a job can set it, but did not add a job to `ci-e2e-openshift.yaml` — standing up another run against the real GPU cluster felt like your call on resourcing rather than mine. Happy to add it if you want it here.

## Testing

`go build ./test/...`, `go vet ./test/...`, and `gofmt` are clean; `bash -n` passes on both changed shell scripts.

I have **not** run this suite against a live cluster — I don't have one with GPUs and KEDA to hand, so the deterministic split values are derived by reading `rebalanceNamespace`, not observed. Worth a real run before merge; if the CI job is the easiest way to get that, say the word and I'll add it.

## Disclosure

Prepared with the assistance of an AI coding agent. I verified the analysis against the source and existing suites; the reasoning about the startup-only flag, the trigger-exclusion trap, and the exact split arithmetic was checked against `internal/coordinator/` before writing the specs. This description is my own.
