### PR TITLE
fix: refresh Go 1.26 builder image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/projectquay/golang:1.26@sha256:ee44710323a5809f03fbe9607fb6ee9229cd32d2c3cbf811616284e74a7f4725 AS builder
+FROM quay.io/projectquay/golang:1.26@sha256:fe24778fb3640a23a3cdc40e50e86e06cea01d0c028bdd06550654a7e2a09df1 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Proposed Changes

Refresh the pinned digest for the existing Go 1.26 builder image used by the WVA Dockerfile.

The currently pinned manifest:

`quay.io/projectquay/golang:1.26@sha256:ee44710323a5809f03fbe9607fb6ee9229cd32d2c3cbf811616284e74a7f4725`

no longer resolves from Quay and causes PR E2E jobs that build the WVA image to fail during `Build WVA image locally`, before the actual Kind/Ginkgo tests run.

This PR keeps the Go 1.26 toolchain unchanged and only refreshes the immutable image digest to the currently resolvable manifest:

`sha256:fe24778fb3640a23a3cdc40e50e86e06cea01d0c028bdd06550654a7e2a09df1`

## Validation

- Confirmed the existing pinned digest returns `not found`.
- Resolved the current `quay.io/projectquay/golang:1.26` OCI image index digest with `docker buildx imagetools inspect`.
- Independently cross-checked the digest against the raw manifest bytes.
- Verified the replacement digest resolves successfully.
- Verified the replacement manifest remains multi-arch for amd64, arm64, ppc64le, and s390x.
- Successfully built the WVA image with the refreshed digest using the repository's `make docker-build` path.
