### PR TITLE
docs: relabel the in-repo monitoring guide as development and CI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Welcome to the WVA documentation! This directory contains comprehensive guides f
 - **[Installation Guide](https://llm-d.ai/docs/guides/workload-autoscaling)** - Installing WVA on your cluster
 - **[Configuration](https://llm-d.ai/docs/architecture/advanced/autoscaling/workload-variant-autoscaling#configuration)** - Configuring WVA for your workloads
 - **[Architecture](https://llm-d.ai/docs/architecture/advanced/autoscaling)** - Understanding how WVA works under the hood
+- **[Monitoring](https://github.com/llm-d/llm-d/blob/main/docs/operations/observability/README.md)** - Dashboards, metrics, and alerting for a deployed cluster
 
 ### Design
 
@@ -30,6 +31,7 @@ Welcome to the WVA documentation! This directory contains comprehensive guides f
 - **[Development Setup](developer-guide/development.md)** - Setting up your dev environment
 - **[Testing](developer-guide/testing.md)** - Running tests and CI workflows
 - **[Debugging](developer-guide/debugging.md)** - Debugging techniques and tools
+- **[Monitoring (development and CI)](developer-guide/monitoring.md)** - The Grafana and Prometheus stack this repository installs for development
 - **[Contributing](../CONTRIBUTING.md)** - How to contribute to the project
 
 ### Benchmark Guide

--- a/docs/developer-guide/monitoring.md
+++ b/docs/developer-guide/monitoring.md
@@ -1,0 +1,132 @@
+# Operational Dashboard (development and CI)
+
+This describes the Grafana and Prometheus stack that this repository installs
+for development and CI. It is not the production monitoring path — for that,
+see the [observability documentation in llm-d](https://github.com/llm-d/llm-d/blob/main/docs/operations/observability/README.md).
+
+## Overview
+For observability, WVA records a number of metrics which are scraped by Prometheus. This document shows how to enable the operational dashboard in your Kubernetes cluster. Once installed, you can view these metrics through the provided dashboard with Grafana.
+
+## Installation
+The operational dashboard is installed by default. To uninstall, set the environment variable `DEPLOY_OPERATIONAL_DASHBOARD` to `false` and run or re-run the installation. Following is an example for installation using `Make` method:
+```console
+export DEPLOY_OPERATIONAL_DASHBOARD=false
+make deploy-wva-on-k8s
+```
+
+## Access Operational Dashboard
+Once the operational dashboard is enabled, Grafana is installed, configured, and ready to display the dashboard. Here are the next steps:
+
+- Forward Grafana port so the dashboard can be accessed locally:
+  ```console
+  $ kubectl port-forward -n workload-variant-autoscaler-monitoring svc/kube-prometheus-stack-grafana 3000:80
+  ```
+- Get Grafana `admin` password:
+  ```console
+  $ kubectl get secret -n workload-variant-autoscaler-monitoring   kube-prometheus-stack-grafana   -o jsonpath="{.data.admin-password}" | base64 -d;echo
+  ```
+- Point browser to `http://localhost:3000/`, login with username `admin` and the password obtained in previous step.
+
+- Browse to "Connections/Data sources", you should see a Prometheus data source `https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090`. Click on `Test` button to test the data source.
+
+- Browse to "Dashboards", you should see a dashboard called `WVA Operational Dashboard`.
+
+
+## Import Operational Dashboard
+The pre-installed `WVA Operational Dashboard` is read-only. You can import `WVA Operational Dashboard` to a new dashboard so you can update the dashboard as follows:
+- Browse to "Dashboards", you should see a dashboard called `WVA Operational Dashboard/New/Import`.
+- Copy and paste the content of `deploy/grafana/operational-dashboard.json`.
+- Name the new dashboard such as `My WVA Operational Dashboard`.
+- Your new dashboard now is the same as `WVA Operational Dashboard` except that you can edit and save.
+
+
+## Understanding Namespace Labels in Metrics
+
+### The `namespace` vs `exported_namespace` Issue
+
+When viewing per-variant metrics in the operational dashboard, you may notice labels named `namespace` and `exported_namespace`. Understanding the difference is important for correctly interpreting dashboard data.
+
+**Root Cause: Prometheus `honorLabels` Setting**
+
+WVA's metrics include a `namespace` label indicating which namespace each variant is running in. However, when Prometheus scrapes these metrics via a ServiceMonitor, the `honorLabels` configuration (default: `false`) affects how labels are handled:
+
+- **With `honorLabels: false` (default)**:
+  - Prometheus **renames** WVA's original `namespace` label to `exported_namespace`
+  - Prometheus adds its own `namespace` label containing the **controller's pod namespace** (e.g., `workload-variant-autoscaler-system`)
+  - **Result**: Per-variant panels show `exported_namespace` for the variant's actual namespace
+
+- **With `honorLabels: true`**:
+  - WVA's original `namespace` label is **preserved** as-is
+  - The `namespace` label contains the **variant's namespace**
+  - **Result**: Per-variant panels use `namespace` for the variant's actual namespace
+
+**Dashboard Configuration**
+
+The operational dashboard includes a template variable `$namespace_label` that can be toggled between:
+- `exported_namespace` (default) - for `honorLabels: false` configurations
+- `namespace` - for `honorLabels: true` configurations
+
+If you see incorrect namespace groupings in per-variant panels (e.g., all variants showing the controller's namespace instead of their actual namespaces), toggle the `$namespace_label` dropdown at the top of the dashboard.
+
+**Why the Default is `honorLabels: false`**
+
+Setting `honorLabels: false` is a security best practice that prevents scraped applications from spoofing infrastructure labels. For example, it prevents a pod from claiming to be in a different namespace via its exported metrics.
+
+## Troubleshooting
+### services "kube-prometheus-stack-grafana" not found
+  - Make sure to install WVA cluster with `DEPLOY_OPERATIONAL_DASHBOARD=true` (default) as this would install Grafana.
+  
+### No Data
+  - Hover over the information (`i`) icon in the panel. The information may show cases where data is not available.
+  - Check the datasource by browse to "Connections/Data sources", you should see a Prometheus data source `https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090`. Click on `Test` button to test the data source.
+  - Check data source which is defined in `kube-prometheus-stack-grafana-datasource` configmap:
+    ```console
+      $ oc get cm kube-prometheus-stack-grafana-datasource -n workload-
+    variant-autoscaler-monitoring -o yaml
+    apiVersion: v1
+    data:
+      datasource.yaml: |-
+        apiVersion: 1
+        datasources:
+        - name: "Prometheus"
+          type: prometheus
+          uid: prometheus
+          url: http://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring:9090/
+          access: proxy
+          isDefault: true
+          jsonData:
+            httpMethod: POST
+            timeInterval: 30s
+        - name: "Alertmanager"
+          type: alertmanager
+          uid: alertmanager
+          url: http://kube-prometheus-stack-alertmanager.workload-variant-autoscaler-monitoring:9093/
+          access: proxy
+    ...
+    ```
+  ### Dashboard Not Found
+  - Dashboard is stored in `wva-operation-dashboard` configmap. Check configmap as follows:
+
+    ```console
+    $ oc get cm wva-operation-dashboard -n workload-variant-autoscaler-monitoring -o yaml
+    apiVersion: v1
+    data:
+      operational-dashboard.json: |
+        {
+          "annotations": {
+            "list": [
+              {
+                "builtIn": 1,
+                "datasource": {
+                  "type": "grafana",
+                  "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+              }
+            ]
+        ...
+    ```

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -1,128 +1,15 @@
-# Operational Dashboard
+# Monitoring
 
-## Overview
-For observability, WVA records a number of metrics which are scraped by Prometheus. This document shows how to enable the operational dashboard in your Kubernetes cluster. Once installed, you can view these metrics through the provided dashboard with Grafana.
+WVA's user-facing monitoring assets — the operational and benchmark Grafana
+dashboards, the alerting rules, and the setup instructions that go with them —
+live in the [llm-d](https://github.com/llm-d/llm-d) repository alongside the
+rest of the deployment documentation:
 
-## Installation
-The operational dashboard is installed by default. To uninstall, set the environment variable `DEPLOY_OPERATIONAL_DASHBOARD` to `false` and run or re-run the installation. Following is an example for installation using `Make` method:
-```console
-export DEPLOY_OPERATIONAL_DASHBOARD=false
-make deploy-wva-on-k8s
-```
+- [Observability overview](https://github.com/llm-d/llm-d/blob/main/docs/operations/observability/README.md)
+- [Setup](https://github.com/llm-d/llm-d/blob/main/docs/operations/observability/setup.md)
+- [Metrics](https://github.com/llm-d/llm-d/blob/main/docs/operations/observability/metrics.md)
+- [Alerting](https://github.com/llm-d/llm-d/blob/main/docs/operations/observability/alerting.md)
 
-## Access Operational Dashboard
-Once the operational dashboard is enabled, Grafana is installed, configured, and ready to display the dashboard. Here are the next steps:
-
-- Forward Grafana port so the dashboard can be accessed locally:
-  ```console
-  $ kubectl port-forward -n workload-variant-autoscaler-monitoring svc/kube-prometheus-stack-grafana 3000:80
-  ```
-- Get Grafana `admin` password:
-  ```console
-  $ kubectl get secret -n workload-variant-autoscaler-monitoring   kube-prometheus-stack-grafana   -o jsonpath="{.data.admin-password}" | base64 -d;echo
-  ```
-- Point browser to `http://localhost:3000/`, login with username `admin` and the password obtained in previous step.
-
-- Browse to "Connections/Data sources", you should see a Prometheus data source `https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090`. Click on `Test` button to test the data source.
-
-- Browse to "Dashboards", you should see a dashboard called `WVA Operational Dashboard`.
-
-
-## Import Operational Dashboard
-The pre-installed `WVA Operational Dashboard` is read-only. You can import `WVA Operational Dashboard` to a new dashboard so you can update the dashboard as follows:
-- Browse to "Dashboards", you should see a dashboard called `WVA Operational Dashboard/New/Import`.
-- Copy and paste the content of `deploy/grafana/operational-dashboard.json`.
-- Name the new dashboard such as `My WVA Operational Dashboard`.
-- Your new dashboard now is the same as `WVA Operational Dashboard` except that you can edit and save.
-
-
-## Understanding Namespace Labels in Metrics
-
-### The `namespace` vs `exported_namespace` Issue
-
-When viewing per-variant metrics in the operational dashboard, you may notice labels named `namespace` and `exported_namespace`. Understanding the difference is important for correctly interpreting dashboard data.
-
-**Root Cause: Prometheus `honorLabels` Setting**
-
-WVA's metrics include a `namespace` label indicating which namespace each variant is running in. However, when Prometheus scrapes these metrics via a ServiceMonitor, the `honorLabels` configuration (default: `false`) affects how labels are handled:
-
-- **With `honorLabels: false` (default)**:
-  - Prometheus **renames** WVA's original `namespace` label to `exported_namespace`
-  - Prometheus adds its own `namespace` label containing the **controller's pod namespace** (e.g., `workload-variant-autoscaler-system`)
-  - **Result**: Per-variant panels show `exported_namespace` for the variant's actual namespace
-
-- **With `honorLabels: true`**:
-  - WVA's original `namespace` label is **preserved** as-is
-  - The `namespace` label contains the **variant's namespace**
-  - **Result**: Per-variant panels use `namespace` for the variant's actual namespace
-
-**Dashboard Configuration**
-
-The operational dashboard includes a template variable `$namespace_label` that can be toggled between:
-- `exported_namespace` (default) - for `honorLabels: false` configurations
-- `namespace` - for `honorLabels: true` configurations
-
-If you see incorrect namespace groupings in per-variant panels (e.g., all variants showing the controller's namespace instead of their actual namespaces), toggle the `$namespace_label` dropdown at the top of the dashboard.
-
-**Why the Default is `honorLabels: false`**
-
-Setting `honorLabels: false` is a security best practice that prevents scraped applications from spoofing infrastructure labels. For example, it prevents a pod from claiming to be in a different namespace via its exported metrics.
-
-## Troubleshooting
-### services "kube-prometheus-stack-grafana" not found
-  - Make sure to install WVA cluster with `DEPLOY_OPERATIONAL_DASHBOARD=true` (default) as this would install Grafana.
-  
-### No Data
-  - Hover over the information (`i`) icon in the panel. The information may show cases where data is not available.
-  - Check the datasource by browse to "Connections/Data sources", you should see a Prometheus data source `https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090`. Click on `Test` button to test the data source.
-  - Check data source which is defined in `kube-prometheus-stack-grafana-datasource` configmap:
-    ```console
-      $ oc get cm kube-prometheus-stack-grafana-datasource -n workload-
-    variant-autoscaler-monitoring -o yaml
-    apiVersion: v1
-    data:
-      datasource.yaml: |-
-        apiVersion: 1
-        datasources:
-        - name: "Prometheus"
-          type: prometheus
-          uid: prometheus
-          url: http://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring:9090/
-          access: proxy
-          isDefault: true
-          jsonData:
-            httpMethod: POST
-            timeInterval: 30s
-        - name: "Alertmanager"
-          type: alertmanager
-          uid: alertmanager
-          url: http://kube-prometheus-stack-alertmanager.workload-variant-autoscaler-monitoring:9093/
-          access: proxy
-    ...
-    ```
-  ### Dashboard Not Found
-  - Dashboard is stored in `wva-operation-dashboard` configmap. Check configmap as follows:
-
-    ```console
-    $ oc get cm wva-operation-dashboard -n workload-variant-autoscaler-monitoring -o yaml
-    apiVersion: v1
-    data:
-      operational-dashboard.json: |
-        {
-          "annotations": {
-            "list": [
-              {
-                "builtIn": 1,
-                "datasource": {
-                  "type": "grafana",
-                  "uid": "-- Grafana --"
-                },
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              }
-            ]
-        ...
-    ```
+The dashboard and Prometheus stack that this repository installs are for
+development and CI, not for production clusters. They are documented in
+[developer-guide/monitoring.md](../developer-guide/monitoring.md).


### PR DESCRIPTION
## What

`docs/user-guide/monitoring.md` moves to `docs/developer-guide/monitoring.md`, and the old path becomes a short pointer to the observability docs in llm-d.

## Why

The doc was filed under `user-guide/`, but nothing in it is user-facing. It documents `DEPLOY_OPERATIONAL_DASHBOARD`, `make deploy-wva-on-k8s`, the `workload-variant-autoscaler-monitoring` namespace and the `kube-prometheus-stack` release name — all of which only exist in this repo's development and CI install. Someone running WVA from the llm-d guide has none of them, so the page can only mislead them.

`docs/README.md` already draws this line: its User Guide section links installation, configuration and architecture out to llm-d, while the repo keeps the developer-guide material. This just applies the same split to monitoring. The page wasn't linked from that nav at all, so it's now reachable in both places instead of neither.

This is item 2 from #1466, where @gyliu513 confirmed the dev/CI monitoring should be relabelled in place rather than physically moved, and the user-facing doc collapsed into a pointer.

## Scope

Docs only. No deploy manifests, no `install.sh`, no CI or e2e paths — the dashboard the e2e suite installs is untouched, it's just described under `developer-guide/` now.

The pointer targets `docs/operations/observability/` in llm-d, which exists on main today, so it isn't waiting on llm-d/llm-d#2363.

## Testing

Relative links in the moved doc and the pointer resolve. No code paths touched.
