### PR TITLE
fix(scalefromzero): do not treat a failed EPP scrape as an idle pool

### DIFF
--- a/internal/collector/source/pod/pod_scraping_source.go
+++ b/internal/collector/source/pod/pod_scraping_source.go
@@ -131,6 +131,14 @@ func (p *PodScrapingSource) Refresh(ctx context.Context, spec source.RefreshSpec
 	// Aggregate results
 	aggregated := p.aggregateResults(results)
 
+	// Every ready pod failed to scrape. The aggregated result is otherwise
+	// indistinguishable from a successful scrape of genuinely idle pods (empty
+	// Values, nil Error), which lets consumers read a total collection failure
+	// as "no activity". Surface it as an error so they can tell the two apart.
+	if len(results) == 0 {
+		aggregated.Error = fmt.Errorf("failed to scrape all %d ready pod(s)", len(pods))
+	}
+
 	// Cache the aggregated result under the canonical "all_metrics" key.
 	cacheKey := source.BuildCacheKey("all_metrics", nil)
 	p.cache.Set(cacheKey, *aggregated, p.config.DefaultTTL)

--- a/internal/collector/source/pod/pod_scraping_source_test.go
+++ b/internal/collector/source/pod/pod_scraping_source_test.go
@@ -597,6 +597,7 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 			Expect(err).NotTo(HaveOccurred())
 			Expect(results1).To(HaveKey("all_metrics"))
 			Expect(results1["all_metrics"].Values).To(HaveLen(2)) // 2 metrics from pod1
+			Expect(results1["all_metrics"].HasError()).To(BeFalse())
 
 			// Verify metrics have pod label
 			for _, value := range results1["all_metrics"].Values {
@@ -656,6 +657,9 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 			Expect(results).To(HaveKey("all_metrics"))
 			// Should have empty or no metrics due to unreachable pod
 			Expect(results["all_metrics"].Values).To(BeEmpty())
+			// Every pod failed, so the empty result must carry an error rather
+			// than looking identical to a successful scrape of idle pods.
+			Expect(results["all_metrics"].HasError()).To(BeTrue())
 		})
 
 		It("should handle authentication failures", func() {
@@ -714,6 +718,58 @@ vllm_num_requests_waiting{namespace="test-ns"} 3
 			Expect(results).To(HaveKey("all_metrics"))
 			// Should have no metrics due to auth failure
 			Expect(results["all_metrics"].Values).To(BeEmpty())
+			// A 401 from every pod is a collection failure, not an idle pool.
+			Expect(results["all_metrics"].HasError()).To(BeTrue())
+		})
+
+		It("should not set an error when only some pods fail to scrape", func() {
+			var port1 int32
+			_, err := fmt.Sscanf(mockServer1.URL, "http://127.0.0.1:%d", &port1)
+			Expect(err).NotTo(HaveOccurred())
+
+			// readyPod1 is served by mockServer1; this one is not reachable at all.
+			unreachablePod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "epp-pod-unreachable",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"inferencepool": "test-pool-epp",
+					},
+				},
+				Status: corev1.PodStatus{
+					PodIP: "192.0.2.1", // TEST-NET-1, never routable
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			}
+
+			client := fakeClient.
+				WithObjects(service, readyPod1, unreachablePod).
+				Build()
+
+			config := PodScrapingSourceConfig{
+				ServiceName:          "test-pool-epp",
+				ServiceNamespace:     "test-ns",
+				MetricsPort:          port1,
+				MetricsPath:          "/metrics",
+				MetricsScheme:        "http",
+				ScrapeTimeout:        1 * time.Second,
+				MaxConcurrentScrapes: 10,
+				BearerToken:          "test-token",
+			}
+			source, err := NewPodScrapingSource(ctx, client, config)
+			Expect(err).NotTo(HaveOccurred())
+
+			results, err := source.Refresh(ctx, sourcepkg.RefreshSpec{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveKey("all_metrics"))
+			// Partial data is still usable, so no error is reported.
+			Expect(results["all_metrics"].Values).NotTo(BeEmpty())
+			Expect(results["all_metrics"].HasError()).To(BeFalse())
 		})
 	})
 

--- a/internal/engines/scalefromzero/engine.go
+++ b/internal/engines/scalefromzero/engine.go
@@ -289,8 +289,24 @@ func (e *Engine) processInactiveVariant(ctx context.Context, scaleTargets map[st
 		return err
 	}
 
-	// Check for pending requests using EPP flowcontrol queue size metrics
+	// Check for pending requests using EPP flowcontrol queue size metrics.
+	// A missing or errored result means the queue depth is unknown, not zero:
+	// concluding "no pending requests" here would leave a variant with queued
+	// work scaled to zero, logged identically to a genuinely idle one.
 	result := results["all_metrics"]
+	if result == nil {
+		err := fmt.Errorf("EPP metrics source returned no all_metrics result for pool %s", namespacedPoolName)
+		metrics.IncMetricsCollectionErrors(constants.QueryTypeQueueLength, "missing_result")
+		logger.Error(err, "Cannot determine pending requests", "variant", va.Name, "namespace", va.Namespace)
+		return err
+	}
+	if result.HasError() {
+		reason := prometheus.CategorizePrometheusError(result.Error)
+		metrics.IncMetricsCollectionErrors(constants.QueryTypeQueueLength, reason)
+		logger.Error(result.Error, "Cannot determine pending requests", "variant", va.Name, "namespace", va.Namespace)
+		return fmt.Errorf("collecting EPP metrics for pool %s: %w", namespacedPoolName, result.Error)
+	}
+
 	pendingRequestExist := false
 	for _, value := range result.Values {
 		metricName := value.Labels["__name__"]

--- a/internal/engines/scalefromzero/engine_scrape_failure_test.go
+++ b/internal/engines/scalefromzero/engine_scrape_failure_test.go
@@ -1,0 +1,161 @@
+package scalefromzero
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsV1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/common"
+	utiltest "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	poolreconciler "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
+	vav1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/variant"
+	unittestutil "github.com/llm-d/llm-d-workload-variant-autoscaler/test/utils"
+)
+
+// stubSource is a MetricsSource that returns a canned Refresh result, so tests
+// can drive the engine through collection outcomes that are impractical to
+// reproduce against a live scraper.
+type stubSource struct {
+	results map[string]*source.MetricResult
+}
+
+func (s *stubSource) QueryList() *source.QueryList { return nil }
+
+func (s *stubSource) Refresh(context.Context, source.RefreshSpec) (map[string]*source.MetricResult, error) {
+	return s.results, nil
+}
+
+func (s *stubSource) Get(string, map[string]string) *source.CachedValue { return nil }
+
+// stubSourceDatastore serves a fixed metrics source for every pool while
+// delegating all other datastore behaviour to the embedded implementation.
+type stubSourceDatastore struct {
+	datastore.Datastore
+	src source.MetricsSource
+}
+
+func (d stubSourceDatastore) PoolGetMetricsSource(string) source.MetricsSource { return d.src }
+
+// TestPendingRequestsUnknownIsNotIdle asserts that a variant is only treated as
+// idle when the EPP scrape actually succeeded. A failed collection reports an
+// empty metric set, which is byte-identical to an idle pool; concluding "no
+// pending requests" from it leaves a variant with queued work stuck at zero
+// replicas and logs nothing above DEBUG.
+func TestPendingRequestsUnknownIsNotIdle(t *testing.T) {
+	tests := []struct {
+		name    string
+		results map[string]*source.MetricResult
+		wantErr bool
+	}{
+		{
+			name: "collection failed: error must surface, not read as idle",
+			results: map[string]*source.MetricResult{
+				"all_metrics": {
+					QueryName: "all_metrics",
+					Values:    []source.MetricValue{},
+					Error:     errors.New("failed to scrape all 3 ready pod(s)"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "result absent entirely: queue depth is unknown",
+			results: map[string]*source.MetricResult{},
+			wantErr: true,
+		},
+		{
+			name: "collection succeeded and pool is genuinely idle",
+			results: map[string]*source.MetricResult{
+				"all_metrics": {
+					QueryName: "all_metrics",
+					Values:    []source.MetricValue{},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gvk := schema.GroupVersionKind{
+				Group:   v1.GroupVersion.Group,
+				Version: v1.GroupVersion.Version,
+				Kind:    "InferencePool",
+			}
+			pool := utiltest.MakeInferencePool("pool1").
+				Namespace(namespace).
+				Selector(selector_v1).
+				TargetPorts(8080).
+				EndpointPickerRef("epp-pool1-svc").ObjRef()
+			pool.SetGroupVersionKind(gvk)
+
+			// Variants are discovered from annotated HPAs targeting each Deployment.
+			hpa := managedHPA(namespace, resourceName, deploymentName, modelId)
+			dp := unittestutil.MakeDeployment(deploymentName, namespace, 0, selector_v1)
+			svc := unittestutil.MakeService("epp-pool1-svc", namespace)
+
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = v1alpha2.Install(scheme)
+			_ = v1.Install(scheme)
+			_ = vav1alpha1.AddToScheme(scheme)
+			_ = appsV1.AddToScheme(scheme)
+			_ = corev1.AddToScheme(scheme)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects([]client.Object{pool, dp, hpa, svc}...).
+				Build()
+			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, dp)
+
+			namespacedName := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			gknn := common.GKNN{
+				NamespacedName: namespacedName,
+				GroupKind: schema.GroupKind{
+					Group: pool.GroupVersionKind().Group,
+					Kind:  pool.GroupVersionKind().Kind,
+				},
+			}
+			ctx := context.Background()
+
+			ds := datastore.NewDatastore(nil)
+			reconciler := &poolreconciler.InferencePoolReconciler{Client: fakeClient, Datastore: ds, PoolGKNN: gknn}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
+			require.NoError(t, err)
+
+			engine := &Engine{
+				client:         fakeClient,
+				recorder:       record.NewFakeRecorder(100),
+				Datastore:      stubSourceDatastore{Datastore: ds, src: &stubSource{results: tt.results}},
+				DynamicClient:  fakeDynamicClient,
+				Mapper:         testrestmapper.TestOnlyStaticRESTMapper(scheme, schema.GroupVersion{Group: "apps", Version: "v1"}),
+				maxConcurrency: 30,
+			}
+
+			err = engine.optimize(ctx)
+			if tt.wantErr {
+				require.Error(t, err, "a failed or missing collection must not be reported as an idle pool")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When every EPP pod fails to scrape, a variant with queued requests silently stays scaled to zero, logged identically to a genuinely idle one.

## The problem

Three things line up:

1. `scrapeAllPods` ([pod_scraping_source.go](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/internal/collector/source/pod/pod_scraping_source.go)) logs a failed pod scrape at VERBOSE, bumps an error counter, and returns from the goroutine, dropping that pod from the results map. No `Error` is set on any `MetricResult`.
2. If *every* pod fails, `aggregateResults` returns `{QueryName: "all_metrics", Values: [], Error: nil}`, and `Refresh` returns it with a nil error. That is byte-identical to a successful scrape of a genuinely idle pool.
3. The scale-from-zero engine reads `results["all_metrics"]` directly, finds no queue-size values, and sets `pendingRequestExist = false`.

So when EPP is unreachable (pod down, auth failure, non-200), the engine concludes there is no queued work and leaves the variant at zero replicas. The only trace is a DEBUG line that reads the same as normal idle logging.

## The fix

**Source side.** When no pod scrape succeeded, set `Error` on the aggregated result so a total collection failure is distinguishable from "nothing queued".

`Refresh` still returns a nil function-level error, so consumers that check only `err` are unaffected. Partial failures are deliberately left alone: partial data is still usable and does not set `Error`.

**Consumer side.** Nil-guard the `all_metrics` lookup and check `HasError()` before interpreting the values, returning the error instead of concluding the pool is idle. Both paths increment `IncMetricsCollectionErrors`, so the failure surfaces through existing metrics rather than only in logs.

The nil guard is defensive. `PodScrapingSource` always sets the `all_metrics` key, so it is not reachable through the only implementation that exists today, but any other `MetricsSource` that omitted the key would panic at this line.

## Tests

- `TestPendingRequestsUnknownIsNotIdle` covers three collection outcomes: errored result, absent result, and a clean empty result that must still be read as idle.
- The two existing total-failure cases in the pod source suite (unreachable pods, auth failure) now also assert that the result carries an error.
- A new case asserts that partial failure does **not** set an error.

I confirmed these are not vacuous: with the production changes reverted, the pod-source assertions fail and the consumer test panics with a nil pointer dereference on the absent-result case.

`make test` passes, 36 packages ok. `go build`, `go vet`, and `gofmt` are clean.

## Notes

I could not run `make lint` locally. The pinned `bin/golangci-lint` is built with go1.26 and panics decoding stdlib export data against a go1.27 toolchain, on `test/testconfig/config.go`, which this PR does not touch. It fails the same way on an unmodified `main`, so it looks like a local toolchain mismatch rather than anything in this change, but it does mean lint is unverified on my end.

There is no existing issue for this; I found it while reading the collector. Happy to open one if you would prefer it tracked separately.