### PR TITLE
fix: broken base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/projectquay/golang:1.26@sha256:fe24778fb3640a23a3cdc40e50e86e06cea01d0c028bdd06550654a7e2a09df1 AS builder
+FROM quay.io/projectquay/golang:1.26@sha256:4142f907965c7a70000f34ddfcaefda9b0d61a72dff1b318946c318867f0e53d AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
current build is broken since https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/1540 need to fix SHA1


## Proposed Changes

- :bug: Fix bug


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Go builder image for more reliable and reproducible builds.
  * No changes to application behavior or runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

cc @vivekk16 @mamy-CS 