### PR TITLE
fix(collector): surface per-query metric errors hidden in Refresh results

### DIFF
--- a/internal/collector/registration/engine.go
+++ b/internal/collector/registration/engine.go
@@ -7,7 +7,10 @@
 package registration
 
 import (
+	"strings"
+
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 )
 
@@ -68,4 +71,43 @@ func EngineQuery(engine inferenceengine.Engine, logical string) string {
 func registerForEngine(registry *source.QueryList, engine inferenceengine.Engine, tmpl source.QueryTemplate) { //nolint:unparam // see comment above
 	tmpl.Name = EngineQuery(engine, tmpl.Name)
 	registry.MustRegister(tmpl)
+}
+
+// queryTypeByLogicalName maps each logical query name to the query_type label
+// used by the metrics-collection error counter. Grouped queries share a label
+// (e.g. the token-shape queries) to keep the counter's label cardinality low.
+var queryTypeByLogicalName = map[string]string{
+	QueryKvCacheUsage:          constants.QueryTypeKVCache,
+	QueryQueueLength:           constants.QueryTypeQueueLength,
+	QueryCacheConfigInfo:       constants.QueryTypeCacheConfig,
+	QueryAvgOutputTokens:       constants.QueryTypeTokenMetrics,
+	QueryAvgInputTokens:        constants.QueryTypeTokenMetrics,
+	QueryPrefixCacheHitRate:    constants.QueryTypeTokenMetrics,
+	QuerySchedulerDispatchRate: constants.QueryTypeDispatchRate,
+	QueryAvgTTFT:               constants.QueryTypeLatency,
+	QueryAvgITL:                constants.QueryTypeLatency,
+	QueryGenerationTokenRate:   constants.QueryTypeThroughput,
+	QueryKvUsageInstant:        constants.QueryTypeThroughput,
+	QueryRequestRate:           constants.QueryTypeThroughput,
+	QueryModelArrivalRate:      constants.QueryTypeArrivalRate,
+	QueryModelRequestCount:     constants.QueryTypeRequestCount,
+	QuerySchedulerQueueSize:    constants.QueryTypeSchedulerQueue,
+	QuerySchedulerQueueBytes:   constants.QueryTypeSchedulerQueue,
+}
+
+// QueryTypeFor returns the query_type label for a logical or engine-scoped
+// physical query name (e.g. "kv_cache_usage" or "sglang/kv_cache_usage").
+// Unknown names fall back to the bare name so the error counter still records
+// them instead of dropping the failure silently.
+func QueryTypeFor(queryName string) string {
+	if qt, ok := queryTypeByLogicalName[queryName]; ok {
+		return qt
+	}
+	// Strip an engine prefix ("sglang/…") and retry with the logical name.
+	if idx := strings.Index(queryName, "/"); idx >= 0 {
+		if qt, ok := queryTypeByLogicalName[queryName[idx+1:]]; ok {
+			return qt
+		}
+	}
+	return queryName
 }

--- a/internal/collector/registration/engine_test.go
+++ b/internal/collector/registration/engine_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/inferenceengine"
 )
 
@@ -24,6 +25,30 @@ var _ = Describe("EngineQuery", func() {
 		// Scheduler queries are not engine-specific (sourced from EPP).
 		Expect(IsEngineSpecific(QuerySchedulerDispatchRate)).To(BeFalse())
 		Expect(EngineQuery(inferenceengine.EngineSGLang, QuerySchedulerDispatchRate)).To(Equal(QuerySchedulerDispatchRate))
+	})
+})
+
+var _ = Describe("QueryTypeFor", func() {
+	It("maps critical queries to their dedicated types", func() {
+		Expect(QueryTypeFor(QueryKvCacheUsage)).To(Equal(constants.QueryTypeKVCache))
+		Expect(QueryTypeFor(QueryQueueLength)).To(Equal(constants.QueryTypeQueueLength))
+		Expect(QueryTypeFor(QuerySchedulerQueueSize)).To(Equal(constants.QueryTypeSchedulerQueue))
+	})
+
+	It("maps grouped queries to their shared types", func() {
+		Expect(QueryTypeFor(QueryAvgTTFT)).To(Equal(constants.QueryTypeLatency))
+		Expect(QueryTypeFor(QueryAvgITL)).To(Equal(constants.QueryTypeLatency))
+		Expect(QueryTypeFor(QueryAvgOutputTokens)).To(Equal(constants.QueryTypeTokenMetrics))
+		Expect(QueryTypeFor(QueryRequestRate)).To(Equal(constants.QueryTypeThroughput))
+	})
+
+	It("strips engine prefixes from physical query names", func() {
+		Expect(QueryTypeFor("sglang/" + QueryKvCacheUsage)).To(Equal(constants.QueryTypeKVCache))
+		Expect(QueryTypeFor("sglang/" + QueryAvgTTFT)).To(Equal(constants.QueryTypeLatency))
+	})
+
+	It("falls back to the bare name for unknown queries", func() {
+		Expect(QueryTypeFor("some_future_query")).To(Equal("some_future_query"))
 	})
 })
 

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -44,6 +44,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -387,6 +388,35 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	// the per-engine series. The structural cache-config difference is handled by a
 	// dedicated SGLang pass after the vLLM cache-config block.
 	mergeEngineResults(results, engines, engineSpecificReplicaQueries)
+
+	// Per-query error sweep (issue #1151): Refresh reports query failures through
+	// each MetricResult rather than the returned error (which is non-nil only for
+	// a total backend outage), so the results themselves must be examined. Record
+	// each failure's categorized reason so an operator can tell a broken query
+	// apart from absent data; the per-query blocks below decide the severity —
+	// KV cache and queue length fail collection, the rest degrade gracefully.
+	checked, failed := 0, 0
+	for _, logical := range append(slices.Clone(engineSpecificReplicaQueries), agnosticReplicaQueries...) {
+		result := results[logical]
+		if result == nil {
+			continue // query produced no result entry — not registered for this engine
+		}
+		checked++
+		if !result.HasError() {
+			continue
+		}
+		failed++
+		reason := prometheus.CategorizePrometheusError(result.Error)
+		metrics.IncMetricsCollectionErrors(registration.QueryTypeFor(logical), reason)
+		logger.V(logging.DEBUG).Info("Replica metrics query failed",
+			"query", logical, "reason", reason, "error", result.Error)
+	}
+	// Defense in depth for sources that do not aggregate a total outage into
+	// the returned error: if every query that produced a result failed, treat
+	// the backend as unavailable rather than as an empty-but-successful scrape.
+	if checked > 0 && failed == checked {
+		return nil, fmt.Errorf("all %d replica metric queries failed (metrics backend may be unavailable)", checked)
+	}
 
 	// podMetricData holds per-pod metric values and timestamps
 	type podMetricData struct {
@@ -1112,9 +1142,29 @@ func (c *ReplicaMetricsCollector) CollectSchedulerQueueMetrics(
 		Params:  params,
 	})
 	if err != nil {
+		// Categorize rather than swallow: a failed refresh is a fault, not the
+		// same as flow-control metrics being absent. Record the categorized
+		// reason so the two stay distinguishable via the scheduler_queue error
+		// counter (issue #1151).
+		reason := prometheus.CategorizePrometheusError(err)
+		metrics.IncMetricsCollectionErrors(constants.QueryTypeSchedulerQueue, reason)
 		logger.V(logging.DEBUG).Info("Scheduler queue metrics unavailable",
-			"modelID", modelID, "error", err)
+			"modelID", modelID, "reason", reason, "error", err)
 		return nil
+	}
+
+	// Per-query error sweep (issue #1151): examine results, not just the returned
+	// error. Query failures are recorded but do not fail collection — an absent
+	// flow-control metric remains a legitimate state (no EPP deployed).
+	for _, name := range queries {
+		result := results[name]
+		if result == nil || !result.HasError() {
+			continue
+		}
+		reason := prometheus.CategorizePrometheusError(result.Error)
+		metrics.IncMetricsCollectionErrors(registration.QueryTypeFor(name), reason)
+		logger.V(logging.DEBUG).Info("Scheduler queue query failed",
+			"modelID", modelID, "query", name, "reason", reason, "error", result.Error)
 	}
 
 	var queueSize, queueBytes int64

--- a/internal/collector/replica_metrics_test.go
+++ b/internal/collector/replica_metrics_test.go
@@ -37,6 +37,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/domain"
@@ -574,6 +575,129 @@ func TestCollectReplicaMetrics_ErrorMetrics(t *testing.T) {
 			t.Errorf("Expected error metric for query_type=%s but was not found", queryType)
 		}
 	}
+}
+
+// TestCollectReplicaMetrics_AllQueryResultsFailed verifies the issue #1151
+// scenario: the source's Refresh returns err == nil while every query result
+// carries an error (e.g. the Prometheus backend is down). The collector must
+// treat this as an unavailable backend instead of an empty-but-successful
+// scrape, so collection fails and downstream metrics-unavailable handling
+// (events, fallbacks) kicks in.
+func TestCollectReplicaMetrics_AllQueryResultsFailed(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(ctx context.Context, spec source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			// Every requested query "executes" but fails — err stays nil, the
+			// failures live inside each MetricResult.
+			results := make(map[string]*source.MetricResult, len(spec.Queries))
+			for _, name := range spec.Queries {
+				results[name] = &source.MetricResult{
+					QueryName: name,
+					Error:     errors.New("connection refused"),
+				}
+			}
+			return results, nil
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	collector := NewReplicaMetricsCollector(mockSource, k8sClient, record.NewFakeRecorder(100), nil)
+
+	_, err := collector.CollectReplicaMetrics(
+		context.Background(),
+		"test-model",
+		"test-namespace",
+		make(map[string]scaletarget.ScaleTargetAccessor),
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil,
+		make(map[string]float64),
+	)
+	require.Error(t, err, "all queries failing must fail collection even when Refresh returns err == nil")
+	assert.Contains(t, err.Error(), "metrics backend may be unavailable")
+}
+
+// TestCollectReplicaMetrics_PartialQueryResultFailure verifies that a failed
+// non-critical query (avg TTFT) does not fail the whole collection, but is
+// recorded in the wva_metrics_collection_errors_total counter with its
+// categorized query type so operators can distinguish a broken query from
+// absent data.
+func TestCollectReplicaMetrics_PartialQueryResultFailure(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(ctx context.Context, spec source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			results := make(map[string]*source.MetricResult, len(spec.Queries))
+			for _, name := range spec.Queries {
+				result := &source.MetricResult{QueryName: name, Values: []source.MetricValue{}}
+				if name == registration.QueryAvgTTFT {
+					result.Error = errors.New("query timed out")
+				}
+				results[name] = result
+			}
+			return results, nil
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	collector := NewReplicaMetricsCollector(mockSource, k8sClient, record.NewFakeRecorder(100), nil)
+
+	replicaMetrics, err := collector.CollectReplicaMetrics(
+		context.Background(),
+		"test-model",
+		"test-namespace",
+		make(map[string]scaletarget.ScaleTargetAccessor),
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil,
+		make(map[string]float64),
+	)
+	require.NoError(t, err, "a failed non-critical query must not fail collection")
+	require.Empty(t, replicaMetrics)
+
+	// The failure must be recorded in the error counter under the latency
+	// query type (avg TTFT maps to constants.QueryTypeLatency).
+	metricFamilies, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	var latencyErrCount float64
+	found := false
+	for _, mf := range metricFamilies {
+		if mf.GetName() != constants.WVAMetricsCollectionErrorsTotal {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var queryType string
+			for _, label := range m.GetLabel() {
+				if label.GetName() == constants.LabelQueryType {
+					queryType = label.GetValue()
+					break
+				}
+			}
+			if queryType == constants.QueryTypeLatency {
+				found = true
+				latencyErrCount = m.GetCounter().GetValue()
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Expected error metric for query_type=%s but was not found", constants.QueryTypeLatency)
+	}
+	assert.Equal(t, 1.0, latencyErrCount, "expected exactly one recorded latency query failure")
 }
 
 // TestCollectReplicaMetrics_ThroughputKeyMerge verifies that when the KV-cache

--- a/internal/collector/source/prometheus/prometheus_source.go
+++ b/internal/collector/source/prometheus/prometheus_source.go
@@ -6,6 +6,7 @@ package prometheus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -110,7 +111,33 @@ func (p *PrometheusSource) Refresh(ctx context.Context, spec source.RefreshSpec)
 		"queriesExecuted", len(queryNames),
 		"queriesSucceeded", countSuccessful(results))
 
+	// Surface a total backend outage as a top-level error. Refresh otherwise
+	// reports per-query failures only through each MetricResult, so a caller
+	// that checks only the returned error would treat a down Prometheus as an
+	// empty-but-successful refresh (issue #1151). Partial failures stay
+	// per-result so healthy queries still flow through.
+	if err := joinResultErrors(results); err != nil {
+		return results, fmt.Errorf("all %d Prometheus queries failed: %w", len(queryNames), err)
+	}
+
 	return results, nil
+}
+
+// joinResultErrors returns the joined errors of every result when ALL results
+// carry an error; nil otherwise. A nil or error-free result means at least one
+// query succeeded, so the refresh is not a total outage.
+func joinResultErrors(results map[string]*source.MetricResult) error {
+	if len(results) == 0 {
+		return nil
+	}
+	var errs []error
+	for _, r := range results {
+		if r == nil || r.Error == nil {
+			return nil
+		}
+		errs = append(errs, r.Error)
+	}
+	return errors.Join(errs...)
 }
 
 // executeQuery builds and executes a single query.

--- a/internal/collector/source/prometheus/prometheus_source_test.go
+++ b/internal/collector/source/prometheus/prometheus_source_test.go
@@ -2,7 +2,9 @@ package prometheus
 
 import (
 	"context"
+	"errors"
 	"math"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -184,6 +186,60 @@ var _ = Describe("PrometheusSource", func() {
 			Expect(capturedQuery).To(ContainSubstring(`model_name="x\",namespace=\"other\""`))
 			// Should not contain unescaped injection (extra namespace=)
 			Expect(capturedQuery).NotTo(MatchRegexp(`namespace="other"`))
+		})
+
+		It("should return an error when all queries fail (issue #1151)", func() {
+			// Prometheus is down: every query fails. Refresh must surface this as
+			// a top-level error, not just as per-result Error fields that callers
+			// checking only the returned error would miss.
+			mockAPI.queryFunc = func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+				return nil, nil, errors.New("connection refused")
+			}
+
+			results, err := source.Refresh(ctx, sourcepkg.RefreshSpec{
+				Queries: []string{"test_query"},
+				Params:  map[string]string{"namespace": "test-ns"},
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("all 1 Prometheus queries failed"))
+			// Results are still returned so callers can inspect per-query errors.
+			Expect(results).To(HaveKey("test_query"))
+			Expect(results["test_query"].Error).To(HaveOccurred())
+		})
+
+		It("should not return an error when only some queries fail", func() {
+			// Partial failure: the failed query's error stays per-result and the
+			// refresh is not a total outage, so the top-level error stays nil.
+			mockAPI.queryFunc = func(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+				if strings.Contains(query, "flaky") {
+					return nil, nil, errors.New("execution error")
+				}
+				return model.Vector{
+					&model.Sample{
+						Metric:    model.Metric{"pod": "p1"},
+						Value:     0.5,
+						Timestamp: model.TimeFromUnix(time.Now().Unix()),
+					},
+				}, nil, nil
+			}
+
+			err := registry.Register(sourcepkg.QueryTemplate{
+				Name:        "flaky_query",
+				Type:        sourcepkg.QueryTypePromQL,
+				Template:    `flaky_metric`,
+				Description: "Fails on purpose",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			results, err := source.Refresh(ctx, sourcepkg.RefreshSpec{
+				Queries: []string{"test_query", "flaky_query"},
+				Params:  map[string]string{"namespace": "test-ns"},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results["test_query"].Error).NotTo(HaveOccurred())
+			Expect(results["flaky_query"].Error).To(HaveOccurred())
 		})
 	})
 

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -320,11 +320,25 @@ const (
 // Metric Label Values for query_type
 // These values are used as the query_type label in metrics collection metrics.
 const (
-	QueryTypeKVCache      = "kv_cache"
-	QueryTypeQueueLength  = "queue_length"
-	QueryTypeRequestCount = "request_count"
-	QueryTypeCacheConfig  = "cache_config"
-	QueryTypeArrivalRate  = "arrival_rate"
+	QueryTypeKVCache     = "kv_cache"
+	QueryTypeQueueLength = "queue_length"
+	// QueryTypeSchedulerQueue is the model-level flow-control queue
+	// (scheduler_queue_size / scheduler_queue_bytes), distinct from the
+	// per-engine queue_length.
+	QueryTypeSchedulerQueue = "scheduler_queue"
+	QueryTypeRequestCount   = "request_count"
+	QueryTypeCacheConfig    = "cache_config"
+	QueryTypeArrivalRate    = "arrival_rate"
+	// QueryTypeDispatchRate is the per-instance scheduler dispatch rate.
+	QueryTypeDispatchRate = "dispatch_rate"
+	// QueryTypeTokenMetrics groups the token-shape queries (avg input/output
+	// tokens, prefix cache hit rate).
+	QueryTypeTokenMetrics = "token_metrics"
+	// QueryTypeLatency groups the request latency queries (avg TTFT, avg ITL).
+	QueryTypeLatency = "latency"
+	// QueryTypeThroughput groups the throughput-analyzer queries (generation
+	// token rate, instantaneous KV usage, request rate).
+	QueryTypeThroughput = "throughput"
 )
 
 // Values for the LabelUnit Prometheus label, describing how to interpret the

--- a/internal/engines/scalefromzero/engine.go
+++ b/internal/engines/scalefromzero/engine.go
@@ -289,8 +289,21 @@ func (e *Engine) processInactiveVariant(ctx context.Context, scaleTargets map[st
 		return err
 	}
 
-	// Check for pending requests using EPP flowcontrol queue size metrics
+	// Check for pending requests using EPP flowcontrol queue size metrics.
+	// A failed or missing "all_metrics" result must not be conflated with "no
+	// pending requests" (issue #1151): treating a scrape error as an empty
+	// result would silently pin the variant at zero replicas while requests
+	// are actually queued, and a missing entry would panic below.
 	result := results["all_metrics"]
+	if result == nil || result.HasError() {
+		err := fmt.Errorf("EPP metrics result unavailable for pool %s", namespacedPoolName)
+		if result != nil && result.Error != nil {
+			err = fmt.Errorf("EPP metrics query failed for pool %s: %w", namespacedPoolName, result.Error)
+		}
+		reason := prometheus.CategorizePrometheusError(err)
+		metrics.IncMetricsCollectionErrors(constants.QueryTypeQueueLength, reason)
+		return err
+	}
 	pendingRequestExist := false
 	for _, value := range result.Values {
 		metricName := value.Labels["__name__"]


### PR DESCRIPTION
## Summary

`MetricsSource.Refresh()` returns `err == nil` even when Prometheus is down — query failures are only visible inside each `MetricResult` (#1151). Callers that only check the returned error treat a total outage as an empty-but-successful refresh, and failed non-critical queries were silently dropped (no log, no error counter).

## Changes

- `PrometheusSource.Refresh`: return a joined top-level error when *all* queries fail; partial failures stay per-result
- `collectReplicaMetrics`: sweep per-query results — increment `wva_metrics_collection_errors_total` with the categorized reason + debug log; fail collection only when every query failed (KV-cache / queue-length severity unchanged)
- `CollectSchedulerQueueMetrics`: count refresh and per-result failures under the new `scheduler_queue` query type
- scale-from-zero: guard `all_metrics` for nil/`HasError()` — a failed scrape is no longer conflated with "no pending requests" (which silently pinned variants at zero replicas), and a missing entry no longer panics
- Add `registration.QueryTypeFor()` (query name → counter label, incl. `sglang/` prefixes) and new query types: `scheduler_queue`, `dispatch_rate`, `token_metrics`, `latency`, `throughput`

## Test plan

- [x] `go build ./...`; unit tests for all touched packages, incl. new cases: all queries failing → `Refresh` errors and collection fails; single non-critical query failing → collection succeeds, counter increments under the right query type
- [ ] envtest suites need CI coverage (no kubebuilder binaries locally; they fail identically on pristine main)

Fixes #1151