### PR TITLE
fix(install): install the scaler backend before the WVA controller

### DIFF
--- a/deploy/lib/install_core.sh
+++ b/deploy/lib/install_core.sh
@@ -70,6 +70,8 @@ main() {
 
     deploy_monitoring_stack
 
+    deploy_scaler_backend
+
     # Deploy WVA prerequisites first (environment-specific).
     if [ "$DEPLOY_WVA" = "true" ]; then
         deploy_wva_prerequisites
@@ -81,8 +83,6 @@ main() {
     else
         log_info "Skipping WVA deployment (DEPLOY_WVA=false)"
     fi
-
-    deploy_scaler_backend
 
     verify_deployment
 


### PR DESCRIPTION
Fixes #1534

## Proposed Changes

- :bug: Move `deploy_scaler_backend` ahead of the WVA prerequisites and controller in
  `main()`. The controller probes for `scaledobjects.keda.sh` at startup, so installing
  KEDA afterwards left ScaledObject support off until the #1509 watcher restarted the
  process — a restart on every `make deploy-e2e-infra`. Matches how LWS is already
  installed, in prerequisites, before the controller.

`deploy_scaler_backend` has one call site and needs only vars set before it, so nothing
depended on the old position.

Note: `cleanup.sh` undeploys KEDA before the controller, which is no longer the reverse of
install order. Harmless — the watcher only probes for CRDs absent at boot — but say the
word and I'll reorder teardown too.

## Test evidence

`make smoke-deploy-scripts` passes.

### Pre-review Checklist

- [ ] **E2E tests** — N/A: install ordering only, no behavior change.
- [ ] **Docs PR** — N/A.
- [ ] **Proposal PR** — N/A, implements #1534.

**Release Note**

```release-note
NONE
```
