### PR TITLE
fix(coordinator): damp noise-driven maxReplicas churn in gpu-rebalance

### DIFF
--- a/internal/coordinator/plugins/gpurebalance/damping.go
+++ b/internal/coordinator/plugins/gpurebalance/damping.go
@@ -1,0 +1,117 @@
+package gpurebalance
+
+import (
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Damping guards for the rebalance patch loop.
+//
+// The plugin recomputes every ceiling from an instantaneous EPP queue-depth
+// reading each tick. Queue depth fluctuates a few percent between scrapes, and
+// the allocation is a floor() of a weight, so a one-unit change in queue can
+// move a ceiling across a fractional boundary and back again. Patching on every
+// tick turns that noise into real pod churn: a lowered ceiling is enforced by
+// the HPA immediately, evicting pods mid-request and bypassing the
+// scaleDown.stabilizationWindowSeconds the operator configured.
+//
+// The two directions are not symmetric, so they are not damped the same way:
+//
+//   - Raising a ceiling is cheap and reversible. It only widens the range the
+//     HPA may use; the HPA still decides whether to actually add pods, and its
+//     own scale-up policy still applies. Delaying it makes real demand spikes
+//     late, which is its own SLO problem.
+//   - Lowering a ceiling is destructive. It can force an immediate scale-down.
+//     A lower target therefore has to prove it is not noise before it is acted
+//     on: it must persist across several consecutive ticks.
+//
+// This is deliberately a stabilization window expressed in ticks rather than a
+// blanket cooldown, so it mirrors the semantics the operator already expects
+// from the HPA instead of inventing a second, unrelated delay.
+const (
+	// downscaleStabilizationTicks is how many consecutive ticks a lower ceiling
+	// must be computed before it is applied.
+	//
+	// At the default COORDINATOR_INTERVAL of 15s this is one minute of agreement,
+	// which is long enough to ride out the few-percent scrape-to-scrape jitter
+	// described in the issue, and short enough to stay well inside the HPA's own
+	// 300s default scale-down stabilization window — so the Coordinator relaxing
+	// a ceiling never becomes the slowest link in a genuine scale-down.
+	downscaleStabilizationTicks = 4
+)
+
+// stabilizer tracks, per managed scaler, how many consecutive ticks have
+// computed a ceiling below the one currently set.
+//
+// Coordinator ticks are dispatched sequentially from a single loop, so this is
+// not contended in practice; the mutex is here so the plugin stays safe if the
+// loop ever fans out, and costs nothing in the current path.
+type stabilizer struct {
+	mu sync.Mutex
+	// downTicks maps a scaler key to the number of consecutive ticks its
+	// computed target has been strictly below its current ceiling.
+	downTicks map[string]int
+}
+
+func newStabilizer() *stabilizer {
+	return &stabilizer{downTicks: make(map[string]int)}
+}
+
+// scalerKey identifies a managed scaler across ticks.
+//
+// Namespace and name alone are not enough: an HPA and a KEDA ScaledObject can
+// share a name in one namespace, and they are distinct scalers to this plugin.
+// GroupVersionKind is not always populated on typed objects read through the
+// controller-runtime client, so the plugin's own display kind is used instead.
+func scalerKey(ns, displayKind string, obj client.Object) string {
+	return fmt.Sprintf("%s/%s/%s", ns, displayKind, obj.GetName())
+}
+
+// shouldPatch reports whether a newly computed ceiling should be written now,
+// and records what it observed for the next tick.
+//
+//   - target == current  -> no patch, and any pending downgrade streak resets
+//     (the ceiling agrees with reality again, so earlier low readings were noise)
+//   - target > current   -> patch immediately, and reset the streak
+//   - target < current   -> only patch once this has held for
+//     downscaleStabilizationTicks consecutive ticks; reset the streak when it does
+//
+// The streak resets on apply as well as on recovery. Without that, a scaler
+// drifting steadily downward would clear the threshold once and then patch on
+// every subsequent tick, which is the churn this exists to prevent: each
+// downgrade has to earn its own stabilization window.
+func (s *stabilizer) shouldPatch(key string, current, target int32) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if target >= current {
+		// Nothing to hold back: either the ceiling is being raised, which cannot
+		// evict anything, or it already agrees with the computed target. Either
+		// way any pending downgrade was noise.
+		delete(s.downTicks, key)
+		return target > current
+	}
+
+	s.downTicks[key]++
+	if s.downTicks[key] < downscaleStabilizationTicks {
+		return false
+	}
+	delete(s.downTicks, key)
+	return true
+}
+
+// retain drops state for scalers that were not seen this tick, so the map does
+// not grow without bound as ScaledObjects and HPAs come and go. Called once per
+// tick with every key observed across all namespaces.
+func (s *stabilizer) retain(seen map[string]struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for k := range s.downTicks {
+		if _, ok := seen[k]; !ok {
+			delete(s.downTicks, k)
+		}
+	}
+}

--- a/internal/coordinator/plugins/gpurebalance/damping_test.go
+++ b/internal/coordinator/plugins/gpurebalance/damping_test.go
@@ -1,0 +1,125 @@
+package gpurebalance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testKey = "ns-a/ScaledObject/pool-a-so"
+
+// TestShouldPatch_RaisesImmediately pins the asymmetry: widening a ceiling is
+// reversible and cannot evict anything, so it is never delayed. Delaying it
+// would make a genuine demand spike late, which is the failure mode the damping
+// is not supposed to introduce.
+func TestShouldPatch_RaisesImmediately(t *testing.T) {
+	s := newStabilizer()
+	assert.True(t, s.shouldPatch(testKey, 4, 6), "an increase must be applied on the first tick")
+	assert.True(t, s.shouldPatch(testKey, 6, 9), "consecutive increases must not be throttled")
+}
+
+// TestShouldPatch_LowerTargetMustPersist covers the core of #1427: a single
+// noisy reading that computes a lower ceiling must not reach the cluster,
+// because a lowered ceiling is enforced immediately and evicts pods.
+func TestShouldPatch_LowerTargetMustPersist(t *testing.T) {
+	s := newStabilizer()
+
+	for tick := 1; tick < downscaleStabilizationTicks; tick++ {
+		assert.False(t, s.shouldPatch(testKey, 8, 6),
+			"tick %d: a lower ceiling must be held until it has persisted", tick)
+	}
+
+	assert.True(t, s.shouldPatch(testKey, 8, 6),
+		"the lower ceiling must be applied once it has held for downscaleStabilizationTicks")
+}
+
+// TestShouldPatch_RecoveryResetsStreak is the noise case from the issue: the
+// queue dips for a tick or two, then recovers. The transient dip must not
+// accumulate toward a downgrade, otherwise repeated unrelated blips eventually
+// add up to an eviction.
+func TestShouldPatch_RecoveryResetsStreak(t *testing.T) {
+	s := newStabilizer()
+
+	require.False(t, s.shouldPatch(testKey, 8, 6), "first low reading is held")
+	require.False(t, s.shouldPatch(testKey, 8, 6), "second low reading is held")
+
+	// Queue recovers and the computed ceiling agrees with reality again.
+	assert.False(t, s.shouldPatch(testKey, 8, 8), "agreement is not a patch")
+
+	// The earlier dip must be forgotten, so a fresh dip starts counting from zero.
+	for tick := 1; tick < downscaleStabilizationTicks; tick++ {
+		assert.False(t, s.shouldPatch(testKey, 8, 6),
+			"tick %d: streak should have reset after recovery", tick)
+	}
+	assert.True(t, s.shouldPatch(testKey, 8, 6), "and only then apply")
+}
+
+// TestShouldPatch_ResetsAfterApplying guards the churn case: once a downgrade is
+// applied, the counter has to start over. If it did not, a scaler drifting
+// steadily downward would patch on every subsequent tick.
+func TestShouldPatch_ResetsAfterApplying(t *testing.T) {
+	s := newStabilizer()
+
+	for tick := 1; tick < downscaleStabilizationTicks; tick++ {
+		require.False(t, s.shouldPatch(testKey, 8, 6))
+	}
+	require.True(t, s.shouldPatch(testKey, 8, 6), "applies once persisted")
+
+	// Next tick computes a lower ceiling again; it must serve a fresh window.
+	assert.False(t, s.shouldPatch(testKey, 6, 5),
+		"a further downgrade must serve its own stabilization window, not patch immediately")
+}
+
+// TestShouldPatch_TracksScalersIndependently ensures one noisy pool cannot
+// consume another pool's stabilization window — they are separate scalers with
+// separate keys.
+func TestShouldPatch_TracksScalersIndependently(t *testing.T) {
+	s := newStabilizer()
+	const other = "ns-a/ScaledObject/pool-b-so"
+
+	for tick := 1; tick < downscaleStabilizationTicks; tick++ {
+		require.False(t, s.shouldPatch(testKey, 8, 6))
+	}
+
+	assert.False(t, s.shouldPatch(other, 8, 6),
+		"a different scaler starts its own window")
+	assert.True(t, s.shouldPatch(testKey, 8, 6),
+		"the original scaler's window is unaffected by the other")
+}
+
+// TestRetain_PrunesDepartedScalers keeps the state map bounded to the live set.
+// Without this, every ScaledObject ever observed would be retained for the
+// lifetime of the process.
+func TestRetain_PrunesDepartedScalers(t *testing.T) {
+	s := newStabilizer()
+	const departed = "ns-a/ScaledObject/deleted-so"
+
+	require.False(t, s.shouldPatch(testKey, 8, 6))
+	require.False(t, s.shouldPatch(departed, 8, 6))
+	require.Len(t, s.downTicks, 2)
+
+	s.retain(map[string]struct{}{testKey: {}})
+
+	assert.Contains(t, s.downTicks, testKey, "a live scaler keeps its streak")
+	assert.NotContains(t, s.downTicks, departed, "a departed scaler is pruned")
+}
+
+// TestScalerKey_DistinguishesKindAndNamespace guards the key derivation: an HPA
+// and a ScaledObject may share a name in one namespace, and the same name may
+// exist in two namespaces. Collapsing either would let one scaler's readings
+// damp another's.
+func TestScalerKey_DistinguishesKindAndNamespace(t *testing.T) {
+	obj := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared"},
+	}
+
+	hpaKey := scalerKey("ns-a", displayKindHPA, obj)
+	soKey := scalerKey("ns-a", displayKindScaledObject, obj)
+	otherNS := scalerKey("ns-b", displayKindHPA, obj)
+
+	assert.NotEqual(t, hpaKey, soKey, "kind must be part of the key")
+	assert.NotEqual(t, hpaKey, otherNS, "namespace must be part of the key")
+}

--- a/internal/coordinator/plugins/gpurebalance/plugin.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin.go
@@ -31,6 +31,8 @@ const (
 type Plugin struct {
 	client  client.Client
 	promAPI promv1.API
+	// stab damps noise-driven ceiling changes across ticks. See damping.go.
+	stab *stabilizer
 }
 
 // +kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch
@@ -39,7 +41,7 @@ type Plugin struct {
 
 // New constructs the gpu-rebalance Plugin.
 func New(c client.Client, promAPI promv1.API) *Plugin {
-	return &Plugin{client: c, promAPI: promAPI}
+	return &Plugin{client: c, promAPI: promAPI, stab: newStabilizer()}
 }
 
 // Name returns the unique plugin identifier.
@@ -78,6 +80,18 @@ func (p *Plugin) Tick(ctx context.Context, selected []client.Object) error {
 	if len(byNamespace) == 0 {
 		return nil
 	}
+
+	// Drop damping state for scalers that no longer exist, so the map tracks the
+	// live set rather than every scaler ever seen. Done before rebalancing so a
+	// scaler deleted and quickly recreated starts from a clean streak instead of
+	// inheriting the old object's pending downgrade.
+	seen := make(map[string]struct{})
+	for ns, entries := range byNamespace {
+		for _, e := range entries {
+			seen[scalerKey(ns, e.displayKind, e.obj)] = struct{}{}
+		}
+	}
+	p.stab.retain(seen)
 
 	for ns, entries := range byNamespace {
 		if err := p.rebalanceNamespace(ctx, log, ns, entries); err != nil {
@@ -195,22 +209,29 @@ func (p *Plugin) rebalanceNamespace(ctx context.Context, log logr.Logger, ns str
 		targets[maxWeightIdx] += int32(rem)
 	}
 
-	// TODO: the current patch-on-every-tick approach causes wobble. Instantaneous
-	// queue depth is noisy, so small fluctuations (e.g. q=270 vs q=286) move the
-	// floor/ceil boundary each cycle, producing 1-replica flips every 15s. Each
-	// flip triggers pod churn which perturbs the queue and drives the next flip.
-	// Fix with two complementary guards:
-	//   1. Minimum delta: skip the patch when abs(new - current) < N replicas so
-	//      noise-driven micro-adjustments are ignored.
-	//   2. Per-HPA cooldown: after patching an HPA, skip it for the next K ticks
-	//      so the HPA and its pods have time to converge before the next reading.
-	// An alternative to (2) is EWMA smoothing of the queue metric across ticks,
-	// which dampens burst noise without adding a hard cooldown delay.
-
+	// Ceilings are recomputed from an instantaneous queue reading, so they are
+	// noisy. shouldPatch decides whether a computed change is worth acting on:
+	// increases go through immediately, decreases must persist across several
+	// ticks before they can evict pods. See damping.go for why the directions
+	// are treated differently.
 	for i, e := range entries {
 		if targets[i] == e.currentMax {
+			// Still report agreement so a pending downgrade streak is cleared.
+			p.stab.shouldPatch(scalerKey(ns, e.displayKind, e.obj), e.currentMax, targets[i])
 			continue
 		}
+
+		key := scalerKey(ns, e.displayKind, e.obj)
+		if !p.stab.shouldPatch(key, e.currentMax, targets[i]) {
+			log.V(1).Info("Holding max replica ceiling; lower target has not persisted long enough",
+				"kind", e.displayKind, "name", e.obj.GetName(), "namespace", ns,
+				"pool", e.pool,
+				"current", e.currentMax, "computed", targets[i],
+				"queue", queues[i], "quota", quota,
+			)
+			continue
+		}
+
 		log.Info("Setting max replica ceiling",
 			"kind", e.displayKind, "name", e.obj.GetName(), "namespace", ns,
 			"pool", e.pool,

--- a/internal/coordinator/plugins/gpurebalance/plugin_test.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin_test.go
@@ -120,6 +120,19 @@ func makeGPUQuota(name, ns string, gpus int64) *corev1.ResourceQuota {
 	}
 }
 
+// tickUntilDownscaleApplies drives the plugin for as many ticks as a lowered
+// ceiling must persist before the stabilizer writes it. Raising a ceiling lands
+// on the first tick, so only cases that expect a downgrade need this. See
+// damping.go for why the two directions are treated differently.
+func tickUntilDownscaleApplies(t *testing.T, p *Plugin, objs ...client.Object) {
+	t.Helper()
+	for i := range downscaleStabilizationTicks {
+		if err := p.Tick(context.Background(), objs); err != nil {
+			t.Fatalf("unexpected error on tick %d: %v", i+1, err)
+		}
+	}
+}
+
 func newPlugin(t *testing.T, queues map[string]float64, errs map[string]error, objs ...client.Object) (*Plugin, client.Client) {
 	t.Helper()
 	scheme := newTestScheme(t)
@@ -346,9 +359,7 @@ func TestRebalance_QueryError_TreatedAsZero(t *testing.T) {
 		hpaA, hpaB, makeGPUQuota("q", "ns", 10),
 	)
 
-	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	tickUntilDownscaleApplies(t, p, hpaA, hpaB)
 	// Reserve one replica for each pool, then give the remaining eight to model-b.
 	if got := getMaxReplicas(t, c, hpaA); got != 1 {
 		t.Errorf("model-a maxReplicas = %d, want 1 (query error → treated as 0, clamped to min)", got)
@@ -463,9 +474,7 @@ func TestRebalance_ReservesHPAMinimum(t *testing.T) {
 		hpaA, hpaB, makeGPUQuota("q", "ns", 10),
 	)
 
-	if err := p.Tick(context.Background(), []client.Object{hpaA, hpaB}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	tickUntilDownscaleApplies(t, p, hpaA, hpaB)
 	if got := getMaxReplicas(t, c, hpaA); got != 7 {
 		t.Errorf("model-a maxReplicas = %d, want 7", got)
 	}
@@ -484,9 +493,7 @@ func TestRebalance_ReservesScaledObjectMinimum(t *testing.T) {
 		soA, soB, makeGPUQuota("q", "ns", 10),
 	)
 
-	if err := p.Tick(context.Background(), []client.Object{soA, soB}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	tickUntilDownscaleApplies(t, p, soA, soB)
 	if got := getMaxReplicaCount(t, c, soA); got != 7 {
 		t.Errorf("model-a maxReplicaCount = %d, want 7", got)
 	}
@@ -506,9 +513,7 @@ func TestRebalance_ReservesMixedMinimums(t *testing.T) {
 		hpaA, soB, makeGPUQuota("q", "ns", 12),
 	)
 
-	if err := p.Tick(context.Background(), []client.Object{hpaA, soB}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	tickUntilDownscaleApplies(t, p, hpaA, soB)
 	if got := getMaxReplicas(t, c, hpaA); got != 4 {
 		t.Errorf("model-a maxReplicas = %d, want 4", got)
 	}
@@ -537,9 +542,7 @@ func TestRebalance_AllocationNeverExceedsQuota(t *testing.T) {
 		hpaA, soB, hpaC, makeGPUQuota("q", "ns", quota),
 	)
 
-	if err := p.Tick(context.Background(), []client.Object{hpaA, soB, hpaC}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	tickUntilDownscaleApplies(t, p, hpaA, soB, hpaC)
 
 	gotA := getMaxReplicas(t, c, hpaA)
 	gotB := getMaxReplicaCount(t, c, soB)


### PR DESCRIPTION
## What this PR does

Fixes the maxReplicas flipping and pod churn described in #1427.

`gpu-rebalance` recomputes every ceiling from an instantaneous EPP queue-depth reading and patches on every tick. Queue depth moves a few percent between scrapes and the allocation floors a weight, so a one-unit change in queue can push a ceiling across a fractional boundary and straight back — the sawtooth in the issue. A *lowered* ceiling is enforced by the HPA immediately, so that noise evicts pods mid-request and bypasses the `scaleDown.stabilizationWindowSeconds` the operator configured.

## Approach

The in-code TODO proposed a minimum-delta guard plus a per-object cooldown. I've implemented a variant of that, and I want to flag the one place I deliberately deviated, because it's a design call rather than a detail.

**The risk is not symmetric, so the damping isn't either.**

- **Raising** a ceiling only widens the range the HPA *may* use — the HPA still decides whether to add pods, and its own scale-up policy still applies. It cannot evict anything. Delaying it makes a genuine demand spike late, which is its own SLO problem. So increases still apply on the first tick.
- **Lowering** a ceiling can force an immediate scale-down. So a lower target has to prove it isn't noise: it must hold for `downscaleStabilizationTicks` consecutive ticks before it's written.

A blanket cooldown would have bought stability by making real scale-ups slow. This is effectively a stabilization window enforced at the Coordinator, mirroring the semantics the operator already expects from the HPA rather than introducing a second, unrelated delay.

**Happy to switch to the symmetric min-delta + cooldown exactly as the TODO describes** if you'd prefer the first PR to land that and treat direction-awareness as a follow-up — the change would be small and contained to `shouldPatch`.

## Notable details

- **Ticks, not wall-clock.** The guard is expressed in ticks so it stays in the same units as the control loop and scales with `COORDINATOR_INTERVAL`. The default of 4 is one minute at the default 15s interval — long enough to ride out the few-percent jitter in the issue, and well inside the HPA's own 300s default scale-down window, so the Coordinator never becomes the slowest link in a genuine scale-down.
- **The streak resets on apply as well as on recovery.** Without that, a scaler drifting steadily downward would clear the threshold once and then patch on every subsequent tick — the exact churn this is meant to prevent. Each downgrade earns its own window.
- **State is keyed by namespace/kind/name.** An HPA and a ScaledObject can share a name in one namespace, and the same name can exist in two namespaces; collapsing either would let one pool's readings damp another's. It's pruned every tick to the live scaler set so the map doesn't grow as scalers come and go.
- **No new configuration surface.** The threshold is an unexported constant. The plugin takes no tuning knobs today and I'd rather not add API that has to be supported before anyone has asked for it — easy to promote to `wva-manager-config` later if operators want it.

## Testing

Seven new unit tests in `damping_test.go` covering the contract: increases apply immediately, a lower target is held until it persists, a recovery resets the streak so transient dips can't accumulate, applying resets the streak, scalers are tracked independently, departed scalers are pruned, and the key distinguishes kind and namespace.

Six existing `TestRebalance_*` cases assert downgrades from a seeded `maxReplicas`, which by design no longer land in a single tick. They now drive the plugin through `tickUntilDownscaleApplies` rather than having their expectations changed, so they still assert the same allocation arithmetic.

`internal/coordinator/...` passes and `gofmt` is clean. The failures in `internal/actuator` and `internal/controller` on my machine are missing envtest binaries and reproduce on a clean checkout of `main`.

## Interaction with #1533

Worth flagging for whoever reviews both: the coordinator e2e suite in #1533 asserts that a ceiling change appears within a tick. Once this lands, that's only true for increases. I'll update that PR to drive enough ticks for the downgrade case rather than leave a stale timing assumption — happy to sequence them in whichever order you prefer.

---

*Disclosure: prepared with AI assistance. The approach follows the in-code TODO and the analysis was checked against `rebalanceNamespace` and the existing tests before writing.*
