### PR TITLE
fix(collector): use exported vLLM prefix-cache counters

### DIFF
--- a/internal/collector/registration/engine_test.go
+++ b/internal/collector/registration/engine_test.go
@@ -27,7 +27,7 @@ var _ = Describe("EngineQuery", func() {
 	})
 })
 
-var _ = Describe("SGLang query registration", func() {
+var _ = Describe("Engine-specific query registration", func() {
 	var registry *source.SourceRegistry
 
 	BeforeEach(func() {
@@ -50,6 +50,14 @@ var _ = Describe("SGLang query registration", func() {
 			Expect(get(inferenceengine.EngineVLLM, logical)).NotTo(BeNil(), "missing vLLM "+logical)
 			Expect(get(inferenceengine.EngineSGLang, logical)).NotTo(BeNil(), "missing SGLang "+logical)
 		}
+	})
+
+	It("uses vLLM's exported prefix-cache counter names", func() {
+		prefixCache := get(inferenceengine.EngineVLLM, QueryPrefixCacheHitRate).Template
+		Expect(prefixCache).To(ContainSubstring("vllm:prefix_cache_hits_total{"))
+		Expect(prefixCache).To(ContainSubstring("vllm:prefix_cache_queries_total{"))
+		Expect(prefixCache).NotTo(ContainSubstring("vllm:prefix_cache_hits{"))
+		Expect(prefixCache).NotTo(ContainSubstring("vllm:prefix_cache_queries{"))
 	})
 
 	It("uses sglang:* metric names in SGLang templates", func() {

--- a/internal/collector/registration/saturation.go
+++ b/internal/collector/registration/saturation.go
@@ -100,7 +100,7 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryPrefixCacheHitRate,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(vllm:prefix_cache_hits{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:prefix_cache_queries{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(vllm:prefix_cache_hits_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:prefix_cache_queries_total{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Prefix cache hit rate per instance (0.0-1.0, 5m rate)",
 	})

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -61,11 +61,11 @@ const (
 
 	// VLLMPrefixCacheHits is a counter of prefix cache block hits.
 	// Used with VLLMPrefixCacheQueries to compute prefix cache hit rate.
-	VLLMPrefixCacheHits = "vllm:prefix_cache_hits"
+	VLLMPrefixCacheHits = "vllm:prefix_cache_hits_total"
 
 	// VLLMPrefixCacheQueries is a counter of prefix cache block queries.
 	// Used with VLLMPrefixCacheHits to compute prefix cache hit rate.
-	VLLMPrefixCacheQueries = "vllm:prefix_cache_queries"
+	VLLMPrefixCacheQueries = "vllm:prefix_cache_queries_total"
 )
 
 // SGLang Input Metrics
@@ -125,7 +125,7 @@ const (
 
 	// SGLangCachedTokensTotal is a counter of prompt tokens served from the prefix cache.
 	// Used with SGLangPromptTokensTotal to compute the prefix cache hit rate, the
-	// unit-safe analog of vllm:prefix_cache_hits / vllm:prefix_cache_queries.
+	// unit-safe analog of vllm:prefix_cache_hits_total / vllm:prefix_cache_queries_total.
 	SGLangCachedTokensTotal = "sglang:cached_tokens_total"
 
 	// SGLangPromptTokensTotal is a counter of total prompt tokens.

--- a/internal/domain/saturation_analyzer.go
+++ b/internal/domain/saturation_analyzer.go
@@ -97,7 +97,7 @@ type ReplicaMetrics struct {
 	AvgInputTokens float64
 
 	// PrefixCacheHitRate is the fraction of prefix cache queries that were hits (0.0-1.0).
-	// Derived from rate(vllm:prefix_cache_hits[5m]) / rate(vllm:prefix_cache_queries[5m]).
+	// Derived from rate(vllm:prefix_cache_hits_total[5m]) / rate(vllm:prefix_cache_queries_total[5m]).
 	// Used to reduce estimated input token demand for scheduler-queued requests.
 	// Zero when prefix caching is disabled or metrics are unavailable.
 	PrefixCacheHitRate float64


### PR DESCRIPTION
Fixes #1526

The vLLM prefix-cache hit-rate query uses the Prometheus counter family names without the `_total` suffix. WVA passes metric selectors through unchanged, so the query matches no series and silently treats the prefix-cache hit rate as zero.

## Proposed Changes

- Query `vllm:prefix_cache_hits_total` and `vllm:prefix_cache_queries_total` in the saturation V2 prefix-cache hit-rate template.
- Add focused registration coverage that requires the exported `_total` series and rejects the unsuffixed selectors, while leaving SGLang unchanged.
- Align the shared metric constants and related code comments with the exported vLLM counter names.

## Test Evidence

- `go test ./internal/collector/registration` — passed
- `make test` — passed
- `make lint` — passed with 0 issues

### Pre-review Checklist

- [x] **E2E tests** for any new behavior — Not run; this metric-selector correction is covered by the focused query-registration regression test and does not require a new E2E scenario.
- [x] **Docs PR** for any user-facing impact — Follow-up: a few user/developer-guide references still show the unsuffixed vLLM counter names. I will open a separate PR to update those docs.
- [x] **Proposal PR** for any new enhancement or change to existing behavior — N/A; this is a targeted bug fix for #1526.

**Release Note**

```release-note
Fixed vLLM prefix-cache hit-rate collection so saturation V2 accounts for prefix-cache hits when estimating input-token demand.
```

**Docs**

I will create a follow-up PR to update leftover unsuffixed names in `docs/user-guide/sglang-backend.md`, `docs/developer-guide/throughput-analyzer.md`, and `docs/proposals/sglang-backend.md`. This PR does not change public API, configuration, or deployment procedure.