### PR TITLE
benchmark: extend the Grafana dashboard, add a token-aware scenario, drop deprecated session_id

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -246,6 +246,7 @@ chosen cluster-config + harness/workload, without leaving the browser. See
 [`docs/interactive-dashboard.md`](docs/interactive-dashboard.md).
 
 Each session can also get a standalone HTML summary (`report.html`) with
-links to Grafana panels (vLLM KV-cache utilization, queue size) for that
-session's benchmark-run time window, including a permanent snapshot that survives
+links to Grafana panels for that session's benchmark-run time window --
+vLLM engine metrics, llm-d EPP (router) metrics, and the replica counts the
+scaling strategy is judged on -- including a permanent snapshot that survives
 Prometheus data retention. See [`docs/benchmark-report.md`](docs/benchmark-report.md).

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -35,7 +35,8 @@ benchmark/
     │       └── pd-disaggregation/
     │           ├── baseline.yaml         # control = recommended strategy
     │           ├── queue-aggressive.yaml # variant (<strategy>.yaml)
-    │           └── kv-early.yaml          # variant
+    │           ├── kv-early.yaml          # variant
+    │           └── token-aware.yaml       # variant
     └── cluster-configs/      # swappable backend overlays (--cluster-config), grouped by platform
         ├── k8s/
         │   └── inference-sim.yaml       #   llm-d-inference-sim
@@ -90,7 +91,12 @@ Rules:
   the strategy does — e.g. `queue-aggressive.yaml`, `kv-early.yaml`. The file's
   header comment records the exact delta from `baseline.yaml`.
 - **Change only the `keda:` block** in a variant; keep everything else identical
-  to `baseline.yaml`.
+  to `baseline.yaml`. The one admissible exception is a trigger whose *metric
+  does not exist* under baseline — then add the minimum needed to publish it and
+  say so in the header. `token-aware.yaml` does this: its prefill trigger reads
+  `llm_d_epp_inflight_tokens`, so it adds the EPP `inflight-load-producer`
+  plugin (a producer, referenced from no scheduling profile, so routing is
+  unchanged).
 - **Promote a winner** by copying its `keda:` block back into
   `scenarios/guides/<guide>.yaml`; retire the losing variants.
 

--- a/benchmark/config/grafana/dashboard.json
+++ b/benchmark/config/grafana/dashboard.json
@@ -17,12 +17,22 @@
   "graphTooltip": 1,
   "id": null,
   "links": [],
+  "description": "Per-run view of a benchmark session: vLLM engine metrics, llm-d EPP (router) metrics, and the replica counts every autoscaling experiment is judged on. Two conventions: (1) panel queries may only reference the $namespace and $session_id variables and must use literal range durations (no $__rate_interval), because benchmark_report.py's snapshot capture substitutes exactly those two variables and sends the expression to Prometheus verbatim; (2) every vllm: query is wrapped in `max by (pod, namespace, engine)` so that pods scraped by both a PodMonitor and a ServiceMonitor -- the usual llm-d layout -- are counted once, and gated on `max by (namespace) (kube_pod_labels{...})` so that $session_id selects the namespace a session ran in rather than matching pod-for-pod. See benchmark/docs/benchmark-report.md.",
   "panels": [
+    {
+      "id": 100,
+      "title": "vLLM - capacity & queueing",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
     {
       "id": 1,
       "title": "KV Cache Utilization",
+      "description": "Per-pod vLLM KV-cache occupancy (1 = full). The primary saturation signal for KV-based scaling triggers.",
       "type": "timeseries",
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
       "datasource": { "type": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -51,12 +61,12 @@
       },
       "targets": [
         {
-          "expr": "vllm:kv_cache_usage_perc{namespace=~\"$namespace\"} * on (pod, namespace) group_left(label_llmdbench_ai_session_id) kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}",
+          "expr": "max by (pod, namespace, engine) (vllm:kv_cache_usage_perc{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
           "legendFormat": "{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "avg(vllm:kv_cache_usage_perc{namespace=~\"$namespace\"} * on (pod, namespace) group_left(label_llmdbench_ai_session_id) kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
+          "expr": "avg(max by (pod, namespace, engine) (vllm:kv_cache_usage_perc{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
           "legendFormat": "avg",
           "refId": "B"
         }
@@ -66,8 +76,9 @@
     {
       "id": 2,
       "title": "Queue Size",
+      "description": "Per-pod running and waiting request counts straight from the vLLM engine.",
       "type": "timeseries",
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 9 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
       "datasource": { "type": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -87,13 +98,1126 @@
       },
       "targets": [
         {
-          "expr": "vllm:num_requests_waiting{namespace=~\"$namespace\"} * on (pod, namespace) group_left(label_llmdbench_ai_session_id) kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}",
+          "expr": "max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
           "legendFormat": "{{pod}} waiting",
           "refId": "A"
         },
         {
-          "expr": "vllm:num_requests_running{namespace=~\"$namespace\"} * on (pod, namespace) group_left(label_llmdbench_ai_session_id) kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}",
+          "expr": "max by (pod, namespace, engine) (vllm:num_requests_running{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
           "legendFormat": "{{pod}} running",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 3,
+      "title": "Fleet Requests (running / waiting)",
+      "description": "Same signals as \"Queue Size\", summed over the fleet. \"waiting (avg per pod)\" is the shape a KEDA AverageValue trigger sees: the HPA divides the summed metric by the replica count.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(max by (pod, namespace, engine) (vllm:num_requests_running{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "running (fleet)",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "waiting (fleet)",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "waiting (avg per pod)",
+          "refId": "C"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 4,
+      "title": "Waiting Requests by Reason",
+      "description": "vllm:num_requests_waiting_by_reason splits the queue into 'capacity' (no scheduling capacity -- the queue depth that should drive scale-out) and 'deferred' (transient constraints: LoRA budget, KV transfer, blocked status). Empty on vLLM builds that predate the metric.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (max by (pod, namespace, engine, reason) (vllm:num_requests_waiting_by_reason{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 5,
+      "title": "Preemptions",
+      "description": "Rate of engine preemptions. Sustained preemption means the fleet is over-committed on KV cache -- a scale-out signal that KV utilization alone can under-report.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 17 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:num_preemptions_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "preemptions/s (fleet)",
+          "refId": "A"
+        },
+        {
+          "expr": "max by (pod, namespace, engine) (rate(vllm:num_preemptions_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
+          "legendFormat": "{{pod}}",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 6,
+      "title": "Prefix Cache Hit Rate",
+      "description": "Token-weighted hit rate. 'local' is the engine's own prefix cache; 'external' is the KV-connector (NIXL) cache and is only populated on P/D runs. Prefix reuse changes the cost of a prefill, so it moves the throughput a given replica count can sustain.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 17 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:prefix_cache_hits_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})) / sum(max by (pod, namespace, engine) (rate(vllm:prefix_cache_queries_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "local",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:external_prefix_cache_hits_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})) / sum(max by (pod, namespace, engine) (rate(vllm:external_prefix_cache_queries_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "external (KV connector)",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 101,
+      "title": "vLLM - throughput & latency",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 7,
+      "title": "Token Throughput",
+      "description": "Prefill (prompt) and decode (generation) tokens per second across the fleet. The denominator for any tokens/s-per-replica calibration, e.g. token-aware.yaml's peakPrefillThroughput.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:prompt_tokens_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "prompt tokens/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:generation_tokens_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "generation tokens/s",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 8,
+      "title": "Completed Requests by Finish Reason",
+      "description": "Completion rate split by finished_reason. A rising 'abort'/'length' share while load is flat usually means the fleet is shedding rather than serving.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (finished_reason) (max by (pod, namespace, engine, finished_reason) (rate(vllm:request_success_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "{{finished_reason}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 9,
+      "title": "Time To First Token (TTFT)",
+      "description": "Fleet-wide TTFT percentiles. The SLO that prefill scaling is tuned against -- token-aware.yaml derives its prefill threshold from a TTFT budget.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 34 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 10,
+      "title": "Inter-Token Latency (ITL / TPOT)",
+      "description": "Decode-side latency percentiles. Falls back to vllm:time_per_output_token_seconds on vLLM builds that predate the inter_token_latency rename.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 34 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 11,
+      "title": "End-to-End Request Latency",
+      "description": "Engine-observed request latency (queueing + prefill + decode), excluding anything the router adds.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 42 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 12,
+      "title": "Request Queue Time",
+      "description": "How long admitted requests sat in the engine queue before scheduling. This is the part of TTFT that adding replicas actually removes, so it is the cleanest 'was the scale-out justified' read.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 42 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 102,
+      "title": "Replicas & autoscaling",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 13,
+      "title": "Serving Replicas by Role",
+      "description": "Replicas counted from the metrics themselves: one count per pod actually scraped, deduplicated with `max by (pod, namespace)` so a pod covered by both a PodMonitor and a ServiceMonitor isn't counted twice. Backend- and workload-API-agnostic (Deployment, LeaderWorkerSet, standalone), and the only replica panel that honours $session_id (as a namespace gate -- see the Session ID variable's description). Role comes from the pod name (`*-prefill-*` / `*-decode-*`); anything else counts as 'aggregated'.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 51 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "count by (role) (label_replace(label_replace(max by (pod, namespace) (vllm:num_requests_running{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}), \"role\", \"aggregated\", \"pod\", \".*\"), \"role\", \"$1\", \"pod\", \".*-(prefill|decode)-.*\"))",
+          "legendFormat": "{{role}}",
+          "refId": "A"
+        },
+        {
+          "expr": "count(max by (pod, namespace) (vllm:num_requests_running{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "legendFormat": "all serving pods",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 14,
+      "title": "Deployment Replicas (kube-state-metrics)",
+      "description": "Ground truth for what the autoscaler asked for (spec) versus what is serving (available). The gap is scale-up latency -- image pull + model load -- which is why a run's throughput lags its replica count. Namespace- and time-scoped only; $session_id does not apply (see benchmark-report.md).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 51 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "kube_deployment_spec_replicas{namespace=~\"$namespace\"}",
+          "legendFormat": "{{deployment}} spec",
+          "refId": "A"
+        },
+        {
+          "expr": "kube_deployment_status_replicas_available{namespace=~\"$namespace\"}",
+          "legendFormat": "{{deployment}} available",
+          "refId": "B"
+        },
+        {
+          "expr": "kube_deployment_status_replicas_unavailable{namespace=~\"$namespace\"}",
+          "legendFormat": "{{deployment}} unavailable",
+          "refId": "C"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 15,
+      "title": "HPA Desired vs Current (KEDA)",
+      "description": "KEDA drives scaling through a generated HPA, so this is where a trigger's arithmetic surfaces: desired = ceil(metric / threshold), clamped to [min, max]. Desired pinned to max means the trigger is saturated; desired stuck at min means it never activated.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 59 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "kube_horizontalpodautoscaler_status_desired_replicas{namespace=~\"$namespace\"}",
+          "legendFormat": "{{horizontalpodautoscaler}} desired",
+          "refId": "A"
+        },
+        {
+          "expr": "kube_horizontalpodautoscaler_status_current_replicas{namespace=~\"$namespace\"}",
+          "legendFormat": "{{horizontalpodautoscaler}} current",
+          "refId": "B"
+        },
+        {
+          "expr": "kube_horizontalpodautoscaler_spec_min_replicas{namespace=~\"$namespace\"}",
+          "legendFormat": "{{horizontalpodautoscaler}} min",
+          "refId": "C"
+        },
+        {
+          "expr": "kube_horizontalpodautoscaler_spec_max_replicas{namespace=~\"$namespace\"}",
+          "legendFormat": "{{horizontalpodautoscaler}} max",
+          "refId": "D"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 16,
+      "title": "KEDA Trigger Values",
+      "description": "The value each KEDA scaler reported to the HPA, and whether the scaler is active. Thresholds are not exported by KEDA -- read them from the scenario's `keda:` block. Requires the keda-operator metrics endpoint to be scraped; the namespace label lands as exported_namespace when the metric's own label collides with the scrape target's, hence the `or`.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 59 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*active$" },
+            "properties": [
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "max", "value": 1 },
+              { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [8, 4] } }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "max by (scaledObject, scaler, metric) (keda_scaler_metrics_value{exported_namespace=~\"$namespace\"} or keda_scaler_metrics_value{namespace=~\"$namespace\"})",
+          "legendFormat": "{{scaledObject}} / {{metric}}",
+          "refId": "A"
+        },
+        {
+          "expr": "max by (scaledObject, scaler) (keda_scaler_active{exported_namespace=~\"$namespace\"} or keda_scaler_active{namespace=~\"$namespace\"})",
+          "legendFormat": "{{scaledObject}} / {{scaler}} active",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 17,
+      "title": "WVA Desired vs Current Replicas",
+      "description": "Workload-Variant-Autoscaler's own view, per VariantAutoscaling. Only populated on runs that take the WVA path (`wva.enabled`); KEDA-only runs leave this empty. WVA's namespace label usually arrives as exported_namespace because it collides with the controller pod's own namespace label.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 67 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max by (variant_name) (wva_desired_replicas{exported_namespace=~\"$namespace\"} or wva_desired_replicas{namespace=~\"$namespace\"})",
+          "legendFormat": "{{variant_name}} desired",
+          "refId": "A"
+        },
+        {
+          "expr": "max by (variant_name) (wva_current_replicas{exported_namespace=~\"$namespace\"} or wva_current_replicas{namespace=~\"$namespace\"})",
+          "legendFormat": "{{variant_name}} current",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 18,
+      "title": "EPP Ready Endpoints",
+      "description": "Replica count as the router sees it: endpoints it is willing to route to. Lags the Deployment's available count by the readiness-probe + EPP refresh delay, which is the delay any router-metric-driven trigger actually reacts through. Falls back to the deprecated inference_pool_ready_pods on older EPP builds.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 67 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max by (name) (llm_d_epp_ready_endpoints{namespace=~\"$namespace\"}) or max by (name) (inference_pool_ready_pods{namespace=~\"$namespace\"})",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 29,
+      "title": "KEDA Autoscaler Errors & Health",
+      "description": "Why nothing is scaling. 'registered' vs 'reporting a metric' is the important pair: a ScaledObject that fails its check (bad trigger metadata, missing TriggerAuthentication bearer token, unreachable Prometheus) is still registered, but KEDA never creates its HPA and never publishes a scaler value for it -- so the two lines diverge and every other autoscaling panel goes quiet. Error counters cover the opposite case, where the ScaledObject is live but its queries fail. Diagnose a divergence with `kubectl get scaledobject -n <ns> -o json` and read the Ready condition's message. Note KEDA reports the ScaledObject's namespace as exported_namespace (its own `namespace` label is the operator's), hence the `or`.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 75 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*errors \\(5m\\)$" },
+            "properties": [
+              { "id": "custom.fillOpacity", "value": 20 },
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "sum(keda_resource_registered_total{type=~\"scaled_?object\", exported_namespace=~\"$namespace\"} or keda_resource_registered_total{type=~\"scaled_?object\", namespace=~\"$namespace\"})",
+          "legendFormat": "ScaledObjects registered",
+          "refId": "A"
+        },
+        {
+          "expr": "count(count by (scaledObject) (keda_scaler_metrics_value{exported_namespace=~\"$namespace\"} or keda_scaler_metrics_value{namespace=~\"$namespace\"})) or vector(0)",
+          "legendFormat": "ScaledObjects reporting a metric",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (scaledObject) (increase(keda_scaled_object_errors_total{exported_namespace=~\"$namespace\"}[5m]) or increase(keda_scaled_object_errors_total{namespace=~\"$namespace\"}[5m]))",
+          "legendFormat": "{{scaledObject}} errors (5m)",
+          "refId": "C"
+        },
+        {
+          "expr": "sum by (scaledObject, scaler) (increase(keda_scaler_detail_errors_total{exported_namespace=~\"$namespace\"}[5m]) or increase(keda_scaler_detail_errors_total{namespace=~\"$namespace\"}[5m])) or sum by (scaledObject, scaler) (increase(keda_scaler_errors_total{exported_namespace=~\"$namespace\"}[5m]) or increase(keda_scaler_errors_total{namespace=~\"$namespace\"}[5m]))",
+          "legendFormat": "{{scaledObject}} / {{scaler}} trigger errors (5m)",
+          "refId": "D"
+        },
+        {
+          "expr": "sum by (horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_condition{namespace=~\"$namespace\", condition=\"ScalingActive\", status=\"false\"})",
+          "legendFormat": "{{horizontalpodautoscaler}} ScalingActive=false",
+          "refId": "E"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 103,
+      "title": "EPP (router / endpoint picker)",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 83 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 19,
+      "title": "EPP Pool KV Cache Utilization",
+      "description": "The router's pool-wide KV view (average across endpoints, plus its spread). A large std dev means load is unevenly distributed, so the pool average understates how close individual replicas are to saturation. Panels in this row are namespace- and time-scoped only: $session_id does not apply, because EPP pods do not carry the llmdbench.ai/session-id label.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 84 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max by (name) (llm_d_epp_average_kv_cache_utilization{namespace=~\"$namespace\"}) or max by (name) (inference_pool_average_kv_cache_utilization{namespace=~\"$namespace\"})",
+          "legendFormat": "{{name}} avg",
+          "refId": "A"
+        },
+        {
+          "expr": "max by (name) (llm_d_epp_std_dev_kv_cache_utilization{namespace=~\"$namespace\"})",
+          "legendFormat": "{{name}} std dev",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 20,
+      "title": "EPP Pool Queue & Running Requests",
+      "description": "Router-side averages per endpoint. Compare against the vLLM fleet panels above: a divergence means the router's view of the pool is stale or its endpoint set is wrong.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 84 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max by (name) (llm_d_epp_average_queue_size{namespace=~\"$namespace\"}) or max by (name) (inference_pool_average_queue_size{namespace=~\"$namespace\"})",
+          "legendFormat": "{{name}} avg queue size",
+          "refId": "A"
+        },
+        {
+          "expr": "max by (name) (llm_d_epp_average_running_requests{namespace=~\"$namespace\"}) or max by (name) (inference_pool_average_running_requests{namespace=~\"$namespace\"})",
+          "legendFormat": "{{name}} avg running",
+          "refId": "B"
+        },
+        {
+          "expr": "max by (name) (llm_d_epp_std_dev_queue_size{namespace=~\"$namespace\"})",
+          "legendFormat": "{{name}} queue std dev",
+          "refId": "C"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 21,
+      "title": "EPP Per-Endpoint Queue Size",
+      "description": "Pending depth per backend endpoint, rebuilt from the live endpoint set on every scrape -- so a scaled-down pod's series disappears instead of going stale. token-aware.yaml uses exactly this property as a liveness gate for its prefill trigger.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 92 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max by (model_server_endpoint) (llm_d_epp_per_endpoint_queue_size{namespace=~\"$namespace\"})",
+          "legendFormat": "{{model_server_endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 22,
+      "title": "EPP Request & Error Rate",
+      "description": "Requests the router accepted, and the errors it returned, by model. Errors rising with replica count is the classic sign of scale-out outrunning model load time.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 92 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (model_name) (rate(llm_d_epp_request_total{namespace=~\"$namespace\"}[2m])) or sum by (model_name) (rate(inference_objective_request_total{namespace=~\"$namespace\"}[2m]))",
+          "legendFormat": "{{model_name}} requests",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (error_code) (rate(llm_d_epp_request_error_total{namespace=~\"$namespace\"}[2m])) or sum by (error_code) (rate(inference_objective_request_error_total{namespace=~\"$namespace\"}[2m]))",
+          "legendFormat": "errors {{error_code}}",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 23,
+      "title": "EPP In-Flight Requests",
+      "description": "Requests the router currently has outstanding, by model. The router-side counterpart to the vLLM fleet running/waiting panel.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 100 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (model_name) (llm_d_epp_request_running{namespace=~\"$namespace\"}) or sum by (model_name) (inference_objective_running_requests{namespace=~\"$namespace\"})",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 24,
+      "title": "EPP Request Latency (router-observed)",
+      "description": "What the client actually experiences: engine time plus routing, queueing and flow control. Compare with the vLLM TTFT/E2E panels -- the delta is the router's own contribution.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 100 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(llm_d_epp_request_ttft_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "TTFT p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(llm_d_epp_request_ttft_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "TTFT p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(llm_d_epp_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(inference_objective_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "request duration p50",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(llm_d_epp_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(inference_objective_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "request duration p95",
+          "refId": "D"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 25,
+      "title": "EPP Scheduling Latency",
+      "description": "End-to-end endpoint-picking time (sub-millisecond when healthy). A spike here means the scheduler itself became the bottleneck -- usually a plugin, not the pool.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 108 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(llm_d_epp_scheduler_e2e_duration_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(inference_extension_scheduler_e2e_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "scheduler p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(llm_d_epp_scheduler_e2e_duration_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(inference_extension_scheduler_e2e_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "scheduler p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, plugin_name) (rate(llm_d_epp_plugin_duration_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(inference_extension_plugin_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "{{plugin_name}} p95",
+          "refId": "C"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 26,
+      "title": "EPP Flow Control Pool Saturation",
+      "description": "The router's own saturation signal, gating dispatch: 1.0 is the set point, and 'effective' is max(prefill, decode). An empty pool also reads 1.0, and stale endpoint metrics score as saturated -- so treat 1.0 during a cold start as 'no data', not 'overloaded'.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 108 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "max by (stage) (llm_d_epp_flow_control_pool_saturation{namespace=~\"$namespace\"}) or max by (stage) (inference_extension_flow_control_pool_saturation{namespace=~\"$namespace\"})",
+          "legendFormat": "{{stage}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 27,
+      "title": "EPP Flow Control Queue",
+      "description": "Requests held in the router's flow-control queue, by priority. Non-zero means the router is absorbing backlog that the engine queue metrics never see -- scaling triggers reading only vllm:num_requests_waiting will under-react.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 116 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "queue wait p95 (s)" },
+            "properties": [
+              { "id": "unit", "value": "s" },
+              { "id": "custom.axisPlacement", "value": "right" }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "sum by (priority) (llm_d_epp_flow_control_queue_size{namespace=~\"$namespace\"}) or sum by (priority) (inference_extension_flow_control_queue_size{namespace=~\"$namespace\"})",
+          "legendFormat": "priority {{priority}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(llm_d_epp_flow_control_request_queue_duration_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(inference_extension_flow_control_request_queue_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "queue wait p95 (s)",
+          "refId": "B"
+        }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 28,
+      "title": "EPP In-Flight Tokens per Endpoint",
+      "description": "Tokens the router has outstanding on each endpoint -- the numerator of token-aware.yaml's prefill trigger (divided by peakPrefillThroughput to get seconds of backlog). Only published when the EPP runs the `inflight-load-producer` plugin, so it is empty for baseline scenarios. Note the series are never deleted when an endpoint goes away; the scenario intersects them with per-endpoint queue size for liveness.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 116 },
+      "datasource": { "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (endpoint_name) (llm_d_epp_inflight_tokens{namespace=~\"$namespace\"})",
+          "legendFormat": "{{endpoint_name}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(llm_d_epp_inflight_tokens{namespace=~\"$namespace\"})",
+          "legendFormat": "total",
           "refId": "B"
         }
       ],
@@ -101,7 +1225,7 @@
     }
   ],
   "schemaVersion": 39,
-  "tags": ["benchmark", "llm-d-autoscaling", "vllm"],
+  "tags": ["benchmark", "llm-d-autoscaling", "vllm", "epp", "autoscaling"],
   "templating": {
     "list": [
       {
@@ -121,7 +1245,7 @@
         "name": "session_id",
         "type": "query",
         "label": "Session ID",
-        "description": "llmdbench.ai/session-id pod label, joined onto the panels below via kube_pod_labels (see docs/benchmark-report.md). Defaults to All (no filtering); pick one session's ID to disambiguate concurrent/reused namespaces.",
+        "description": "llmdbench.ai/session-id pod label, resolved to the namespace(s) where that session had pods and used to gate the vLLM panels (see docs/benchmark-report.md). Defaults to All (no filtering). Namespace resolution rather than pod matching is deliberate: the label is stamped at standup, so a session that only ran against an already-stood-up stack labels just its harness pod -- matching pod-for-pod would blank every panel. Only the vLLM panels key off it; EPP, KEDA, WVA and kube-state-metrics series stay namespace- and time-scoped.",
         "datasource": { "type": "prometheus" },
         "query": { "query": "label_values(kube_pod_labels{namespace=~\"$namespace\"}, label_llmdbench_ai_session_id)", "refId": "session_id" },
         "refresh": 2,

--- a/benchmark/config/grafana/dashboard.json
+++ b/benchmark/config/grafana/dashboard.json
@@ -17,7 +17,7 @@
   "graphTooltip": 1,
   "id": null,
   "links": [],
-  "description": "Per-run view of a benchmark session: vLLM engine metrics, llm-d EPP (router) metrics, and the replica counts every autoscaling experiment is judged on. Two conventions: (1) panel queries may only reference the $namespace and $session_id variables and must use literal range durations (no $__rate_interval), because benchmark_report.py's snapshot capture substitutes exactly those two variables and sends the expression to Prometheus verbatim; (2) every vllm: query is wrapped in `max by (pod, namespace, engine)` so that pods scraped by both a PodMonitor and a ServiceMonitor -- the usual llm-d layout -- are counted once, and gated on `max by (namespace) (kube_pod_labels{...})` so that $session_id selects the namespace a session ran in rather than matching pod-for-pod. See benchmark/docs/benchmark-report.md.",
+  "description": "Per-run view of a benchmark session: vLLM engine metrics, llm-d EPP (router) metrics, and the replica counts every autoscaling experiment is judged on. Two conventions: (1) panel queries may only reference the $namespace variable and must use literal range durations (no $__rate_interval), because benchmark_report.py's snapshot capture substitutes exactly that variable and sends the expression to Prometheus verbatim; (2) every vllm: query is wrapped in `max by (pod, namespace, engine)` so that pods scraped by both a PodMonitor and a ServiceMonitor -- the usual llm-d layout -- are counted once. A session is identified by its namespace plus the run's time window; there is no session-id pod label. See benchmark/docs/benchmark-report.md.",
   "panels": [
     {
       "id": 100,
@@ -61,12 +61,12 @@
       },
       "targets": [
         {
-          "expr": "max by (pod, namespace, engine) (vllm:kv_cache_usage_perc{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
+          "expr": "max by (pod, namespace, engine) (vllm:kv_cache_usage_perc{namespace=~\"$namespace\"})",
           "legendFormat": "{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "avg(max by (pod, namespace, engine) (vllm:kv_cache_usage_perc{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "avg(max by (pod, namespace, engine) (vllm:kv_cache_usage_perc{namespace=~\"$namespace\"}))",
           "legendFormat": "avg",
           "refId": "B"
         }
@@ -98,12 +98,12 @@
       },
       "targets": [
         {
-          "expr": "max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
+          "expr": "max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"})",
           "legendFormat": "{{pod}} waiting",
           "refId": "A"
         },
         {
-          "expr": "max by (pod, namespace, engine) (vllm:num_requests_running{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
+          "expr": "max by (pod, namespace, engine) (vllm:num_requests_running{namespace=~\"$namespace\"})",
           "legendFormat": "{{pod}} running",
           "refId": "B"
         }
@@ -135,17 +135,17 @@
       },
       "targets": [
         {
-          "expr": "sum(max by (pod, namespace, engine) (vllm:num_requests_running{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum(max by (pod, namespace, engine) (vllm:num_requests_running{namespace=~\"$namespace\"}))",
           "legendFormat": "running (fleet)",
           "refId": "A"
         },
         {
-          "expr": "sum(max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum(max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"}))",
           "legendFormat": "waiting (fleet)",
           "refId": "B"
         },
         {
-          "expr": "avg(max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "avg(max by (pod, namespace, engine) (vllm:num_requests_waiting{namespace=~\"$namespace\"}))",
           "legendFormat": "waiting (avg per pod)",
           "refId": "C"
         }
@@ -177,7 +177,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (reason) (max by (pod, namespace, engine, reason) (vllm:num_requests_waiting_by_reason{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum by (reason) (max by (pod, namespace, engine, reason) (vllm:num_requests_waiting_by_reason{namespace=~\"$namespace\"}))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -209,12 +209,12 @@
       },
       "targets": [
         {
-          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:num_preemptions_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:num_preemptions_total{namespace=~\"$namespace\"}[2m])))",
           "legendFormat": "preemptions/s (fleet)",
           "refId": "A"
         },
         {
-          "expr": "max by (pod, namespace, engine) (rate(vllm:num_preemptions_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})",
+          "expr": "max by (pod, namespace, engine) (rate(vllm:num_preemptions_total{namespace=~\"$namespace\"}[2m]))",
           "legendFormat": "{{pod}}",
           "refId": "B"
         }
@@ -247,12 +247,12 @@
       },
       "targets": [
         {
-          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:prefix_cache_hits_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})) / sum(max by (pod, namespace, engine) (rate(vllm:prefix_cache_queries_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:prefix_cache_hits_total{namespace=~\"$namespace\"}[2m]))) / sum(max by (pod, namespace, engine) (rate(vllm:prefix_cache_queries_total{namespace=~\"$namespace\"}[2m])))",
           "legendFormat": "local",
           "refId": "A"
         },
         {
-          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:external_prefix_cache_hits_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})) / sum(max by (pod, namespace, engine) (rate(vllm:external_prefix_cache_queries_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:external_prefix_cache_hits_total{namespace=~\"$namespace\"}[2m]))) / sum(max by (pod, namespace, engine) (rate(vllm:external_prefix_cache_queries_total{namespace=~\"$namespace\"}[2m])))",
           "legendFormat": "external (KV connector)",
           "refId": "B"
         }
@@ -292,12 +292,12 @@
       },
       "targets": [
         {
-          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:prompt_tokens_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:prompt_tokens_total{namespace=~\"$namespace\"}[2m])))",
           "legendFormat": "prompt tokens/s",
           "refId": "A"
         },
         {
-          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:generation_tokens_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum(max by (pod, namespace, engine) (rate(vllm:generation_tokens_total{namespace=~\"$namespace\"}[2m])))",
           "legendFormat": "generation tokens/s",
           "refId": "B"
         }
@@ -329,7 +329,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (finished_reason) (max by (pod, namespace, engine, finished_reason) (rate(vllm:request_success_total{namespace=~\"$namespace\"}[2m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "sum by (finished_reason) (max by (pod, namespace, engine, finished_reason) (rate(vllm:request_success_total{namespace=~\"$namespace\"}[2m])))",
           "legendFormat": "{{finished_reason}}",
           "refId": "A"
         }
@@ -361,17 +361,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:time_to_first_token_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -403,17 +403,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:inter_token_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]) or rate(vllm:time_per_output_token_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -445,17 +445,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:e2e_request_latency_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -487,17 +487,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"})))",
+          "expr": "histogram_quantile(0.99, sum by (le) (max by (pod, namespace, engine, le) (rate(vllm:request_queue_time_seconds_bucket{namespace=~\"$namespace\"}[5m]))))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -515,7 +515,7 @@
     {
       "id": 13,
       "title": "Serving Replicas by Role",
-      "description": "Replicas counted from the metrics themselves: one count per pod actually scraped, deduplicated with `max by (pod, namespace)` so a pod covered by both a PodMonitor and a ServiceMonitor isn't counted twice. Backend- and workload-API-agnostic (Deployment, LeaderWorkerSet, standalone), and the only replica panel that honours $session_id (as a namespace gate -- see the Session ID variable's description). Role comes from the pod name (`*-prefill-*` / `*-decode-*`); anything else counts as 'aggregated'.",
+      "description": "Replicas counted from the metrics themselves: one count per pod actually scraped, deduplicated with `max by (pod, namespace)` so a pod covered by both a PodMonitor and a ServiceMonitor isn't counted twice. Backend- and workload-API-agnostic (Deployment, LeaderWorkerSet, standalone). Role comes from the pod name (`*-prefill-*` / `*-decode-*`); anything else counts as 'aggregated'.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 51 },
       "datasource": { "type": "prometheus" },
@@ -539,12 +539,12 @@
       },
       "targets": [
         {
-          "expr": "count by (role) (label_replace(label_replace(max by (pod, namespace) (vllm:num_requests_running{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}), \"role\", \"aggregated\", \"pod\", \".*\"), \"role\", \"$1\", \"pod\", \".*-(prefill|decode)-.*\"))",
+          "expr": "count by (role) (label_replace(label_replace(max by (pod, namespace) (vllm:num_requests_running{namespace=~\"$namespace\"}), \"role\", \"aggregated\", \"pod\", \".*\"), \"role\", \"$1\", \"pod\", \".*-(prefill|decode)-.*\"))",
           "legendFormat": "{{role}}",
           "refId": "A"
         },
         {
-          "expr": "count(max by (pod, namespace) (vllm:num_requests_running{namespace=~\"$namespace\"}) * on (namespace) group_left() max by (namespace) (kube_pod_labels{namespace=~\"$namespace\", label_llmdbench_ai_session_id=~\"$session_id\"}))",
+          "expr": "count(max by (pod, namespace) (vllm:num_requests_running{namespace=~\"$namespace\"}))",
           "legendFormat": "all serving pods",
           "refId": "B"
         }
@@ -554,7 +554,7 @@
     {
       "id": 14,
       "title": "Deployment Replicas (kube-state-metrics)",
-      "description": "Ground truth for what the autoscaler asked for (spec) versus what is serving (available). The gap is scale-up latency -- image pull + model load -- which is why a run's throughput lags its replica count. Namespace- and time-scoped only; $session_id does not apply (see benchmark-report.md).",
+      "description": "Ground truth for what the autoscaler asked for (spec) versus what is serving (available). The gap is scale-up latency -- image pull + model load -- which is why a run's throughput lags its replica count. Namespace- and time-scoped, like every panel on this dashboard (see benchmark-report.md).",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 51 },
       "datasource": { "type": "prometheus" },
@@ -836,7 +836,7 @@
     {
       "id": 19,
       "title": "EPP Pool KV Cache Utilization",
-      "description": "The router's pool-wide KV view (average across endpoints, plus its spread). A large std dev means load is unevenly distributed, so the pool average understates how close individual replicas are to saturation. Panels in this row are namespace- and time-scoped only: $session_id does not apply, because EPP pods do not carry the llmdbench.ai/session-id label.",
+      "description": "The router's pool-wide KV view (average across endpoints, plus its spread). A large std dev means load is unevenly distributed, so the pool average understates how close individual replicas are to saturation.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 84 },
       "datasource": { "type": "prometheus" },
@@ -1234,20 +1234,6 @@
         "label": "Namespace",
         "datasource": { "type": "prometheus" },
         "query": { "query": "label_values(vllm:num_requests_running, namespace)", "refId": "namespace" },
-        "refresh": 2,
-        "sort": 1,
-        "multi": true,
-        "includeAll": true,
-        "allValue": ".*",
-        "current": { "value": "$__all", "text": "All" }
-      },
-      {
-        "name": "session_id",
-        "type": "query",
-        "label": "Session ID",
-        "description": "llmdbench.ai/session-id pod label, resolved to the namespace(s) where that session had pods and used to gate the vLLM panels (see docs/benchmark-report.md). Defaults to All (no filtering). Namespace resolution rather than pod matching is deliberate: the label is stamped at standup, so a session that only ran against an already-stood-up stack labels just its harness pod -- matching pod-for-pod would blank every panel. Only the vLLM panels key off it; EPP, KEDA, WVA and kube-state-metrics series stay namespace- and time-scoped.",
-        "datasource": { "type": "prometheus" },
-        "query": { "query": "label_values(kube_pod_labels{namespace=~\"$namespace\"}, label_llmdbench_ai_session_id)", "refId": "session_id" },
         "refresh": 2,
         "sort": 1,
         "multi": true,

--- a/benchmark/config/scenarios/staging/pd-disaggregation/token-aware.yaml
+++ b/benchmark/config/scenarios/staging/pd-disaggregation/token-aware.yaml
@@ -1,0 +1,421 @@
+# P/D DISAGGREGATION — KEDA experiment: token-aware (BACKEND-AGNOSTIC)
+#
+# Port of the token-aware ScaledObjects published in
+#   asm582/token-aware-autoscaling@7e70bf5  pd-setup/launch-scaledobjects.sh:288-358
+#   (design rationale: TOKEN-AWARE-AUTOSCALING-SUMMARY.md sections 2-6)
+# The source repo's pd-setup/ deploys the upstream llm-d `pd-disaggregation`
+# guide, so this lands as a variant of that guide's staging directory.
+#
+# WHAT IT CHANGES vs baseline.yaml (this dir)
+#   prefill: vllm:num_requests_waiting + vllm:kv_cache_usage_perc
+#            -> SECONDS OF UNCACHED PREFILL BACKLOG, from EPP router metrics:
+#               sum(inflight_tokens over LIVE prefill pods) / peakPrefillThroughput
+#               threshold 1.5 s of queue wait per replica.
+#   decode:  vllm:num_requests_waiting + max(kv_cache_usage_perc) @ 0.95
+#            -> sum(vllm:kv_cache_usage_perc over decode pods) @ 0.80
+#               ("pods' worth of full KV cache"; act at 80% full).
+#   min/max: 1/4 -> 1/10 (the published figures). Set maxReplicas back to 4 if
+#            you want a cap-for-cap comparison against baseline.yaml.
+#   behavior + pollingInterval are unchanged from baseline (they already match
+#   the source: scaleUp 1 pod/180s, scaleDown 1 pod/300s after a 300s window).
+#
+# NECESSARY DEVIATION FROM THE "keda: BLOCK ONLY" RULE
+# The prefill trigger reads `llm_d_epp_inflight_tokens`, which only exists if
+# the EPP runs the `inflight-load-producer` plugin. Baseline's plugin chain does
+# not include it, so this variant adds that one plugin (a producer — it is not
+# referenced from any schedulingProfile, so routing decisions are unchanged).
+# Nothing else outside `keda:` differs from baseline.
+#
+# WHY sum() AND NOT max(), AND WHY THE LIVENESS GATE — see the header of
+# launch-scaledobjects.sh; both are load-bearing:
+#   * metricType AverageValue makes the HPA compute ceil(total / threshold), so
+#     the numerator must GROW with the pool. max() of a per-pod value cannot,
+#     which would structurally cap the role's replicas.
+#   * `or vector(0)` only collapses to a single series when the left side has an
+#     empty label set — which sum() guarantees. Without it KEDA gets two series
+#     and fails with FailedGetExternalMetric.
+#   * inflight_tokens is a GaugeVec whose series are never deleted when a pod
+#     goes away, so a scaled-down pod would strand a non-zero series and turn
+#     scale-down into a one-way ratchet. Intersecting with
+#     llm_d_epp_per_endpoint_queue_size (rebuilt from live endpoints each scrape)
+#     on a derived `target_pod` label admits only live pods.
+#
+# DECODE SIGNAL. This file renders the published (default) occupancy trigger.
+# The source script also offers `--decode-signal waiters`
+# (avg_over_time(sum(vllm:num_requests_waiting_by_reason{reason="capacity"}))[2m:15s]
+# gated on a strict-majority fleet-wide test, threshold 1). That is a different
+# unit, not a different threshold — add it as a separate sibling
+# (token-aware-waiters.yaml) rather than editing this one.
+#
+# PREREQUISITES
+#   1. peakPrefillThroughput (tokenAware.peakPrefillThroughput below) is
+#      hardware-, model-, TP- and fabric-specific. MEASURE IT on the target
+#      stack before trusting a result — a wrong divisor silently changes when
+#      prefill scales (the same load asked for 8 replicas at 2665 tok/s and 3 at
+#      15928 tok/s on the reference stack).
+#   2. EPP metrics must be scraped into the Prometheus/Thanos that KEDA queries.
+#      `modelservice.router.epp.monitoring.prometheus.enabled: true` (below,
+#      inherited from baseline) does that.
+#   3. On OpenShift, KEDA reaches Thanos with bearer auth — that connection and
+#      its `prometheus-auth` Secret come from the cluster-config overlay
+#      (see benchmark/config/cluster-configs/ocp/*.yaml), not from this file.
+#
+# This scenario deliberately contains NO backend-specific settings (image,
+# accelerator, per-role resources, vLLM command, plugins). Pick a backend by
+# layering one of benchmark/config/cluster-configs/{vllm,vllm-sim-qwen3-32b,inference-sim}.yaml
+# via `--cluster-config`. See benchmark/README.md.
+#
+# Merge note: the harness deep-merges dicts but REPLACES lists wholesale. The
+# scaling strategy (keda) lives here because its scaleTargetRef.kind is a
+# topology concern (Deployment); backend overlays must not set `keda`.
+
+scenario:
+  - name: "pd-disaggregation"
+
+    # =========================================================================
+    # TOKEN-AWARE CONSTANTS — referenced by the KEDA queries below via
+    # ${tokenAware.*}. Kept out of `keda:` so a run can override one number:
+    #   --set tokenAware.peakPrefillThroughput=2665
+    # =========================================================================
+    tokenAware:
+      # V_P, tokens/sec that ONE prefill replica retires. NOT a constant: it is
+      # hardware-, model-, TP- and fabric-specific. 2696 is the reference P/D
+      # stack's calibrated figure (Qwen3-32B, summary section 6); upstream lists
+      # 15928 for Qwen3-32B / H100 / TP=2 on the AGGREGATED path, and a P/D path
+      # with a slow KV fabric can be ~6x lower. Measure it on YOUR hardware
+      # (calibrate-peak-prefill.sh / guides/recipes/router/calibration/calibrate.sh)
+      # and override before reading anything into the results.
+      peakPrefillThroughput: 2696
+
+      # Seconds of QUEUE WAIT per prefill replica before scaling out. This is
+      # the budget left after the irreducible idle floor:
+      #     threshold ~= TTFT_SLO - (ISL_uncached / V_P)
+      # The ISL/V_P floor already includes NIXL transfer + first decode step, so
+      # do NOT add a transfer term. At V_P ~= 2696:
+      #     prefill-heavy  ISL 8192 -> floor 3.0s  -> 8s SLO => 5.0
+      #     symmetrical    ISL 2048 -> floor 0.76s -> 3s SLO => 2.2
+      #     decode-heavy   ISL 256  -> TTFT trivially met; decode KV governs
+      # 1.5 is the interactive / short-context default. For a p90/p99 SLO trim
+      # to ~60-70% of the formula (the metric is a per-replica AVERAGE).
+      prefillThresholdSeconds: "1.5"
+
+      # Pods' worth of full decode KV cache. Already a fraction of capacity, so
+      # it is compared directly: 0.8 = "act at 80% full". Lower for more
+      # headroom, raise to run hotter.
+      decodeKvThreshold: "0.8"
+
+    # =========================================================================
+    # KUSTOMIZE DEPLOY METHOD — disabled; deploying via modelservice below
+    # =========================================================================
+    kustomize:
+      enabled: false
+      guideName: "pd-disaggregation"
+      repoPath: ""
+      repoRef: "main"
+      gaieVersion: ""
+      acceleratorBackend: "gpu/vllm"
+      monitoring: false
+      overlayPath: ""
+      extraHelmValues: []
+      extraHelmSets: {}
+      guideVariableOverrides: {}
+      patches: []
+
+    # =========================================================================
+    # MODEL — identity only. Backend overlays set gpuMemoryUtilization.
+    # =========================================================================
+    model:
+      name: Qwen/Qwen3-32B      # served model id + harness request/tokenizer; must equal huggingfaceId
+      shortName: qwen3-32b
+      path: models/Qwen/Qwen3-32B
+      huggingfaceId: Qwen/Qwen3-32B
+      maxModelLen: 16384
+      size: 2Gi
+
+    # =========================================================================
+    # DEPLOYMENT METHOD
+    # =========================================================================
+    modelservice:
+      enabled: true
+
+      uriProtocol: hf # no model-weight download; backends serve without weights
+
+      # Gateway topology — epponly (no Kubernetes Gateway/HTTPRoute)
+      gateway:
+        className: epponly
+
+      # Routing connector — nixlv2 selects the routing-sidecar wire protocol
+      routing:
+        connector: nixlv2
+
+      # EPP router — PD plugin chain. EPP-side and independent of the backend.
+      router:
+        epp:
+          replicas: 1
+          pluginsConfigFile: "pd-config.yaml"
+          pluginsCustomConfig:
+            pd-config.yaml: |
+              apiVersion: llm-d.ai/v1alpha1
+              kind: EndpointPickerConfig
+              plugins:
+              - type: disagg-headers-handler
+              - type: always-disagg-pd-decider
+              - type: disagg-profile-handler
+                parameters:
+                  deciderPluginName: always-disagg-pd-decider
+              # REQUIRED BY THIS VARIANT (only delta from baseline's chain):
+              # publishes per-pod llm_d_epp_inflight_tokens, the prefill
+              # trigger's source. It is a producer, not referenced from any
+              # schedulingProfile below, so routing is identical to baseline.
+              - type: inflight-load-producer
+              - type: prefill-filter
+              - type: decode-filter
+              - type: prefix-cache-scorer
+              - type: queue-scorer
+              - type: kv-cache-utilization-scorer
+              - type: active-request-scorer
+              schedulingProfiles:
+              - name: prefill
+                plugins:
+                - pluginRef: prefill-filter
+                - pluginRef: prefix-cache-scorer
+                  weight: 3
+                - pluginRef: queue-scorer
+                  weight: 2
+                - pluginRef: kv-cache-utilization-scorer
+                  weight: 2
+              - name: decode
+                plugins:
+                - pluginRef: decode-filter
+                - pluginRef: active-request-scorer
+                  weight: 2
+                - pluginRef: prefix-cache-scorer
+                  weight: 3
+          resources:
+            requests:
+              cpu: "100m"
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+        proxy:
+          resources:
+            requests:
+              cpu: "50m"
+              memory: 128Mi
+            limits:
+              cpu: "500m"
+              memory: 512Mi
+        monitoring:
+          prometheus:
+            enabled: true
+
+      httpRoute:
+        requestTimeout: "300s"
+        backendRequestTimeout: "0s"
+
+    # =========================================================================
+    # DECODE — backend-agnostic skeleton. Backend overlays add resources,
+    # accelerator, vllm command, initContainers, env and volumes.
+    # =========================================================================
+    decode:
+      replicas: 1
+      accelerator:
+        count: 1                 # per-role accelerator count; backend overlays override (0 for CPU sims)
+      parallelism:
+        tensor: 1
+        data: 1
+        dataLocal: 1
+        workers: 1
+      extraContainerConfig:
+        ports:
+          - containerPort: 8200 # metrics; matches modelservice decode metricsPort
+            name: metrics
+            protocol: TCP
+      monitoring:
+        podmonitor:
+          enabled: true
+          portName: metrics
+          path: /metrics
+          interval: 15s
+
+    # =========================================================================
+    # PREFILL — backend-agnostic skeleton (see DECODE).
+    # =========================================================================
+    prefill:
+      enabled: true
+      replicas: 1
+      accelerator:
+        count: 1                 # per-role accelerator count; backend overlays override (0 for CPU sims)
+      parallelism:
+        tensor: 1
+        data: 1
+        dataLocal: 1
+        workers: 1
+      extraContainerConfig:
+        ports:
+          - containerPort: 8000 # metrics; matches modelservice prefill metricsPort
+            name: metrics
+            protocol: TCP
+      monitoring:
+        podmonitor:
+          enabled: true
+          portName: metrics
+          path: /metrics
+          interval: 15s
+
+    standalone:
+      enabled: false
+
+    # =========================================================================
+    # SCALING STRATEGY (KEDA) — TOKEN-AWARE per-role autoscaling.
+    # prefill scales on seconds of uncached prefill backlog (EPP router
+    # metrics); decode scales on summed KV-cache occupancy (vLLM metric).
+    # scaleTargetRef.kind is Deployment for this topology. Backend overlays
+    # override `prometheus` (Thanos + bearer auth on OpenShift) but never `keda`
+    # itself.
+    # =========================================================================
+    keda:
+      enabled: true
+      namespace: ""              # defaults to deploy namespace (first slot of `-p`)
+      prometheus:
+        baseUrl: http://prometheus-operated.monitoring.svc.cluster.local
+        port: 9090
+      scaledObjects:
+      # -----------------------------------------------------------------------
+      # PREFILL — 100% llm-d EPP metrics, no vLLM metric involved.
+      # "tokens the router has queued on LIVE prefill pods, divided by prefill
+      # capacity in tokens/s" => seconds of backlog, compared to the TTFT-derived
+      # per-replica budget. `and on (target_pod)` is a set intersection used as a
+      # liveness gate, not arithmetic; the two label_replace calls only rename
+      # endpoint_name / model_server_endpoint onto a common label so PromQL can
+      # line them up. The division must live inside the query — KEDA has no
+      # arithmetic on the result.
+      # -----------------------------------------------------------------------
+      - name: pd-disaggregation-prefill
+        scaleTargetRef:
+          kind: Deployment
+          name: ${model.idLabel}-prefill
+        minReplicas: 1
+        maxReplicas: 10
+        pollingInterval: 15
+        unsafeSsl: true
+        triggers:
+          - name: prefill-token-backlog
+            type: prometheus
+            metricType: AverageValue
+            query: |
+              (
+                sum(
+                    label_replace(
+                      llm_d_epp_inflight_tokens{namespace="${namespace.name}",
+                                                producer_name="inflight-load-producer",
+                                                endpoint_name=~".*prefill.*"},
+                      "target_pod", "$1", "endpoint_name", "(.+)")
+                  and on (target_pod)
+                    label_replace(
+                      llm_d_epp_per_endpoint_queue_size{name="${model.idLabel}-router",
+                                                        model_server_endpoint=~".*prefill.*"},
+                      "target_pod", "$1", "model_server_endpoint", "(.+)")
+                )
+                / ${tokenAware.peakPrefillThroughput}
+              ) or vector(0)
+            threshold: "${tokenAware.prefillThresholdSeconds}"
+            activationThreshold: "0"
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 180
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 300
+      # -----------------------------------------------------------------------
+      # DECODE — one vLLM metric: how full the decode KV caches are, summed
+      # across pods. A vLLM metric rather than an EPP one because the autoscaler
+      # needs a PER-POD KV reading it can filter to decode and sum; the EPP's
+      # only KV metric is a single pool-wide average covering both roles.
+      # No liveness gate needed: kv_cache_usage_perc is scraped from each pod, so
+      # a dead pod's series goes stale on its own.
+      # Known caveat (recorded in the source): occupancy is a LEVEL, and a
+      # full-but-flowing cache is healthy — in the ISL-8192 arm it read 0.72-0.98
+      # while decode was merely waiting on prefill's NIXL handoffs, buying decode
+      # replicas that were not the bottleneck. See the `waiters` alternative in
+      # the file header.
+      # -----------------------------------------------------------------------
+      - name: pd-disaggregation-decode
+        scaleTargetRef:
+          kind: Deployment
+          name: ${model.idLabel}-decode
+        minReplicas: 1
+        maxReplicas: 10
+        pollingInterval: 15
+        unsafeSsl: true
+        triggers:
+          - name: decode-kv-utilization
+            type: prometheus
+            metricType: AverageValue
+            query: |
+              sum(vllm:kv_cache_usage_perc{namespace="${namespace.name}",
+                                           pod=~".*decode.*"}) or vector(0)
+            threshold: "${tokenAware.decodeKvThreshold}"
+            activationThreshold: "0"
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 180
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 300
+
+    # =========================================================================
+    # COMMON — shared-memory volume only. Backends that need extra volumes
+    # (plugins, model config) add them under decode/prefill in their overlay.
+    # =========================================================================
+    vllmCommon:
+      shmMemory: 500Mi
+      volumes:
+        - name: dshm
+          type: emptyDir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 500Mi
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+
+    storage:
+      workloadPvc:
+        accessModes:
+          - ReadWriteMany
+        storageClassName: auto
+      modelPvc:
+        size: 2Gi
+        accessModes:
+          - ReadWriteMany
+        storageClassName: auto
+
+    timeouts:
+      controlWait: 300
+      harnessWait: 900000
+
+    workDir: "~/data/pd-disaggregation"
+
+    harness:
+      name: inference-perf
+      experimentProfile: sanity_random.yaml
+      pvcSize: 3Gi
+      resources:
+        cpu: "1"
+        memory: 2Gi

--- a/benchmark/config/specification/staging/pd-disaggregation/token-aware.yaml.j2
+++ b/benchmark/config/specification/staging/pd-disaggregation/token-aware.yaml.j2
@@ -1,0 +1,25 @@
+# pd-disaggregation KEDA experiment: token-aware (staging / test bed).
+# Delta from baseline: token-velocity triggers ported from
+#   asm582/token-aware-autoscaling@7e70bf5 pd-setup/launch-scaledobjects.sh:288-358
+#   prefill -> seconds of uncached prefill backlog (EPP inflight_tokens / V_P), 1.5s
+#   decode  -> sum(vllm:kv_cache_usage_perc) over decode pods, 0.8
+# Requires a calibrated tokenAware.peakPrefillThroughput — see the scenario header.
+# Select a backend at run time with:
+#   --cluster-config benchmark/config/cluster-configs/{ocp/vllm,ocp/model-sim-qwen3-32b,k8s/inference-sim}.yaml
+# See benchmark/config/scenarios/staging/pd-disaggregation/ and benchmark/README.md.
+
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED] Reuse upstream llm-d-benchmark defaults (sibling clone) — not vendored.
+values_file:
+  path: {{ base_dir }}/../llm-d-benchmark/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/../llm-d-benchmark/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/benchmark/config/scenarios/staging/pd-disaggregation/token-aware.yaml

--- a/benchmark/docs/benchmark-report.md
+++ b/benchmark/docs/benchmark-report.md
@@ -2,9 +2,9 @@
 
 `benchmark/hack/benchmark_report.py`'s `configure` / `snapshot` / `report` /
 `all` subcommands turn a single finished session into a standalone
-`report.html`, with links to the relevant Grafana panels (vLLM KV-cache
-utilization and queue size) for the exact time window of that session's
-benchmark run.
+`report.html`, with links to the relevant Grafana panels (vLLM engine, llm-d
+EPP/router, and replica counts -- see [Dashboard panels](#dashboard-panels))
+for the exact time window of that session's benchmark run.
 
 For the live, multi-session dashboard (`serve`), see
 [`interactive-dashboard.md`](interactive-dashboard.md) instead -- this doc
@@ -202,8 +202,8 @@ has the data).
 ## Identifying a session's metrics
 
 The vLLM metrics this dashboard queries (`vllm:kv_cache_usage_perc`,
-`vllm:num_requests_waiting`, `vllm:num_requests_running` -- see
-`benchmark/config/grafana/dashboard.json`) carry only standard labels:
+`vllm:num_requests_waiting`, `vllm:num_requests_running`, ... -- see
+[Dashboard panels](#dashboard-panels)) carry only standard labels:
 `namespace` and `pod`. There's no `session_id` on them directly. Every
 "which metrics belong to this session" link -- the session-level
 Observability line and Live dashboard link in the
@@ -231,14 +231,57 @@ the same way `namespace` is, so every generated link already carries
 `var-session_id=<id>` and every snapshot's queries have `$session_id`
 substituted.
 
-Both shipped panels join onto the vLLM metrics via `kube_state_metrics`'s
+Every `vllm:*` panel joins onto the vLLM metrics via `kube_state_metrics`'s
 `kube_pod_labels`, e.g.:
 
 ```
-vllm:kv_cache_usage_perc{namespace=~"$namespace"}
-  * on (pod, namespace) group_left(label_llmdbench_ai_session_id)
-    kube_pod_labels{namespace=~"$namespace", label_llmdbench_ai_session_id=~"$session_id"}
+max by (pod, namespace, engine) (vllm:kv_cache_usage_perc{namespace=~"$namespace"})
+  * on (namespace) group_left()
+    max by (namespace) (kube_pod_labels{namespace=~"$namespace",
+                                        label_llmdbench_ai_session_id=~"$session_id"})
 ```
+
+**The join resolves a session to its namespace; it does not match pod for
+pod.** That is deliberate, and the earlier pod-level form was wrong in
+practice. The label is stamped at **standup**, so a session that only *runs*
+against an already-stood-up stack labels nothing but its own harness pod: the
+decode/prefill pods still carry the standup session's ID. Matching
+`on (pod, namespace)` then returned zero series for the run session's ID --
+every vLLM panel went blank for a perfectly valid selection. Verified live:
+picking run session `villardl-20260909-132550-010` in
+`lionel-bench-model-sim-32b-pd-token` matched nothing under the old form and
+matches all 29 vLLM targets under this one.
+
+`max by (namespace)` collapses the right-hand side to one series per
+namespace, so the gate reads "this namespace had a pod belonging to the
+selected session at this instant". Consequences worth knowing:
+
+- Selecting a session ID from a *different* namespace still yields nothing,
+  so it filters rather than being a no-op (verified).
+- Because a harness pod only exists while its run is in flight, gating on a
+  run-only session ID also time-boxes the panels to that run -- outside the
+  window the gate is empty. Gating on the standup session's ID spans the
+  whole stack lifetime.
+- Two sessions overlapping in one namespace can no longer be separated. They
+  never could: their serving pods share one standup ID and the router pod
+  carries none at all.
+- It also removes the many-to-many hazard described below, since the
+  right-hand side is unique per namespace by construction.
+
+**Why the `max by (...)` wrapper:** an llm-d serving pod is typically scraped
+*twice* -- once by the guide's PodMonitor and once by the modelservice
+ServiceMonitor -- producing two identical series per pod that differ only in
+`job`. Confirmed live: `count by (job, pod) (vllm:num_requests_running)`
+returns two jobs per pod on an OpenShift benchmark namespace. Per-pod panels
+would draw each pod twice, and every `sum()`/`count()` would be exactly
+double. Collapsing to `(pod, namespace, engine)` first fixes both, and
+keeping `engine` in the grouping preserves per-engine series for
+data-parallel deployments. The replica-count panel groups by `(pod,
+namespace)` only, since it counts pods rather than engines.
+
+To see which pods a session actually labelled, query
+`kube_pod_labels{namespace="<ns>"}` and read
+`label_llmdbench_ai_session_id` per pod.
 
 `kube_pod_labels` carries one series per pod regardless of whether
 `label_llmdbench_ai_session_id` is populated -- kube-state-metrics emits the
@@ -259,21 +302,19 @@ absent from every series, so a specific (non-`.*`) value matches nothing
 and the panels go blank. That's the tell that the allowlist isn't set, not
 a bug.
 
-**Both sides of the join are scoped to `$namespace`.** `kube_pod_labels` is
-cluster-wide (every namespace, every pod, on a shared Prometheus this can be
-thousands of series), and Prometheus's vector matching requires the match
-group (`pod`, `namespace`) to be unique on the `kube_pod_labels` side across
-*everything the query returns* -- not just the pods that actually match the
-left-hand side. On a busy shared cluster it's common for some unrelated
-pod, anywhere in any namespace, to transiently have two label sets in
-`kube_pod_labels` at once (e.g. mid-rollout, momentarily overlapping
-old/new label values before the stale series drops out); if the right-hand
-side isn't namespace-scoped, that unrelated duplicate makes Prometheus
-reject the *entire* query with `"many-to-many matching not allowed"` --
-observed live against a real OpenShift cluster's shared Prometheus while
-validating this. Filtering `kube_pod_labels` by the same `$namespace` as the
-left-hand side keeps the match group small enough that this essentially
-never happens for a benchmark's own (few-pod) namespace.
+**Both sides of the join are still scoped to `$namespace`.** `kube_pod_labels`
+is cluster-wide (every namespace, every pod, on a shared Prometheus this can
+be thousands of series), so scoping the right-hand side keeps the join cheap
+and its result small.
+
+Historically it was also load-bearing for correctness: with a `on (pod,
+namespace)` match group, one unrelated pod anywhere in the cluster
+transiently carrying two label sets (mid-rollout, before the stale series
+drops out) made Prometheus reject the *entire* query with `"many-to-many
+matching not allowed"` -- observed live against a real OpenShift cluster's
+shared Prometheus. The `max by (namespace)` form is immune by construction,
+since it emits exactly one series per namespace, but keeping the scope costs
+nothing and bounds the work.
 
 Once the allowlist is configured, scope any panel (or an ad-hoc Explore
 query) to one session by setting the dashboard's `session_id` variable, or
@@ -281,11 +322,101 @@ by appending the same join to a new PromQL expression -- always scoped to
 `namespace=~"$namespace"` on the `kube_pod_labels` side for the reason
 above.
 
+**`session_id` only applies to the `vllm:*` panels.** The join keys on
+`(pod, namespace)`, so it can only filter series that a session-labelled pod
+produced. It doesn't apply to:
+
+- **EPP metrics** -- the router pod isn't stamped with
+  `llmdbench.ai/session-id` (the templates above cover serving and harness
+  pods only), and two sessions sharing a namespace would share one router
+  anyway, so the series are not separable even in principle.
+- **kube-state-metrics** (`kube_deployment_*`, `kube_horizontalpodautoscaler_*`)
+  -- these describe objects, not pods.
+- **KEDA and WVA metrics** -- emitted by controllers that live in their own
+  namespaces. Their `namespace` label (the *target's* namespace) collides
+  with the scrape target's, so Prometheus renames it to `exported_namespace`;
+  those panels match `{exported_namespace=~"$namespace"} or
+  {namespace=~"$namespace"}` so they work either way.
+
+Those panels are scoped by `$namespace` and the time window only. With the
+one-namespace-per-session convention that is exactly as precise as the
+`vllm:*` panels; only in a shared namespace do they stay broader.
+
+## Dashboard panels
+
+`benchmark/config/grafana/dashboard.json` is organized into four rows:
+
+| Row | Panels |
+|-----|--------|
+| **vLLM - capacity & queueing** | KV cache utilization (per pod), queue size (per pod), fleet running/waiting, waiting by reason, preemptions, prefix cache hit rate (local + KV-connector) |
+| **vLLM - throughput & latency** | token throughput, completed requests by finish reason, TTFT, inter-token latency, end-to-end latency, request queue time (p50/p95/p99) |
+| **Replicas & autoscaling** | serving replicas by role (prefill/decode, counted from the metrics themselves), Deployment spec/available/unavailable, HPA desired vs current vs min/max, KEDA trigger values + activation, WVA desired vs current, EPP ready endpoints, KEDA autoscaler errors & health |
+| **EPP (router / endpoint picker)** | pool KV utilization and spread, pool queue/running averages, per-endpoint queue size, request + error rate, in-flight requests, router-observed latency, scheduling latency, flow-control saturation and queue, in-flight tokens per endpoint |
+
+Notes on what may legitimately come up empty:
+
+- **Replica counts have four independent sources** and they intentionally
+  disagree: Deployment `spec` is what the autoscaler asked for, Deployment
+  `available` is what Kubernetes has running, EPP `ready_endpoints` is what
+  the router will route to, and "serving replicas by role" counts pods that
+  are actually reporting metrics. The lag between them *is* the scale-up
+  cost of a strategy. "Serving replicas by role" is the only one that is
+  workload-API-agnostic -- it works for LeaderWorkerSet and standalone
+  deployments, where `kube_deployment_*` has nothing to say.
+- **EPP metrics are queried under both names.** llm-d-router renamed them to
+  `llm_d_epp_*` and kept the `inference_pool_*` / `inference_objective_*` /
+  `inference_extension_*` originals as deprecated aliases; each panel is
+  `<new> or <old>`, aggregated first so the two sides share a label set and
+  the `or` doesn't double-plot when a build emits both. Metrics with no
+  legacy equivalent (std devs, TTFT, per-endpoint queue size) query the new
+  name only.
+- `llm_d_epp_inflight_tokens` requires the EPP `inflight-load-producer`
+  plugin, so its panel is empty unless the scenario enables it (see
+  `scenarios/staging/pd-disaggregation/token-aware.yaml`).
+- **An empty HPA/KEDA panel is a finding, not a gap.** "KEDA Autoscaler
+  Errors & Health" exists to tell the two apart. A ScaledObject that fails
+  its check -- bad trigger metadata, a `TriggerAuthentication` with an empty
+  bearer token, unreachable Prometheus -- is still *registered*, but KEDA
+  never creates its HPA and never publishes a scaler value, so every other
+  autoscaling panel is silent and the run quietly measures a fixed replica
+  count. The panel plots `ScaledObjects registered` against `ScaledObjects
+  reporting a metric`; a gap between them is that failure. Observed live on
+  a token-aware run: registered 2, reporting 0, with
+  `kubectl get scaledobject -n <ns> -o json` giving the reason --
+  `ScaledObjectCheckFailed: ... bearer token=<empty> is required`. When the
+  ScaledObject *is* live but its queries fail, the error counters and
+  `ScalingActive=false` carry the signal instead.
+- KEDA panels need the `keda-operator` metrics endpoint scraped; WVA panels
+  need the run to take the `wva.enabled` path; `vllm:num_requests_waiting_by_reason`
+  needs a recent vLLM; flow-control panels need the EPP's flow-control layer
+  enabled. Simulated backends (`inference-sim`) implement only a subset of
+  the `vllm:*` surface.
+- KEDA's error metric changed names across versions, so the trigger-error
+  target queries `keda_scaler_detail_errors_total` with a fallback to
+  `keda_scaler_errors_total`, each aggregated before the `or` so the two
+  don't double-plot.
+
 ## Extending the dashboard
 
-`benchmark/config/grafana/dashboard.json` starts minimal — KV-cache
-utilization and queue size — scoped by a `namespace` dashboard variable so
-the same dashboard works across benchmark namespaces. Add panels the same
-way (replica counts, scaling activity, latency) and re-run `configure` to
-push the update; `snapshot` picks up whatever panels/targets exist on the
-dashboard at capture time.
+Add panels the same way and re-run `configure` to push the update;
+`snapshot` picks up whatever panels/targets exist on the dashboard at
+capture time. Two constraints come from `_capture_snapshot`, which replays
+each target's `expr` against Prometheus itself rather than letting Grafana
+render it:
+
+1. **Only `$namespace` and `$session_id` may appear in an expression.** Those
+   are the two variables it substitutes; any other dashboard variable reaches
+   Prometheus unexpanded and the query fails (the snapshot warns and that
+   panel freezes empty). Grafana leaves `$1`-style `label_replace` capture
+   groups alone, so those are safe.
+2. **Use literal range durations, not `$__rate_interval` / `$__interval`.**
+   Those macros are expanded by Grafana at render time, not by the snapshot
+   path. The shipped panels use `[2m]` for counter rates and `[5m]` for
+   anything feeding `histogram_quantile`: latency samples arrive only as
+   requests complete, and on a bursty run a 2-minute window can contain zero
+   of them, which renders the percentile as `NaN`. That was observed on a
+   real session -- `increase(vllm:time_to_first_token_seconds_count[2m])` was
+   0 mid-run while the `[5m]` window held ~245 samples.
+
+`configure` rejects a dashboard that breaks (1). Both are worth re-checking
+with a quick PromQL parse of every target after editing the JSON.

--- a/benchmark/docs/benchmark-report.md
+++ b/benchmark/docs/benchmark-report.md
@@ -99,15 +99,14 @@ benchmark/hack/benchmark_report.sh configure --prometheus-url http://localhost:9
 ### Why Thanos Querier specifically
 
 On OpenShift, vLLM's `PodMonitor`-scraped metrics live in the
-**user-workload** Prometheus while `kube-state-metrics` (needed for the
-`kube_pod_labels` join -- see "Identifying a session's metrics" below) is
-scraped by the **platform** Prometheus. Those are two separate TSDBs; a
-query can't join across them directly. Thanos Querier merges both, so it's
-the only endpoint where the join panels actually return data. This was
-confirmed by querying each Prometheus directly: `prometheus-operated` in
-`openshift-user-workload-monitoring` has `vllm:*` but zero
-`kube_pod_labels` series, and `prometheus-operated` in
-`openshift-monitoring` has `kube_pod_labels` but zero `vllm:*` series.
+**user-workload** Prometheus while `kube-state-metrics` (which the
+Deployment- and HPA-replica panels query) is scraped by the **platform**
+Prometheus. Those are two separate TSDBs, so neither one alone can serve the
+whole dashboard. Thanos Querier merges both, so it's the only endpoint where
+every panel returns data. This was confirmed by querying each Prometheus
+directly: `prometheus-operated` in `openshift-user-workload-monitoring` has
+`vllm:*` but zero `kube_deployment_*` series, and `prometheus-operated` in
+`openshift-monitoring` has `kube_deployment_*` but zero `vllm:*` series.
 
 ### Alternative: Grafana already running in-cluster (no port-forwarding)
 
@@ -204,69 +203,36 @@ has the data).
 The vLLM metrics this dashboard queries (`vllm:kv_cache_usage_perc`,
 `vllm:num_requests_waiting`, `vllm:num_requests_running`, ... -- see
 [Dashboard panels](#dashboard-panels)) carry only standard labels:
-`namespace` and `pod`. There's no `session_id` on them directly. Every
-"which metrics belong to this session" link -- the session-level
-Observability line and Live dashboard link in the
-[interactive dashboard](interactive-dashboard.md), and the Grafana snapshots
-covered here -- **default** to working around that by scoping the Grafana
-dashboard's `namespace` variable to the session's namespace and time-boxing
-the query to that session's (or that experiment's run's) window. That's
-sufficient as long as **one namespace is used by only one session at a
-time**, which is how the "Start a session" form and the `run-benchmark`
+`namespace` and `pod`. There is no session identifier on them, and nothing
+in the pipeline stamps one: **a session is identified by its namespace plus
+its time window, and by nothing else.** Every "which metrics belong to this
+session" link -- the session-level Observability line and Live dashboard
+link in the [interactive dashboard](interactive-dashboard.md), and the
+Grafana snapshots covered here -- works by scoping the Grafana dashboard's
+`namespace` variable to the session's namespace and time-boxing the query to
+that session's (or that experiment's run's) window. `_live_dashboard_url`
+and `_capture_snapshot` in `benchmark/hack/benchmark_report.py` thread
+exactly those two things through, and `$namespace` is the only variable a
+panel query may reference (see [Extending the
+dashboard](#extending-the-dashboard)).
+
+That is sufficient as long as **one namespace is used by only one session at
+a time**, which is how the "Start a session" form and the `run-benchmark`
 skill both work in practice (a fresh namespace, or an intentionally reused
-one you tear down before reusing).
+one you tear down before reusing). It breaks down if two sessions overlap in
+the same namespace, or if a namespace is reused enough that retention no
+longer cleanly separates their time windows -- in those cases the panels
+show both sessions' pods and there is no way to tell them apart.
 
-It breaks down if two sessions ever overlap in the same namespace, or if a
-namespace is reused enough that retention no longer cleanly separates their
-time windows. For that case, the sibling `llm-d-benchmark` clone's harness
-and serving pod templates now stamp a `llmdbench.ai/session-id: <session-id>`
-label on the pods that produce these metrics (`config/templates/jinja/13_ms-values.yaml.j2`,
-`14_standalone-deployment_yaml.j2`, `20_harness_pod.yaml.j2`), where
-`<session-id>` is the llmdbenchmark workspace/session directory name (e.g.
-`<user>-<timestamp>`) -- the same value used as the session ID everywhere
-else in this dashboard. `session_id` is also a dashboard template variable
-here (`benchmark/config/grafana/dashboard.json`) and is threaded through
-`_live_dashboard_url`/`_capture_snapshot` in `benchmark/hack/benchmark_report.py`
-the same way `namespace` is, so every generated link already carries
-`var-session_id=<id>` and every snapshot's queries have `$session_id`
-substituted.
-
-Every `vllm:*` panel joins onto the vLLM metrics via `kube_state_metrics`'s
-`kube_pod_labels`, e.g.:
-
-```
-max by (pod, namespace, engine) (vllm:kv_cache_usage_perc{namespace=~"$namespace"})
-  * on (namespace) group_left()
-    max by (namespace) (kube_pod_labels{namespace=~"$namespace",
-                                        label_llmdbench_ai_session_id=~"$session_id"})
-```
-
-**The join resolves a session to its namespace; it does not match pod for
-pod.** That is deliberate, and the earlier pod-level form was wrong in
-practice. The label is stamped at **standup**, so a session that only *runs*
-against an already-stood-up stack labels nothing but its own harness pod: the
-decode/prefill pods still carry the standup session's ID. Matching
-`on (pod, namespace)` then returned zero series for the run session's ID --
-every vLLM panel went blank for a perfectly valid selection. Verified live:
-picking run session `villardl-20260909-132550-010` in
-`lionel-bench-model-sim-32b-pd-token` matched nothing under the old form and
-matches all 29 vLLM targets under this one.
-
-`max by (namespace)` collapses the right-hand side to one series per
-namespace, so the gate reads "this namespace had a pod belonging to the
-selected session at this instant". Consequences worth knowing:
-
-- Selecting a session ID from a *different* namespace still yields nothing,
-  so it filters rather than being a no-op (verified).
-- Because a harness pod only exists while its run is in flight, gating on a
-  run-only session ID also time-boxes the panels to that run -- outside the
-  window the gate is empty. Gating on the standup session's ID spans the
-  whole stack lifetime.
-- Two sessions overlapping in one namespace can no longer be separated. They
-  never could: their serving pods share one standup ID and the router pod
-  carries none at all.
-- It also removes the many-to-many hazard described below, since the
-  right-hand side is unique per namespace by construction.
+> **Deprecated:** earlier revisions gated every `vllm:*` panel on a
+> `kube_pod_labels{label_llmdbench_ai_session_id=~"$session_id"}` join,
+> against a `llmdbench.ai/session-id` pod label stamped by the sibling
+> `llm-d-benchmark` clone's pod templates. That label was never adopted
+> upstream, so the join matched nothing useful and the `session_id`
+> dashboard variable had no values to offer. Both the variable and the join
+> are gone; the panels are plain namespace-scoped queries now. Nothing else
+> about the dashboard changed -- the join was a multiply-by-1 no-op at its
+> default `session_id=.*` anyway.
 
 **Why the `max by (...)` wrapper:** an llm-d serving pod is typically scraped
 *twice* -- once by the guide's PodMonitor and once by the modelservice
@@ -279,68 +245,14 @@ keeping `engine` in the grouping preserves per-engine series for
 data-parallel deployments. The replica-count panel groups by `(pod,
 namespace)` only, since it counts pods rather than engines.
 
-To see which pods a session actually labelled, query
-`kube_pod_labels{namespace="<ns>"}` and read
-`label_llmdbench_ai_session_id` per pod.
-
-`kube_pod_labels` carries one series per pod regardless of whether
-`label_llmdbench_ai_session_id` is populated -- kube-state-metrics emits the
-base metric (`pod`, `namespace`, `uid`) unconditionally, and only attaches
-the `label_llmdbench_ai_session_id` dimension if that pod label is in its
-`--metric-labels-allowlist`. **OpenShift's built-in cluster-monitoring
-kube-state-metrics ships with `--metric-labels-allowlist=pods=[*]`** (every
-pod label, confirmed on a live OCP cluster), so this works with zero extra
-config there. A manually-installed `kube-prometheus-stack` (e.g. the "local
-Kind" path earlier in this doc) doesn't allowlist custom labels by default --
-set `--metric-labels-allowlist=pods=[llmdbench.ai/session-id]`, or the
-chart's `kube-state-metrics.metricLabelsAllowlist` equivalent, to enable it
-there. Either way, with the default `session_id=.*` the join is a no-op
-multiply-by-1: panels render identically whether or not the allowlist is
-configured. Setting `session_id` to one session's actual ID only filters
-correctly once the allowlist is enabled -- without it, the label is simply
-absent from every series, so a specific (non-`.*`) value matches nothing
-and the panels go blank. That's the tell that the allowlist isn't set, not
-a bug.
-
-**Both sides of the join are still scoped to `$namespace`.** `kube_pod_labels`
-is cluster-wide (every namespace, every pod, on a shared Prometheus this can
-be thousands of series), so scoping the right-hand side keeps the join cheap
-and its result small.
-
-Historically it was also load-bearing for correctness: with a `on (pod,
-namespace)` match group, one unrelated pod anywhere in the cluster
-transiently carrying two label sets (mid-rollout, before the stale series
-drops out) made Prometheus reject the *entire* query with `"many-to-many
-matching not allowed"` -- observed live against a real OpenShift cluster's
-shared Prometheus. The `max by (namespace)` form is immune by construction,
-since it emits exactly one series per namespace, but keeping the scope costs
-nothing and bounds the work.
-
-Once the allowlist is configured, scope any panel (or an ad-hoc Explore
-query) to one session by setting the dashboard's `session_id` variable, or
-by appending the same join to a new PromQL expression -- always scoped to
-`namespace=~"$namespace"` on the `kube_pod_labels` side for the reason
-above.
-
-**`session_id` only applies to the `vllm:*` panels.** The join keys on
-`(pod, namespace)`, so it can only filter series that a session-labelled pod
-produced. It doesn't apply to:
-
-- **EPP metrics** -- the router pod isn't stamped with
-  `llmdbench.ai/session-id` (the templates above cover serving and harness
-  pods only), and two sessions sharing a namespace would share one router
-  anyway, so the series are not separable even in principle.
-- **kube-state-metrics** (`kube_deployment_*`, `kube_horizontalpodautoscaler_*`)
-  -- these describe objects, not pods.
-- **KEDA and WVA metrics** -- emitted by controllers that live in their own
-  namespaces. Their `namespace` label (the *target's* namespace) collides
-  with the scrape target's, so Prometheus renames it to `exported_namespace`;
-  those panels match `{exported_namespace=~"$namespace"} or
-  {namespace=~"$namespace"}` so they work either way.
-
-Those panels are scoped by `$namespace` and the time window only. With the
-one-namespace-per-session convention that is exactly as precise as the
-`vllm:*` panels; only in a shared namespace do they stay broader.
+**Not every panel's `namespace` label means the same thing.** KEDA and WVA
+metrics are emitted by controllers living in their own namespaces, so the
+*target's* namespace collides with the scrape target's and Prometheus renames
+it to `exported_namespace`; those panels match
+`{exported_namespace=~"$namespace"} or {namespace=~"$namespace"}` so they
+work either way. The `kube_deployment_*` / `kube_horizontalpodautoscaler_*`
+panels describe objects rather than pods, but their `namespace` is the
+object's, so `$namespace` scopes them correctly as-is.
 
 ## Dashboard panels
 
@@ -404,11 +316,11 @@ capture time. Two constraints come from `_capture_snapshot`, which replays
 each target's `expr` against Prometheus itself rather than letting Grafana
 render it:
 
-1. **Only `$namespace` and `$session_id` may appear in an expression.** Those
-   are the two variables it substitutes; any other dashboard variable reaches
-   Prometheus unexpanded and the query fails (the snapshot warns and that
-   panel freezes empty). Grafana leaves `$1`-style `label_replace` capture
-   groups alone, so those are safe.
+1. **Only `$namespace` may appear in an expression.** It is the one variable
+   it substitutes; any other dashboard variable reaches Prometheus unexpanded
+   and the query fails (the snapshot warns and that panel freezes empty).
+   Grafana leaves `$1`-style `label_replace` capture groups alone, so those
+   are safe.
 2. **Use literal range durations, not `$__rate_interval` / `$__interval`.**
    Those macros are expanded by Grafana at render time, not by the snapshot
    path. The shipped panels use `[2m]` for counter rates and `[5m]` for

--- a/benchmark/docs/interactive-dashboard.md
+++ b/benchmark/docs/interactive-dashboard.md
@@ -89,9 +89,9 @@ doesn't leave one behind holding the port.
   links can only disambiguate sessions by time window, so if the same
   namespace is reused for a later session, the two can't be told apart in
   Grafana/Prometheus once their windows overlap or once retention drops the
-  time boundary. Use one namespace per session if that matters to you, or see
+  time boundary. Use one namespace per session -- see
   [`benchmark-report.md`](benchmark-report.md)'s "Identifying a session's
-  metrics" for a more durable fix.
+  metrics".
   Each experiment's **Grafana** section has its own **Live dashboard**
   link — time-boxed to that run's window and scoped to its
   namespace, so it shows only that run's data — available as soon as

--- a/benchmark/hack/benchmark_report.py
+++ b/benchmark/hack/benchmark_report.py
@@ -178,7 +178,7 @@ def _forget_port_forward(target, context):
 # the panel freezes empty in the snapshot -- see "Extending the dashboard" in
 # docs/benchmark-report.md. `$1`-style label_replace capture groups are fine:
 # Grafana leaves them alone and so do we.
-SNAPSHOT_SAFE_VARIABLES = ("namespace", "session_id")
+SNAPSHOT_SAFE_VARIABLES = ("namespace",)
 
 
 def _dashboard_expression_errors(dashboard):
@@ -194,7 +194,7 @@ def _dashboard_expression_errors(dashboard):
                 errors.append(
                     f"panel {panel.get('title')!r} target {target.get('refId')}: "
                     f"${variable} is not substituted during snapshot capture "
-                    f"(only {', '.join('$' + v for v in SNAPSHOT_SAFE_VARIABLES)} are)"
+                    f"(only {', '.join('$' + v for v in SNAPSHOT_SAFE_VARIABLES)})"
                 )
     return errors
 
@@ -327,20 +327,16 @@ def _run_window(experiment_dir):
     return namespace, start_s, stop_s, meta.get("experiment_id", os.path.basename(experiment_dir))
 
 
-def _live_dashboard_url(grafana_url, dashboard_uid, namespace, start_s, stop_s, session_id=None):
+def _live_dashboard_url(grafana_url, dashboard_uid, namespace, start_s, stop_s):
     """Build a Grafana dashboard URL time-boxed to a run window and scoped to its namespace,
-    so the dashboard shows only the data for that run. `session_id`, if given, is passed
-    through as the `session_id` dashboard variable -- see "Identifying a session's metrics"
-    in docs/benchmark-report.md; the shipped panels don't key off it, but it's there for a
-    panel query that's been opted into the kube_pod_labels join."""
-    url = (
+    so the dashboard shows only the data for that run. Namespace + time window is the whole
+    of a session's identity here -- the pods carry no session-id label to filter on; see
+    "Identifying a session's metrics" in docs/benchmark-report.md."""
+    return (
         f"{grafana_url.rstrip('/')}/d/{dashboard_uid}"
         f"?orgId=1&from={int(start_s * 1000)}&to={int(stop_s * 1000)}"
         f"&var-namespace={urllib.parse.quote(namespace)}"
     )
-    if session_id:
-        url += f"&var-session_id={urllib.parse.quote(session_id)}"
-    return url
 
 
 def _session_id_from_experiment_dir(experiment_dir):
@@ -455,7 +451,7 @@ def _capture_snapshot(experiment_dir, grafana_url, user, password, dashboard_uid
             query_spec = query["spec"]
             refid = query_spec["refId"]
             orig = query_spec["query"]["spec"]
-            expr = orig["expr"].replace("$namespace", namespace).replace("$session_id", session_id)
+            expr = orig["expr"].replace("$namespace", namespace)
             legend_format = orig.get("legendFormat", "")
 
             series = _query_range(grafana_url, ds_uid, user, password, expr, namespace, start_s, stop_s, step_s)
@@ -500,9 +496,7 @@ def _capture_snapshot(experiment_dir, grafana_url, user, password, dashboard_uid
         "captured_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "snapshot_url": snap_result.get("url"),
         "snapshot_delete_url": snap_result.get("deleteUrl"),
-        "live_dashboard_url": _live_dashboard_url(
-            grafana_url, dashboard_uid, namespace, start_s, stop_s, session_id=session_id
-        ),
+        "live_dashboard_url": _live_dashboard_url(grafana_url, dashboard_uid, namespace, start_s, stop_s),
     }
     out_path = os.path.join(experiment_dir, "grafana_snapshot.yaml")
     with open(out_path, "w") as f:
@@ -590,9 +584,8 @@ def _render_experiment(experiment_dir):
 
     snapshot = _load_yaml(os.path.join(experiment_dir, "grafana_snapshot.yaml"))
     window = _run_window_epochs(meta)
-    session_id = _session_id_from_experiment_dir(experiment_dir)
     live_url = snapshot.get("live_dashboard_url") if snapshot else (
-        _live_dashboard_url(DEFAULT_GRAFANA_URL, DASHBOARD_UID, *window, session_id=session_id) if window else None
+        _live_dashboard_url(DEFAULT_GRAFANA_URL, DASHBOARD_UID, *window) if window else None
     )
     live_html = (
         "<p><strong>Live dashboard</strong> (time-boxed to this run &amp; its namespace, so it shows "
@@ -874,9 +867,17 @@ def _scan_stacks(session_dir):
         return stacks
     for entry in sorted(os.listdir(plan_dir)):
         stack_dir = os.path.join(plan_dir, entry)
-        if not os.path.isdir(stack_dir) or not os.path.isfile(os.path.join(plan_dir, entry + ".yaml")):
-            continue  # not a stack dir (e.g. a dry-run's nested plan/setup/)
-        cfg = _load_yaml(os.path.join(stack_dir, "config.yaml"))
+        config_path = os.path.join(stack_dir, "config.yaml")
+        # A stack dir is one holding a rendered config.yaml. Don't key off a
+        # sibling plan/<entry>.yaml: that file is named after the *experiment*
+        # (e.g. plan/token-aware.yaml), which needn't match the stack dir's
+        # name (plan/pd-disaggregation/), and requiring it silently dropped
+        # every stack -- leaving the session with no namespace, and its
+        # Grafana link scoped to `.*`. A dry-run's nested plan/setup/ has no
+        # config.yaml, so it's still excluded.
+        if not os.path.isdir(stack_dir) or not os.path.isfile(config_path):
+            continue
+        cfg = _load_yaml(config_path)
         model = cfg.get("model") or {}
         namespace = cfg.get("namespace") or {}
         stacks.append({
@@ -946,10 +947,7 @@ def _scan_experiment(workspace, experiment_dir, grafana_url=DEFAULT_GRAFANA_URL,
     # straight from the run window -- available as soon as run_metadata.yaml exists, with
     # no snapshot required (it just needs Grafana + Prometheus still holding the data).
     window = _run_window_epochs(meta)
-    grafana_live_url = (
-        _live_dashboard_url(grafana_url, dashboard_uid, *window, session_id=_session_id_from_experiment_dir(experiment_dir))
-        if window else None
-    )
+    grafana_live_url = _live_dashboard_url(grafana_url, dashboard_uid, *window) if window else None
 
     harness_delta_seconds = _parse_iso8601_duration_seconds(meta.get("harness_delta")) if meta else None
 
@@ -988,6 +986,15 @@ def _scan_session(workspace, session_id, grafana_url=DEFAULT_GRAFANA_URL, dashbo
         d for d in glob.glob(os.path.join(results_dir, "*")) if os.path.isdir(d)
     ) if os.path.isdir(results_dir) else []
     experiments = [_scan_experiment(workspace, d, grafana_url, dashboard_uid) for d in experiment_dirs]
+
+    # A session that ran against an already-stood-up stack has no plan/<stack>/
+    # of its own, so fall back to the namespace its runs recorded. Namespace is
+    # the only thing scoping this session's Grafana/Prometheus links (see
+    # "Identifying a session's metrics" in docs/benchmark-report.md), so an
+    # unknown one costs the link all of its precision.
+    namespace = primary.get("namespace") or next(
+        (e["metadata"]["namespace"] for e in experiments if (e.get("metadata") or {}).get("namespace")), None
+    )
 
     combined_text = stdout_text + "\n" + stderr_text
     is_dry_run = "[DRY RUN]" in stdout_text or "would have executed" in stdout_text
@@ -1046,8 +1053,8 @@ def _scan_session(workspace, session_id, grafana_url=DEFAULT_GRAFANA_URL, dashbo
     session_window_to = last_ts if (stage == "torn_down" and last_ts) else now
     session_grafana_live_url = (
         _live_dashboard_url(
-            grafana_url, dashboard_uid, primary.get("namespace") or ".*",
-            first_ts.timestamp(), session_window_to.timestamp(), session_id=session_id,
+            grafana_url, dashboard_uid, namespace or ".*",
+            first_ts.timestamp(), session_window_to.timestamp(),
         )
         if first_ts else None
     )
@@ -1058,7 +1065,7 @@ def _scan_session(workspace, session_id, grafana_url=DEFAULT_GRAFANA_URL, dashbo
         "scenario_spec": scenario_spec,
         "scenario_kind": scenario_kind,
         "backend": backend,
-        "namespace": primary.get("namespace"),
+        "namespace": namespace,
         "model": primary.get("model_name"),
         "stacks": stacks,
         "is_dry_run": is_dry_run,

--- a/benchmark/hack/benchmark_report.py
+++ b/benchmark/hack/benchmark_report.py
@@ -172,6 +172,33 @@ def _forget_port_forward(target, context):
 # configure
 # --------------------------------------------------------------------------
 
+# The only variables _capture_snapshot substitutes before replaying a panel's
+# expression against Prometheus. Anything else (another dashboard variable, a
+# Grafana macro such as $__rate_interval) reaches Prometheus unexpanded, and
+# the panel freezes empty in the snapshot -- see "Extending the dashboard" in
+# docs/benchmark-report.md. `$1`-style label_replace capture groups are fine:
+# Grafana leaves them alone and so do we.
+SNAPSHOT_SAFE_VARIABLES = ("namespace", "session_id")
+
+
+def _dashboard_expression_errors(dashboard):
+    """Return a list of human-readable reasons the dashboard's panel queries wouldn't
+    survive snapshot capture, empty if they all would."""
+    errors = []
+    for panel in dashboard.get("panels", []):
+        for target in panel.get("targets", []) or []:
+            expr = target.get("expr", "")
+            for variable in re.findall(r"\$(\w+)", expr):
+                if variable.isdigit() or variable in SNAPSHOT_SAFE_VARIABLES:
+                    continue
+                errors.append(
+                    f"panel {panel.get('title')!r} target {target.get('refId')}: "
+                    f"${variable} is not substituted during snapshot capture "
+                    f"(only {', '.join('$' + v for v in SNAPSHOT_SAFE_VARIABLES)} are)"
+                )
+    return errors
+
+
 def cmd_configure(args):
     err = resolve_remote_prometheus(args, context=getattr(args, "context", None))
     if err:
@@ -251,6 +278,12 @@ def cmd_configure(args):
 
     with open(DASHBOARD_JSON_PATH) as f:
         dashboard = json.load(f)
+    expr_errors = _dashboard_expression_errors(dashboard)
+    if expr_errors:
+        print(f"ERROR: {DASHBOARD_JSON_PATH} has queries that snapshots can't replay:", file=sys.stderr)
+        for e in expr_errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
     dashboard["id"] = None
     status, result = _http(
         "POST",


### PR DESCRIPTION
<!-- No issue: this is benchmark test-bed tooling under benchmark/, not WVA runtime behavior. -->

Grows the benchmark Grafana dashboard from 2 panels to something you can
actually judge an autoscaling strategy with, adds a token-aware p/d scenario
to drive it, and drops the `session_id` machinery that turned out to be dead.

## Proposed Changes

- :gift: **Extend `benchmark/config/grafana/dashboard.json` to 29 panels** in four
  rows — vLLM capacity/queueing, vLLM throughput/latency, replicas &
  autoscaling, and EPP (router). Replica counts come from four independent
  sources that intentionally disagree (Deployment `spec`, Deployment
  `available`, EPP ready endpoints, and a count of pods reporting metrics);
  the lag between them *is* the scale-up cost of a strategy, and the
  metrics-derived count is the only one that also works for LeaderWorkerSet
  and standalone topologies. EPP metrics are queried under both the current
  `llm_d_epp_*` names and the deprecated `inference_pool_*` /
  `inference_objective_*` / `inference_extension_*` aliases, aggregated
  before the `or` so a build emitting both doesn't double-plot.
- :gift: **Add the `staging/pd-disaggregation/token-aware` scenario** — a
  token-velocity KEDA variant (prefill on seconds of uncached backlog, decode
  on KV-cache utilization) to exercise the new panels.
- :wastebasket: **Remove the deprecated `session_id` dashboard variable and its
  `kube_pod_labels` join.** The `llmdbench.ai/session-id` pod label it keyed on
  was never adopted upstream in `llm-d-benchmark`, so the variable had no
  values to offer and the join was dead weight — a multiply-by-1 no-op at its
  default `.*`, and a blank panel for any specific value. `benchmark_report.py`
  no longer appends `var-session_id` to generated links or substitutes
  `$session_id` during snapshot capture, and `SNAPSHOT_SAFE_VARIABLES` is
  narrowed to `$namespace` so `configure` rejects any panel that reintroduces
  it. A session is now identified by its namespace plus its time window.
- :bug: **Fix session namespace detection in `_scan_stacks`.** It only recognized
  `plan/<entry>/` as a stack when a sibling `plan/<entry>.yaml` existed, but
  that file is named after the *experiment* (`plan/token-aware.yaml`) rather
  than the stack (`plan/pd-disaggregation/`). Every stack was dropped, so the
  interactive dashboard's session-level Grafana link fell back to
  `var-namespace=.*` — nothing selected. It now keys off the rendered
  `config.yaml`, with a fallback to the namespace recorded in
  `run_metadata.yaml` for sessions that ran against an already-stood-up stack.
  This was invisible until the `session_id` removal made the namespace the
  only thing scoping those links.
- :broom: Update `benchmark/docs/benchmark-report.md` and
  `interactive-dashboard.md` to match, including why Thanos Querier is still
  required (`vllm:*` and `kube_deployment_*` live in separate TSDBs on
  OpenShift) and what may legitimately come up empty in each panel.

### Pre-review Checklist

- [ ] **E2E tests** for any new behavior — N/A: this is benchmark test-bed
      tooling under `benchmark/`, outside the operator's e2e surface. Verified
      by hand: `_dashboard_expression_errors()` returns `[]` against the edited
      dashboard, and `benchmark_report.py index` regenerates cleanly over a
      real 5-session workspace with correctly-scoped links.
- [x] **Docs PR** for any user-facing impact — included in this PR
      (`benchmark/docs/`), which is where this tooling is documented.
- [ ] **Proposal PR** — N/A: no change to WVA behavior.

**Release Note**

```release-note

```

**Docs**

N/A — no user-facing WVA change; the benchmark test bed documents itself under `benchmark/docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
