### PR TITLE
chore: allow sed branch label "ba" in typos config

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -8,6 +8,8 @@ parms = "parms"
 # Short code fragments / false positives
 ot = "ot"
 vas = "vas"
+# sed branch label in `sed ':a; N; $!ba; s/\n/:/g'` (branch to label `a`)
+ba = "ba"
 # "mis-" prefix used as a hyphenated modifier (mis-classified, mis-attributed)
 mis = "mis"
 # Valid English variant (unparseable vs unparsable)


### PR DESCRIPTION
The nightly typo scan reported `ba` -> `by` in `benchmark/config/templates/values/defaults.yaml:564`.

That `ba` is not a typo. The line is:

```
export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
```

`:a` defines a sed label and `$!ba` branches back to it, the standard idiom for joining all input lines. Rewriting `ba` to `by` would break the command.

This adds `ba` to the existing "Short code fragments / false positives" list in `_typos.toml`, alongside `ot` and `vas`. It is the only standalone `ba` in the repository, so the entry does not mask a real typo anywhere else.

Fixes #1529